### PR TITLE
Allow developers to use their own SSLConntext ...

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/SSLSupport.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/SSLSupport.java
@@ -16,6 +16,8 @@
 
 package org.vertx.java.core;
 
+import javax.net.ssl.SSLContext;
+
 public interface SSLSupport<T> {
 
   /**
@@ -29,6 +31,15 @@ public interface SSLSupport<T> {
    * @return Is SSL enabled?
    */
   boolean isSSL();
+
+  /**
+   * Set the SSL context explicitly.  This method should only be used in SSL mode, i.e. after {@link #setSSL(boolean)}
+   * has been set to {@code true}.<p>
+   * The SSL context has to be properly initialized.
+   * Only use this method if you have very special requirements concerning your key managers, trust managers and/or
+   * corresponding stores.
+   */
+  T setSSLContext(SSLContext sslContext);
 
   /**
    * Set the path to the SSL key store. This method should only be used in SSL mode, i.e. after {@link #setSSL(boolean)}

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClient.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClient.java
@@ -39,6 +39,7 @@ import org.vertx.java.core.net.NetSocket;
 import org.vertx.java.core.net.impl.TCPSSLHelper;
 import org.vertx.java.core.net.impl.VertxEventLoopGroup;
 
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLParameters;
@@ -389,6 +390,14 @@ public class DefaultHttpClient implements HttpClient {
     checkClosed();
     checkConfigurable();
     tcpHelper.setVerifyHost(verifyHost);
+    return this;
+  }
+
+  @Override
+  public HttpClient setSSLContext(SSLContext sslContext) {
+    checkClosed();
+    checkConfigurable();
+    tcpHelper.setExternalSSLContext(sslContext);
     return this;
   }
 

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServer.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServer.java
@@ -50,6 +50,7 @@ import org.vertx.java.core.logging.Logger;
 import org.vertx.java.core.logging.impl.LoggerFactory;
 import org.vertx.java.core.net.impl.*;
 
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -319,6 +320,13 @@ public class DefaultHttpServer implements HttpServer, Closeable {
   public HttpServer setSSL(boolean ssl) {
     checkListening();
     tcpHelper.setSSL(ssl);
+    return this;
+  }
+
+  @Override
+  public HttpServer setSSLContext(SSLContext sslContext) {
+    checkListening();
+    tcpHelper.setExternalSSLContext(sslContext);
     return this;
   }
 

--- a/vertx-core/src/main/java/org/vertx/java/core/net/impl/DefaultNetClient.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/impl/DefaultNetClient.java
@@ -34,6 +34,7 @@ import org.vertx.java.core.logging.impl.LoggerFactory;
 import org.vertx.java.core.net.NetClient;
 import org.vertx.java.core.net.NetSocket;
 
+import javax.net.ssl.SSLContext;
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -247,6 +248,13 @@ public class DefaultNetClient implements NetClient {
   public NetClient setSSL(boolean ssl) {
     checkConfigurable();
     tcpHelper.setSSL(ssl);
+    return this;
+  }
+
+  @Override
+  public NetClient setSSLContext(SSLContext sslContext) {
+    checkConfigurable();
+    tcpHelper.setExternalSSLContext(sslContext);
     return this;
   }
 

--- a/vertx-core/src/main/java/org/vertx/java/core/net/impl/DefaultNetServer.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/impl/DefaultNetServer.java
@@ -41,6 +41,7 @@ import org.vertx.java.core.logging.impl.LoggerFactory;
 import org.vertx.java.core.net.NetServer;
 import org.vertx.java.core.net.NetSocket;
 
+import javax.net.ssl.SSLContext;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Map;
@@ -421,6 +422,13 @@ public class DefaultNetServer implements NetServer, Closeable {
   public NetServer setSSL(boolean ssl) {
     checkListening();
     tcpHelper.setSSL(ssl);
+    return this;
+  }
+
+  @Override
+  public NetServer setSSLContext(SSLContext sslContext) {
+    checkListening();
+    tcpHelper.setExternalSSLContext(sslContext);
     return this;
   }
 

--- a/vertx-core/src/main/java/org/vertx/java/core/net/impl/TCPSSLHelper.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/impl/TCPSSLHelper.java
@@ -69,6 +69,8 @@ public class TCPSSLHelper {
 
   private SSLContext sslContext;
 
+  private SSLContext externalSSLContext = null;
+
   public TCPSSLHelper() {
   }
 
@@ -223,6 +225,10 @@ public class TCPSSLHelper {
     this.ssl = ssl;
   }
 
+  public void setExternalSSLContext(SSLContext externalSSLContext) {
+    this.externalSSLContext = externalSSLContext;
+  }
+
   public void setVerifyHost(boolean verifyHost) {
     this.verifyHost = verifyHost;
   }
@@ -294,6 +300,9 @@ public class TCPSSLHelper {
                                    final String tsPath,
                                    final String tsPassword,
                                    final boolean trustAll) {
+    if ( externalSSLContext != null ) {
+      return externalSSLContext;
+    }
     try {
       SSLContext context = SSLContext.getInstance("TLS");
       KeyManager[] keyMgrs = ksPath == null ? null : getKeyMgrs(vertx, ksPath, ksPassword);


### PR DESCRIPTION
... if default configuration does not suffice

In my current project we have some pretty strickt requirements concerning SSL configuration, so that we cannot use the default KeyManager and default KeyStore i.e. we have to create and initialize our own SSLContext.

The change is not very elegant but minimalistic (i.e. with this I'm able to configure an HTTPs server as we need it without breaking the existing API)
