### PR TITLE
Issue with JsonObject.toMap with JsonArray

### DIFF
--- a/src/main/java/org/vertx/java/core/json/JsonArray.java
+++ b/src/main/java/org/vertx/java/core/json/JsonArray.java
@@ -159,22 +159,20 @@ public class JsonArray implements Iterable<Object> {
   }
 
   public Object[] toArray() {
-    return convertList(list);
+    return convertList(list).toArray();
   }
 
   @SuppressWarnings("unchecked")
-  static Object[] convertList(List<?> list) {
-    Object[] arr = new Object[list.size()];
-    int index = 0;
+  static List<Object> convertList(List<?> list) {
+    List<Object> arr = new ArrayList<>(list.size());
     for (Object obj: list) {
       if (obj instanceof Map) {
-        arr[index] = JsonObject.convertMap((Map<String, Object>) obj);
+        arr.add(JsonObject.convertMap((Map<String, Object>) obj));
       } else if (obj instanceof List) {
-        arr[index] = convertList((List<?>) obj);
+          arr.add(convertList((List<?>) obj));
       } else {
-        arr[index] = obj;
+          arr.add(obj);
       }
-      index++;
     }
     return arr;
   }

--- a/src/tests/java/vertx/tests/core/json/TestJsonArrayToMap.java
+++ b/src/tests/java/vertx/tests/core/json/TestJsonArrayToMap.java
@@ -1,0 +1,28 @@
+package vertx.tests.core.json;
+
+import org.junit.Test;
+import org.vertx.java.core.json.JsonArray;
+import org.vertx.java.core.json.JsonObject;
+
+/**
+ * Test for toMap issue in JsonArray
+ *
+ * @author Adam Hathcock, <a href="mailto:adam@hathcock.co.uk">adam@hathcock.co.uk</a>
+ */
+public final class TestJsonArrayToMap {
+
+    @Test
+    public void expectJsonArrayToClone() {
+        JsonArray array = new JsonArray();
+        array.add("test");
+        JsonObject object = new JsonObject();
+        object.putArray("array", array);
+
+        //want to clone
+        JsonObject object2 = new JsonObject(object.toMap());
+        //this shouldn't throw an exception, it does before patch
+        JsonArray array2 = object2.getArray("array");
+
+    }
+}
+


### PR DESCRIPTION
Basically, JsonArray.convertList ought to return a List<Object> instead of Object[].  Otherwise, exceptions will occur.

See the test class to see the use case.

Thanks!
