### PR TITLE
Adding common hierarchy for JSON classes

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/json/JsonArray.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/json/JsonArray.java
@@ -16,17 +16,21 @@
 
 package org.vertx.java.core.json;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
 import org.vertx.java.core.http.impl.ws.Base64;
 import org.vertx.java.core.json.impl.Json;
-
-import java.util.*;
 
 /**
  * Represents a JSON array
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class JsonArray implements Iterable<Object> {
+public class JsonArray extends JsonElement implements Iterable<Object> {
 
   final List<Object> list;
 
@@ -62,6 +66,14 @@ public class JsonArray implements Iterable<Object> {
     return this;
   }
 
+  public JsonArray addElement(JsonElement value) {
+    if (value.isArray()) {
+      return addArray(value.asArray());
+    }
+
+    return addObject(value.asObject());
+  }
+
   public JsonArray addNumber(Number value) {
     list.add(value);
     return this;
@@ -80,9 +92,9 @@ public class JsonArray implements Iterable<Object> {
 
   public JsonArray add(Object obj) {
     if (obj instanceof JsonObject) {
-      obj = ((JsonObject)obj).map;
+      obj = ((JsonObject) obj).map;
     } else if (obj instanceof JsonArray) {
-      obj = ((JsonArray)obj).list;
+      obj = ((JsonArray) obj).list;
     }
     list.add(obj);
     return this;
@@ -91,11 +103,12 @@ public class JsonArray implements Iterable<Object> {
   public int size() {
     return list.size();
   }
-  
+
   public Object get(final int index) {
     return convertObject(list.get(index));
   }
-  
+
+  @Override
   public Iterator<Object> iterator() {
     return new Iterator<Object>() {
 
@@ -131,17 +144,21 @@ public class JsonArray implements Iterable<Object> {
     return new JsonArray(encode());
   }
 
+  @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
+    if (this == o)
+      return true;
 
-    if (o == null || getClass() != o.getClass()) return false;
+    if (o == null || getClass() != o.getClass())
+      return false;
 
     JsonArray that = (JsonArray) o;
 
-    if (this.list.size() != that.list.size()) return false;
+    if (this.list.size() != that.list.size())
+      return false;
 
     Iterator<?> iter = that.iterator();
-    for (Object entry: this.list) {
+    for (Object entry : this.list) {
       Object other = iter.next();
       if (!entry.equals(other)) {
         return false;
@@ -157,23 +174,23 @@ public class JsonArray implements Iterable<Object> {
   @SuppressWarnings("unchecked")
   static List<Object> convertList(List<?> list) {
     List<Object> arr = new ArrayList<>(list.size());
-    for (Object obj: list) {
+    for (Object obj : list) {
       if (obj instanceof Map) {
         arr.add(JsonObject.convertMap((Map<String, Object>) obj));
       } else if (obj instanceof JsonObject) {
-        arr.add(((JsonObject)obj).toMap());
+        arr.add(((JsonObject) obj).toMap());
       } else if (obj instanceof List) {
-          arr.add(convertList((List<?>) obj));
+        arr.add(convertList((List<?>) obj));
       } else {
-          arr.add(obj);
+        arr.add(obj);
       }
     }
     return arr;
   }
-  
+
   private static Object convertObject(final Object obj) {
     Object retVal = obj;
-    
+
     if (obj != null) {
       if (obj instanceof List) {
         retVal = new JsonArray((List<Object>) obj);
@@ -181,7 +198,7 @@ public class JsonArray implements Iterable<Object> {
         retVal = new JsonObject((Map<String, Object>) obj);
       }
     }
-    
+
     return retVal;
   }
 }

--- a/vertx-core/src/main/java/org/vertx/java/core/json/JsonElement.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/json/JsonElement.java
@@ -1,0 +1,19 @@
+package org.vertx.java.core.json;
+
+public abstract class JsonElement {
+  public boolean isArray() {
+    return this instanceof JsonArray;
+  }
+
+  public boolean isObject() {
+    return this instanceof JsonObject;
+  }
+
+  public JsonArray asArray() {
+    return (JsonArray) this;
+  }
+
+  public JsonObject asObject() {
+    return (JsonObject) this;
+  }
+}

--- a/vertx-core/src/main/java/org/vertx/java/core/json/JsonObject.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/json/JsonObject.java
@@ -16,13 +16,13 @@
 
 package org.vertx.java.core.json;
 
-import org.vertx.java.core.http.impl.ws.Base64;
-import org.vertx.java.core.json.impl.Json;
-
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.vertx.java.core.http.impl.ws.Base64;
+import org.vertx.java.core.json.impl.Json;
 
 /**
  *
@@ -30,12 +30,13 @@ import java.util.Set;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class JsonObject {
+public class JsonObject extends JsonElement {
 
   final Map<String, Object> map;
 
   /**
    * Create a JSON object based on the specified Map
+   * 
    * @param map
    */
   public JsonObject(Map<String, Object> map) {
@@ -51,7 +52,9 @@ public class JsonObject {
 
   /**
    * Create a JSON object from a string form of a JSON object
-   * @param jsonString The string form of a JSON object
+   * 
+   * @param jsonString
+   *          The string form of a JSON object
    */
   @SuppressWarnings("unchecked")
   public JsonObject(String jsonString) {
@@ -89,7 +92,7 @@ public class JsonObject {
   }
 
   public String getString(String fieldName) {
-    return (String)map.get(fieldName);
+    return (String) map.get(fieldName);
   }
 
   @SuppressWarnings("unchecked")
@@ -104,26 +107,35 @@ public class JsonObject {
     return l == null ? null : new JsonArray(l);
   }
 
+  public JsonElement getElement(String fieldName) {
+    JsonElement elem = this.getObject(fieldName);
+    if (elem != null) {
+      return elem;
+    }
+
+    return this.getArray(fieldName);
+  }
+
   public Number getNumber(String fieldName) {
-    return (Number)map.get(fieldName);
+    return (Number) map.get(fieldName);
   }
 
   public Long getLong(String fieldName) {
-    Number num = (Number)map.get(fieldName);
+    Number num = (Number) map.get(fieldName);
     return num == null ? null : num.longValue();
   }
 
   public Integer getInteger(String fieldName) {
-    Number num = (Number)map.get(fieldName);
+    Number num = (Number) map.get(fieldName);
     return num == null ? null : num.intValue();
   }
 
   public Boolean getBoolean(String fieldName) {
-    return (Boolean)map.get(fieldName);
+    return (Boolean) map.get(fieldName);
   }
 
   public byte[] getBinary(String fieldName) {
-    String encoded = (String)map.get(fieldName);
+    String encoded = (String) map.get(fieldName);
     return Base64.decode(encoded);
   }
 
@@ -140,6 +152,11 @@ public class JsonObject {
   public JsonArray getArray(String fieldName, JsonArray def) {
     JsonArray arr = getArray(fieldName);
     return arr == null ? def : arr;
+  }
+
+  public JsonElement getElement(String fieldName, JsonElement def) {
+    JsonElement elem = getElement(fieldName);
+    return elem == null ? def : elem;
   }
 
   public boolean getBoolean(String fieldName, boolean def) {
@@ -194,20 +211,25 @@ public class JsonObject {
     return new JsonObject(encode());
   }
 
+  @Override
   public String toString() {
     return encode();
   }
 
+  @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
+    if (this == o)
+      return true;
 
-    if (o == null || getClass() != o.getClass()) return false;
+    if (o == null || getClass() != o.getClass())
+      return false;
 
     JsonObject that = (JsonObject) o;
 
-    if (this.map.size() != that.map.size()) return false;
+    if (this.map.size() != that.map.size())
+      return false;
 
-    for (Map.Entry<String, Object> entry: this.map.entrySet()) {
+    for (Map.Entry<String, Object> entry : this.map.entrySet()) {
       Object val = entry.getValue();
       if (val == null) {
         if (that.map.get(entry.getKey()) != null) {
@@ -229,7 +251,7 @@ public class JsonObject {
   @SuppressWarnings("unchecked")
   static Map<String, Object> convertMap(Map<String, Object> map) {
     Map<String, Object> converted = new LinkedHashMap<>(map.size());
-    for (Map.Entry<String, Object> entry: map.entrySet()) {
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
       Object obj = entry.getValue();
       if (obj instanceof Map) {
         Map<String, Object> jm = (Map<String, Object>) obj;
@@ -243,4 +265,5 @@ public class JsonObject {
     }
     return converted;
   }
+
 }


### PR DESCRIPTION
JsonArray and JsonObject inherit from JsonElement. JsonElement allows
people to check if it is an Array or Object, convert to those relevant
types. This is also more convenient when dealing with fields that could
be either an Array or an Object; one can simply getElement(), check if
it is an array or object then convert asArray or asObject, instead of
using try-catch.
