### PR TITLE
update install_rhino.sh script for ant 1.8.4 release

### DIFF
--- a/src/scripts/install_rhino.sh
+++ b/src/scripts/install_rhino.sh
@@ -4,13 +4,13 @@
 # This script is only necessary for a short period, until Rhino1.7.R4 is released
 mkdir inst_tmp
 cd inst_tmp
-curl http://www.apache.org/dist/ant/binaries/apache-ant-1.8.3-bin.tar.gz > ant.tar.gz
+curl http://www.apache.org/dist/ant/binaries/apache-ant-1.8.4-bin.tar.gz > ant.tar.gz
 tar -zxf ant.tar.gz
 curl https://nodeload.github.com/mozilla/rhino/tarball/master > rhino.tar.gz
 tar -zxf rhino.tar.gz
 mv mozilla-rhino-* mozilla-rhino
 cd mozilla-rhino
-../apache-ant-1.8.3/bin/ant jar
+../apache-ant-1.8.4/bin/ant jar
 cp build/rhino1_7R4*/js.jar ../../lib/jars
 cd ../..
 rm -rf inst_tmp


### PR DESCRIPTION
1.8.3 is no longer available at the URL in the script, which breaks it quite a bit ;)
