### PR TITLE
Adding possibility to use thread context class loader to load cluster.xml for embedded vert.x

### DIFF
--- a/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/HazelcastClusterManager.java
+++ b/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/HazelcastClusterManager.java
@@ -167,9 +167,16 @@ class HazelcastClusterManager implements ClusterManager, MembershipListener {
   }
 
   private InputStream getConfigStream() {
-    InputStream is = getClass().getClassLoader().getResourceAsStream(CONFIG_FILE);
+    ClassLoader ctxClsLoader = Thread.currentThread().getContextClassLoader();
+    InputStream is = null;
+    if (ctxClsLoader != null) {
+      is = ctxClsLoader.getResourceAsStream(CONFIG_FILE);
+    }
     if (is == null) {
-      is = getClass().getClassLoader().getResourceAsStream(DEFAULT_CONFIG_FILE);
+      is = getClass().getClassLoader().getResourceAsStream(CONFIG_FILE);
+      if (is == null) {
+        is = getClass().getClassLoader().getResourceAsStream(DEFAULT_CONFIG_FILE);
+      }
     }
     return is;
   }


### PR DESCRIPTION
For embedded vert.x, there are cases that the cluster configuration file is loaded after the application starts up. Using current class loader will limit this, using the thread context class loader will make it possible.

See: https://groups.google.com/forum/#!topic/vertx/oyEeTWNKwWk
