### PR TITLE
Potential leak of handlers in EventBusBridge

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/EventBusBridge.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/EventBusBridge.java
@@ -137,6 +137,10 @@ public class EventBusBridge implements Handler<SockJSSocket> {
     sock.dataHandler(new Handler<Buffer>() {
 
       private void handleRegister(final String address) {
+        // To avoid a leak of handlers
+        if (handlers.get(address) != null) {
+            return;
+        }
         Handler<Message<JsonObject>> handler = new Handler<Message<JsonObject>>() {
           public void handle(final Message<JsonObject> msg) {
             if (checkMatches(false, address, msg.body, false)) {


### PR DESCRIPTION
Though the eventbus javascript library ensures that for a certain address only one register request is ever sent, the server should make sure that the same address for the same socket should never registered more than once in EventBus, so the handlers can get cleaned on disconnection.
