### PR TITLE
Test failures because of file permissions if umask is not 022

### DIFF
--- a/vertx-testsuite/src/test/java/vertx/tests/core/filesystem/TestClient.java
+++ b/vertx-testsuite/src/test/java/vertx/tests/core/filesystem/TestClient.java
@@ -637,11 +637,6 @@ public class TestClient extends TestClientBase {
       public void handle() {
         tu.azzert(fileExists(dirName));
         tu.azzert(Files.isDirectory(Paths.get(TEST_DIR + pathSep + dirName)));
-        /*
-         * Cannot assume DEFAULT_DIR_PERMS is correct
-         * Different umask values will cause different default values
-         */
-        // tu.azzert(DEFAULT_DIR_PERMS.equals(getPerms(dirName)));
       }
     });
   }
@@ -658,11 +653,7 @@ public class TestClient extends TestClientBase {
       public void handle() {
         tu.azzert(fileExists(dirName));
         tu.azzert(Files.isDirectory(Paths.get(TEST_DIR + pathSep + dirName)));
-        /*
-         * Cannot assume DEFAULT_DIR_PERMS is correct
-         * Different umask values will cause different default values
-         */
-        // tu.azzert(DEFAULT_DIR_PERMS.equals(getPerms(dirName)));
+        tu.azzert(perms.equals(getPerms(dirName)));
       }
     });
   }
@@ -673,9 +664,6 @@ public class TestClient extends TestClientBase {
       public void handle() {
         tu.azzert(fileExists(dirName));
         tu.azzert(Files.isDirectory(Paths.get(TEST_DIR + pathSep + dirName)));
-        // Cannot assume DEFAULT_DIR_PERMS is correct
-        // Different umask values will cause different default values
-        // tu.azzert(DEFAULT_DIR_PERMS.equals(getPerms(dirName)));
       }
     });
   }


### PR DESCRIPTION
Some of the tests for the file system are assuming a specific default file permission and directory permission.  Two things have changed.

**NOTE :** _I am not positive this is the best way to do these things, but tests pass, so I wanted someone to look at it_
1. chmod tests are testing that files and directories have certain default permissions before doing the chmod.  To enforce this, I created a method setPerms which is called whenever a temporary file or directory is created to **force** these default permissions.
2. commented out the assertion for the DEFAULT_DIR_PERMS in mkdir tests where the actual default permissions cannot be guaranteed.  Assertion doesn't seem to be verifying the test.  The test is if the directory has been created.  There is another test for permissions of created directories.

**I found this while trying to get travis_ci builds up and running for vert.x, I am pretty close [Build on Travis CI with only 1 Failure!](https://travis-ci.org/#!/aaboyd/vert.x/jobs/2685621)**
