### PR TITLE
Fixed ClassCastException in org.vertx.java.busmods.BusModBase.getOptionalLongConfig()

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/busmods/BusModBase.java
+++ b/vertx-platform/src/main/java/org/vertx/java/busmods/BusModBase.java
@@ -96,17 +96,17 @@ public abstract class BusModBase extends Verticle {
   }
 
   protected String getOptionalStringConfig(String fieldName, String defaultValue) {
-    String b = config.getString(fieldName);
-    return b == null ? defaultValue : b;
+    String s = config.getString(fieldName);
+    return s == null ? defaultValue : s;
   }
 
   protected int getOptionalIntConfig(String fieldName, int defaultValue) {
-    Integer b = (Integer)config.getNumber(fieldName);
-    return b == null ? defaultValue : b.intValue();
+    Number i = config.getNumber(fieldName);
+    return i == null ? defaultValue : i.intValue();
   }
 
   protected long getOptionalLongConfig(String fieldName, long defaultValue) {
-    Long l = (Long)config.getNumber(fieldName);
+    Number l = config.getNumber(fieldName);
     return l == null ? defaultValue : l.longValue();
   }
 
@@ -137,19 +137,19 @@ public abstract class BusModBase extends Verticle {
   }
 
   protected int getMandatoryIntConfig(String fieldName) {
-    Integer i = (Integer)config.getNumber(fieldName);
+    Number i = config.getNumber(fieldName);
     if (i == null) {
       throw new IllegalArgumentException(fieldName + " must be specified in config for busmod");
     }
-    return i;
+    return i.intValue();
   }
 
   protected long getMandatoryLongConfig(String fieldName) {
-    Long l = (Long)config.getNumber(fieldName);
+    Number l = config.getNumber(fieldName);
     if (l == null) {
       throw new IllegalArgumentException(fieldName + " must be specified in config for busmod");
     }
-    return l;
+    return l.longValue();
   }
 
 }


### PR DESCRIPTION
<a href="https://github.com/vert-x/vert.x/issues/494">Issue #494</a> - when deploying a module with config containing a <code>Long</code> value which is less than MAXINT, reading the value from within the module fails with <code>ClassCastException</code>.
