### PR TITLE
add Eclipse stuff to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 .idea
+.classpath
+.project
+.settings
+bin
 target
 out
 *.iml


### PR DESCRIPTION
A small amount of tidying, add the Eclipse standard project dir/files to .gitignore.
