### PR TITLE
add peerCertificateChain() to NetSocket, ServerWebSocket, and SockJSSocket

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/ServerWebSocket.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/ServerWebSocket.java
@@ -16,6 +16,9 @@
 
 package org.vertx.java.core.http;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
+
 import org.vertx.java.core.MultiMap;
 
 /**
@@ -45,6 +48,13 @@ public interface ServerWebSocket extends WebSocketBase<ServerWebSocket> {
    * A map of all headers in the request to upgrade to websocket
    */
   MultiMap headers();
+  
+  /**
+   * @return an array of the peer certificates.  Returns null if connection is
+   *         not SSL.
+   * @throws SSLPeerUnverifiedException SSL peer's identity has not been verified.
+  */
+  X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
 
   /**
    * Reject the WebSocket<p>

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultServerWebSocket.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultServerWebSocket.java
@@ -16,6 +16,9 @@
 
 package org.vertx.java.core.http.impl;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
+
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.MultiMap;
 import org.vertx.java.core.buffer.Buffer;
@@ -62,6 +65,11 @@ public class DefaultServerWebSocket extends WebSocketImplBase<ServerWebSocket> i
   @Override
   public MultiMap headers() {
     return headers;
+  }
+  
+  @Override
+  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+    return conn.getPeerCertificateChain();
   }
 
   @Override

--- a/vertx-core/src/main/java/org/vertx/java/core/net/NetSocket.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/NetSocket.java
@@ -24,6 +24,9 @@ import org.vertx.java.core.streams.WriteStream;
 
 import java.net.InetSocketAddress;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
+
 /**
  * Represents a socket-like interface to a TCP/SSL connection on either the
  * client or the server side.<p>
@@ -106,5 +109,13 @@ public interface NetSocket extends ReadStream<NetSocket>, WriteStream<NetSocket>
    * Returns {@code true} if this {@link NetSocket} is encrypted via SSL/TLS.
    */
   boolean isSsl();
+  
+  /**
+   * @return an array of the peer certificates.  Returns null if connection is
+   *         not SSL.
+   * @throws SSLPeerUnverifiedException SSL peer's identity has not been verified.
+  */
+  X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
+
 }
 

--- a/vertx-core/src/main/java/org/vertx/java/core/net/impl/DefaultNetSocket.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/impl/DefaultNetSocket.java
@@ -25,6 +25,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+
 import org.vertx.java.core.AsyncResult;
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.VoidHandler;
@@ -42,6 +43,9 @@ import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.UUID;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
 
 public class DefaultNetSocket extends ConnectionBase implements NetSocket {
 
@@ -330,6 +334,11 @@ public class DefaultNetSocket extends ConnectionBase implements NetSocket {
   @Override
   public boolean isSsl() {
     return channel.pipeline().get(SslHandler.class) != null;
+  }
+  
+  @Override
+  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+    return getPeerCertificateChain();
   }
 }
 

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/SockJSSocket.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/SockJSSocket.java
@@ -22,6 +22,9 @@ import org.vertx.java.core.streams.WriteStream;
 
 import java.net.InetSocketAddress;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
+
 /**
  *
  * You interact with SockJS clients through instances of SockJS socket.<p>
@@ -68,4 +71,11 @@ public interface SockJSSocket extends ReadStream<SockJSSocket>, WriteStream<Sock
    * Return the URI corresponding to the last request for this socket or the websocket handshake
    */
   String uri();
+  
+  /**
+   * @return an array of the peer certificates.  Returns null if connection is
+   *         not SSL.
+   * @throws SSLPeerUnverifiedException SSL peer's identity has not been verified.
+  */
+  X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
 }

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/BaseTransport.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/BaseTransport.java
@@ -56,10 +56,10 @@ class BaseTransport {
   }
 
   protected Session getSession(final long timeout, final long heartbeatPeriod, final String sessionID,
-                               Handler<SockJSSocket> sockHandler) {
+                               Handler<SockJSSocket> sockHandler, final HttpServerRequest req) {
     Session session = sessions.get(sessionID);
     if (session == null) {
-      session = new Session(vertx, sessions, sessionID, timeout, heartbeatPeriod, sockHandler);
+      session = new HttpSession(vertx, sessions, sessionID, timeout, heartbeatPeriod, sockHandler, req);
       sessions.put(sessionID, session);
     }
     return session;

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/EventSourceTransport.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/EventSourceTransport.java
@@ -45,8 +45,7 @@ class EventSourceTransport extends BaseTransport {
       public void handle(final HttpServerRequest req) {
         if (log.isTraceEnabled()) log.trace("EventSource transport, get: " + req.uri());
         String sessionID = req.params().get("param0");
-        Session session = getSession(config.getLong("session_timeout"), config.getLong("heartbeat_period"), sessionID, sockHandler);
-        session.setInfo(req.localAddress(), req.remoteAddress(), req.uri(), req.headers());
+        Session session = getSession(config.getLong("session_timeout"), config.getLong("heartbeat_period"), sessionID, sockHandler, req);
         session.register(new EventSourceListener(config.getInteger("max_bytes_streaming"), req, session));
       }
     });

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/HtmlFileTransport.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/HtmlFileTransport.java
@@ -81,8 +81,7 @@ class HtmlFileTransport extends BaseTransport {
         }
 
         String sessionID = req.params().get("param0");
