### PR TITLE
Bumping up mod-lang-groovy version to 2.1RC3

### DIFF
--- a/vertx-testsuite/src/test/resources/langs.properties
+++ b/vertx-testsuite/src/test/resources/langs.properties
@@ -23,7 +23,7 @@
 
 rhino=io.vertx~lang-rhino~2.0.0-final:org.vertx.java.platform.impl.RhinoVerticleFactory
 jruby=io.vertx~lang-jruby~2.0.0-final:org.vertx.java.platform.impl.JRubyVerticleFactory
-groovy=io.vertx~lang-groovy~2.1RC1:org.vertx.groovy.platform.impl.GroovyVerticleFactory
+groovy=io.vertx~lang-groovy~2.1RC3:org.vertx.groovy.platform.impl.GroovyVerticleFactory
 jython=io.vertx~lang-jython~2.1.0-RC1:org.vertx.java.platform.impl.JythonVerticleFactory
 scala=io.vertx~lang-scala~1.0.0:org.vertx.scala.platform.impl.ScalaVerticleFactory
 clojure=io.vertx~lang-clojure~1.0.1:io.vertx.lang.clojure.ClojureVerticleFactory


### PR DESCRIPTION
The 2.1RC3 is released and tested, but I'd like people to use and test it when testing Vert.X 2.1 RC builds :)
