### PR TITLE
Precompile CoffeeScript to reduce startup time

### DIFF
--- a/vertx-lang/vertx-lang-rhino/build.gradle
+++ b/vertx-lang/vertx-lang-rhino/build.gradle
@@ -15,6 +15,7 @@
  */
 
 apply from: "$rootDir/gradle/maven.gradle"
+apply plugin: 'java'
 
 sourceSets {
 	main {
@@ -32,4 +33,17 @@ dependencies {
 
 artifacts {
 	platform jar
+}
+
+compileJava {
+	javaexec {
+        classpath sourceSets.main.compileClasspath
+        main = "org.mozilla.javascript.tools.jsc.Main"
+        args = [
+            '-opt', '9',
+            '-d', 'build/classes/main/',
+            '-package', 'org.vertx.java.deploy.impl.rhino',
+            'src/main/coffeescript/coffee-script.js'
+		]
+	}
 }


### PR DESCRIPTION
I might be spoiled by V8/Node, but when developing with coffee I got a bit annoyed by the startup time.

This change precompiles coffee-script.js to a Java class, and reduces the coffee startup time by a bit over a second on my laptop.
