### PR TITLE
Typo in webserver busmod documentation

### DIFF
--- a/mods_manual.html
+++ b/mods_manual.html
@@ -276,7 +276,7 @@ mods/my-web-app/web-root/index.html
 }
 </pre>
 <ul>
-<li><code>web-root</code>. This is the root directory from where files will be served. <em>Anything that you place here or in sub directories will be externally accessible</em>. Default is <code>web</code>.</li>
+<li><code>web_root</code>. This is the root directory from where files will be served. <em>Anything that you place here or in sub directories will be externally accessible</em>. Default is <code>web</code>.</li>
 <li><code>index_page</code>. The page to serve when the root <code>/</code> is requested. Default is <code>index.html</code>.</li>
 <li><code>host</code>. The host or ip address to listen at for connections. <code>0.0.0.0</code> means listen at all available addresses. Default is <code>0.0.0.0</code>.</li>
 <li><code>port</code>. The port to listen at for connections. Default is <code>80</code>.</li>

--- a/mods_manual.md
+++ b/mods_manual.md
@@ -184,7 +184,7 @@ The web-server configuration is as follows:
         "auth_address": <auth_address>
     }
     
-* `web-root`. This is the root directory from where files will be served. *Anything that you place here or in sub directories will be externally accessible*. Default is `web`.
+* `web_root`. This is the root directory from where files will be served. *Anything that you place here or in sub directories will be externally accessible*. Default is `web`.
 * `index_page`. The page to serve when the root `/` is requested. Default is `index.html`.
 * `host`. The host or ip address to listen at for connections. `0.0.0.0` means listen at all available addresses. Default is `0.0.0.0`.
 * `port`. The port to listen at for connections. Default is `80`.


### PR DESCRIPTION
The description of webserver busmod configuration had web-root instead of web_root.
