### PR TITLE
Support path parameters with spaces in vertx.bat on Windows

### DIFF
--- a/src/scripts/vertx.bat
+++ b/src/scripts/vertx.bat
@@ -11,4 +11,4 @@ for %%a in ("%VERTX_HOME%\lib\jars\*.jar") do set VERTX_CP=!VERTX_CP!%%a;
 for /d %%a in ("%VERTX_HOME%\lib\*") do set VERTX_CP=!VERTX_CP!%%a;
 set VERTX_CP=%VERTX_CP%;%JRUBY_HOME%\lib\jruby.jar
 
-java -Djava.util.logging.config.file="%VERTX_HOME%\conf\logging.properties" -Djruby.home="%JRUBY_HOME%" -Dvertx.mods=%VERTX_MODS% -Dvertx.install="%VERTX_HOME%" -cp "%VERTX_CP%" org.vertx.java.deploy.impl.cli.VertxMgr %*
+java -Djava.util.logging.config.file="%VERTX_HOME%\conf\logging.properties" -Djruby.home="%JRUBY_HOME%" -Dvertx.mods="%VERTX_MODS%" -Dvertx.install="%VERTX_HOME%" -cp "%VERTX_CP%" org.vertx.java.deploy.impl.cli.VertxMgr %*


### PR DESCRIPTION
Changes to allow installing and using vert.x and related tools on paths containing spaces, on Windows.
