### PR TITLE
GROOVY "unable to resolve class RouteMatcher"

### DIFF
--- a/src/main/java/org/vertx/java/deploy/impl/groovy/GroovyVerticleFactory.java
+++ b/src/main/java/org/vertx/java/deploy/impl/groovy/GroovyVerticleFactory.java
@@ -20,6 +20,8 @@ import groovy.lang.Binding;
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyCodeSource;
 import groovy.lang.Script;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.control.customizers.ImportCustomizer;
 import org.vertx.groovy.core.Vertx;
 import org.vertx.groovy.deploy.Container;
 import org.vertx.java.core.impl.VertxInternal;
@@ -64,7 +66,15 @@ public class GroovyVerticleFactory implements VerticleFactory {
 
     URL url = cl.getResource(main);
     GroovyCodeSource gcs = new GroovyCodeSource(url);
-    GroovyClassLoader gcl = new GroovyClassLoader(cl);
+
+    CompilerConfiguration config = new CompilerConfiguration();
+
+    ImportCustomizer imports = new ImportCustomizer();
+    imports.addImport("RouteMatcher","org.vertx.groovy.core.http.RouteMatcher");
+
+    config.addCompilationCustomizers(imports);
+
+    GroovyClassLoader gcl = new GroovyClassLoader(cl, config);
     Class clazz = gcl.parseClass(gcs);
 
     Method stop;
@@ -93,6 +103,7 @@ public class GroovyVerticleFactory implements VerticleFactory {
     Binding binding = new Binding();
     binding.setVariable("vertx", new Vertx((VertxInternal) VertxLocator.vertx));
     binding.setVariable("container", new Container(new org.vertx.java.deploy.Container((mgr))));
+
     verticle.setBinding(binding);
 
     return new Verticle() {


### PR DESCRIPTION
If you read the basic examples in the Groovy documentation to use the RouteMatcher, no "import" is involved. But if you try to run a minimal verticle with :

def routeMatcher = new RouteMatcher()

that will fail with an ugly :

org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
file:/Users/amaury/Desktop/verticle.groovy: 5: unable to resolve class RouteMatcher 

That's only solved if you prepend a "import org.vertx.groovy.core.http.RouteMatcher".

Code attached has a freshly added Groovy Compiler configuration to fit documentation promises about RouteMatcher.
