### PR TITLE
Map .coffee file extension to the Rhino verticle factory

### DIFF
--- a/src/dist/conf/langs.properties
+++ b/src/dist/conf/langs.properties
@@ -3,6 +3,7 @@
 java=org.vertx.java.deploy.impl.java.JavaVerticleFactory
 class=org.vertx.java.deploy.impl.java.JavaVerticleFactory
 js=org.vertx.java.deploy.impl.rhino.RhinoVerticleFactory
+coffee=org.vertx.java.deploy.impl.rhino.RhinoVerticleFactory
 rb=org.vertx.java.deploy.impl.jruby.JRubyVerticleFactory
 groovy=org.vertx.groovy.deploy.impl.groovy.GroovyVerticleFactory
 py=org.vertx.java.deploy.impl.jython.JythonVerticleFactory


### PR DESCRIPTION
coffee was missing from langs.properties
