### PR TITLE
Minor documentation fix

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/shareddata/SharedData.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/shareddata/SharedData.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ConcurrentMap;
  *   {@code byte[]} - this will be automatically copied, and the copy will be stored in the structure.
  *   {@link org.vertx.java.core.buffer.Buffer} - this will be automatically copied, and the copy will be stored in the
  *   structure.
+ *   Classes implementing {@link org.vertx.java.core.shareddata.Shareable}
  * </pre>
  * <p>
  *


### PR DESCRIPTION
`SharedData` data structures allow to store classes implementing the marker interface `Shareable`, but this possibility wasn't listed in `SharedData` Javadoc.
