### PR TITLE
Use ISO 8601 UTC formatted dates in JSON messages instead of timestamp format

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/json/impl/Json.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/json/impl/Json.java
@@ -20,14 +20,13 @@ package org.vertx.java.core.json.impl;
 
 import java.util.TimeZone;
 
+import org.vertx.java.core.json.DecodeException;
+import org.vertx.java.core.json.EncodeException;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
-
-import org.vertx.java.core.json.DecodeException;
-import org.vertx.java.core.json.EncodeException;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>


### PR DESCRIPTION
There has been discussion in the Vert.x group on the date format used in JSON messages. See: https://groups.google.com/forum/#!topic/vertx/a0yeLL23GyQ. 

With the standard Jackson ObjectMapper the format defaults to using timestamps.
However for JSON a format of ISO 8601 in UTC timezone is considered to be a best-practice (see for example the excellent webinar by Les Hazlewood on this subject http://www.youtube.com/watch?v=mZ8_QgJ5mbs).

Note: I didn't write testcode for the change in the ObjectMapper config...unfamiliar with the Gradle setup (used to Maven), so didn't get tests working properly and test in a working vert.x build. Maybe someone can add this.

(also used 'Organize imports' in Eclipse...sorry :)

Change will probably cause backward-compatibility issues....please review.
