### PR TITLE
Make configuration available in the VerticleFactory

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/platform/DeploymentVerticleFactory.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/DeploymentVerticleFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vertx.java.platform;
+
+
+import org.vertx.java.platform.impl.Deployment;
+
+/**
+ * Extends {@link VerticleFactory} to provide the {@link Deployment} instance when creating a {@link Verticle}.
+ * <p/>
+ * This makes all deployment settings available to the factory, including the configuration.
+ */
+public interface DeploymentVerticleFactory extends VerticleFactory {
+
+  /**
+   * Creates a {@link Verticle} instance for the provided {@link Deployment}
+   *
+   * @param deployment
+   * @return the new {@link Verticle} instance
+   * @throws Exception
+   */
+  Verticle createVerticle(Deployment deployment) throws Exception;
+
+}

--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
@@ -29,6 +29,7 @@ import org.vertx.java.core.json.JsonObject;
 import org.vertx.java.core.logging.Logger;
 import org.vertx.java.core.logging.impl.LoggerFactory;
 import org.vertx.java.core.spi.cluster.ClusterManager;
+import org.vertx.java.platform.DeploymentVerticleFactory;
 import org.vertx.java.platform.PlatformManagerException;
 import org.vertx.java.platform.Verticle;
 import org.vertx.java.platform.VerticleFactory;
@@ -1351,7 +1352,11 @@ public class DefaultPlatformManager implements PlatformManagerInternal, ModuleRe
           public void run() {
             Verticle verticle;
             try {
-              verticle = verticleFactory.createVerticle(main);
+              if (verticleFactory instanceof DeploymentVerticleFactory) {
+                verticle = ((DeploymentVerticleFactory)verticleFactory).createVerticle(deployment);
+              } else {
+                verticle = verticleFactory.createVerticle(main);
+              }
             } catch (Throwable t) {
               handleDeployFailure(t, deploymentID, aggHandler);
               return;


### PR DESCRIPTION
Added interface VerticleFactory2 to allow creating a verticle with all the deployment properties available, including the configuration.

This is a backwards compatible way to solve: https://bugs.eclipse.org/bugs/show_bug.cgi?id=417119
