### PR TITLE
Use deterministic prefix in loggerName so level can be configured

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/deploy/impl/VerticleManager.java
+++ b/vertx-platform/src/main/java/org/vertx/java/deploy/impl/VerticleManager.java
@@ -728,7 +728,7 @@ public class VerticleManager implements ModuleReloader {
   // Must be synchronized since called directly from different thread
   private synchronized void addVerticle(Deployment deployment, Verticle verticle,
                                         VerticleFactory factory) {
-    String loggerName = deployment.name + "-" + deployment.verticles.size();
+    String loggerName = "org.vertx.deployments." + deployment.name + "-" + deployment.verticles.size();
     Logger logger = LoggerFactory.getLogger(loggerName);
     Context context = Context.getContext();
     VerticleHolder holder = new VerticleHolder(deployment, context, verticle,


### PR DESCRIPTION
Without a common hierarchy for the name of a logger, its level cannot be set granularly.  Without this, if I wanted to enable INFO for a JavaScript verticle's logger, I'd have to configure the entire application's root level to INFO or lower.  This still doesn't address the fact that you can't configure a specific logger (because you can't set the logger's name externally), but that would require another deploy-time config param.
