### PR TITLE
On Windows,　in some cases,   ClasspathPathResolver.resolve()  throws "IllegalArgumentException: URI is not hierarchical"

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/file/impl/ClasspathPathResolver.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/file/impl/ClasspathPathResolver.java
@@ -56,7 +56,9 @@ public class ClasspathPathResolver implements PathResolver {
           // E.g. windows
           // See http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4701321
           try {
-            return Paths.get(new URI(url.toExternalForm()));
+          	URI uri = new URI(url.toExternalForm());
+          	if (uri.isOpaque()) uri = new File(url.getPath()).toURI();
+            return Paths.get(uri);
           } catch (Exception exc) {
             throw new VertxException(exc);
           }


### PR DESCRIPTION
Vert.x version :  2.0.0-CR3-SNAPSHOT

When some opaque uri was created by ["new URI(url.toExternalForm())"](http://goo.gl/MYqDb),  Paths.get throws IllegalAurgumentException(). ( [see](http://goo.gl/H5Zw9) )
A opaque uri　for example, "file:src/main/resources/index.html".
There may be any other solutions for that.

stacktrace:

```
org.vertx.java.core.VertxException: java.lang.IllegalArgumentException: URI is not hierarchical
        at org.vertx.java.core.file.impl.ClasspathPathResolver.resolve(ClasspathPathResolver.java:61)
        at org.vertx.java.core.file.impl.PathAdjuster.adjust(PathAdjuster.java:35)
        at org.vertx.java.core.file.impl.PathAdjuster.adjust(PathAdjuster.java:42)
        at com.wingnest.mathcloud.MathCloud.start(MathCloud.java:27)
        at org.vertx.java.platform.Verticle.start(Verticle.java:82)
        at org.vertx.java.platform.impl.DefaultPlatformManager$18.run(DefaultPlatformManager.java:1270)
        at org.vertx.java.core.impl.DefaultContext$3.run(DefaultContext.java:171)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:353)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:366)
        at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:101)
        at java.lang.Thread.run(Thread.java:722)
Caused by: java.lang.IllegalArgumentException: URI is not hierarchical
        at sun.nio.fs.WindowsUriSupport.fromUri(WindowsUriSupport.java:122)
        at sun.nio.fs.WindowsFileSystemProvider.getPath(WindowsFileSystemProvider.java:91)
        at java.nio.file.Paths.get(Paths.java:138)
        at org.vertx.java.core.file.impl.ClasspathPathResolver.resolve(ClasspathPathResolver.java:59)
        ... 10 more
```
