### PR TITLE
Add compression support for WriteStream and ReadStream.

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/file/AsyncFile.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/file/AsyncFile.java
@@ -36,11 +36,6 @@ public interface AsyncFile extends ReadStream<AsyncFile>, WriteStream<AsyncFile>
 
   /**
    * Close the file. The actual close happens asynchronously.
-   */
-  void close();
-
-  /**
-   * Close the file. The actual close happens asynchronously.
    * The handler will be called when the close is complete, or an error occurs.
    */
   void close(Handler<AsyncResult<Void>> handler);

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClientRequest.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClientRequest.java
@@ -489,4 +489,8 @@ public class DefaultHttpClientRequest implements HttpClientRequest {
     }
   }
 
+  @Override
+  public void close() {
+    end();
+  }
 }

--- a/vertx-core/src/main/java/org/vertx/java/core/net/NetSocket.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/NetSocket.java
@@ -81,11 +81,6 @@ public interface NetSocket extends ReadStream<NetSocket>, WriteStream<NetSocket>
   InetSocketAddress localAddress();
 
   /**
-   * Close the NetSocket
-   */
-  void close();
-
-  /**
    * Set a handler that will be called when the NetSocket is closed
    */
   NetSocket closeHandler(Handler<Void> handler);

--- a/vertx-core/src/main/java/org/vertx/java/core/streams/Compression.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/streams/Compression.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package org.vertx.java.core.streams;
+
+import io.netty.handler.codec.compression.JdkZlibDecoder;
+import io.netty.handler.codec.compression.JdkZlibEncoder;
+import io.netty.handler.codec.compression.ZlibWrapper;
+import org.vertx.java.core.streams.impl.EmbeddedChannelReadStream;
+import org.vertx.java.core.streams.impl.EmbeddedChannelWriteStream;
+
+
+/**
+ * Utility class which allows to create wrappers around {@link ReadStream} and {@link WriteStream} implementations
+ * which enabled compression.
+ *
+ * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
+ */
+public final class Compression {
+
+  /**
+   * Wrap the given {@link ReadStream} and decompress its content with ZLIB.
+   */
+  public static ReadStream<?> zlib(ReadStream<?> readStream) {
+    return EmbeddedChannelReadStream.create(readStream, new JdkZlibDecoder(ZlibWrapper.ZLIB));
+  }
+
+  /**
+   * Wrap the given {@link ReadStream} and decompress its content with ZLIB using the given dictionary.
+   */
+  public static ReadStream<?> zlib(ReadStream<?> readStream, byte[] dictionary) {
+    return EmbeddedChannelReadStream.create(readStream, new JdkZlibDecoder(dictionary.clone()));
+  }
+
+  /**
+   * Wrap the given {@link WriteStream} and compress the written buffers via ZLIB.
+   */
+  public static WriteStream<?> zlib(WriteStream<?> writeStream) {
+    return EmbeddedChannelWriteStream.create(writeStream, new JdkZlibEncoder(ZlibWrapper.ZLIB));
+  }
+
+  /**
+   * Wrap the given {@link WriteStream} and compress the written buffers via ZLIB using the given compressionLevel.
+   */
+  public static WriteStream<?> zlib(WriteStream<?> writeStream, int compressionLevel) {
+    return EmbeddedChannelWriteStream.create(writeStream, new JdkZlibEncoder(ZlibWrapper.ZLIB, compressionLevel));
+  }
+
+  /**
+   * Wrap the given {@link WriteStream} and compress the written buffers via ZLIB using the
+   * the given dictionary.
+   */
+  public static WriteStream<?> zlib(WriteStream<?> writeStream, byte[] dictionary) {
+    return EmbeddedChannelWriteStream.create(writeStream, new JdkZlibEncoder(dictionary.clone()));
+  }
+
+  /**
+   * Wrap the given {@link WriteStream} and compress the written buffers via ZLIB using the given compressionLevel using
+   * the given dictionary.
+   */
+  public static WriteStream<?> zlib(WriteStream<?> writeStream, int compressionLevel, byte[] dictionary) {
+    return EmbeddedChannelWriteStream.create(writeStream, new JdkZlibEncoder(compressionLevel, dictionary.clone()));
+  }
+
+  /**
+   * Wrap the given {@link ReadStream} and decompress its content with GZIP.
+   */
+  public static ReadStream<?> gzip(ReadStream<?> readStream) {
+    return EmbeddedChannelReadStream.create(readStream, new JdkZlibDecoder(ZlibWrapper.GZIP));
+  }
+
+  /**
+   * Wrap the given {@link WriteStream} and compress the written buffers via GZIP.
+   */
+  public static WriteStream<?> gzip(WriteStream<?> writeStream) {
+    return EmbeddedChannelWriteStream.create(writeStream, new JdkZlibEncoder(ZlibWrapper.GZIP));
+  }
+
+  /**
+   * Wrap the given {@link WriteStream} and compress the written buffers via GZIP using the given compressionLevel.
+   */
+  public static WriteStream<?> gzip(WriteStream<?> writeStream, int compressionLevel) {
+    return EmbeddedChannelWriteStream.create(writeStream, new JdkZlibEncoder(ZlibWrapper.GZIP, compressionLevel));
+  }
+
+  private Compression() {
+    // only contains static methods
+  }
+}

