### PR TITLE
Use keepAlive property on sockets that was previously being ignored

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/net/impl/TCPSSLHelper.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/impl/TCPSSLHelper.java
@@ -96,6 +96,9 @@ public class TCPSSLHelper {
     if (soLinger != null) {
       options.put(prefix + "soLinger", soLinger);
     }
+    if (tcpKeepAlive != null) {
+      options.put(prefix + "keepAlive", tcpKeepAlive);
+    }
     if (trafficClass != null) {
       options.put(prefix + "trafficClass", trafficClass);
     }


### PR DESCRIPTION
Previously the keepAlive option to network sockets was not being used as it was not passed to the connectionOptions.

Since the default in this class is to have keepAlive enabled, and without the property set as far as I can tell netty defaults to off, this commit does change the existing default behaviour from keep alive being disabled to enabled. If we don't want to change the existing default behaviour let me know and I can change it to disabled by default.
