### PR TITLE
Read maven repo credentials from repo.txt 

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/BintrayResolution.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/BintrayResolution.java
@@ -23,9 +23,6 @@ import org.vertx.java.core.logging.Logger;
 import org.vertx.java.core.logging.impl.LoggerFactory;
 import org.vertx.java.platform.impl.ModuleIdentifier;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 public class BintrayResolution extends HttpResolution {
 
   private static final Logger log = LoggerFactory.getLogger(BintrayResolution.class);
@@ -33,7 +30,7 @@ public class BintrayResolution extends HttpResolution {
   private final String uri;
 
   public BintrayResolution(Vertx vertx, String repoScheme, String repoHost, int repoPort, ModuleIdentifier moduleID, final String filename, String contentRoot) {
-    super(vertx, repoScheme, repoHost, repoPort, moduleID, filename);
+    super(vertx, repoScheme, null, null, repoHost, repoPort, moduleID, filename);
     addHandler(200, new Handler<HttpClientResponse>() {
       @Override
       public void handle(HttpClientResponse resp) {

--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/HttpRepoResolver.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/HttpRepoResolver.java
@@ -42,6 +42,8 @@ public abstract class HttpRepoResolver implements RepoResolver {
   protected final Vertx vertx;
   protected final String repoScheme;
   protected final String repoHost;
+  protected final String repoUsername;
+  protected final String repoPassword;
   protected final int repoPort;
   protected final String contentRoot;
 
@@ -49,6 +51,14 @@ public abstract class HttpRepoResolver implements RepoResolver {
     this.vertx = vertx;
     try {
       URI uri = new URI(repoID);
+      if (uri.getUserInfo() != null && uri.getUserInfo().contains(":")) {
+        repoUsername = uri.getUserInfo().substring(0, uri.getUserInfo().indexOf(":"));
+        repoPassword = uri.getUserInfo().substring(uri.getUserInfo().indexOf(":")+1);
+      } else {
+        repoUsername = null;
+        repoPassword = null;
+      }
+
       repoScheme = uri.getScheme();
       repoHost = uri.getHost();
       int port = uri.getPort();

--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/HttpResolution.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/HttpResolution.java
@@ -58,11 +58,14 @@ public abstract class HttpResolution {
   protected final String repoHost;
   protected final int repoPort;
   protected final String repoScheme;
+  protected final String repoPassword;
+  protected final String repoUsername;
   protected final ModuleIdentifier modID;
   protected final String filename;
   protected final String proxyHost = getProxyHost();
   protected final int proxyPort = getProxyPort();
   private final Map<Integer, Handler<HttpClientResponse>> handlers = new HashMap<>();
+
   protected HttpClient client;
 
   private boolean result;
@@ -80,10 +83,12 @@ public abstract class HttpResolution {
     return result;
   }
 
-  public HttpResolution(Vertx vertx, String repoScheme, String repoHost, int repoPort, ModuleIdentifier modID, String filename) {
+  public HttpResolution(Vertx vertx, String repoScheme, String repoUsername, String repoPassword, String repoHost, int repoPort, ModuleIdentifier modID, String filename) {
     this.vertx = vertx;
     this.repoHost = repoHost;
     this.repoPort = repoPort;
+    this.repoUsername = repoUsername;
+    this.repoPassword = repoPassword;
     this.modID = modID;
     this.filename = filename;
     this.repoScheme = repoScheme;
@@ -264,11 +269,14 @@ public abstract class HttpResolution {
     return System.getProperty(HTTP_PROXY_HOST_PROP_NAME);
   }
 
-  private static String getBasicAuth() {
-    if ((System.getProperty(HTTP_BASIC_AUTH_USER_PROP_NAME) != null)
-        && (System.getProperty(HTTP_BASIC_AUTH_PASSWORD_PROP_NAME)  != null)) {
-      String authinfo = new StringBuilder(System.getProperty(HTTP_BASIC_AUTH_USER_PROP_NAME))
-          .append(":").append(System.getProperty(HTTP_BASIC_AUTH_PASSWORD_PROP_NAME)).toString();
+  private String getBasicAuth() {
+    String authinfo;
+    if (repoUsername != null && repoPassword != null) {
+      authinfo = repoUsername + ":" + repoPassword;
+      return Base64.encodeBytes(authinfo.getBytes());
+    } else if ((System.getProperty(HTTP_BASIC_AUTH_USER_PROP_NAME) != null)
+            && (System.getProperty(HTTP_BASIC_AUTH_PASSWORD_PROP_NAME)  != null)) {
+      authinfo = System.getProperty(HTTP_BASIC_AUTH_USER_PROP_NAME) + ":" + System.getProperty(HTTP_BASIC_AUTH_PASSWORD_PROP_NAME);
       return Base64.encodeBytes(authinfo.getBytes());
     }
     return null;

--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/MavenRepoResolver.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/MavenRepoResolver.java
@@ -27,7 +27,7 @@ public class MavenRepoResolver extends HttpRepoResolver {
 
   @Override
   public boolean getModule(String filename, ModuleIdentifier moduleIdentifier) {
-    HttpResolution res = new MavenResolution(vertx, repoScheme, repoHost, repoPort, moduleIdentifier, filename, contentRoot);
+    HttpResolution res = new MavenResolution(vertx, repoScheme, repoUsername, repoPassword, repoHost, repoPort, moduleIdentifier, filename, contentRoot);
     res.getModule();
     return res.waitResult();
   }

--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/MavenResolution.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/MavenResolution.java
@@ -30,9 +30,9 @@ public class MavenResolution extends HttpResolution {
   protected ModuleIdentifier moduleIdentifier;
   protected String uriRoot;
 
-  public MavenResolution(Vertx vertx, String repoScheme, String repoHost, int repoPort, ModuleIdentifier moduleIdentifier, String filename,
+  public MavenResolution(Vertx vertx, String repoScheme, String repoUsername, String repoPassword, String repoHost, int repoPort, ModuleIdentifier moduleIdentifier, String filename,
                          String contentRoot) {
-    super(vertx, repoScheme, repoHost, repoPort, moduleIdentifier, filename);
+    super(vertx, repoScheme, repoUsername, repoPassword, repoHost, repoPort, moduleIdentifier, filename);
     this.contentRoot = contentRoot;
     this.moduleIdentifier = moduleIdentifier;
     uriRoot = getMavenURI(moduleIdentifier);

--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/OldRepoResolution.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/OldRepoResolution.java
@@ -27,7 +27,7 @@ public class OldRepoResolution extends HttpResolution {
 
   public OldRepoResolution(Vertx vertx, String repoScheme, String repoHost, int repoPort, ModuleIdentifier moduleIdentifier, String filename,
                            String contentRoot) {
-    super(vertx, repoScheme, repoHost, repoPort, moduleIdentifier, filename);
+    super(vertx, repoScheme, null, null, repoHost, repoPort, moduleIdentifier, filename);
     this.contentRoot = contentRoot;
   }
 


### PR DESCRIPTION
Allows per maven repository  credentials configuration in repos.txt

a  maven repo uri can now handle basic auth  maven:https://user:password@repo.url

Both user and password have to be assigned for the authorization header to be set. All other options (no password) will not add the authorization header.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=426857
