### PR TITLE
Added -debug-port parameter

### DIFF
--- a/src/dist/scripts/vertx
+++ b/src/dist/scripts/vertx
@@ -164,8 +164,23 @@ function splitJvmOpts() {
 }
 eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $VERTX_OPTS
 
+for arg in "$@" ; do
+    IS_NUMBER=`echo "$arg" | egrep -c "^[0-9]+$"`
+    PREV_DEBUG_ARG=`echo "$prev" | grep -c "^-debug-port$"`
+
+    if [ $PREV_DEBUG_ARG -eq 1 ] ; then
+        if [ $IS_NUMBER -eq 1 ] ; then
+            DEBUG_PARAM="-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$arg"
+        else
+            echo "Invalid debug port"
+        fi
+    fi
+    prev=$arg
+done
+
 exec "$JAVACMD" \
     "${JVM_OPTS[@]}" \
+    $DEBUG_PARAM \
     -Djava.util.logging.config.file=${VERTX_JUL_CONFIG:-${APP_HOME}/conf/logging.properties} \
     -Djruby.home=$JRUBY_HOME \
     -classpath "$CLASSPATH" \


### PR DESCRIPTION
By adding e.g. -debug-port 9999 to the vertx command, a JPDA port is opened on this port. This allows remote debugging from an IDE like Eclipse. You set a break point, and the verticle thread jumps to it when the code is reached. 
