### PR TITLE
vertx.mods path fix

### DIFF
--- a/src/scripts/vertx.bat
+++ b/src/scripts/vertx.bat
@@ -7,8 +7,7 @@ setlocal enabledelayedexpansion
 
 for %%? in ("%~dp0..") do set VERTX_HOME=%%~f?
 set VERTX_CP=%VERTX_HOME%\conf;
-set VERTX_MODS=%VERTX_HOME%\mods
 for %%a in ("%VERTX_HOME%\lib\jars\*.jar") do set VERTX_CP=!VERTX_CP!%%a;
 for /d %%a in ("%VERTX_HOME%\lib\*") do set VERTX_CP=!VERTX_CP!%%a;
 
-java -Djava.util.logging.config.file=%VERTX_HOME%\conf\logging.properties -Djruby.home=%JRUBY_HOME% -Dvertx.mods=%VERTX_MODS% -Dvertx.install=%VERTX_HOME%\.. -cp %VERTX_CP% org.vertx.java.deploy.impl.cli.VertxMgr %*
+java -Djava.util.logging.config.file=%VERTX_HOME%\conf\logging.properties -Djruby.home=%JRUBY_HOME% -Dvertx.mods=%VERTX_MODS% -Dvertx.install=%VERTX_HOME% -cp %VERTX_CP% org.vertx.java.deploy.impl.cli.VertxMgr %*


### PR DESCRIPTION
I think the variable VERTX_MODS is missed out and so vertx can not find mods path. exception is :

C:\Users\mp\Desktop\vert.x-1.0.beta7\examples\javascript\webapp>vertx run app.js
Nis 18, 2012 11:23:11 PM org.vertx.java.core.logging.impl.JULLogDelegate error
SEVERE: Failed to create verticle
java.lang.ClassNotFoundException: mongo-persistor
        at java.net.URLClassLoader$1.run(Unknown Source)
        at java.net.URLClassLoader$1.run(Unknown Source)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(Unknown Source)
        at java.lang.ClassLoader.loadClass(Unknown Source)
        at org.vertx.java.deploy.impl.ParentLastURLClassLoader.loadClass(ParentLastURLClassLoader.java:61)
        at java.lang.ClassLoader.loadClass(Unknown Source)
        at org.vertx.java.deploy.impl.java.JavaVerticleFactory.createVerticle(JavaVerticleFactory.java:36)
        at org.vertx.java.deploy.impl.VerticleManager$2.run(VerticleManager.java:278)
        at org.vertx.java.core.impl.DefaultVertx$2.run(DefaultVertx.java:251)
        at org.vertx.java.core.impl.Context$2.run(Context.java:114)
        at org.jboss.netty.channel.socket.nio.AbstractNioWorker.processEventQueue(AbstractNioWorker.java:352)
        at org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioWorker.java:236)
        at org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:38)
        at org.jboss.netty.util.internal.DeadLockProofWorker$1.run(DeadLockProofWorker.java:42)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.lang.Thread.run(Unknown Source)

Nis 18, 2012 11:23:11 PM org.vertx.java.core.logging.impl.JULLogDelegate error
SEVERE: Failed to create verticle
java.lang.ClassNotFoundException: auth-mgr
        at java.net.URLClassLoader$1.run(Unknown Source)
        at java.net.URLClassLoader$1.run(Unknown Source)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(Unknown Source)
        at java.lang.ClassLoader.loadClass(Unknown Source)
        at org.vertx.java.deploy.impl.ParentLastURLClassLoader.loadClass(ParentLastURLClassLoader.java:61)
        at java.lang.ClassLoader.loadClass(Unknown Source)
        at org.vertx.java.deploy.impl.java.JavaVerticleFactory.createVerticle(JavaVerticleFactory.java:36)
        at org.vertx.java.deploy.impl.VerticleManager$2.run(VerticleManager.java:278)
        at org.vertx.java.core.impl.DefaultVertx$2.run(DefaultVertx.java:251)
        at org.vertx.java.core.impl.Context$2.run(Context.java:114)
        at org.jboss.netty.channel.socket.nio.AbstractNioWorker.processEventQueue(AbstractNioWorker.java:352)
        at org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioWorker.java:236)
        at org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:38)
        at org.jboss.netty.util.internal.DeadLockProofWorker$1.run(DeadLockProofWorker.java:42)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.lang.Thread.run(Unknown Source)

Nis 18, 2012 11:23:11 PM org.vertx.java.core.logging.impl.JULLogDelegate error
SEVERE: Failed to create verticle
java.lang.ClassNotFoundException: mailer
        at java.net.URLClassLoader$1.run(Unknown Source)
        at java.net.URLClassLoader$1.run(Unknown Source)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(Unknown Source)
        at java.lang.ClassLoader.loadClass(Unknown Source)
        at org.vertx.java.deploy.impl.ParentLastURLClassLoader.loadClass(ParentLastURLClassLoader.java:61)
        at java.lang.ClassLoader.loadClass(Unknown Source)
        at org.vertx.java.deploy.impl.java.JavaVerticleFactory.createVerticle(JavaVerticleFactory.java:36)
        at org.vertx.java.deploy.impl.VerticleManager$2.run(VerticleManager.java:278)
        at org.vertx.java.core.impl.DefaultVertx$2.run(DefaultVertx.java:251)
        at org.vertx.java.core.impl.Context$2.run(Context.java:114)
        at org.jboss.netty.channel.socket.nio.AbstractNioWorker.processEventQueue(AbstractNioWorker.java:352)
        at org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioWorker.java:236)
        at org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:38)
        at org.jboss.netty.util.internal.DeadLockProofWorker$1.run(DeadLockProofWorker.java:42)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.lang.Thread.run(Unknown Source)
