### PR TITLE
Set umask in mk to make tests work more reliably

### DIFF
--- a/mk
+++ b/mk
@@ -103,6 +103,9 @@ if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
     else
         warn "Could not query businessSystem maximum file descriptor limit: $MAX_FD_LIMIT"
     fi
+
+    # set umask to sane default for FileSystem tests
+    umask 0022
 fi
 
 # For Darwin, add APP_NAME to the JAVA_OPTS as -Xdock:name


### PR DESCRIPTION
The FileSystem tests (chmod and mkdir) assume a specific default umask.
For example in Fedora the default umask differs and the tests fail.
To make the tests reliable set the default umask to 0022 explicilty in mk.
