### PR TITLE
Log fatal exceptions with stacktraces

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/cli/Starter.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/cli/Starter.java
@@ -106,12 +106,9 @@ public class Starter {
           Throwable cause = res.cause();
           if (cause instanceof VertxException) {
             VertxException ve = (VertxException)cause;
-            log.error(ve.getMessage());
-            if (ve.getCause() != null) {
-              log.error(ve.getCause());
-            }
+            log.error(ve.getMessage(), ve);
           } else {
-            log.error(cause);
+            log.error(cause, cause);
           }
         } else {
           log.trace(successMessage);


### PR DESCRIPTION
Fixes #693

Both Vertx and Generic exceptions have an exposed stacktrace.
