### PR TITLE
Add note about JYTHON_HOME to BUILD_README.md

### DIFF
--- a/BUILD_README.md
+++ b/BUILD_README.md
@@ -3,7 +3,8 @@
 The build uses Gradle. The build script will automatically install the bits it needs if they aren't already installed.
 
 ### Prerequisites
-* jython - for building python support
+* jython - for building python support (even if you don't plan to use Jython)
+ * Ensure that the `JYTHON_HOME` environment variable points to the Jython base directory, or you'll get errors like `A problem occurred starting process 'command 'null/jython''`.
 * yard - for building ruby docs (you can exclude it passing `-x yard` to the build tool)
 
 ## On *nix


### PR DESCRIPTION
Jython didn't do this by default when I installed it, took a while to figure out what I needed. So figured, mention it in the build docs. (It's mentioned in the run docs, but you won't necessarily look there when trying to build.)
