### PR TITLE
Override getResource() in ModJSONClassLoader to behave the same as getResources()

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
@@ -1960,6 +1960,15 @@ public class DefaultPlatformManager implements PlatformManagerInternal, ModuleRe
     }
 
     @Override
+    public URL getResource(String name) {
+      URL url = findResource(name);
+      if (url == null) {
+        url = super.getResource(name);
+      }
+      return url;
+    }
+
+    @Override
     public Enumeration<URL> getResources(String name) throws IOException {
       List<URL> resources = new ArrayList<>(Collections.list(findResources(name)));
       if (parent != null) {


### PR DESCRIPTION
DefaultPlatformManager now uses ModJSONClassLoader getResource() rather than getResources().  This method was not overridden to work the same way so the wrong mod.json file could be loaded.

This is related to issue #780
