### PR TITLE
There's a missing mkdir for the ruby docs that causes ant dist to fail

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -251,6 +251,7 @@
         <fileset dir="${target}/${javadoc-dir}"/>
     </copy>
 
+    <mkdir dir="${target}/${rubydoc-dir}"/>
     <copy todir="${dist-build}/${rubydoc-dir}">
         <fileset dir="${target}/${rubydoc-dir}"/>
     </copy>


### PR DESCRIPTION
The change I've made fixes it, but you might want to put it somewhere saner
