### PR TITLE
Regression : ensure threads names are not modified (eg. by Jython)

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/impl/Context.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/impl/Context.java
@@ -121,11 +121,14 @@ public abstract class Context {
   protected Runnable wrapTask(final Runnable task) {
     return new Runnable() {
       public void run() {
+        String threadName = Thread.currentThread().getName();
         try {
           vertx.setContext(Context.this);
           task.run();
         } catch (Throwable t) {
           reportException(t);
+        } finally {
+          Thread.currentThread().setName(threadName);
         }
         if (closed) {
           // We allow tasks to be run after the context is closed but we make sure we unset the context afterwards


### PR DESCRIPTION
Regression from d564f0aa49624a2e7af5ab399b4a0e66d5979160

Making some "Not a worker thread" exceptions because Jython does rename vert.x-worker-thread-x to MainThread.

Signed-off-by: Julien jlehuraux@chyro.fr
