### PR TITLE
Fix NPE in JsonArray.equals when array contains nulls

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/json/JsonArray.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/json/JsonArray.java
@@ -186,7 +186,11 @@ public class JsonArray extends JsonElement implements Iterable<Object> {
     Iterator<?> iter = that.list.iterator();
     for (Object entry : this.list) {
       Object other = iter.next();
-      if (!entry.equals(other)) {
+      if (entry == null) {
+        if (other != null) {
+          return false;
+        }
+      } else if (!entry.equals(other)) {
         return false;
       }
     }

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/json/JavaJsonTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/json/JavaJsonTest.java
@@ -326,6 +326,22 @@ public class JavaJsonTest extends TestBase {
 
     assertEquals(array1, array2);
   }
+  
+  @Test
+  public void testJsonArraysWithNullsEquality() {
+    JsonArray array1 = new JsonArray(new Object[]{null, "a"});
+    JsonArray array2 = new JsonArray(new Object[]{null, "a"});
+
+    assertEquals(array1, array2);
+  }
+
+  @Test
+  public void testJsonArraysWithNullsEquality2() {
+    JsonArray array1 = new JsonArray(new Object[]{null, "a"});
+    JsonArray array2 = new JsonArray(new Object[]{"b", "a"});
+
+    assertFalse(array1.equals(array2));
+  }
 
   @Test
   public void testGetBinary() {


### PR DESCRIPTION
Hello.  I signed commit and Eclipse CLA as requested in #801
Not sure how to sign commit that already pushed, so I created new branch, sorry for inconvenience.
