### PR TITLE
Vertx cancelTimer returns boolean in Java but void in Groovy. Fixed Groovy to also return boolean

### DIFF
--- a/vertx-lang/vertx-lang-groovy/src/main/groovy/org/vertx/groovy/core/Vertx.groovy
+++ b/vertx-lang/vertx-lang-groovy/src/main/groovy/org/vertx/groovy/core/Vertx.groovy
@@ -157,8 +157,8 @@ class Vertx {
    * Cancel the timer with the specified {@code id}. Returns {@code} true if the timer was successfully cancelled, or
    * {@code false} if the timer does not exist.
    */
-  void cancelTimer(long timerID) {
-    jVertex.cancelTimer(timerID)
+  boolean cancelTimer(long timerID) {
+    return jVertex.cancelTimer(timerID)
   }
 
   /**


### PR DESCRIPTION
...Timer method which signature returns boolean. so instead of just calling and doing nothing with the return value, I changed the Vertx Groovy signature to return boolean and return the results from VertxInternal
