### PR TITLE
Package declarations for Java examples

### DIFF
--- a/vertx-examples/src/main/java/deploymod/Deploy.java
+++ b/vertx-examples/src/main/java/deploymod/Deploy.java
@@ -1,3 +1,5 @@
+package deploymod;
+
 import org.vertx.java.deploy.Verticle;
 import org.vertx.java.core.json.JsonObject;
 import org.vertx.java.core.Handler;

--- a/vertx-examples/src/main/java/echo/EchoClient.java
+++ b/vertx-examples/src/main/java/echo/EchoClient.java
@@ -1,3 +1,5 @@
+package echo;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/echo/EchoServer.java
+++ b/vertx-examples/src/main/java/echo/EchoServer.java
@@ -1,3 +1,5 @@
+package echo;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/echo/PerfClient.java
+++ b/vertx-examples/src/main/java/echo/PerfClient.java
@@ -1,3 +1,5 @@
+package echo;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/eventbusbridge/BridgeServer.java
+++ b/vertx-examples/src/main/java/eventbusbridge/BridgeServer.java
@@ -1,3 +1,5 @@
+package eventbusbridge;
+
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.http.HttpServer;
 import org.vertx.java.core.http.HttpServerRequest;

--- a/vertx-examples/src/main/java/fanout/FanoutServer.java
+++ b/vertx-examples/src/main/java/fanout/FanoutServer.java
@@ -1,3 +1,5 @@
+package fanout;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/http/ClientExample.java
+++ b/vertx-examples/src/main/java/http/ClientExample.java
@@ -1,3 +1,5 @@
+package http;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/http/ServerExample.java
+++ b/vertx-examples/src/main/java/http/ServerExample.java
@@ -1,3 +1,5 @@
+package http;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/httpperf/PerfClient.java
+++ b/vertx-examples/src/main/java/httpperf/PerfClient.java
@@ -1,3 +1,5 @@
+package httpperf;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/httpperf/PerfServer.java
+++ b/vertx-examples/src/main/java/httpperf/PerfServer.java
@@ -1,3 +1,5 @@
+package httpperf;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/https/ClientExample.java
+++ b/vertx-examples/src/main/java/https/ClientExample.java
@@ -1,3 +1,5 @@
+package https;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/https/ServerExample.java
+++ b/vertx-examples/src/main/java/https/ServerExample.java
@@ -1,3 +1,5 @@
+package https;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/perf/RateCounter.java
+++ b/vertx-examples/src/main/java/perf/RateCounter.java
@@ -1,3 +1,5 @@
+package perf;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/proxy/Client.java
+++ b/vertx-examples/src/main/java/proxy/Client.java
@@ -1,3 +1,5 @@
+package proxy;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/proxy/ProxyServer.java
+++ b/vertx-examples/src/main/java/proxy/ProxyServer.java
@@ -1,3 +1,5 @@
+package proxy;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/proxy/Server.java
+++ b/vertx-examples/src/main/java/proxy/Server.java
@@ -1,3 +1,5 @@
+package proxy;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/pubsub/PubSubServer.java
+++ b/vertx-examples/src/main/java/pubsub/PubSubServer.java
@@ -1,3 +1,5 @@
+package pubsub;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/resourceload/Quux.java
+++ b/vertx-examples/src/main/java/resourceload/Quux.java
@@ -1,3 +1,5 @@
+package resourceload;
+
 /**
  *
  * This gets built into its own jar which is loaded in the example

--- a/vertx-examples/src/main/java/resourceload/ResourceLoadExample.java
+++ b/vertx-examples/src/main/java/resourceload/ResourceLoadExample.java
@@ -1,3 +1,5 @@
+package resourceload;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/route_match/RouteMatchExample.java
+++ b/vertx-examples/src/main/java/route_match/RouteMatchExample.java
@@ -1,3 +1,5 @@
+package route_match;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/sendfile/SendFileExample.java
+++ b/vertx-examples/src/main/java/sendfile/SendFileExample.java
@@ -1,3 +1,5 @@
+package sendfile;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/sockjs/SockJSExample.java
+++ b/vertx-examples/src/main/java/sockjs/SockJSExample.java
@@ -1,3 +1,5 @@
+package sockjs;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/ssl/SSLClient.java
+++ b/vertx-examples/src/main/java/ssl/SSLClient.java
@@ -1,3 +1,5 @@
+package ssl;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/ssl/SSLServer.java
+++ b/vertx-examples/src/main/java/ssl/SSLServer.java
@@ -1,3 +1,5 @@
+package ssl;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/upload/UploadClient.java
+++ b/vertx-examples/src/main/java/upload/UploadClient.java
@@ -1,3 +1,5 @@
+package upload;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/upload/UploadServer.java
+++ b/vertx-examples/src/main/java/upload/UploadServer.java
@@ -1,3 +1,5 @@
+package upload;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/websockets/WebsocketsExample.java
+++ b/vertx-examples/src/main/java/websockets/WebsocketsExample.java
@@ -1,3 +1,5 @@
+package websockets;
+
 /*
  * Copyright 2011 the original author or authors.
  *

--- a/vertx-examples/src/main/java/wsperf/ConnectClient.java
+++ b/vertx-examples/src/main/java/wsperf/ConnectClient.java
@@ -1,3 +1,5 @@
+package wsperf;
+
 /*
  * Copyright 2011-2012 the original author or authors.
  *

--- a/vertx-examples/src/main/java/wsperf/ConnectServer.java
+++ b/vertx-examples/src/main/java/wsperf/ConnectServer.java
@@ -1,3 +1,5 @@
+package wsperf;
+
 /*
  * Copyright 2011-2012 the original author or authors.
  *

--- a/vertx-examples/src/main/java/wsperf/PerfClient.java
+++ b/vertx-examples/src/main/java/wsperf/PerfClient.java
@@ -1,3 +1,5 @@
+package wsperf;
+
 /*
  * Copyright 2011-2012 the original author or authors.
  *

--- a/vertx-examples/src/main/java/wsperf/PerfServer.java
+++ b/vertx-examples/src/main/java/wsperf/PerfServer.java
@@ -1,3 +1,5 @@
+package wsperf;
+
 /*
  * Copyright 2011-2012 the original author or authors.
  *


### PR DESCRIPTION
I am working with the vert.x project in the Eclipse IDE and the compiler is complaining about the lack of package declarations in the Java examples. To appease the Eclipse IDE I would like to add these package declarations (also, they are a standard part of most Java classes).
