### PR TITLE
Change EventBus into a Service and load it via the ServiceProvider (like VertxFactory)

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/eventbus/EventBusFactory.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/eventbus/EventBusFactory.java
@@ -1,0 +1,13 @@
+package org.vertx.java.core.eventbus;
+
+import org.vertx.java.core.impl.VertxInternal;
+
+public interface EventBusFactory {
+
+	public EventBus createEventBus(VertxInternal v);
+
+	public EventBus createEventBus(VertxInternal v, String hostname);
+
+	public EventBus createEventBus(VertxInternal v, int port, String hostname);
+
+}

--- a/vertx-core/src/main/java/org/vertx/java/core/eventbus/impl/DefaultEventBusFactory.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/eventbus/impl/DefaultEventBusFactory.java
@@ -1,0 +1,24 @@
+package org.vertx.java.core.eventbus.impl;
+
+import org.vertx.java.core.eventbus.EventBus;
+import org.vertx.java.core.eventbus.EventBusFactory;
+import org.vertx.java.core.impl.VertxInternal;
+
+public class DefaultEventBusFactory implements EventBusFactory {
+
+	@Override
+	public EventBus createEventBus(VertxInternal v) {
+		return new DefaultEventBus(v);
+	}
+
+	@Override
+	public EventBus createEventBus(VertxInternal v, String hostname) {
+		return new DefaultEventBus(v, hostname);
+	}
+
+	@Override
+	public EventBus createEventBus(VertxInternal v, int port, String hostname) {
+		return new DefaultEventBus(v, port, hostname);
+	}
+
+}

--- a/vertx-core/src/main/java/org/vertx/java/core/impl/DefaultVertx.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/impl/DefaultVertx.java
@@ -23,7 +23,6 @@ import org.jboss.netty.util.Timeout;
 import org.jboss.netty.util.TimerTask;
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.eventbus.EventBus;
-import org.vertx.java.core.eventbus.impl.DefaultEventBus;
 import org.vertx.java.core.file.FileSystem;
 import org.vertx.java.core.file.impl.DefaultFileSystem;
 import org.vertx.java.core.http.HttpClient;
@@ -81,15 +80,15 @@ public class DefaultVertx extends VertxInternal {
   private final Map<Long, TimeoutHolder> timeouts = new ConcurrentHashMap<>();
 
   public DefaultVertx() {
-    this.eventBus = new DefaultEventBus(this);
+    this.eventBus = loadEventBusFactory().createEventBus(this);
   }
 
   public DefaultVertx(String hostname) {
-    this.eventBus = new DefaultEventBus(this, hostname);
+    this.eventBus = loadEventBusFactory().createEventBus(this, hostname);
   }
 
   public DefaultVertx(int port, String hostname) {
-    this.eventBus = new DefaultEventBus(this, port, hostname);
+    this.eventBus = loadEventBusFactory().createEventBus(this, port, hostname);
   }
 
   public NetServer createNetServer() {

--- a/vertx-core/src/main/java/org/vertx/java/core/impl/VertxInternal.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/impl/VertxInternal.java
@@ -17,11 +17,13 @@
 package org.vertx.java.core.impl;
 
 import org.vertx.java.core.Vertx;
+import org.vertx.java.core.eventbus.EventBusFactory;
 import org.vertx.java.core.http.impl.DefaultHttpServer;
 import org.vertx.java.core.net.impl.DefaultNetServer;
 import org.vertx.java.core.net.impl.ServerID;
 
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
@@ -33,6 +35,11 @@ import java.util.concurrent.ExecutorService;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public abstract class VertxInternal extends Vertx {
+
+  protected static EventBusFactory loadEventBusFactory() {
+    ServiceLoader<EventBusFactory> factories = ServiceLoader.load(EventBusFactory.class);
+    return factories.iterator().next();
+  }
 
   public abstract Executor getAcceptorPool();
 

--- a/vertx-platform/src/main/resources/META-INF/services/org.vertx.java.core.eventbus.EventBusFactory
+++ b/vertx-platform/src/main/resources/META-INF/services/org.vertx.java.core.eventbus.EventBusFactory
@@ -1,0 +1,1 @@
+org.vertx.java.core.eventbus.impl.DefaultEventBusFactory


### PR DESCRIPTION
After understanding git a little bit more, this is https://github.com/purplefox/vert.x/pull/213 reopened without all those extra commits.

Having DefaultEventBus registered as a Service like DefaultVertx, it will be easier to replace the implementation of the EventBus.
