### PR TITLE
added additional test for event bus timeouts

### DIFF
--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/eventbus/JavaEchoTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/eventbus/JavaEchoTest.java
@@ -194,6 +194,11 @@ public class JavaEchoTest extends TestBase {
   }
 
   @Test
+  public void testSendReplyWithTimeoutNoReplyHandler() {
+    runPeerTest(getMethodName());
+  }
+
+  @Test
   public void testSendWithDefaultTimeoutNoReply() {
     runPeerTest(getMethodName());
   }

--- a/vertx-testsuite/src/test/java/vertx/tests/core/eventbus/LocalEchoClient.java
+++ b/vertx-testsuite/src/test/java/vertx/tests/core/eventbus/LocalEchoClient.java
@@ -255,6 +255,11 @@ public class LocalEchoClient extends EventBusAppBase {
     });
   }
 
+  public void testSendReplyWithTimeoutNoReplyHandler() {
+    String address = "some-address";
+    eb.send(address, "foo");
+  }
+
   public void testSendWithDefaultTimeoutNoReply() {
     final long timeout = 500;
     eb.setDefaultReplyTimeout(timeout);

--- a/vertx-testsuite/src/test/java/vertx/tests/core/eventbus/LocalEchoPeer.java
+++ b/vertx-testsuite/src/test/java/vertx/tests/core/eventbus/LocalEchoPeer.java
@@ -195,6 +195,33 @@ public class LocalEchoPeer extends EventBusAppBase {
 
   }
 
+  public void testSendReplyWithTimeoutNoReplyHandlerInitialise() {
+    final long timeout = 500;
+    String address = "some-address";
+    eb.registerHandler(address, new Handler<Message<String>>() {
+      @Override
+      public void handle(final Message<String> message) {
+        // Reply *after* the timeout
+        message.replyWithTimeout("bar", timeout, new Handler<AsyncResult<Message<String>>>() {
+          @Override
+          public void handle(AsyncResult<Message<String>> event) {
+            tu.azzert(event.failed(), "Should not get a reply after timeout");
+            tu.testComplete();
+          }
+        });
+      }
+    }, new Handler<AsyncResult<Void>>() {
+      @Override
+      public void handle(AsyncResult<Void> res) {
+        if (res.succeeded()) {
+          tu.testComplete();
+        } else {
+          tu.azzert(false, "Failed to register");
+        }
+      }
+    });
+  }
+
   public void testSendWithDefaultTimeoutNoReplyInitialise() {
     final long timeout = 500;
     eb.setDefaultReplyTimeout(timeout);


### PR DESCRIPTION
Looks like there is a corner case that does not working yet.

If I do a `send()` without a reply handler, a `replyWithTimeout` will never receive a timeout (or similar) failure. I hope the provided test case helps investigating this.
