### PR TITLE
Added missing default prettyprint color

### DIFF
--- a/css/sunburst.css
+++ b/css/sunburst.css
@@ -15,6 +15,7 @@ pre .dec, code .dec { color: #3387CC; } /* decimal - blue */
 
 pre.prettyprint, code.prettyprint {
 	background-color: #000;
+	color: #fff;
 	-moz-border-radius: 8px;
 	-webkit-border-radius: 8px;
 	-o-border-radius: 8px;


### PR DESCRIPTION
If the javascript pretty-printing does not run, the code samples were left in an unreadable color scheme: dark grey on black. 

They will now be white on black.

This is in response to a google group thread: https://groups.google.com/d/msg/vertx/CuskZzuKzwc/EzWzTh0CdF8J

Eclipse CLA signed by `danny@kichmeier.us`
