### PR TITLE
Vertx-Hazelcast Fixes

### DIFF
--- a/vertx-hazelcast/src/main/resources/META-INF/services/org.vertx.java.core.spi.cluster.ClusterManagerFactory
+++ b/vertx-hazelcast/src/main/resources/META-INF/services/org.vertx.java.core.spi.cluster.ClusterManagerFactory
@@ -1,0 +1,1 @@
+org.vertx.java.spi.cluster.impl.hazelcast.HazelcastClusterManagerFactory


### PR DESCRIPTION
- Adds a ServiceProvider configuration file as per [spec](http://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html) else ServiceLoader cannot pick up the service implementation.

[Configuration File](https://github.com/darylteo/vert.x/blob/b950a440b255c24c258ac2cceeff72eaf3eb8a80/vertx-hazelcast/src/main/resources/META-INF/services/org.vertx.java.core.spi.cluster.ClusterManagerFactory)
- moves files to correct package to match vertx-core.

``` bash
> ./gradlew vertx-hazelcast:install
> jar -tf ~/.m2/repository/io/vertx/vertx-hazelcast/2.1M6-SNAPSHOT/vertx-hazelcast-2.1M6-SNAPSHOT.jar
META-INF/
META-INF/MANIFEST.MF
org/
org/vertx/
org/vertx/java/
org/vertx/java/core/
org/vertx/java/core/spi/
org/vertx/java/core/spi/cluster/
org/vertx/java/core/spi/cluster/impl/
org/vertx/java/core/spi/cluster/impl/hazelcast/
org/vertx/java/core/spi/cluster/impl/hazelcast/ChoosableSet.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastAsyncMap$1.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastAsyncMap$2.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastAsyncMap$3.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastAsyncMap.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastAsyncMultiMap$1.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastAsyncMultiMap$2.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastAsyncMultiMap$3.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastAsyncMultiMap$4.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastAsyncMultiMap$5.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastAsyncMultiMap.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastClusterManager.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastClusterManagerFactory.class
org/vertx/java/core/spi/cluster/impl/hazelcast/HazelcastServerID.class
org/vertx/java/core/spi/cluster/impl/hazelcast/ProgrammableClusterManagerFactory$1.class
org/vertx/java/core/spi/cluster/impl/hazelcast/ProgrammableClusterManagerFactory.class
META-INF/services/
META-INF/services/org.vertx.java.core.spi.cluster.ClusterManagerFactory
```

Note: I was very naughty, and --force pushed new commit messages to make Eclipse CLA happy.
