### PR TITLE
Added check for less than 2 processors

### DIFF
--- a/src/tests/framework/java/org/vertx/java/framework/TestBase.java
+++ b/src/tests/framework/java/org/vertx/java/framework/TestBase.java
@@ -176,6 +176,10 @@ public class TestBase extends TestCase {
   }
 
   protected String startApp(boolean worker, String main, JsonObject config, int instances, boolean await) throws Exception {
+    if(Runtime.getRuntime().availableProcessors() < 2) {
+        log.error("*** The test framework requires at least 2 processors ***");
+        fail("The test framework requires at least 2 processors");
+    }
     URL url;
     if (main.endsWith(".js") || main.endsWith(".rb") || main.endsWith(".groovy") || main.endsWith(".py")) {
       url = getClass().getClassLoader().getResource(main);


### PR DESCRIPTION
Added this based on the discussion here:

https://groups.google.com/d/msg/vertx/RKN-5sHAt9k/Mc_tMZO-uU8J

This one caught me out when I was setting up on a Amazon EC2 with a single CPU. 

Not sure if it is still relevant given pid's gradle pull request ;)
