### PR TITLE
Added ModJSONClassLoader for the DefaultPlatformManager

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
@@ -1171,7 +1171,7 @@ public class DefaultPlatformManager implements PlatformManagerInternal, ModuleRe
             e.printStackTrace();
             throw new PlatformManagerException(e);
           }
-          modJSON = loadModJSONFromClasspath(modID, new URLClassLoader(cpList.toArray(new URL[cpList.size()]), platformClassLoader));
+          modJSON = loadModJSONFromClasspath(modID, new ModJSONClassLoader(cpList.toArray(new URL[cpList.size()]), platformClassLoader));
         } catch (Exception e) {
           throw new PlatformManagerException(e);
         }
@@ -1922,5 +1922,23 @@ public class DefaultPlatformManager implements PlatformManagerInternal, ModuleRe
     }
   }
 
+  private static class ModJSONClassLoader extends URLClassLoader {
+
+    private final ClassLoader parent;
+
+    private ModJSONClassLoader(URL[] urls, ClassLoader parent) {
+      super(urls, parent);
+      this.parent = parent;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+      List<URL> resources = new ArrayList<>(Collections.list(findResources(name)));
+      if (parent != null) {
+        resources.addAll(Collections.list(parent.getResources(name)));
+      }
+      return Collections.enumeration(resources);
+    }
+  }
 
 }


### PR DESCRIPTION
Added ModJSONClassLoader for the DefaultPlatformManager to fix an issue when running integration tests using module.links.

When running integration tests with maven or gradle, the platformClassLoader potentially has all provided/test scoped dependencies added to the class path.  If there are vert.x modules added, the wrong mod.json was being picked up.  The ModJSONClassLoader overrides getResources to use the provided urls first.
