### PR TITLE
Fixed links to tutorial source in documementation.

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -83,10 +83,15 @@
           <li>Fanout server example</li>
           <li>'Real-time' web application</li>
         </ul>
-        <p>You can browse the examples in GitHub here: <a href="https://github.com/purplefox/vert.x/tree/master/src/examples/javascript">JavaScript</a>,
-        <a href="https://github.com/purplefox/vert.x/tree/master/src/examples/ruby">Ruby</a>,
-        <a href="https://github.com/purplefox/vert.x/tree/master/src/examples/groovy">Groovy</a> or
-        <a href="https://github.com/purplefox/vert.x/tree/master/src/examples/java">Java</a></p>
+        <p>You can browse the examples in GitHub here:
+        <ul> 
+          <li><a href="https://github.com/purplefox/vert.x/tree/master/vertx-examples/src/main/javascript">JavaScript</a></li>
+          <li><a href="https://github.com/purplefox/vert.x/tree/master/vertx-examples/src/main/coffeescript">CoffeeScript</a></li> 
+          <li><a href="https://github.com/purplefox/vert.x/tree/master/vertx-examples/src/main/ruby">Ruby</a></li>
+          <li><a href="https://github.com/purplefox/vert.x/tree/master/vertx-examples/src/main/groovy">Groovy</a></li> 
+          <li><a href="https://github.com/purplefox/vert.x/tree/master/vertx-examples/src/main/java">Java</a></li>
+          <li><a href="https://github.com/purplefox/vert.x/tree/master/vertx-examples/src/main/python">Python</a></li>
+        </ul> 
       </div>
     </div>
   </div>

--- a/groovy_web_tutorial.html
+++ b/groovy_web_tutorial.html
@@ -76,7 +76,7 @@
 <p>The only thing that needs to be written on the server is a simple script which tells Vert.x to start the persistor and the web server. The script can also contain configuration needed for the application.</p>
 <p>In this version of this tutorial we've written the script in Groovy. If you'd prefer to write it in Ruby or JavaScript, please see the Ruby or JavaScript version of this tutorial.</p>
 <p>If you'd rather just run the complete code, the working example is present in the <code>webapp</code> directory of the examples in the distribution. Read the README there for instructions on how to run it.</p>
-<p>You can also see the code in <a href="https://github.com/purplefox/vert.x/tree/master/src/examples/groovy/webapp">github</a>.</p>
+<p>You can also see the code in <a href="https://github.com/purplefox/vert.x/tree/master/vertx-examples/src/main/groovy/webapp">github</a>.</p>
 <h2 id="step-1-install-vertx">Step 1. Install vert.x</h2><br/>
 <p>If you haven't yet installed vert.x, <a href="install.html">do that now</a>. </p>
 <p>The rest of the tutorial will assume you have installed vert.x in directory <code>VERTX_HOME</code>.</p>

--- a/groovy_web_tutorial.md
+++ b/groovy_web_tutorial.md
@@ -14,7 +14,7 @@ In this version of this tutorial we've written the script in Groovy. If you'd pr
 
 If you'd rather just run the complete code, the working example is present in the `webapp` directory of the examples in the distribution. Read the README there for instructions on how to run it.
 
-You can also see the code in [github](https://github.com/purplefox/vert.x/tree/master/src/examples/groovy/webapp).
+You can also see the code in [github](https://github.com/purplefox/vert.x/tree/master/vertx-examples/src/main/groovy/webapp).
 
 ## Step 1. Install vert.x
 

--- a/js_web_tutorial.html
+++ b/js_web_tutorial.html
@@ -76,7 +76,7 @@
 <p>The only thing that needs to be written on the server is a simple script which tells Vert.x to start the persistor and the web server. The script can also contain configuration needed for the application.</p>
 <p>In this version of this tutorial we've written the script in JavaScript. If you'd prefer to write it in Ruby or Groovy, please see the Ruby or Groovy version of this tutorial.</p>
 <p>If you'd rather just run the complete code, the working example is present in the <code>webapp</code> directory of the examples in the distribution. Read the README there for instructions on how to run it.</p>
-<p>You can also see the code in <a href="https://github.com/purplefox/vert.x/tree/master/src/examples/javascript/webapp">github</a>.</p>
+<p>You can also see the code in <a href="https://github.com/purplefox/vert.x/tree/master/vertx-examples/src/main/javascript/webapp">github</a>.</p>
 <h2 id="step-1-install-vertx">Step 1. Install vert.x</h2><br/>
 <p>If you haven't yet installed vert.x, <a href="install.html">do that now</a>. </p>
 <p>The rest of the tutorial will assume you have installed vert.x in directory <code>VERTX_HOME</code>.</p>

--- a/js_web_tutorial.md
+++ b/js_web_tutorial.md
@@ -14,7 +14,7 @@ In this version of this tutorial we've written the script in JavaScript. If you'
 
 If you'd rather just run the complete code, the working example is present in the `webapp` directory of the examples in the distribution. Read the README there for instructions on how to run it.
 
-You can also see the code in [github](https://github.com/purplefox/vert.x/tree/master/src/examples/javascript/webapp).
+You can also see the code in [github](https://github.com/purplefox/vert.x/tree/master/vertx-examples/src/main/javascript/webapp).
 
 ## Step 1. Install vert.x
 

--- a/ruby_web_tutorial.html
+++ b/ruby_web_tutorial.html
@@ -76,7 +76,7 @@
 <p>The only thing that needs to be written on the server is a simple script which tells Vert.x to start the persistor and the web server. The script can also contain configuration needed for the application.</p>
 <p>In this version of this tutorial we've written the script in Ruby. If you'd prefer to write it in Groovy or JavaScript, please see the Groovy or JavaScript version of this tutorial.</p>
 <p>If you'd rather just run the complete code, the working example is present in the <code>webapp</code> directory of the examples in the distribution. Read the README there for instructions on how to run it.</p>
-<p>You can also see the code in <a href="https://github.com/purplefox/vert.x/tree/master/src/examples/ruby/webapp">github</a>.</p>
+<p>You can also see the code in <a href="https://github.com/purplefox/vert.x/tree/master/vertx-examples/src/main/ruby/webapp">github</a>.</p>
 <h2 id="step-1-install-vertx">Step 1. Install vert.x</h2><br/>
 <p>If you haven't yet installed vert.x, <a href="install.html">do that now</a>. </p>
 <p>The rest of the tutorial will assume you have installed vert.x in directory <code>VERTX_HOME</code>.</p>

--- a/ruby_web_tutorial.md
+++ b/ruby_web_tutorial.md
@@ -14,7 +14,7 @@ In this version of this tutorial we've written the script in Ruby. If you'd pref
 
 If you'd rather just run the complete code, the working example is present in the `webapp` directory of the examples in the distribution. Read the README there for instructions on how to run it.
 
-You can also see the code in [github](https://github.com/purplefox/vert.x/tree/master/src/examples/ruby/webapp).
+You can also see the code in [github](https://github.com/purplefox/vert.x/tree/master/vertx-examples/src/main/ruby/webapp).
 
 ## Step 1. Install vert.x
 


### PR DESCRIPTION
Following the project re-structure, the links to the examples source code in the documentation were broken.
