### PR TITLE
AMD compliance for vertxbus

### DIFF
--- a/src/dist/client/vertxbus.js
+++ b/src/dist/client/vertxbus.js
@@ -16,158 +16,174 @@
 
 var vertx = vertx || {};
 
-vertx.EventBus = function(url, options) {
-
-  var that = this;
-  var sockJSConn = new SockJS(url, options);
-  var handlerMap = {};
-  var replyHandlers = {};
-  var state = vertx.EventBus.CONNECTING;
-
-  that.onopen = null;
-  that.onclose = null;
-
-  that.send = function(address, message, replyHandler) {
-    sendOrPub("send", address, message, replyHandler)
+!function(factory) {
+  if (typeof define === "function" && define.amd) {
+    // Expose as an AMD module with SockJS dependency.
+    // "vertxbus" and "sockjs" names are used because
+    // AMD module names are derived from file names.
+    define("vertxbus", ["sockjs"], factory);
+  } else {
+    // No AMD-compliant loader
+    factory(SockJS);
   }
+}(function(SockJS) {
 
-  that.publish = function(address, message, replyHandler) {
-    sendOrPub("publish", address, message, replyHandler)
-  }
-
-  that.registerHandler = function(address, handler) {
-    checkSpecified("address", 'string', address);
-    checkSpecified("handler", 'function', handler);
-    checkOpen();
-    var handlers = handlerMap[address];
-    if (!handlers) {
-      handlers = [handler];
-      handlerMap[address] = handlers;
-      // First handler for this address so we should register the connection
-      var msg = { type : "register",
-                  address: address };
-      sockJSConn.send(JSON.stringify(msg));
-    } else {
-      handlers[handlers.length] = handler;
+  vertx.EventBus = function(url, options) {
+  
+    var that = this;
+    var sockJSConn = new SockJS(url, options);
+    var handlerMap = {};
+    var replyHandlers = {};
+    var state = vertx.EventBus.CONNECTING;
+  
+    that.onopen = null;
+    that.onclose = null;
+  
+    that.send = function(address, message, replyHandler) {
+      sendOrPub("send", address, message, replyHandler)
     }
-  }
-
-  that.unregisterHandler = function(address, handler) {
-    checkSpecified("address", 'string', address);
-    checkSpecified("handler", 'function', handler);
-    checkOpen();
-    var handlers = handlerMap[address];
-    if (handlers) {
-      var idx = handlers.indexOf(handler);
-      if (idx != -1) handlers.splice(idx, 1);
-      if (handlers.length == 0) {
-        // No more local handlers so we should unregister the connection
-
-        var msg = { type : "unregister",
-                    address: address};
+  
+    that.publish = function(address, message, replyHandler) {
+      sendOrPub("publish", address, message, replyHandler)
+    }
+  
+    that.registerHandler = function(address, handler) {
+      checkSpecified("address", 'string', address);
+      checkSpecified("handler", 'function', handler);
+      checkOpen();
+      var handlers = handlerMap[address];
+      if (!handlers) {
+        handlers = [handler];
+        handlerMap[address] = handlers;
+        // First handler for this address so we should register the connection
+        var msg = { type : "register",
+                    address: address };
         sockJSConn.send(JSON.stringify(msg));
-        delete handlerMap[address];
+      } else {
+        handlers[handlers.length] = handler;
       }
     }
-  }
-
-  that.close = function() {
-    checkOpen();
-    state = vertx.EventBus.CLOSING;
-    sockJSConn.close();
-  }
-
-  that.readyState = function() {
-    return state;
-  }
-
-  sockJSConn.onopen = function() {
-    state = vertx.EventBus.OPEN;
-    if (that.onopen) {
-      that.onopen();
-    }
-  };
-
-  sockJSConn.onclose = function() {
-    state = vertx.EventBus.CLOSED;
-    if (that.onclose) {
-      that.onclose();
-    }
-  };
-
-  sockJSConn.onmessage = function(e) {
-    var msg = e.data;
-    var json = JSON.parse(msg);
-    var body = json.body;
-    var replyAddress = json.replyAddress;
-    var address = json.address;
-    var replyHandler;
-    if (replyAddress) {
-      replyHandler = function(reply, replyHandler) {
-        // Send back reply
-        that.send(replyAddress, reply, replyHandler);
-      };
-    }
-    var handlers = handlerMap[address];
-    if (handlers) {
-      // We make a copy since the handler might get unregistered from within the
-      // handler itself, which would screw up our iteration
-      var copy = handlers.slice(0);
-      for (var i  = 0; i < copy.length; i++) {
-        copy[i](body, replyHandler);
-      }
-    } else {
-      // Might be a reply message
-      var handler = replyHandlers[address];
-      if (handler) {
-        delete replyHandlers[replyAddress];
-        handler(body, replyHandler);
+  
+    that.unregisterHandler = function(address, handler) {
+      checkSpecified("address", 'string', address);
+      checkSpecified("handler", 'function', handler);
+      checkOpen();
+      var handlers = handlerMap[address];
+      if (handlers) {
+        var idx = handlers.indexOf(handler);
+        if (idx != -1) handlers.splice(idx, 1);
+        if (handlers.length == 0) {
+          // No more local handlers so we should unregister the connection
+  
+          var msg = { type : "unregister",
+                      address: address};
+          sockJSConn.send(JSON.stringify(msg));
+          delete handlerMap[address];
+        }
       }
     }
-  }
-
-  function sendOrPub(sendOrPub, address, message, replyHandler) {
-    checkSpecified("address", 'string', address);
-    checkSpecified("message", 'object', message);
-    checkSpecified("replyHandler", 'function', replyHandler, true);
-    checkOpen();
-    var envelope = { type : sendOrPub,
-                     address: address,
-                     body: message };
-    if (replyHandler) {
-      var replyAddress = makeUUID();
-      envelope.replyAddress = replyAddress;
-      replyHandlers[replyAddress] = replyHandler;
+  
+    that.close = function() {
+      checkOpen();
+      state = vertx.EventBus.CLOSING;
+      sockJSConn.close();
     }
-    var str = JSON.stringify(envelope);
-    sockJSConn.send(str);
-  }
-
-  function checkOpen() {
-    if (state != vertx.EventBus.OPEN) {
-      throw new Error('INVALID_STATE_ERR');
+  
+    that.readyState = function() {
+      return state;
     }
-  }
-
-  function checkSpecified(paramName, paramType, param, optional) {
-    if (!optional && !param) {
-      throw new Error("Parameter " + paramName + " must be specified");
+  
+    sockJSConn.onopen = function() {
+      state = vertx.EventBus.OPEN;
+      if (that.onopen) {
+        that.onopen();
+      }
+    };
+  
+    sockJSConn.onclose = function() {
+      state = vertx.EventBus.CLOSED;
+      if (that.onclose) {
+        that.onclose();
+      }
+    };
+  
+    sockJSConn.onmessage = function(e) {
+      var msg = e.data;
+      var json = JSON.parse(msg);
+      var body = json.body;
+      var replyAddress = json.replyAddress;
+      var address = json.address;
+      var replyHandler;
+      if (replyAddress) {
+        replyHandler = function(reply, replyHandler) {
+          // Send back reply
+          that.send(replyAddress, reply, replyHandler);
+        };
+      }
+      var handlers = handlerMap[address];
+      if (handlers) {
+        // We make a copy since the handler might get unregistered from within the
+        // handler itself, which would screw up our iteration
+        var copy = handlers.slice(0);
+        for (var i  = 0; i < copy.length; i++) {
+          copy[i](body, replyHandler);
+        }
+      } else {
+        // Might be a reply message
+        var handler = replyHandlers[address];
+        if (handler) {
+          delete replyHandlers[replyAddress];
+          handler(body, replyHandler);
+        }
+      }
     }
-    if (param && typeof param != paramType) {
-      throw new Error("Parameter " + paramName + " must be of type " + paramType);
+  
+    function sendOrPub(sendOrPub, address, message, replyHandler) {
+      checkSpecified("address", 'string', address);
+      checkSpecified("message", 'object', message);
+      checkSpecified("replyHandler", 'function', replyHandler, true);
+      checkOpen();
+      var envelope = { type : sendOrPub,
+                       address: address,
+                       body: message };
+      if (replyHandler) {
+        var replyAddress = makeUUID();
+        envelope.replyAddress = replyAddress;
+        replyHandlers[replyAddress] = replyHandler;
+      }
+      var str = JSON.stringify(envelope);
+      sockJSConn.send(str);
     }
+  
+    function checkOpen() {
+      if (state != vertx.EventBus.OPEN) {
+        throw new Error('INVALID_STATE_ERR');
+      }
+    }
+  
+    function checkSpecified(paramName, paramType, param, optional) {
+      if (!optional && !param) {
+        throw new Error("Parameter " + paramName + " must be specified");
+      }
+      if (param && typeof param != paramType) {
+        throw new Error("Parameter " + paramName + " must be of type " + paramType);
+      }
+    }
+  
+    function isFunction(obj) {
+      return !!(obj && obj.constructor && obj.call && obj.apply);
+    }
+  
+    function makeUUID(){return"xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
+        .replace(/[xy]/g,function(a,b){return b=Math.random()*16,(a=="y"?b&3|8:b|0).toString(16)})}
+  
   }
+  
+  vertx.EventBus.CONNECTING = 0;
+  vertx.EventBus.OPEN = 1;
+  vertx.EventBus.CLOSING = 2;
+  vertx.EventBus.CLOSED = 3;
 
-  function isFunction(obj) {
-    return !!(obj && obj.constructor && obj.call && obj.apply);
-  }
+  return vertx.EventBus;
 
-  function makeUUID(){return"xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
-      .replace(/[xy]/g,function(a,b){return b=Math.random()*16,(a=="y"?b&3|8:b|0).toString(16)})}
-
-}
-
-vertx.EventBus.CONNECTING = 0;
-vertx.EventBus.OPEN = 1;
-vertx.EventBus.CLOSING = 2;
-vertx.EventBus.CLOSED = 3;
+});


### PR DESCRIPTION
SockJS is already compliant with AMD so vertxbus can define it as a dependency.

After my modification the library is still working if you simply load it using a script tag, but you can optimize the loading and benefit of the automatic dependency management if you are using an AMD compliant loader.

See more about AMD and why to use it: http://requirejs.org/docs/whyamd.html

The implementation is based on the following UMD pattern: https://github.com/umdjs/umd/blob/master/amdWeb.js

The changeset looks a bit complicated here on github because I had to indent the lines for the factory function, but without the whitespace changes you can see that there are only few added lines in the beginning and in the end of the file. (https://github.com/vert-x/vert.x/pull/323/files?w=1)
