### PR TITLE
Fix for using tcpkeepalive with groovy netserver

### DIFF
--- a/src/main/groovy/org/vertx/groovy/core/net/NetServer.groovy
+++ b/src/main/groovy/org/vertx/groovy/core/net/NetServer.groovy
@@ -178,6 +178,7 @@ abstract class NetServer {
    */
   NetServer setTCPKeepAlive(boolean keepAlive) {
     jServer.setTCPKeepAlive(keepAlive)
+    this
   }
 
   /**
@@ -242,7 +243,7 @@ abstract class NetServer {
    * @return true if TCP keep alive is enabled
    */
   Boolean isTCPKeepAlive() {
-    return jServer.isTCPKeepAlive()
+    jServer.isTCPKeepAlive()
   }
 
   /**
@@ -320,9 +321,4 @@ abstract class NetServer {
   private Handler wrapHandler(Closure hndlr) {
     return {hndlr(new NetSocket(it))} as Handler
   }
-
-
-
-  
-
 }


### PR DESCRIPTION
A simple verticle like this one, in Groovy :

```
def server = vertx.createNetServer(TCPKeepAlive: true)

server.connectHandler { sock ->
  println 'Client has connected'
}

server.listen(8080, 'localhost')
```

leads to :

```
Exception in Groovy verticle 
java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.vertx.java.deploy.impl.groovy.GroovyVerticleFactory$1.start(GroovyVerticleFactory.java:101)
    at org.vertx.java.deploy.impl.VerticleManager$9.run(VerticleManager.java:615)
    at org.vertx.java.core.impl.Context$2.run(Context.java:118)
    at org.jboss.netty.channel.socket.nio.AbstractNioWorker.processEventQueue(AbstractNioWorker.java:360)
    at org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioWorker.java:244)
    at org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:38)
    at org.jboss.netty.util.ThreadRenamingRunnable.run(ThreadRenamingRunnable.java:102)
    at org.jboss.netty.util.internal.DeadLockProofWorker$1.run(DeadLockProofWorker.java:42)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1110)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:603)
    at java.lang.Thread.run(Thread.java:722)
Caused by: org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'org.vertx.java.core.net.impl.DefaultNetServer@24243e9f' with class 'org.vertx.java.core.net.impl.DefaultNetServer' to class 'org.vertx.groovy.core.net.NetServer'
    at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.castToType(DefaultTypeTransformation.java:360)
    at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.castToType(ScriptBytecodeAdapter.java:599)
    at org.vertx.groovy.core.net.NetServer.setTCPKeepAlive(NetServer.groovy:180)
```

Fix included.
