### PR TITLE
Exporting org.vertx.java.core.buffer.Buffer to vertx.Buffer

### DIFF
--- a/src/main/javascript/core/buffer.js
+++ b/src/main/javascript/core/buffer.js
@@ -16,8 +16,5 @@
 
 var vertx = vertx || {};
 
-if (!vertx.Buffer) {
-  vertx.Buffer = function(p) {
-    return new org.vertx.java.core.buffer.Buffer(p);
-  }
-}
+if (!vertx.Buffer)
+  vertx.Buffer = org.vertx.java.core.buffer.Buffer;


### PR DESCRIPTION
There is no need to wrap a Object with another javascript function.
