### PR TITLE
Echotest random failure fix

### DIFF
--- a/vertx-testsuite/src/test/java/vertx/tests/core/eventbus/LocalEchoClient.java
+++ b/vertx-testsuite/src/test/java/vertx/tests/core/eventbus/LocalEchoClient.java
@@ -143,7 +143,7 @@ public class LocalEchoClient extends EventBusAppBase {
   }
 
   public void testEchoFloat() {
-    Float fl = (float)(new Random().nextInt() / 37);
+    Float fl = new Random().nextInt() / 37.0f;
     Handler<Message<Float>> handler = echoHandler(fl);
     eb.send(ECHO_ADDRESS, fl, handler);
   }
@@ -155,7 +155,7 @@ public class LocalEchoClient extends EventBusAppBase {
   }
 
   public void testEchoDouble() {
-    Double db = (double)(new Random().nextInt() / 37);
+    Double db = new Random().nextInt() / 37.0d;
     Handler<Message<Double>> handler = echoHandler(db);
     eb.send(ECHO_ADDRESS, db, handler);
   }


### PR DESCRIPTION
The test creates a random positive integer and then autoboxes it. The azzert code assumes that the object would never be the same instance for any value.
But the JVM caches all number objects (Long,Integer etc) for values < 128 (or larger if -XX:AutoBoxCacheMax is specified).

Fix by avoiding autoboxing with explicit new constructors.
Also changed the double and float tests to actually values with nonzero decimal part.