-        Session session = getSession(config.getLong("session_timeout"), config.getLong("heartbeat_period"), sessionID, sockHandler);
-        session.setInfo(req.localAddress(), req.remoteAddress(), req.uri(), req.headers());
+        Session session = getSession(config.getLong("session_timeout"), config.getLong("heartbeat_period"), sessionID, sockHandler, req);
         session.register(new HtmlFileListener(config.getInteger("max_bytes_streaming"), req, callback, session));
       }
     });

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/HttpSession.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/HttpSession.java
@@ -1,0 +1,51 @@
+package org.vertx.java.core.sockjs.impl;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
+
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.MultiMap;
+import org.vertx.java.core.http.HttpServerRequest;
+import org.vertx.java.core.impl.VertxInternal;
+import org.vertx.java.core.sockjs.SockJSSocket;
+
+class HttpSession extends Session {
+
+  private final HttpServerRequest req;
+
+  HttpSession(VertxInternal vertx, Map<String, Session> sessions, String id, long timeout, long heartbeatPeriod,
+      Handler<SockJSSocket> sockHandler, HttpServerRequest req) {
+    super(vertx, sessions, id, timeout, heartbeatPeriod, sockHandler);
+    this.req = req;
+  }
+
+  @Override
+  public InetSocketAddress remoteAddress() {
+    return req.remoteAddress();
+  }
+
+  @Override
+  public InetSocketAddress localAddress() {
+    return req.localAddress();
+  }
+
+  @Override
+  public MultiMap headers() {
+    return req.headers();
+  }
+
+  @Override
+  public String uri() {
+    return req.uri();
+  }
+
+  @Override
+  public X509Certificate[] peerCertificateChain()
+      throws SSLPeerUnverifiedException {
+    return req.peerCertificateChain();
+  }
+
+}

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/JsonPTransport.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/JsonPTransport.java
@@ -57,8 +57,7 @@ class JsonPTransport extends BaseTransport {
         }
 
         String sessionID = req.params().get("param0");
-        Session session = getSession(config.getLong("session_timeout"), config.getLong("heartbeat_period"), sessionID, sockHandler);
-        session.setInfo(req.localAddress(), req.remoteAddress(), req.uri(), req.headers());
+        Session session = getSession(config.getLong("session_timeout"), config.getLong("heartbeat_period"), sessionID, sockHandler, req);
         session.register(new JsonPListener(req, session, callback));
       }
     });

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/RawWebSocketTransport.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/RawWebSocketTransport.java
@@ -30,6 +30,9 @@ import org.vertx.java.core.sockjs.SockJSSocket;
 
 import java.net.InetSocketAddress;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
+
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -124,6 +127,11 @@ class RawWebSocketTransport {
     @Override
     public String uri() {
       return ws.uri();
+    }
+    
+    @Override
+    public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+      return ws.peerCertificateChain();
     }
   }
 

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/Session.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/Session.java
@@ -17,7 +17,6 @@
 package org.vertx.java.core.sockjs.impl;
 
 import org.vertx.java.core.Handler;
-import org.vertx.java.core.MultiMap;
 import org.vertx.java.core.buffer.Buffer;
 import org.vertx.java.core.impl.VertxInternal;
 import org.vertx.java.core.json.DecodeException;
@@ -26,7 +25,6 @@ import org.vertx.java.core.logging.impl.LoggerFactory;
 import org.vertx.java.core.shareddata.Shareable;
 import org.vertx.java.core.sockjs.SockJSSocket;
 
