### PR TITLE
Adds two new, public methods: ConnectionBase.getPeerCertificateChain() a...

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/HttpServerRequest.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/HttpServerRequest.java
@@ -20,6 +20,8 @@ import org.vertx.java.core.http.impl.HttpReadStreamBase;
 import org.vertx.java.core.logging.Logger;
 import org.vertx.java.core.logging.impl.LoggerFactory;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
 import java.util.Map;
 
 /**
@@ -86,4 +88,11 @@ public abstract class HttpServerRequest extends HttpReadStreamBase {
    * Returns a map of all the parameters in the request
    */
   public abstract Map<String, String> params();
+
+  /**
+   * @return an array of the peer certificates.  Returns null if connection is
+   *         not SSL.
+   * @throws SSLPeerUnverifiedException SSL peer's identity has not been verified.
+   */
+  public abstract X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException;
 }

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServerRequest.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServerRequest.java
@@ -25,6 +25,8 @@ import org.vertx.java.core.http.HttpServerResponse;
 import org.vertx.java.core.logging.Logger;
 import org.vertx.java.core.logging.impl.LoggerFactory;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +78,10 @@ public class DefaultHttpServerRequest extends HttpServerRequest {
       }
     }
     return params;
+  }
+
+  public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
+    return conn.getPeerCertificateChain();
   }
 
   public void dataHandler(Handler<Buffer> dataHandler) {


### PR DESCRIPTION
...nd HttpServerRequest.getPeerCertificateChain(). The methods return unmodifiable lists of the X509 cert chain for the incoming client request (if the request is ssl).

The cert chain ultimately comes from the netty channel.  This gets passed into ConnectionBase.  The connection is a member of DefaultHttpServerRequest, so we're now able to get the peer certs from the  request via the connection.  This seemed to make more sense than adding the channel dependency to the request class itself.

NOTE:  when I tried to run my vertical with the latest vertx source, ran into a problem (something with "langs.properties). To get vertx to run with the code I've been working on, I forced my vertx source to the 1.2.3.final tag.  This commit is against that tagged version of the source.  This is a small change, and I expect it will merge fine with the current vertx source.
