### PR TITLE
Improvements for Logger

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/logging/Logger.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/logging/Logger.java
@@ -15,6 +15,7 @@
 
 package org.vertx.java.core.logging;
 
+import java.text.MessageFormat;
 import org.vertx.java.core.logging.impl.LogDelegate;
 
 /**
@@ -55,52 +56,124 @@ public class Logger {
     return delegate.isTraceEnabled();
   }
 
+  public boolean isWarnEnabled() {
+    return delegate.isWarnEnabled();
+  }
+  
+  public boolean isFatalEnabled() {
+    return delegate.isFatalEnabled();
+  }
+  
+  public boolean isErrorEnabled() {
+    return delegate.isErrorEnabled();
+  }
+  
   public void fatal(final Object message) {
-    delegate.fatal(message);
+    if (isFatalEnabled()) {
+      delegate.fatal(message);
+	}
+  }
+  
+  public void fatal(final String pattern, final Object... params) {
+    if (isFatalEnabled()) {
+      delegate.fatal(MessageFormat.format(pattern, params));
+	}
   }
 
   public void fatal(final Object message, final Throwable t) {
-    delegate.fatal(message, t);
+    if (isFatalEnabled()) {
+      delegate.fatal(message, t);
+	}
   }
 
   public void error(final Object message) {
-    delegate.error(message);
+    if (isErrorEnabled()) {
+	  delegate.error(message);
+	}
   }
 
+  public void error(final String pattern, final Object... params) {
+    if (isErrorEnabled()) {
+      delegate.error(MessageFormat.format(pattern, params));
+	}
+  }
+  
   public void error(final Object message, final Throwable t) {
-    delegate.error(message, t);
+    if (isErrorEnabled()) {
+      delegate.error(message, t);
+	}
   }
 
   public void warn(final Object message) {
-    delegate.warn(message);
+    if (isWarnEnabled()) {
+	  delegate.warn(message);
+	}
   }
 
+  public void warn(final String pattern, final Object... params) {
+    if (isWarnEnabled()) {
+      delegate.warn(MessageFormat.format(pattern, params));
+	}
+  }
+  
   public void warn(final Object message, final Throwable t) {
-    delegate.warn(message, t);
+    if (isWarnEnabled()) {
+      delegate.warn(message, t);
+	}
   }
 
   public void info(final Object message) {
-    delegate.info(message);
+    if (isInfoEnabled()) {
+      delegate.info(message);
+    }
   }
 
+  public void info(final String pattern, final Object... params) {
+    if (isInfoEnabled()) {
+      delegate.info(MessageFormat.format(pattern, params));
+	}
+  }
+  
   public void info(final Object message, final Throwable t) {
-    delegate.info(message, t);
+    if (isInfoEnabled()) {
+      delegate.info(message, t);
+	}
   }
 
   public void debug(final Object message) {
-    delegate.debug(message);
+    if (isDebugEnabled()) {
+      delegate.debug(message);
+	}
   }
 
+  public void debug(final String pattern, final Object... params) {
+    if (isDebugEnabled()) {
+      delegate.debug(MessageFormat.format(pattern, params));
+	}
+  }
+  
   public void debug(final Object message, final Throwable t) {
-    delegate.debug(message, t);
+    if (isDebugEnabled()) {
+      delegate.debug(message, t);
+	}
   }
 
   public void trace(final Object message) {
-    delegate.trace(message);
+    if (isTraceEnabled()) {
+      delegate.trace(message);
+	}
   }
 
+  public void trace(final String pattern, final Object... params) {
+    if (isTraceEnabled()) {
+      delegate.trace(MessageFormat.format(pattern, params));
+	}
+  }
+  
   public void trace(final Object message, final Throwable t) {
-    delegate.trace(message, t);
+    if (isTraceEnabled()) {
+      delegate.trace(message, t);
+	}
   }
 
 }

--- a/vertx-core/src/main/java/org/vertx/java/core/logging/impl/JULLogDelegate.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/logging/impl/JULLogDelegate.java
@@ -40,6 +40,18 @@ public class JULLogDelegate implements LogDelegate {
   public boolean isTraceEnabled() {
     return logger.isLoggable(Level.FINEST);
   }
+  
+  public boolean isWarnEnabled() {
+    return logger.isLoggable(Level.WARNING);
+  }
+  
+  public boolean isFatalEnabled() {
+    return logger.isLoggable(Level.SEVERE);
+  }
+  
+  public boolean isErrorEnabled() {
+    return logger.isLoggable(Level.SEVERE);
+  }
 
   public void fatal(final Object message) {
     logger.log(Level.SEVERE, message == null ? "NULL" : message.toString());

--- a/vertx-core/src/main/java/org/vertx/java/core/logging/impl/Log4jLogDelegate.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/logging/impl/Log4jLogDelegate.java
@@ -15,6 +15,8 @@
 
 package org.vertx.java.core.logging.impl;
 
+import org.apache.log4j.Level;
+
 /**
  * A {@link LogDelegate} which delegates to Apache Log4j
  *
@@ -39,6 +41,18 @@ public class Log4jLogDelegate implements LogDelegate {
     return logger.isTraceEnabled();
   }
 
+  public boolean isWarnEnabled() {
+    return logger.isEnabledFor(Level.WARN);
+  }
+  
+  public boolean isFatalEnabled() {
+    return logger.isEnabledFor(Level.FATAL);
+  }
+  
+  public boolean isErrorEnabled() {
+    return logger.isEnabledFor(Level.ERROR);
+  }
+  
   public void fatal(final Object message) {
     logger.fatal(message);
   }

--- a/vertx-core/src/main/java/org/vertx/java/core/logging/impl/LogDelegate.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/logging/impl/LogDelegate.java
@@ -26,6 +26,12 @@ public interface LogDelegate {
   boolean isDebugEnabled();
 
   boolean isTraceEnabled();
+  
+  boolean isWarnEnabled();
+  
+  boolean isFatalEnabled();
+  
+  boolean isErrorEnabled();
 
   void fatal(Object message);
 

--- a/vertx-core/src/main/java/org/vertx/java/core/logging/impl/SLF4JLogDelegate.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/logging/impl/SLF4JLogDelegate.java
@@ -45,6 +45,18 @@ public class SLF4JLogDelegate implements LogDelegate{
     return logger.isTraceEnabled();
   }
 
+  public boolean isWarnEnabled() {
+    return logger.isWarnEnabled();
+  }
+  
+  public boolean isFatalEnabled() {
+    return logger.isErrorEnabled();
+  }
+  
+  public boolean isErrorEnabled() {
+    return logger.isErrorEnabled();
+  }
+  
   public void fatal(final Object message) {
     logger.error(message.toString());
   }


### PR DESCRIPTION
[ADDED] Methods to check if the log message is FALTAL, ERROR or WARN
[ADDED] Check log level before writting the log message
[ADDED] Some more log methods with variable parameters. Now Vert.x can log messages with parameters. Example:

logger.info("Example message with {0} and {1}", "parameter 1", "parameter 2");

Prints: "Example message with parameter 1 and parameter 2"