-import java.net.InetSocketAddress;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
@@ -40,7 +38,7 @@ import java.util.Queue;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-class Session extends SockJSSocketBase implements Shareable {
+abstract class Session extends SockJSSocketBase implements Shareable {
 
   private static final Logger log = LoggerFactory.getLogger(Session.class);
   private final Map<String, Session> sessions;
@@ -62,10 +60,6 @@ class Session extends SockJSSocketBase implements Shareable {
   private Handler<Void> endHandler;
   private Handler<Throwable> exceptionHandler;
   private boolean handleCalled;
-  private InetSocketAddress localAddress;
-  private InetSocketAddress remoteAddress;
-  private String uri;
-  private MultiMap headers;
 
   Session(VertxInternal vertx, Map<String, Session> sessions, long heartbeatPeriod,
           Handler<SockJSSocket> sockHandler) {
@@ -173,26 +167,6 @@ class Session extends SockJSSocketBase implements Shareable {
     if (listener != null && handleCalled) {
       listener.sessionClosed();
     }
-  }
-
-  @Override
-  public InetSocketAddress remoteAddress() {
-    return remoteAddress;
-  }
-
-  @Override
-  public InetSocketAddress localAddress() {
-    return localAddress;
-  }
-
-  @Override
-  public MultiMap headers() {
-    return headers;
-  }
-
-  @Override
-  public String uri() {
-    return uri;
   }
 
   synchronized boolean isClosed() {
@@ -365,13 +339,5 @@ class Session extends SockJSSocketBase implements Shareable {
     StringBuilder sb = new StringBuilder("o");
     lst.sendFrame(sb.toString());
     openWritten = true;
-  }
-
-  void setInfo(InetSocketAddress localAddress, InetSocketAddress remoteAddress, String uri,
-               MultiMap headers) {
-    this.localAddress = localAddress;
-    this.remoteAddress = remoteAddress;
-    this.uri = uri;
-    this.headers = BaseTransport.removeCookieHeaders(headers);
   }
 }

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/WebSocketSession.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/WebSocketSession.java
@@ -1,0 +1,51 @@
+package org.vertx.java.core.sockjs.impl;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
+
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.MultiMap;
+import org.vertx.java.core.http.ServerWebSocket;
+import org.vertx.java.core.impl.VertxInternal;
+import org.vertx.java.core.sockjs.SockJSSocket;
+
+class WebSocketSession extends Session {
+
+  private final ServerWebSocket ws;
+
+  WebSocketSession(VertxInternal vertx, Map<String, Session> sessions, long heartbeatPeriod, 
+      Handler<SockJSSocket> sockHandler, ServerWebSocket ws) {
+    super(vertx, sessions, heartbeatPeriod, sockHandler);
+    this.ws = ws;
+  }
+
+  @Override
+  public InetSocketAddress remoteAddress() {
+    return ws.remoteAddress();
+  }
+
+  @Override
+  public InetSocketAddress localAddress() {
+    return ws.localAddress();
+  }
+
+  @Override
+  public MultiMap headers() {
+    return ws.headers();
+  }
+
+  @Override
+  public String uri() {
+    return ws.uri();
+  }
+
+  @Override
+  public X509Certificate[] peerCertificateChain()
+      throws SSLPeerUnverifiedException {
+    return ws.peerCertificateChain();
+  }
+
+}

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/WebSocketTransport.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/WebSocketTransport.java
@@ -16,6 +16,8 @@
 
 package org.vertx.java.core.sockjs.impl;
 
+import java.util.Map;
+
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.VoidHandler;
 import org.vertx.java.core.buffer.Buffer;
@@ -28,8 +30,6 @@ import org.vertx.java.core.json.JsonObject;
 import org.vertx.java.core.logging.Logger;
 import org.vertx.java.core.logging.impl.LoggerFactory;
 import org.vertx.java.core.sockjs.SockJSSocket;
-
-import java.util.Map;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -49,8 +49,7 @@ class WebSocketTransport extends BaseTransport {
 
       public void handle(final WebSocketMatcher.Match match) {
         if (log.isTraceEnabled()) log.trace("WS, handler");
-        final Session session = new Session(vertx, sessions, config.getLong("heartbeat_period"), sockHandler);
-        session.setInfo(match.ws.localAddress(), match.ws.remoteAddress(), match.ws.uri(), match.ws.headers());
+        final Session session = new WebSocketSession(vertx, sessions, config.getLong("heartbeat_period"), sockHandler, match.ws);
         session.register(new WebSocketListener(match.ws, session));
       }
     });

--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/XhrTransport.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/XhrTransport.java
@@ -90,8 +90,7 @@ class XhrTransport extends BaseTransport {
         if (log.isTraceEnabled()) log.trace("XHR, post, " + req.uri());
         setNoCacheHeaders(req);
         String sessionID = req.params().get("param0");
-        Session session = getSession(config.getLong("session_timeout"), config.getLong("heartbeat_period"), sessionID, sockHandler);
-        session.setInfo(req.localAddress(), req.remoteAddress(), req.uri(), req.headers());
+        Session session = getSession(config.getLong("session_timeout"), config.getLong("heartbeat_period"), sessionID, sockHandler, req);
         session.register(streaming? new XhrStreamingListener(config.getInteger("max_bytes_streaming"), req, session) : new XhrPollingListener(req, session));
       }
     });


### PR DESCRIPTION
Currently you can only access the peer certificate chain on `HttpServerRequest`.  This change makes it available on the socket related classes as well.

This is required at my company because we need to validate the client certificate `SubjectDN`.

For SockJS, I removed the `setInfo()` approach to sessions and created subclasses that pass through the calls to either the `HttpServerRequest` or the `ServerWebSocket` depending on the type of session.  This avoids the cost of handling the `SSLPeerUnverifiedException` that can be thrown for `.peerCertificateChain()` unless the peer certificate chain is requested explicitly.
