### PR TITLE
Add timeout to SockJSSocket 

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/EventBusBridge.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/EventBusBridge.java
@@ -281,8 +281,8 @@ public class EventBusBridge implements Handler<SockJSSocket> {
         @Override
         public void handle(Long id) {
           if (System.currentTimeMillis() - pingInfo.lastPing >= pingTimeout) {
-            // We didn't receive a ping in time so close the socket
-            sock.close();
+            // We didn't receive a ping in time so time out the socket
+            sock.timeout();
           }
         }
       });

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/SockJSSocket.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/SockJSSocket.java
@@ -49,6 +49,11 @@ public interface SockJSSocket extends ReadStream<SockJSSocket>, WriteStream<Sock
   void close();
 
   /**
+   * Indicates that this socket has timed out, and any sessions (if any) associated with it should be closed/shutdown.
+   */
+  void timeout();
+
+  /**
    * Return the remote address for this socket
    */
   InetSocketAddress remoteAddress();

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/BaseTransport.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/BaseTransport.java
@@ -104,6 +104,8 @@ class BaseTransport {
 
     @Override
     public void sessionClosed() {
+      session.writeClosed(this);
+      close();
     }
   }
 

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/RawWebSocketTransport.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/RawWebSocketTransport.java
@@ -104,6 +104,11 @@ class RawWebSocketTransport {
     }
 
     @Override
+    public void timeout() {
+      close();
+    }
+
+    @Override
     public InetSocketAddress remoteAddress() {
       return ws.remoteAddress();
     }

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/Session.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/Session.java
@@ -157,6 +157,13 @@ class Session extends SockJSSocketBase implements Shareable {
     return this;
   }
 
+  @Override
+  public void timeout() {
+    if (!closed) {
+      close();
+    }
+    shutdown();
+  }
 
   public synchronized void shutdown() {
     doClose();

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/XhrTransport.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/XhrTransport.java
@@ -143,12 +143,6 @@ class XhrTransport extends BaseTransport {
 
     public void close() {
     }
-
-    @Override
-    public void sessionClosed() {
-      session.writeClosed(this);
-      close();
-    }
   }
 
   private class XhrPollingListener extends BaseXhrListener {


### PR DESCRIPTION
This seems to work. All protocol (except ha) and client tests pass still. I cannot produce the NPE on the server anymore when JS is paused and ping timed out.
