### PR TITLE
Fix HttpResolution to follow entire location header uri

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/HttpResolution.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/resolver/HttpResolution.java
@@ -243,8 +243,14 @@ public abstract class HttpResolution {
         if (redirectPort == -1) {
           redirectPort = 80;
         }
+        // Use raw values from location header
+        String uri = redirectURI.getRawPath();
+        String query = redirectURI.getRawQuery();
+        if (query != null) {
+          uri = uri + "?" + query; // Include query in URL
+        }
         createClient(redirectURI.getScheme(), redirectURI.getHost(), redirectPort);
-        makeRequest(redirectURI.getScheme(), redirectURI.getHost(), redirectPort, redirectURI.getPath());
+        makeRequest(redirectURI.getScheme(), redirectURI.getHost(), redirectPort, uri);
       } catch (URISyntaxException e) {
         log.error("Invalid redirect URI: " + location);
       }


### PR DESCRIPTION
Bintray redirects to cloudfront for some of it's files and the location header includes query parameters.

This should work:
vertx runmod nscavell~openshift-quickstart~1.0.0

The module exists @ http://dl.bintray.com/nscavell/vertx-mods/openshift-quickstart/openshift-quickstart-1.0.0.zip however it redirects to quite a lengthy cloudfront URL w/ query params.