--- a/vertx-core/src/main/java/org/vertx/java/core/streams/WriteStream.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/streams/WriteStream.java
@@ -36,4 +36,9 @@ public interface WriteStream<T> extends ExceptionSupport<T>, DrainSupport<T> {
    * check the {@link #writeQueueFull} method before writing. This is done automatically if using a {@link Pump}.
    */
   T write(Buffer data);
+
+  /**
+   * Close the stream. The actual close happens asynchronously.
+   */
+  void close();
 }

--- a/vertx-core/src/main/java/org/vertx/java/core/streams/impl/AbstractEmbeddedChannelStream.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/streams/impl/AbstractEmbeddedChannelStream.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package org.vertx.java.core.streams.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.net.impl.PartialPooledByteBufAllocator;
+import org.vertx.java.core.streams.ExceptionSupport;
+
+/**
+ * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
+ */
+public abstract class AbstractEmbeddedChannelStream<T> implements ExceptionSupport<T>{
+
+  protected final EmbeddedChannel channel;
+  private Handler<Throwable> errorHandler;
+  private final boolean inbound;
+
+  AbstractEmbeddedChannelStream(ChannelHandler handler) {
+    this.channel = new EmbeddedChannel(handler);
+    channel.config().setAllocator(PartialPooledByteBufAllocator.INSTANCE);
+    inbound = handler instanceof ChannelInboundHandler;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public final T exceptionHandler(Handler<Throwable> handler) {
+    this.errorHandler = handler;
+    return (T) this;
+  }
+
+  protected final void handleException(Throwable cause) {
+    if (errorHandler != null) {
+      errorHandler.handle(cause);
+    }
+  }
+
+  protected final void handleInput(Buffer event) {
+    try {
+      ByteBuf buf = event.getByteBuf();
+      boolean pending;
+      if (inbound) {
+        pending = channel.writeInbound(buf);
+      } else {
+        pending = channel.writeOutbound(buf);
+      }
+      if (pending) {
+        processPending();
+      }
+    } catch (Throwable cause) {
+      handleException(cause);
+    }
+  }
+
+  protected final void finish() {
+    try {
+      if (channel.finish()) {
+        processPending();
+      }
+    } catch (Throwable cause) {
+      handleException(cause);
+    } finally {
+      finish0();
+    }
+  }
+
+  protected final void processPending() {
+    for (;;) {
+      ByteBuf buf;
+      if (inbound) {
+        buf = (ByteBuf) channel.readInbound();
+      } else {
+        buf = (ByteBuf) channel.readOutbound();
+      }
+      if (buf == null) {
+        return;
+      }
+      try {
+        handleOutput(buf);
+      } catch (Throwable cause) {
+        handleException(cause);
+      }
+    }
+  }
+
+  protected abstract void handleOutput(ByteBuf buf);
+  protected abstract void finish0();
+}

--- a/vertx-core/src/main/java/org/vertx/java/core/streams/impl/EmbeddedChannelReadStream.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/streams/impl/EmbeddedChannelReadStream.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package org.vertx.java.core.streams.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelInboundHandler;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.streams.ReadStream;
+
+/**
+ * {@link ReadStream} wrapper which allows to make use of {@link ChannelInboundHandler} implementations to process the buffers
+ *
+ * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
+ */
+public final class EmbeddedChannelReadStream extends AbstractEmbeddedChannelStream<EmbeddedChannelReadStream>
+        implements ReadStream<EmbeddedChannelReadStream> {
+
+  private final ReadStream<?> stream;
+
+  private Handler<Buffer> handler;
+  private Handler<Void> endHandler;
+
+  private EmbeddedChannelReadStream(ReadStream<?> stream, ChannelInboundHandler handler) {
+    super(handler);
+    this.stream = stream;
+  }
+
+  @Override
+  protected void finish0() {
+    if (endHandler != null) {
+      endHandler.handle(null);
+    }
+  }
+
+  @Override
+  protected void handleOutput(ByteBuf buf) {
+    if (handler != null) {
+      handler.handle(new Buffer(buf));
+    }
+  }
+
+  @Override
+  public EmbeddedChannelReadStream endHandler(Handler<Void> endHandler) {
+    this.endHandler = endHandler;
+    return this;
+  }
+
+  @Override
+  public EmbeddedChannelReadStream dataHandler(Handler<Buffer> handler) {
+    this.handler = handler;
+    return this;
+  }
+
+  @Override
+  public EmbeddedChannelReadStream pause() {
+    stream.pause();
+    return this;
+  }
+
+  @Override
+  public EmbeddedChannelReadStream resume() {
+    stream.resume();
+    return this;
+  }
+
+  public static EmbeddedChannelReadStream create(ReadStream<?> stream, ChannelInboundHandler handler) {
+    final EmbeddedChannelReadStream readStream = new EmbeddedChannelReadStream(stream, handler);
+    stream.endHandler(new Handler<Void>() {
+      @Override
+      public void handle(Void event) {
+        readStream.finish();
+      }
+    });
+    stream.dataHandler(new Handler<Buffer>() {
+      @Override
+      public void handle(Buffer event) {
+        readStream.handleInput(event);
+      }
+    });
+    stream.exceptionHandler(new Handler<Throwable>() {
+      @Override
+      public void handle(Throwable event) {
+        readStream.handleException(event);
+      }
+    });
+    return readStream;
+  }
+}

--- a/vertx-core/src/main/java/org/vertx/java/core/streams/impl/EmbeddedChannelWriteStream.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/streams/impl/EmbeddedChannelWriteStream.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package org.vertx.java.core.streams.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelOutboundHandler;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.streams.WriteStream;
+
+/**
+ * {@link WriteStream} wrapper which allows to make use of {@link ChannelOutboundHandler} implementations to process the buffers
+ * which should be written.
+
+ * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
+ */
+public final class EmbeddedChannelWriteStream extends AbstractEmbeddedChannelStream<EmbeddedChannelWriteStream>
+        implements WriteStream<EmbeddedChannelWriteStream> {
+
+  private final WriteStream<?> stream;
+
+  private Handler<Void> drainHandler;
+
+  private EmbeddedChannelWriteStream(WriteStream<?> stream, ChannelOutboundHandler handler) {
+    super(handler);
+    this.stream = stream;
+  }
+
+  @Override
+  public EmbeddedChannelWriteStream write(Buffer data) {
+    handleInput(data);
+    return this;
+  }
+
+  @Override
+  public EmbeddedChannelWriteStream setWriteQueueMaxSize(int maxSize) {
+    stream.setWriteQueueMaxSize(maxSize);
+    return this;
+  }
+
+  @Override
+  public boolean writeQueueFull() {
+    return stream.writeQueueFull();
+  }
+
+  @Override
+  public EmbeddedChannelWriteStream drainHandler(Handler<Void> handler) {
+    this.drainHandler = handler;
+    return this;
+  }
+
+  @Override
+  protected void finish0() {
+    stream.close();
+  }
+
+  private void handleDrained() {
+    if (drainHandler != null) {
+      drainHandler.handle(null);
+    }
+  }
+
+  @Override
+  public void close() {
+    finish();
+  }
+
+  @Override
+  protected void handleOutput(ByteBuf buf) {
+    stream.write(new Buffer(buf));
+  }
+
+  public static WriteStream<?> create(WriteStream<?> stream, ChannelOutboundHandler handler) {
+    final EmbeddedChannelWriteStream writeStream = new EmbeddedChannelWriteStream(stream, handler);
+    stream.drainHandler(new Handler<Void>() {
+      @Override
+      public void handle(Void event) {
+        writeStream.handleDrained();
+      }
+    });
+    stream.exceptionHandler(new Handler<Throwable>() {
+      @Override
+      public void handle(Throwable event) {
+        writeStream.handleException(event);
+      }
+    });
+    return writeStream;
+  }
+}

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/streams/FakeReadStream.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/streams/FakeReadStream.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package org.vertx.java.tests.core.streams;
+
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.streams.ReadStream;
+
+public class FakeReadStream implements ReadStream<FakeReadStream> {
+
+  private Handler<Buffer> dataHandler;
+  private Handler<Void> endHandler;
+
+  private boolean paused;
+  private int pauseCount;
+  private int resumeCount;
+
+  void addData(Buffer data) {
+    if (dataHandler != null) {
+      dataHandler.handle(data);
+    }
+  }
+
+  boolean isPaused() {
+    return paused;
+  }
+
+  int pauseCount() {
+    return pauseCount;
+  }
+
+  int resumeCount() {
+    return resumeCount;
+  }
+
+  public FakeReadStream dataHandler(Handler<Buffer> handler) {
+    this.dataHandler = handler;
+    return this;
+  }
+
+  public FakeReadStream pause() {
+    paused = true;
+    pauseCount++;
+    return this;
+  }
+
+  public FakeReadStream resume() {
+    paused = false;
+    resumeCount++;
+    return this;
+  }
+
+  public FakeReadStream exceptionHandler(Handler<Throwable> handler) {
+    return this;
+  }
+
+  public FakeReadStream endHandler(Handler<Void> endHandler) {
+    this.endHandler = endHandler;
+    return this;
+  }
+
+  public void end() {
+    if (endHandler != null) {
+      endHandler.handle(null);
+    }
+  }
+}

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/streams/FakeWriteStream.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/streams/FakeWriteStream.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package org.vertx.java.tests.core.streams;
+
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.streams.WriteStream;
+
+public class FakeWriteStream implements WriteStream<FakeWriteStream> {
+
+  private int maxSize;
+  private Buffer received = new Buffer();
+  private Handler<Void> drainHandler;
+
+  void clearReceived() {
+    boolean callDrain = writeQueueFull();
+    received = new Buffer();
+    if (callDrain && drainHandler != null) {
+      drainHandler.handle(null);
+    }
+  }
+
+  public FakeWriteStream setWriteQueueMaxSize(int maxSize) {
+    this.maxSize = maxSize;
+    return this;
+  }
+
+  public boolean writeQueueFull() {
+    return received.length() >= maxSize;
+  }
+
+  public FakeWriteStream drainHandler(Handler<Void> handler) {
+    this.drainHandler = handler;
+    return this;
+  }
+
+  public FakeWriteStream write(Buffer data) {
+    received.appendBuffer(data);
+    return this;
+  }
+
+  public FakeWriteStream exceptionHandler(Handler<Throwable> handler) {
+    return this;
+  }
+
+  @Override
+  public void close() {
+    // NOOP
+  }
+
+  int maxSize() {
+    return maxSize;
+  }
+
+  Buffer received() {
+    return received;
+  }
+}

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/streams/JavaCompressionTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/streams/JavaCompressionTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package org.vertx.java.tests.core.streams;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.streams.Compression;
+import org.vertx.java.core.streams.ReadStream;
+import org.vertx.java.core.streams.WriteStream;
+import org.vertx.java.testframework.TestUtils;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
+ */
+public class JavaCompressionTest {
+
+  @Test
+  public void testZlib() {
+    FakeReadStream readStream = new FakeReadStream();
+    FakeWriteStream writeStream = new FakeWriteStream();
+
+    ReadStream<?> compressedReadStream = Compression.zlib(readStream);
+    WriteStream<?> compressedWriteStream = Compression.zlib(writeStream);
+    testCompression(readStream, writeStream, compressedReadStream, compressedWriteStream);
+  }
+
+  @Test
+  public void testZlibWithCompressionLevel() {
+    FakeReadStream readStream = new FakeReadStream();
+    FakeWriteStream writeStream = new FakeWriteStream();
+
+    ReadStream<?> compressedReadStream = Compression.zlib(readStream);
+    WriteStream<?> compressedWriteStream = Compression.zlib(writeStream, 9);
+    testCompression(readStream, writeStream, compressedReadStream, compressedWriteStream);
+  }
+
+
+  @Test
+  public void testZlibCorrupt() {
+    FakeReadStream readStream = new FakeReadStream();
+    ReadStream<?> compressedReadStream = Compression.zlib(readStream);
+    testCompressionCorrupt(readStream, compressedReadStream);
+  }
+
+  @Test
+  public void testGzip() {
+    FakeReadStream readStream = new FakeReadStream();
+    FakeWriteStream writeStream = new FakeWriteStream();
+
+    ReadStream<?> compressedReadStream = Compression.gzip(readStream);
+    WriteStream<?> compressedWriteStream = Compression.gzip(writeStream);
+    testCompression(readStream, writeStream, compressedReadStream, compressedWriteStream);
+  }
+
+  @Test
+  public void testGzipWithCompressionLevel() {
+    FakeReadStream readStream = new FakeReadStream();
+    FakeWriteStream writeStream = new FakeWriteStream();
+
+    ReadStream<?> compressedReadStream = Compression.gzip(readStream);
+    WriteStream<?> compressedWriteStream = Compression.gzip(writeStream, 7);
+    testCompression(readStream, writeStream, compressedReadStream, compressedWriteStream);
+  }
+
+  @Test
+  public void testGzipCorrupt() {
+    FakeReadStream readStream = new FakeReadStream();
+    ReadStream<?> compressedReadStream = Compression.gzip(readStream);
+    testCompressionCorrupt(readStream, compressedReadStream);
+  }
+
+  private static void testCompression(FakeReadStream readStream, FakeWriteStream writeStream, ReadStream<?> compressedReadStream, WriteStream<?> compressedWriteStream) {
+    Buffer inp = new Buffer();
+    for (int j = 0; j < 10; j++) {
+      Buffer b = TestUtils.generateRandomBuffer(100);
+      inp.appendBuffer(b);
+      compressedWriteStream.write(b);
+    }
+
+    Buffer written = writeStream.received();
+    Assert.assertFalse(TestUtils.buffersEqual(inp, written));
+
+    final Buffer out = new Buffer();
+    final AtomicBoolean end = new AtomicBoolean();
+    compressedReadStream.dataHandler(new Handler<Buffer>() {
+      @Override
+      public void handle(Buffer event) {
+        out.appendBuffer(event);
+      }
+    });
+    compressedReadStream.endHandler(new Handler<Void>() {
+      @Override
+      public void handle(Void event) {
+        end.set(true);
+      }
+    });
+    readStream.addData(written);
+    readStream.end();
+
+    Assert.assertTrue(end.get());
+    Assert.assertTrue(TestUtils.buffersEqual(inp, out));
+  }
+
+  private static void testCompressionCorrupt(FakeReadStream readStream, ReadStream<?> compressedReadStream) {
+    final AtomicBoolean error = new AtomicBoolean();
+    compressedReadStream.exceptionHandler(new Handler<Throwable>() {
+      @Override
+      public void handle(Throwable event) {
+        error.set(true);
+      }
+    });
+    Buffer inp = new Buffer();
+    for (int j = 0; j < 10; j++) {
+      Buffer b = TestUtils.generateRandomBuffer(100);
+      inp.appendBuffer(b);
+      readStream.addData(b);
+    }
+    readStream.end();
+    Assert.assertTrue(error.get());
+
+  }
+}

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/streams/JavaPumpTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/streams/JavaPumpTest.java
@@ -45,16 +45,16 @@ public class JavaPumpTest extends TestCase {
         inp.appendBuffer(b);
         rs.addData(b);
       }
-      TestUtils.buffersEqual(inp, ws.received);
-      assertFalse(rs.paused);
-      assertEquals(0, rs.pauseCount);
-      assertEquals(0, rs.resumeCount);
+      TestUtils.buffersEqual(inp, ws.received());
+      assertFalse(rs.isPaused());
+      assertEquals(0, rs.pauseCount());
+      assertEquals(0, rs.resumeCount());
 
       p.stop();
       ws.clearReceived();
       Buffer b = TestUtils.generateRandomBuffer(100);
       rs.addData(b);
-      assertEquals(0, ws.received.length());
+      assertEquals(0, ws.received().length());
     }
   }
 
