### PR TITLE
Connection failures cause connection pool to fill.

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClient.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClient.java
@@ -436,6 +436,11 @@ public class DefaultHttpClient implements HttpClient {
   }
 
   private void failed(NioSocketChannel ch, final Throwable t) {
+    tcpHelper.runOnCorrectThread(ch, new Runnable() {
+      public void run() {
+        pool.connectionClosed();
+      }
+    });
     if (t instanceof Exception && exceptionHandler != null) {
       tcpHelper.runOnCorrectThread(ch, new Runnable() {
         public void run() {


### PR DESCRIPTION
HttpClient connection failures will never decrement the count of the connection pool.  The result is that the usage of the client will hang when trying to use it again.

Here's my test that demonstrates the issue in the current code:

```
public final class TestVerticle extends Verticle {
    @Override
    public void start() throws Exception {
        final HttpClient client = getVertx().createHttpClient().setHost("localhost").setPort(1337).setMaxPoolSize(1).setBossThreads(1).setKeepAlive(false);
        TryConnect(client);
    }

    private void TryConnect(final HttpClient client) {
        client.exceptionHandler(new Handler<Exception>() {
            @Override
            public void handle(final Exception event) {
                System.out.println("Failed because it's connecting to a bad address.");
                //just do this to simulate another connection request after the previous failed
                TryConnect(client);
            }
        });
        System.out.println("Connecting to bad address.");
        client.getNow("/", new Handler<HttpClientResponse>() {
            @Override
            public void handle(final HttpClientResponse event) {
                throw new UnsupportedOperationException("handling response");
            }
        });
    }
}
```
