### PR TITLE
Using user.name system property instead of hardcoded "tim"

### DIFF
--- a/src/tests/javascript/busmods/mailer/test_client.js
+++ b/src/tests/javascript/busmods/mailer/test_client.js
@@ -21,7 +21,7 @@ var tu = new TestUtils();
 
 var eb = vertx.eventBus;
 
-var user = 'tim@localhost';
+var user = java.lang.System.getProperty("user.name") + '@localhost';
 
 function testMailer() {
 


### PR DESCRIPTION
The tests don't pass for me (I don't have a user "tim" on my machine). vertx.env["USER"] would also work, but I think java.lang.System.getProperty("user.name") makes more sense than vertx.env["USER"], thinking about windows users...

See https://groups.google.com/forum/?fromgroups#!topic/vertx/RKN-5sHAt9k for more info