@@ -71,100 +71,23 @@ public class JavaPumpTest extends TestCase {
         Buffer b = TestUtils.generateRandomBuffer(100);
         inp.appendBuffer(b);
         rs.addData(b);
-        assertFalse(rs.paused);
-        assertEquals(i, rs.pauseCount);
-        assertEquals(i, rs.resumeCount);
+        assertFalse(rs.isPaused());
+        assertEquals(i, rs.pauseCount());
+        assertEquals(i, rs.resumeCount());
       }
       Buffer b = TestUtils.generateRandomBuffer(100);
       inp.appendBuffer(b);
       rs.addData(b);
-      assertTrue(rs.paused);
-      assertEquals(i + 1, rs.pauseCount);
-      assertEquals(i, rs.resumeCount);
+      assertTrue(rs.isPaused());
+      assertEquals(i + 1, rs.pauseCount());
+      assertEquals(i, rs.resumeCount());
 
-      TestUtils.buffersEqual(inp, ws.received);
+      TestUtils.buffersEqual(inp, ws.received());
       ws.clearReceived();
       inp = new Buffer();
-      assertFalse(rs.paused);
-      assertEquals(i + 1, rs.pauseCount);
-      assertEquals(i + 1, rs.resumeCount);
-    }
-  }
-
-  private class FakeReadStream implements ReadStream<FakeReadStream> {
-
-    private Handler<Buffer> dataHandler;
-    private boolean paused;
-    int pauseCount;
-    int resumeCount;
-
-    void addData(Buffer data) {
-      if (dataHandler != null) {
-        dataHandler.handle(data);
-      }
-    }
-
-    public FakeReadStream dataHandler(Handler<Buffer> handler) {
-      this.dataHandler = handler;
-      return this;
-    }
-
-    public FakeReadStream pause() {
-      paused = true;
-      pauseCount++;
-      return this;
-    }
-
-    public FakeReadStream resume() {
-      paused = false;
-      resumeCount++;
-      return this;
-    }
-
-    public FakeReadStream exceptionHandler(Handler<Throwable> handler) {
-      return this;
-    }
-
-    public FakeReadStream endHandler(Handler<Void> endHandler) {
-      return this;
-    }
-  }
-
-  private class FakeWriteStream implements WriteStream<FakeWriteStream> {
-
-    int maxSize;
-    Buffer received = new Buffer();
-    Handler<Void> drainHandler;
-
-    void clearReceived() {
-      boolean callDrain = writeQueueFull();
-      received = new Buffer();
-      if (callDrain && drainHandler != null) {
-        drainHandler.handle(null);
-      }
-    }
-
-    public FakeWriteStream setWriteQueueMaxSize(int maxSize) {
-      this.maxSize = maxSize;
-      return this;
-    }
-
-    public boolean writeQueueFull() {
-      return received.length() >= maxSize;
-    }
-
-    public FakeWriteStream drainHandler(Handler<Void> handler) {
-      this.drainHandler = handler;
-      return this;
-    }
-
-    public FakeWriteStream write(Buffer data) {
-      received.appendBuffer(data);
-      return this;
-    }
-
-    public FakeWriteStream exceptionHandler(Handler<Throwable> handler) {
-      return this;
+      assertFalse(rs.isPaused());
+      assertEquals(i + 1, rs.pauseCount());
+      assertEquals(i + 1, rs.resumeCount());
     }
   }
 }


### PR DESCRIPTION
- To support this a close() method was added to the WriteStream interface. This is needed because otherwise there is no way to know once the complete data was written and a pending footer needs to be written.
