### PR TITLE
Fix JsonArray.equals to succeed when JsonObjects are in the array.

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/json/JsonArray.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/json/JsonArray.java
@@ -157,7 +157,7 @@ public class JsonArray extends JsonElement implements Iterable<Object> {
     if (this.list.size() != that.list.size())
       return false;
 
-    Iterator<?> iter = that.iterator();
+    Iterator<?> iter = that.list.iterator();
     for (Object entry : this.list) {
       Object other = iter.next();
       if (!entry.equals(other)) {

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/json/JavaJsonTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/json/JavaJsonTest.java
@@ -245,5 +245,12 @@ public class JavaJsonTest extends TestBase {
     
     assertEquals(arrayElement.get(0), testElement.asArray().get(0));
   }
-  
+
+  @Test
+  public void testJsonArraysOfJsonObjectsEquality() {
+    JsonArray array1 = new JsonArray().addObject(new JsonObject("{ \"a\": \"b\" }"));
+    JsonArray array2 = new JsonArray().addObject(new JsonObject("{ \"a\": \"b\" }"));
+
+    assertEquals(array1, array2);
+  }
 }


### PR DESCRIPTION
Previously, there was a bug where "this" array's item would be a HashMap but the "other" array's item would be a JsonObject.  This patch makes both sides work off an iterator of the list.
