### PR TITLE
Fix default FileSystem.open behavior

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/file/impl/DefaultAsyncFile.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/file/impl/DefaultAsyncFile.java
@@ -41,6 +41,7 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -70,18 +71,9 @@ public class DefaultAsyncFile implements AsyncFile {
   private int readPos;
   private boolean readInProgress;
 
-  DefaultAsyncFile(final VertxInternal vertx, final String path, String perms, final boolean read, final boolean write, final boolean createNew,
-            final boolean flush, final DefaultContext context) {
-    if (!read && !write) {
-      throw new FileSystemException("Cannot open file for neither reading nor writing");
-    }
+  DefaultAsyncFile(final VertxInternal vertx, final String path, String perms, Set<OpenOption> options, final DefaultContext context) {
     this.vertx = vertx;
     Path file = Paths.get(path);
-    HashSet<OpenOption> options = new HashSet<>();
-    if (read) options.add(StandardOpenOption.READ);
-    if (write) options.add(StandardOpenOption.WRITE);
-    if (createNew) options.add(StandardOpenOption.CREATE_NEW);
-    if (flush) options.add(StandardOpenOption.DSYNC);
     try {
       if (perms != null) {
         FileAttribute<?> attrs = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(perms));

--- a/vertx-core/src/main/java/org/vertx/java/core/file/impl/WindowsFileSystem.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/file/impl/WindowsFileSystem.java
@@ -64,10 +64,10 @@ public class WindowsFileSystem extends DefaultFileSystem {
   }
 
   @Override
-  protected AsyncFile doOpen(String path, String perms, boolean read, boolean write, boolean createNew, boolean flush,
+  protected AsyncFile doOpen(String path, String perms, boolean read, boolean write, boolean create, boolean createNew, boolean flush,
                              DefaultContext context) {
     logInternal(perms);
-    return new DefaultAsyncFile(vertx, path, null, read, write, createNew, flush, context);
+    return super.doOpen(path, perms, read, write, create, createNew, flush, context);
   }
 
   @Override

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/filesystem/JavaFileSystemTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/filesystem/JavaFileSystemTest.java
@@ -350,6 +350,22 @@ public class JavaFileSystemTest extends TestBase {
     startTest(getMethodName());
   }
 
+  public void testOpenNewFile() throws Exception {
+    startTest(getMethodName());
+  }
+
+  public void testOpenFileExists() throws Exception {
+    startTest(getMethodName());
+  }
+
+  public void testOpenCreateNew() throws Exception {
+    startTest(getMethodName());
+  }
+
+  public void testOpenCreateNewFileExists() throws Exception {
+    startTest(getMethodName());
+  }
+
   private AsyncResultHandler createHandler() {
     return new AsyncResultHandler<Void>() {
       public void handle(AsyncResult<Void> event) {


### PR DESCRIPTION
Fixing behavior of open with respect to javadocs.
- Open w/out options opens it for read, write, and create
- Open w/ options will interpret createNew flag correctly, and throw exception of file exists. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=424493
