### PR TITLE
add default Future handling to method signature of httpServer.listen()

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/HttpServer.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/HttpServer.java
@@ -17,6 +17,7 @@
 package org.vertx.java.core.http;
 
 import org.vertx.java.core.AsyncResult;
+import org.vertx.java.core.Future;
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.ServerSSLSupport;
 import org.vertx.java.core.ServerTCPSupport;
@@ -87,7 +88,13 @@ public interface HttpServer extends ServerSSLSupport<HttpServer>, ServerTCPSuppo
    *
    */
   HttpServer listen(int port, String host, Handler<AsyncResult<HttpServer>> listenHandler);
-  
+
+  /**
+   * Tell the server to start listening on port {@code port} and hostname or ip address given by {@code host}.
+   *
+   */
+  HttpServer listen(int port, String host, Future<Void> future);
+
   /**
    * Close the server. Any open HTTP connections will be closed.
    */

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServer.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServer.java
@@ -31,6 +31,7 @@ import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.vertx.java.core.AsyncResult;
+import org.vertx.java.core.Future;
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.VoidHandler;
 import org.vertx.java.core.http.HttpServer;
@@ -123,17 +124,32 @@ public class DefaultHttpServer implements HttpServer, Closeable {
   }
 
   public HttpServer listen(int port) {
-    listen(port, "0.0.0.0", null);
+    listen(port, "0.0.0.0", (Handler<AsyncResult<HttpServer>>) null);
     return this;
   }
 
   public HttpServer listen(int port, String host) {
-    listen(port, host, null);
+    listen(port, host, (Handler<AsyncResult<HttpServer>>) null);
     return this;
   }
 
   public HttpServer listen(int port, Handler<AsyncResult<HttpServer>> listenHandler) {
     listen(port, "0.0.0.0", listenHandler);
+    return this;
+  }
+
+  public HttpServer listen(int port, String host, final Future<Void> future) {
+    listen(port, host, new Handler<AsyncResult<HttpServer>>() {
+      @Override
+      public void handle(final AsyncResult<HttpServer> event) {
+        if (event.succeeded()) {
+          future.setResult(null);
+        }
+        else {
+          future.setFailure(event.cause());
+        }
+      }
+    });
     return this;
   }
 


### PR DESCRIPTION
Interacting with a Future to indicate Verticle success or failure of start up is complete is a common pattern with methods such as 'listen' on HttpServer.

We can just implement this as a convenience method.
