### PR TITLE
We should refrain from sending back 100-continue if "Expect: 100- continue" is specified until after the request handler has been called, unless the user has already sent back a response code.

### DIFF
--- a/src/main/java/org/vertx/java/core/http/HttpServer.java
+++ b/src/main/java/org/vertx/java/core/http/HttpServer.java
@@ -360,10 +360,6 @@ public class HttpServer extends NetServerBase {
         if (msg instanceof HttpRequest) {
           HttpRequest request = (HttpRequest) msg;
 
-          if (HttpHeaders.is100ContinueExpected(request)) {
-            ch.write(new DefaultHttpResponse(HTTP_1_1, CONTINUE));
-          }
-
           if (HttpHeaders.Values.UPGRADE.equalsIgnoreCase(request.getHeader(CONNECTION)) &&
               WEBSOCKET.equalsIgnoreCase(request.getHeader(HttpHeaders.Names.UPGRADE))) {
             // Websocket handshake
@@ -381,6 +377,9 @@ public class HttpServer extends NetServerBase {
             }
           } else {
             conn.handleMessage(msg);
+            if (HttpHeaders.is100ContinueExpected(request) && !conn.isResponded()) {
+              ch.write(new DefaultHttpResponse(HTTP_1_1, CONTINUE));
+            }
           }
         } else {
           conn.handleMessage(msg);

--- a/src/main/java/org/vertx/java/core/http/ServerConnection.java
+++ b/src/main/java/org/vertx/java/core/http/ServerConnection.java
@@ -43,6 +43,7 @@ class ServerConnection extends AbstractConnection {
   private boolean channelPaused;
   private boolean paused;
   private boolean sentCheck;
+  private boolean responded = false;
   private final Queue<Object> pending = new LinkedList<>();
 
   ServerConnection(Channel channel, long contextID, Thread th) {
@@ -66,6 +67,10 @@ class ServerConnection extends AbstractConnection {
     }
   }
 
+  public boolean isResponded(){
+      return responded;
+  }
+
   void handleMessage(Object msg) {
     if (paused || (msg instanceof HttpRequest && pendingResponse) || !pending.isEmpty()) {
       //We queue requests if paused or a request is in progress to prevent responses being written in the wrong order
@@ -84,6 +89,7 @@ class ServerConnection extends AbstractConnection {
 
   void responseComplete() {
     pendingResponse = false;
+    responded = true;
     checkNextTick();
   }
 


### PR DESCRIPTION
Signed-off-by: Erdi Calli erdicalli@gmail.com
