### PR TITLE
Full ISO 8601 datetime by default in VertxLoggerFormatter

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/logging/impl/VertxLoggerFormatter.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/logging/impl/VertxLoggerFormatter.java
@@ -29,7 +29,7 @@ public class VertxLoggerFormatter extends java.util.logging.Formatter {
   @Override
   public String format(final LogRecord record) {
     Date date = new Date();
-    SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss,SSS");
+    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
     StringBuffer sb = new StringBuffer();
     // Minimize memory allocations here.
     date.setTime(record.getMillis());


### PR DESCRIPTION
Hi, 
how about an ISO8601 as a default datetime format for VertxLoggerFormatter? It may be very helpful for lazy or forgetful users.

Printing 

```
[vert.x-eventloop-thread-0] 2014-01-12T13:21:55.566+01:00 INFO [org.vertx.java.platform.impl.cli.Starter]  Succeeded in deploying verticle
```

instead of current

```
[vert.x-eventloop-thread-1] 13:24:31,090 INFO [org.vertx.java.platform.impl.cli.Starter]  Succeeded in deploying verticle
```

Regards
