### PR TITLE
Fixing pydoc and yardoc tasks on windows

### DIFF
--- a/vertx-lang/vertx-lang-jruby/build.gradle
+++ b/vertx-lang/vertx-lang-jruby/build.gradle
@@ -49,6 +49,10 @@ task yardoc(type:Exec) {
 		"--output-dir","${project.buildDir}/docs/ruby/api",
 		"src/main/ruby/**/*.rb", "src/main/ruby_scripts/**/*.rb",
 		"-", "$rootDir/LICENSE.txt" ]
+		
+  if( System.properties['os.name'].toLowerCase().contains('windows') ) {
+    commandLine = ['cmd', '/c'] + commandLine
+  }
 }
 
 javadoc.dependsOn yardoc

--- a/vertx-lang/vertx-lang-jython/build.gradle
+++ b/vertx-lang/vertx-lang-jython/build.gradle
@@ -45,11 +45,14 @@ task pydoc(type: Exec) {
 	workingDir = project.projectDir
 	
 	commandLine = [ System.getenv()['JYTHON_HOME'] + "/jython",
-		"-J-classpath", project.files(project.configurations.compile).files.join(':'), 
 		"-Dproj.base=${project.projectDir}",
-		"-Dpython.path=${project.projectDir}/src/build_tools/doclib:src/main/python_scripts",
+		"-Dpython.path=${project.projectDir}/src/build_tools/doclib" + System.properties['path.separator'] + "src/main/python_scripts",
 		"-Dproj.base=$project.projectDir.path",
 		"${project.projectDir}/src/build_tools/pydocx.py" ]
+	
+  if( System.properties['os.name'].toLowerCase().contains('windows') ) {
+    commandLine = ['cmd', '/c'] + commandLine
+  }	
 }
 
 javadoc.dependsOn pydoc


### PR DESCRIPTION
Gradle requires cmd /c to be prepended to the command line on windows for most commands.  Windows users can now run `wmk.bat assemble` successfully ( at least I can ).

Also, removed the -J-classpath parameter from the pydoc task.  Do not know what it is used for.  I googled around and couldn't find anything.   I compared the output for pydoc with and without -J-classpath.  Only difference is in timestamp.  It appears to be doing nothing useful.

May want to verify the code still works on other OS ...

Should fix #379
