### PR TITLE
On Windows, ClasspathPathResolver#resolve() doesn't work properly.

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/file/impl/ClasspathPathResolver.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/file/impl/ClasspathPathResolver.java
@@ -36,7 +36,9 @@ public class ClasspathPathResolver implements PathResolver {
   public Path resolve(Path path) {
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
     if (cl != null) {
-      URL url = cl.getResource(path.toString());
+      char sysSeparator = path.getFileSystem().getSeparator().charAt(0);
+      String sPath = path.toString();
+      URL url = cl.getResource(sysSeparator == '/' ? sPath : sPath.replace(sysSeparator, '/'));
       if (url != null) {
         String sfile = url.getFile();
         if (sfile != null) {


### PR DESCRIPTION
Hi,
[ClasspathPathResolver#resolve()](http://goo.gl/Wa6vY) doesn't work properly when that was called with the 'path' that has two or many separator(\) on Windows.

For example, when the 'path' is '.\static\css\bootstrap.css', 
[cl.getResource(path.toString())](http://goo.gl/mpSEM) returned 'file:src/main/resources/.%5cstatic%5ccss%5cbootstrap.css'.

Vertx 2.0.0-CR2
