### PR TITLE
Please change javadoc encoding to UTF-8 for asian developer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ subprojects {
   
   javadoc {
     destinationDir = file("build/docs/java/api")
+    options.encoding = 'UTF-8'
   }
 
   task collectDeps(type: Copy) {


### PR DESCRIPTION
I'm a big fan fo vert.x. however when i'm about to build vertx-platform javadoc task with eclipse, it was failed with the following message

[sts] -----------------------------------------------------
[sts] Starting Gradle build for the following tasks: 
[sts]      :vertx-platform:javadoc
[sts] -----------------------------------------------------
:vertx-core:compileJava UP-TO-DATE
:vertx-core:processResources UP-TO-DATE
:vertx-core:classes UP-TO-DATE
:vertx-core:jar UP-TO-DATE
:vertx-core:javadoc UP-TO-DATE
:vertx-platform:compileJava UP-TO-DATE
:vertx-platform:processResources UP-TO-DATE
:vertx-platform:classes UP-TO-DATE
:vertx-platform:javadoc/Volumes/Relppob/Repositories/vert.x/vertx-platform/src/main/java/org/vertx/java/platform/impl/ModuleIdentifier.java:30: error: unmappable character for encoding ASCII
  private static final String LEGAL = "[A-Za-z0-9!??$()-_+=@~;,]+";
                                                  ^
/Volumes/Relppob/Repositories/vert.x/vertx-platform/src/main/java/org/vertx/java/platform/impl/ModuleIdentifier.java:30: error: unmappable character for encoding ASCII
  private static final String LEGAL = "[A-Za-z0-9!??$()-_+=@~;,]+";
                                                   ^

It was because of the character '£' , it was not encoded ASCII.
So i propose to change javadoc encoding to UTF-8. 

Please approve this pull request for better develop environment. thanks
