### PR TITLE
Tweak to the ant build.xml to make it clear what java version is required

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -64,7 +64,7 @@
 
     <target name="compile-core" depends="init" description="compile the source for the core">
         <mkdir dir="${core-target}"/>
-        <javac srcdir="${core-src}" destdir="${core-target}" classpathref="core-lib-classpath" debug="on" includeantruntime="false"/>
+        <javac srcdir="${core-src}" destdir="${core-target}" classpathref="core-lib-classpath" debug="on" includeantruntime="false" target="1.7" source="1.7"/>
     </target>
 
     <target name="jar-core" depends="compile-core" description="generate the core jar">


### PR DESCRIPTION
Hope you don't mind me pushing a few changes to your project while I test drive it.

Tweak to the ant build.xml to make it clear what java version is required to build this project.

This change will result in very clear error when trying to build on 1.6.

```
compile-core:
    [javac] Compiling 94 source files to /Users/markw/Code/Java/vert.x/target/core/classes
    [javac] javac: invalid target release: 1.7
    [javac] Usage: javac <options> <source files>
    [javac] use -help for a list of possible options

BUILD FAILED
/Users/markw/Code/Java/vert.x/build.xml:67: Compile failed; see the compiler error output for details.

Total time: 0 seconds
```

Otherwise I get the following error.

```
    [javac] /Users/markw/Code/Java/vert.x/src/main/java/org/vertx/java/scratch/Pool.java:25: illegal start of type
    [javac]   private Queue<T> connections = new ConcurrentLinkedQueue<>();
    [javac]                                                            ^
    [javac] /Users/markw/Code/Java/vert.x/src/main/java/org/vertx/java/scratch/Pool.java:26: illegal start of type
    [javac]   private Queue<ConnectionHandler<T>> waiters = new ConcurrentLinkedQueue<>();
    [javac]                                                                           ^
    [javac] 40 errors

BUILD FAILED
/Users/markw/Code/Java/vert.x/build.xml:67: Compile failed; see the compiler error output for details.
```

I have tested these changes on ubuntu with Java 1.7 and it compiles without error.
