### PR TITLE
Fix for incorrectly ordered code in JS web-app tutorial

### DIFF
--- a/wsver-0002/js_web_tutorial.md
+++ b/wsver-0002/js_web_tutorial.md
@@ -212,6 +212,17 @@ Edit the code in `web_server.js` so it looks like:
 
     var server = new vertx.HttpServer();
         
+    server.requestHandler(function(req) {
+      if (req.path === '/') {
+        req.response.sendFile('web/index.html');
+      } else if (req.path.indexOf('..') === -1) {
+        req.response.sendFile('web' + req.path);
+      } else {
+        req.response.statusCode = 404;
+        req.response.end;
+      }
+    });
+    
     // Link up the client side to the server side event bus
     new vertx.SockJSBridge(server, {prefix : '/eventbus'},
       [
@@ -226,16 +237,7 @@ Edit the code in `web_server.js` so it looks like:
       ]
     );
     
-    server.requestHandler(function(req) {
-      if (req.path === '/') {
-        req.response.sendFile('web/index.html');
-      } else if (req.path.indexOf('..') === -1) {
-        req.response.sendFile('web' + req.path);
-      } else {
-        req.response.statusCode = 404;
-        req.response.end;
-      }
-    }).listen(8080, 'localhost');
+    server.listen(8080, 'localhost');
     
     function vertxStop() {
       server.close();


### PR DESCRIPTION
I was following the JS tutorial using _beta5_ and got stuck at the point after adding the `SockJSBridge` to _web_server.js_. The chrome console showed a 404 for `http://localhost:8080/eventbus/info` and none of the static data appeared in the page.

After Googling I found [this thread](http://groups.google.com/group/vertx/browse_thread/thread/0e375c39d011a929/3d5711e54d4e657d?show_docid=3d5711e54d4e657d&pli=1) which suggested that the `SockJSBridge` needs to be initialized only _after_ the request handler is attached to the server. Sure enough, switching the example code around fixed the problem.

I've patched the markdown file with a corrected code sample.
