### PR TITLE
Bugfix: WebSocketFrameEncoder08.java for payload length > 65535 bytes

### DIFF
--- a/src/main/java/org/vertx/java/core/http/impl/ws/hybi08/WebSocketFrameEncoder08.java
+++ b/src/main/java/org/vertx/java/core/http/impl/ws/hybi08/WebSocketFrameEncoder08.java
@@ -65,7 +65,7 @@ public class WebSocketFrameEncoder08 extends OneToOneEncoder {
         encoded.writeShort(dataLen);
       } else {
         encoded.writeByte(applyMaskBit(0x7F));
-        encoded.writeInt(dataLen);
+        encoded.writeLong(dataLen);
       }
 
       if (shouldMask()) {


### PR DESCRIPTION
Fix WebSocketFrameEncoder08.java for payload length > 65535 bytes. Needed to write a long, not int. It was already correct in WebSocketFrameDecoder08 for large payloads.
