### PR TITLE
Fix for exception being thrown on programmatic verticle deployment without a done handler

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/deploy/impl/VerticleManager.java
+++ b/vertx-platform/src/main/java/org/vertx/java/deploy/impl/VerticleManager.java
@@ -166,7 +166,9 @@ public class VerticleManager implements ModuleReloader {
     AsyncResultHandler<String> handler = new AsyncResultHandler<String>() {
       public void handle(AsyncResult<String> res) {
         if (res.succeeded()) {
-          doneHandler.handle(res.result);
+          if (doneHandler != null) {
+            doneHandler.handle(res.result);
+          }
         } else {
           res.exception.printStackTrace();
         }


### PR DESCRIPTION
Added a null check for doneHandler. It is null when a deployVerticle call doesn't define a callback.
