### PR TITLE
Add ability to retrieve JsonArray element by index

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/json/JsonArray.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/json/JsonArray.java
@@ -95,7 +95,11 @@ public class JsonArray implements Iterable<Object> {
   public int size() {
     return list.size();
   }
-
+  
+  public Object get(final int index) {
+    return convertObject(list.get(index));
+  }
+  
   public Iterator<Object> iterator() {
     return new Iterator<Object>() {
 
@@ -107,17 +111,9 @@ public class JsonArray implements Iterable<Object> {
       }
 
       @SuppressWarnings("unchecked")
-	  @Override
+      @Override
       public Object next() {
-        Object next = iter.next();
-        if (next != null) {
-          if (next instanceof List) {
-            next = new JsonArray((List<Object>) next);
-          } else if (next instanceof Map) {
-            next = new JsonObject((Map<String, Object>) next);
-          }
-        }
-        return next;
+        return convertObject(iter.next());
       }
 
       @Override
@@ -177,5 +173,19 @@ public class JsonArray implements Iterable<Object> {
       }
     }
     return arr;
+  }
+  
+  private static Object convertObject(final Object obj) {
+    Object retVal = obj;
+    
+    if (obj != null) {
+      if (obj instanceof List) {
+        retVal = new JsonArray((List<Object>) obj);
+      } else if (obj instanceof Map) {
+        retVal = new JsonObject((Map<String, Object>) obj);
+      }
+    }
+    
+    return retVal;
   }
 }

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/json/JavaJsonTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/json/JavaJsonTest.java
@@ -64,4 +64,14 @@ public class JavaJsonTest extends TestBase {
     JsonArray array2 = object2.getArray("array");
   }
 
+  @Test
+  public void testRetrieveArrayItemByIndex() {
+    JsonArray arr = new JsonArray();
+    
+    arr.addString("foo");
+    arr.addObject(new JsonObject().putString("bar", "baz"));
+    arr.addString("bap");
+    
+    assertEquals("baz", ((JsonObject) arr.get(1)).getString("bar"));
+  }
 }


### PR DESCRIPTION
`JsonArray#get(int)` avoids having to use `JsonArray#toArray()[index]`.
