### PR TITLE
Fixed incorrect formatter class name.

### DIFF
--- a/conf/logging.properties
+++ b/conf/logging.properties
@@ -15,10 +15,10 @@
 #
 
 handlers=java.util.logging.ConsoleHandler,java.util.logging.FileHandler
-java.util.logging.ConsoleHandler.formatter=org.vertx.java.core.logging.VertxLoggerFormatter
+java.util.logging.ConsoleHandler.formatter=org.vertx.java.core.logging.impl.VertxLoggerFormatter
 java.util.logging.ConsoleHandler.level=INFO
 java.util.logging.FileHandler.level=INFO
-java.util.logging.FileHandler.formatter=org.vertx.java.core.logging.VertxLoggerFormatter
+java.util.logging.FileHandler.formatter=org.vertx.java.core.logging.impl.VertxLoggerFormatter
 
 # Put the log in the system temporary directory
 java.util.logging.FileHandler.pattern=%t/vertx.log


### PR DESCRIPTION
Had wrong package name for VertxLoggerFormatter, so J.U.L. ended up falling back to its default formatter.
