### PR TITLE
Make sure we throw an exception if DefaultPlatformManager construction d...

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
@@ -44,6 +44,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -131,17 +132,26 @@ public class DefaultPlatformManager implements PlatformManagerInternal, ModuleRe
   }
 
   private VertxInternal createVertxSynchronously(int port, String hostname) {
+    final AtomicReference<AsyncResult<Vertx>>  resultReference = new AtomicReference<>();
     final CountDownLatch latch = new CountDownLatch(1);
     DefaultVertx v = new DefaultVertx(port, hostname, new Handler<AsyncResult<Vertx>>() {
       @Override
       public void handle(AsyncResult<Vertx> result) {
+        resultReference.set(result);
         latch.countDown();
       }
     });
     try {
-      latch.await(10, TimeUnit.SECONDS);
-    } catch (Exception e) {
-      e.printStackTrace();
+      if (!latch.await(10, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Unable to start Vertx within 10 seconds");
+      }
+      AsyncResult<Vertx> result = resultReference.get();
+      if (result.failed()) {
+        throw new IllegalStateException("Unable to start Vertx", result.cause());
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(e);
     }
     return new WrappedVertx(v);
   }


### PR DESCRIPTION
...oes not success because of createVertxSynchronously(...) fails with an exception or timeout. Before we just returned an not fully initialized Vertx instance which then later may cause a NPE when you act on it. This is related to BZ-432519
