### PR TITLE
Clear ping timer when sockjs closed.

### DIFF
--- a/src/dist/client/vertxbus.js
+++ b/src/dist/client/vertxbus.js
@@ -106,7 +106,6 @@ var vertx = vertx || {};
   
     that.close = function() {
       checkOpen();
-      if (pingTimerID) clearInterval(pingTimerID);
       state = vertx.EventBus.CLOSING;
       sockJSConn.close();
     }
@@ -127,6 +126,7 @@ var vertx = vertx || {};
   
     sockJSConn.onclose = function() {
       state = vertx.EventBus.CLOSED;
+      if (pingTimerID) clearInterval(pingTimerID);
       if (that.onclose) {
         that.onclose();
       }


### PR DESCRIPTION
Sometimes the sockjs connection may be closed by the server side(e.g. 10 seconds timeout when js is paused at a breakpoint), at this case, there is no chance to clear the ping timer.
