### PR TITLE
Http client response timeouts

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/HttpClientResponse.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/HttpClientResponse.java
@@ -63,4 +63,17 @@ public abstract class HttpClientResponse extends HttpReadStreamBase {
    */
   public abstract Map<String, String> trailers();
 
+  /**
+   * Set's the amount of time after which if the response's end() or endWithError() is not called a TimeoutException()
+   * will be sent to the exception handler of this response. Calling this method more than once
+   * has the effect of canceling any existing timeout and starting the timeout from scratch.
+   *
+   * The HttpClientResponse has a separate timeout from the request, to allow adjusting the timeout based on some parameters
+   * that may be returned in the headers. For example, if the Content-Length header indicates a very large file, the
+   * timeout may be set to a larger number to accommodate how long is allowed for the response to be fully read.
+   *
+   * @param timeoutMs The quantity of time in milliseconds.
+   */
+  public abstract void setTimeout(long timeoutMs);
+
 }

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/ClientConnection.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/ClientConnection.java
@@ -191,6 +191,10 @@ class ClientConnection extends AbstractConnection {
     req.handleResponse(nResp);
   }
 
+  VertxInternal getVertx() {
+    return vertx;
+  }
+
   void handleResponseChunk(Buffer buff) {
     setContext();
     try {

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/http/JavaHttpTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/http/JavaHttpTest.java
@@ -498,6 +498,19 @@ public class JavaHttpTest extends TestBase {
     startTest(getMethodName());
   }
 
+  public void testResponseTimesoutWhenIndicatedPeriodExpiresWithoutFullyReadingResponse() {
+    startTest(getMethodName());
+  }
+
+  public void testResponseTimeoutCanceledWhenResponseEndsNormally() {
+    startTest(getMethodName());
+  }
+
+// This really can't be tested since I don't know how I would simulate an error reading the response.
+//  public void testResponseTimeoutCanceledWhenAnotherResponseExceptionOccurs() {
+//    startTest(getMethodName());
+//  }
+
   @Test
   // Client trusts all server certs
   public void testTLSClientTrustAll() throws Exception {


### PR DESCRIPTION
Allow specification of a timeout period for responses. If the response has not completed (server not sending bytes fast enough or at all) within the specified timeout, fire the exception handler with a timeout exception. If no timeout set, defaults to old behavior (no timeout). If used, of course the timeout can be adjusted to the expected file size (as known from the Content-Length header in the case of non-chunked responses), in essence requiring a certain minimum average bytes per second. The primary use case is to not hang the response for too long in cases of flakey network connections or very busy servers. 
