### PR TITLE
Quoting fix in src/dist/scripts/vertx.bat

### DIFF
--- a/src/dist/scripts/vertx.bat
+++ b/src/dist/scripts/vertx.bat
@@ -50,7 +50,7 @@ goto fail
 if not "%VERTX_MODS%" == "" set VERTX_MODULE_OPTS="-Dvertx.mods=%VERTX_MODS%"
 
 @rem Configure JUL using custom properties file
-if "%VERTX_JUL_CONFIG%" == "" set VERTX_JUL_CONFIG="%APP_HOME%\conf\logging.properties"
+if "%VERTX_JUL_CONFIG%" == "" set VERTX_JUL_CONFIG=%APP_HOME%\conf\logging.properties
 
 @rem Get command-line arguments, handling Windowz variants
 


### PR DESCRIPTION
Remove quotes from VERTX_JUL_CONFIG. vertx command line later wraps the var in quotes and without this change it ends up with double quotes, which will fail if run from a path with spaces.  Bash quoting is easier to understand. :(
