### PR TITLE
Removed invalid logger declaration from code

### DIFF
--- a/js_web_tutorial.md
+++ b/js_web_tutorial.md
@@ -343,8 +343,6 @@ So, app.js should now look like this:
 
     load('vertx.js');
 
-    var log = vertx.getLogger();
-
     // Our application config
 
     var persistorConf =  {


### PR DESCRIPTION
Working through the JS tutorial I found that the logger declaration included in `app.js` during the login step appears to be invalid.
