### PR TITLE
Remove null checks from hashCode as those cannot be null.

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/eventbus/impl/DefaultEventBus.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/eventbus/impl/DefaultEventBus.java
@@ -1101,9 +1101,7 @@ public class DefaultEventBus implements EventBus {
 
     @Override
     public int hashCode() {
-      int result = address != null ? address.hashCode() : 0;
-      result = 31 * result + (handler != null ? handler.hashCode() : 0);
-      return result;
+      return 31 * address.hashCode() + handler.hashCode();
     }
 
     // Called by context on undeploy


### PR DESCRIPTION
HandlerEntry objects are added to a HashSet so hashCode is called
pretty often.

Signed-off-by: Thomas Cataldo thomas.cataldo@blue-mind.net
