### PR TITLE
Change fs.truncate to act like truncate(2) and extend the file, also.

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/file/impl/DefaultFileSystem.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/file/impl/DefaultFileSystem.java
@@ -426,7 +426,7 @@ public class DefaultFileSystem implements FileSystem {
         try {
           try {
             raf = new RandomAccessFile(path, "rw");
-            raf.getChannel().truncate(len);
+            raf.setLength(len);
           } finally {
             if (raf != null) raf.close();
           }

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/filesystem/JavaFileSystemTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/filesystem/JavaFileSystemTest.java
@@ -120,6 +120,11 @@ public class JavaFileSystemTest extends TestBase {
   }
 
   @Test
+  public void testTruncateExtendsFile() throws Exception {
+    startTest(getMethodName());
+  }
+
+  @Test
   public void testTruncateFileDoesNotExist() throws Exception {
     startTest(getMethodName());
   }

--- a/vertx-testsuite/src/test/java/vertx/tests/core/filesystem/TestClient.java
+++ b/vertx-testsuite/src/test/java/vertx/tests/core/filesystem/TestClient.java
@@ -283,6 +283,19 @@ public class TestClient extends TestClientBase {
     });
   }
 
+  public void testTruncateExtendsFile() throws Exception {
+    final String file1 = "some-file.dat";
+    long initialLen = 500;
+    final long truncatedLen = 1000;
+    createFileWithJunk(file1, initialLen);
+    tu.azzert(fileLength(file1) == initialLen);
+    testTruncate(file1, truncatedLen, true, new VoidHandler() {
+      public void handle() {
+        tu.azzert(fileLength(file1) == truncatedLen);
+      }
+    });
+  }
+
   public void testTruncateFileDoesNotExist() throws Exception {
     String file1 = "some-file.dat";
     long truncatedLen = 534;


### PR DESCRIPTION
The standard truncate also extends a file when given a length greater than the current file length. It would be nice for vert.x to emulate this behavior.

```
TRUNCATE(2)                 BSD System Calls Manual                TRUNCATE(2)

NAME
     ftruncate, truncate -- truncate or extend a file to a specified length
```
