### PR TITLE
Support null values for JsonObject

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/json/JsonObject.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/json/JsonObject.java
@@ -82,16 +82,20 @@ public class JsonObject extends JsonElement {
 
   public JsonObject putArray(String fieldName, JsonArray value) {
     checkCopy();
-    map.put(fieldName, value.list);
+    map.put(fieldName, value == null ? null : value.list);
     return this;
   }
 
   public JsonObject putElement(String fieldName, JsonElement value) {
     checkCopy();
-    if (value.isArray()) {
+    if (value == null) {
+      map.put(fieldName, null);
+      return this;
+    } else if (value.isArray()) {
       return putArray(fieldName, value.asArray());
+    } else {
+      return putObject(fieldName, value.asObject());
     }
-    return putObject(fieldName, value.asObject());
   }
 
   public JsonObject putNumber(String fieldName, Number value) {
@@ -108,12 +112,14 @@ public class JsonObject extends JsonElement {
 
   public JsonObject putBinary(String fieldName, byte[] binary) {
     checkCopy();
-    map.put(fieldName, Base64.encodeBytes(binary));
+    map.put(fieldName, binary == null ? null : Base64.encodeBytes(binary));
     return this;
   }
 
   public JsonObject putValue(String fieldName, Object value) {
-    if (value instanceof JsonObject) {
+    if (value == null) {
+      putObject(fieldName, null);
+    } else if (value instanceof JsonObject) {
       putObject(fieldName, (JsonObject)value);
     } else if (value instanceof JsonArray) {
       putArray(fieldName, (JsonArray)value);
@@ -149,6 +155,8 @@ public class JsonObject extends JsonElement {
 
   public JsonElement getElement(String fieldName) {
     Object element = map.get(fieldName);
+    if (element == null) return null;
+
     if (element instanceof Map<?,?>){
       return getObject(fieldName);
     }

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/json/JavaJsonTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/json/JavaJsonTest.java
@@ -82,15 +82,74 @@ public class JavaJsonTest extends TestBase {
   public void testPutsNullObjectWithoutException() {
     log.debug(
       new JsonObject()
+        .putString("null", null)
+        .encode()
+    );
+    log.debug(
+      new JsonObject()
         .putObject("null", null) // this shouldn't cause a NullPointerException
         .encode()
     );
-    
+    log.debug(
+      new JsonObject()
+        .putArray("null", null)
+        .encode()
+    );
+    log.debug(
+      new JsonObject()
+        .putElement("null", null)
+        .encode()
+    );
+    log.debug(
+      new JsonObject()
+        .putNumber("null", null)
+        .encode()
+    );
+    log.debug(
+      new JsonObject()
+        .putBoolean("null", null)
+        .encode()
+    );
+    log.debug(
+      new JsonObject()
+        .putBinary("null", null)
+        .encode()
+    );
+    log.debug(
+      new JsonObject()
+        .putValue("null", null)
+        .encode()
+    );
+
     log.debug(
       new JsonObject()
         .putObject("null", new JsonObject().putString("foo", "bar"))
         .encode()
     );
+  }
+
+  @Test
+  public void testGetNullValues() {
+    assertNull(new JsonObject().putString("foo", null).getString("foo"));
+    assertNull(new JsonObject().putObject("foo", null).getObject("foo"));
+    assertNull(new JsonObject().putArray("foo", null).getArray("foo"));
+    assertNull(new JsonObject().putElement("foo", null).getElement("foo"));
+    assertNull(new JsonObject().putNumber("foo", null).getNumber("foo"));
+    assertNull(new JsonObject().putBoolean("foo", null).getBoolean("foo"));
+    assertNull(new JsonObject().putBinary("foo", null).getBinary("foo"));
+    assertNull(new JsonObject().putValue("foo", null).getValue("foo"));
+  }
+
+  @Test
+  public void testContainsNullValues() {
+    assertTrue(new JsonObject().putString("foo", null).containsField("foo"));
+    assertTrue(new JsonObject().putObject("foo", null).containsField("foo"));
+    assertTrue(new JsonObject().putArray("foo", null).containsField("foo"));
+    assertTrue(new JsonObject().putElement("foo", null).containsField("foo"));
+    assertTrue(new JsonObject().putNumber("foo", null).containsField("foo"));
+    assertTrue(new JsonObject().putBoolean("foo", null).containsField("foo"));
+    assertTrue(new JsonObject().putBinary("foo", null).containsField("foo"));
+    assertTrue(new JsonObject().putValue("foo", null).containsField("foo"));
   }
   
   @Test


### PR DESCRIPTION
The putString, putNumber, etc methods probably should call an internal putValue method that does the checkCopy and null checks, but would introduce extra instanceof calls, which could possibly (not that likely) effect perf.

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=426816
