### PR TITLE
fixed classpathresolver again for windows

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/file/impl/ClasspathPathResolver.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/file/impl/ClasspathPathResolver.java
@@ -44,7 +44,7 @@ public class ClasspathPathResolver implements PathResolver {
       if (url != null) {
         String sfile = url.getFile();
         if (sfile != null) {
-          return Paths.get(spath);
+          return Paths.get(sfile);
         }
       }
     }


### PR DESCRIPTION
Hi,
Today, I have tried gradlew runModEclipse, but failed it.
The previous [COMMIT](https://github.com/vert-x/vert.x/commit/9f7e37b2472d5ed98a2396dbd23d340c227a3407)　was not enough.
Since I wasn't on top of making sure of things, I overlooked that, sorry.
