### PR TITLE
Re-order classpath declaration in batch file to be consistent with equiv...

### DIFF
--- a/src/dist/scripts/vertx.bat
+++ b/src/dist/scripts/vertx.bat
@@ -79,7 +79,7 @@ set CMD_LINE_ARGS=%$
 :execute
 @rem Setup the command line
 
-set CLASSPATH=%CLASSPATH%;%VERTX_HOME%\lib\*;%VERTX_HOME%\conf
+set CLASSPATH=%CLASSPATH%;%VERTX_HOME%\conf;%VERTX_HOME%\lib\*
 
 @rem Execute vertx
 "%JAVA_EXE%" %JVM_OPTS% %JMX_OPTS% %JAVA_OPTS% %VERTX_OPTS% %VERTX_MODULE_OPTS% -Djava.util.logging.config.file="%VERTX_JUL_CONFIG%" -Dvertx.home="%VERTX_HOME%" -classpath "%CLASSPATH%" org.vertx.java.platform.impl.cli.Starter %CMD_LINE_ARGS%


### PR DESCRIPTION
...alent shell script.  Fixes an issue where the default cluster.xml in %VERTX_HOME%\lib\vertx-platform.jar was taking precedence over a custom cluster.xml in %VERTX_HOME%\conf.

Resolves https://bugs.eclipse.org/bugs/show_bug.cgi?id=416964
