### PR TITLE
Split keepalive from pipelining in HTTP connections (bug https://bugs.ec...

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/HttpClient.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/HttpClient.java
@@ -58,11 +58,12 @@ public interface HttpClient extends ClientSSLSupport<HttpClient>, TCPSupport<Htt
   int getMaxPoolSize();
 
   /**
-   * If {@code keepAlive} is {@code true} then, after the request has ended the connection will be returned to the pool
-   * where it can be used by another request. In this manner, many HTTP requests can be pipe-lined over an HTTP connection.
+   * If {@code keepAlive} is {@code true} then the connection will be returned to the pool after the request has ended (if
+   * {@code pipelining} is {@code true}), or after both request and response have ended (if {@code pipelining} is
+   * {@code false}). In this manner, many HTTP requests can reuse the same HTTP connection.
    * Keep alive connections will not be closed until the {@link #close() close()} method is invoked.<p>
    * If {@code keepAlive} is {@code false} then a new connection will be created for each request and it won't ever go in the pool,
-   * the connection will closed after the response has been received. Even with no keep alive,
+   * the connection will get closed after the response has been received. Even with no keep alive,
    * the client will not allow more than {@link #getMaxPoolSize()} connections to be created at any one time. <p>
    * @return A reference to this, so multiple invocations can be chained together.
    */
@@ -73,6 +74,22 @@ public interface HttpClient extends ClientSSLSupport<HttpClient>, TCPSupport<Htt
    * @return Is the client keep alive?
    */
   boolean isKeepAlive();
+
+  /**
+   * If {@code pipelining} is {@code true} and {@code keepAlive} is also {@code true} then, after the request has ended the
+   * connection will be returned to the pool where it can be used by another request. In this manner, many HTTP requests can
+   * be pipelined over an HTTP connection. If {@code pipelining} is {@code false} and {@code keepAlive} is {@code true}, then
+   * the connection will be returned to the pool when both request and response have ended. If {@code keepAlive} is false,
+   * then pipelining value is ignored.
+   * @return A reference to this, so multiple invocations can be chained together.
+   */
+  HttpClient setPipelining(boolean pipelining);
+
+  /**
+   *
+   * @return Is enabled HTTP pipelining?
+   */
+  boolean isPipelining();
 
   /**
    * Set the port that the client will attempt to connect to the server on to {@code port}. The default value is

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClient.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClient.java
@@ -68,6 +68,7 @@ public class DefaultHttpClient implements HttpClient {
     }
   };
   private boolean keepAlive = true;
+  private boolean pipelining = true;
   private boolean configurable = true;
   private boolean closed;
   private final Closeable closeHook = new Closeable() {
@@ -117,6 +118,20 @@ public class DefaultHttpClient implements HttpClient {
   public boolean isKeepAlive() {
     checkClosed();
     return keepAlive;
+  }
+
+  @Override
+  public DefaultHttpClient setPipelining(boolean pipelining) {
+    checkClosed();
+    checkConfigurable();
+    this.pipelining = pipelining;
+    return this;
+  }
+
+  @Override
+  public boolean isPipelining() {
+    checkClosed();
+    return pipelining;
   }
 
   @Override
@@ -738,7 +753,7 @@ public class DefaultHttpClient implements HttpClient {
 
   private void createConn(Channel ch, Handler<ClientConnection> connectHandler) {
     final ClientConnection conn = new ClientConnection(vertx, DefaultHttpClient.this, ch,
-        tcpHelper.isSSL(), host, port, keepAlive, actualCtx);
+        tcpHelper.isSSL(), host, port, keepAlive, pipelining, actualCtx);
     conn.closeHandler(new VoidHandler() {
       public void handle() {
         // The connection has been closed - tell the pool about it, this allows the pool to create more

--- a/vertx-testsuite/src/test/java/vertx/tests/core/http/HttpTestClient.java
+++ b/vertx-testsuite/src/test/java/vertx/tests/core/http/HttpTestClient.java
@@ -2486,18 +2486,23 @@ public class HttpTestClient extends TestClientBase {
   }
 
   public void testPooling() throws Exception {
-    testPooling(true);
+    testPooling(true, true);
+  }
+
+  public void testPoolingNoPipelining() throws Exception {
+    testPooling(true, false);
   }
 
   public void testPoolingNoKeepAlive() throws Exception {
-    testPooling(false);
+    testPooling(false, false);
+    testPooling(false, true);
   }
 
-  private void testPooling(final boolean keepAlive) throws Exception {
+  private void testPooling(final boolean keepAlive, final boolean pipelining) throws Exception {
     final String path = "foo.txt";
     final int numGets = 1000;
     int maxPoolSize = 10;
-    client.setKeepAlive(keepAlive).setMaxPoolSize(maxPoolSize);
+    client.setKeepAlive(keepAlive).setPipelining(pipelining).setMaxPoolSize(maxPoolSize);
     final AtomicInteger cnt = new AtomicInteger(0);
     for (int i = 0; i < numGets; i++) {
       final int theCount = i;


### PR DESCRIPTION
...lipse.org/bugs/show_bug.cgi?id=434402). A new property 'pipelining' is added to HttpClient to disable HTTP pipelining (by default, pipelining is true to maintain backwards compatibility)
