### PR TITLE
Support installation path params with spaces in vertx.bat on Windows

### DIFF
--- a/src/dist/scripts/vertx.bat
+++ b/src/dist/scripts/vertx.bat
@@ -72,7 +72,7 @@ set CMD_LINE_ARGS=%$
 set CLASSPATH=%APP_HOME%\lib\*;%APP_HOME%\conf;%JYTHON_HOME%\jython.jar;%JRUBY_HOME%\lib\jruby.jar
 
 @rem Execute vertx
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %VERTX_OPTS%  -Dvertx.install=%APP_HOME% -Djruby.home=%JRUBY_HOME% -Djython.home=%JYTHON_HOME% -Djava.util.logging.config.file=%APP_HOME%\conf\logging.properties -classpath "%CLASSPATH%" org.vertx.java.deploy.impl.cli.Starter %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %VERTX_OPTS% -Dvertx.install="%APP_HOME%" -Djruby.home="%JRUBY_HOME%" -Djython.home="%JYTHON_HOME%" -Djava.util.logging.config.file="%APP_HOME%\conf\logging.properties" -classpath "%CLASSPATH%" org.vertx.java.deploy.impl.cli.Starter %CMD_LINE_ARGS%
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
That has already been fixed for 1.0 and the fix landed in 1.1. Alas, in 1.2 that has been broken again. Thus I am sending another fix for it.
