### PR TITLE
(Windows) timeout issue

### DIFF
--- a/vertx-testsuite/src/test/java/vertx/tests/core/http/HttpTestClient.java
+++ b/vertx-testsuite/src/test/java/vertx/tests/core/http/HttpTestClient.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -672,14 +671,15 @@ public class HttpTestClient extends TestClientBase {
         exception.set(event);
       }
     });
-    req.setTimeout(500);
+    req.setTimeout(800);
     req.end();
 
-    getVertx().setTimer(1000, new Handler<Long>() {
+    getVertx().setTimer(1500, new Handler<Long>() {
       @Override
       public void handle(Long event) {
         tu.azzert(exception.get() != null, "Expected an exception to be set");
-        tu.azzert(!(exception.get() instanceof TimeoutException), "Expected to end with timeout exception but ended with other exception: " + exception.get());
+        tu.azzert(!(exception.get() instanceof TimeoutException), 
+        		"Expected to not end with timeout exception, but did: " + exception.get());
         tu.checkContext();
         tu.testComplete();
       }
@@ -758,12 +758,7 @@ public class HttpTestClient extends TestClientBase {
     req.end();
   }
 
-
-
-
   public void testUseRequestAfterComplete() {
-
-    final Buffer body = TestUtils.generateRandomBuffer(1000);
 
     startServer(new Handler<HttpServerRequest>() {
       public void handle(HttpServerRequest req) {
@@ -785,7 +780,6 @@ public class HttpTestClient extends TestClientBase {
       }
     };
     Buffer buff = new Buffer();
-    Map<String, String> map = new HashMap<>();
 
     try {
       req.end();
@@ -1066,7 +1060,6 @@ public class HttpTestClient extends TestClientBase {
       }
       req.end();
     }
-
   }
 
   private void writeChunk(final int remaining, final int chunkSize, final HttpClientRequest req, final Buffer totBuffer) {
@@ -1187,9 +1180,7 @@ public class HttpTestClient extends TestClientBase {
     }
   }
 
-
   public void testRequestWriteBuffer() {
-
     final Buffer body = TestUtils.generateRandomBuffer(1000);
 
     startServer(new Handler<HttpServerRequest>() {
@@ -1368,8 +1359,6 @@ public class HttpTestClient extends TestClientBase {
 
   public void testUseResponseAfterComplete() {
 
-    final Buffer body = TestUtils.generateRandomBuffer(1000);
-
     startServer(new Handler<HttpServerRequest>() {
       public void handle(HttpServerRequest req) {
         tu.checkContext();
@@ -1379,11 +1368,9 @@ public class HttpTestClient extends TestClientBase {
 
           }
         };
+        
         Buffer buff = new Buffer();
-        Map<String, String> map = new HashMap<>();
-
         HttpServerResponse resp = req.response;
-
         resp.end();
 
         try {
@@ -1499,7 +1486,6 @@ public class HttpTestClient extends TestClientBase {
         }
 
         tu.testComplete();
-
       }
     });
 
@@ -1510,8 +1496,6 @@ public class HttpTestClient extends TestClientBase {
     });
 
     req.end();
-
-
   }
 
   public void testResponseBodyBufferAtEnd() {
@@ -1539,7 +1523,6 @@ public class HttpTestClient extends TestClientBase {
 
     req.end();
   }
-
 
   public void testResponseBodyStringDefaultEncodingAtEnd() {
     testResponseBodyStringAtEnd(null);
@@ -1787,9 +1770,7 @@ public class HttpTestClient extends TestClientBase {
       }
     });
     req.end();
-
   }
-
 
   public void testResponseWriteBuffer() {
 

--- a/vertx-testsuite/src/test/java/vertx/tests/core/timer/TestClient.java
+++ b/vertx-testsuite/src/test/java/vertx/tests/core/timer/TestClient.java
@@ -83,23 +83,22 @@ public class TestClient extends TestClientBase {
     }));
   }
 
-  /*
-  Test the timers fire with approximately the correct delay
+  /**
+   * Test the timers fire with approximately the correct delay
    */
   public void testTimings() throws Exception {
-    final long start = System.nanoTime();
+    final long start = System.currentTimeMillis();
     final long delay = 500;
     vertx.setTimer(delay, new Handler<Long>() {
       public void handle(Long timerID) {
         tu.checkContext();
-        long dur = (System.nanoTime() - start) / 1000000;
+        long dur = System.currentTimeMillis() - start;
         tu.azzert(dur >= delay);
-        tu.azzert(dur < delay * 1.5); // 50% margin of error
+        long maxDelay = (long)(delay * 1.5);
+        tu.azzert(dur < maxDelay, "Timer accuracy: " + dur + " vs " + maxDelay); // 50% margin of error
         vertx.cancelTimer(timerID);
         tu.testComplete();
       }
     });
   }
-
-
 }


### PR DESCRIPTION
- JavaTimerTest: windows has its issues with nanoTime(). Since millis are sufficient ...
- testRequestTimeoutCanceledWhenRequestHasAnOtherError: my laptop is obviously a little slow. Can we release the timeout a little bit?
- removed some unused variables in HttpTestClient
