### PR TITLE
Fix for #209

### DIFF
--- a/src/main/java/org/vertx/java/core/parsetools/RecordParser.java
+++ b/src/main/java/org/vertx/java/core/parsetools/RecordParser.java
@@ -179,6 +179,11 @@ public class RecordParser implements Handler<Buffer> {
           delimPos = 0;
           output.handle(ret);
         }
+      } else {
+        if (delimPos > 0) {
+          pos -= delimPos;
+          delimPos = 0;
+        }
       }
     }
   }

--- a/src/tests/controllers/org/vertx/java/tests/core/parsetools/JavaRecordParserTest.java
+++ b/src/tests/controllers/org/vertx/java/tests/core/parsetools/JavaRecordParserTest.java
@@ -252,4 +252,17 @@ public class JavaRecordParserTest extends TestCase {
     }
     return chunkSizes;
   }
+
+  @Test
+  /*
+   * test issue-209
+   */
+  public void testSpreadDelimiter() {
+    doTestDelimited(new Buffer("start-a-b-c-dddabc"), "abc".getBytes(),
+            new Integer[] { 18 }, new Buffer("start-a-b-c-ddd"));
+    doTestDelimited(new Buffer("start-abc-dddabc"), "abc".getBytes(),
+            new Integer[] { 18 }, new Buffer("start-"), new Buffer("-ddd"));
+    doTestDelimited(new Buffer("start-ab-c-dddabc"), "abc".getBytes(),
+            new Integer[] { 18 }, new Buffer("start-ab-c-ddd"));
+  }
 }


### PR DESCRIPTION
If a delimitor match fail halfway, then restart matching from the next position.
