### PR TITLE
HTTP Tests

### DIFF
--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/newtests/HttpCompressionTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/newtests/HttpCompressionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2011-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package org.vertx.java.tests.newtests;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
+ */
+public class HttpCompressionTest extends HttpTestBase {
+
+  @Before
+  public void before() {
+    client.setTryUseCompression(true);
+    server.setCompressionSupported(true);
+  }
+
+  @Test
+  public void testDefaultRequestHeaders() {
+    server.requestHandler(req -> {
+      assertEquals(2, req.headers().size());
+      assertEquals("localhost:" + port, req.headers().get("host"));
+      assertNotNull(req.headers().get("Accept-Encoding"));
+      req.response().end();
+    });
+
+    server.listen(port, onSuccess(server -> {
+      client.getNow("some-uri", resp -> testComplete());
+    }));
+
+    await();
+  }
+}

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/newtests/HttpRouteMatcherTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/newtests/HttpRouteMatcherTest.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2011-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package org.vertx.java.tests.newtests;
+
+import org.junit.Test;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.http.HttpClientRequest;
+import org.vertx.java.core.http.HttpClientResponse;
+import org.vertx.java.core.http.HttpServerRequest;
+import org.vertx.java.core.http.RouteMatcher;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
+ */
+public class HttpRouteMatcherTest extends HttpTestBase {
+
+  @Test
+  public void testRouteWithPattern1GET() {
+    testRouteWithPattern1("GET");
+  }
+
+  @Test
+  public void testRouteWithPattern2GET() {
+    testRouteWithPattern2("GET");
+  }
+
+  @Test
+  public void testRouteWithPattern3GET() {
+    testRouteWithPattern3("GET");
+  }
+
+  @Test
+  public void testRouteWithPattern4GET() {
+    testRouteWithPattern4("GET");
+  }
+
+  @Test
+  public void testRouteWithPattern5GET() {
+    testRouteWithPattern5("GET");
+  }
+
+  @Test
+  public void testRouteWithPattern6GET() {
+    testRouteWithPattern6("GET");
+  }
+
+  @Test
+  public void testRouteWithPattern7GET() {
+    testRouteWithPattern6("GET");
+  }
+
+  // There's no need to repeat patterns 1-6 for all HTTP methods
+
+  @Test
+  public void testRouteWithPatternPUT() {
+    testRouteWithPattern1("PUT");
+  }
+
+  @Test
+  public void testRouteWithPatternPOST() {
+    testRouteWithPattern1("POST");
+  }
+
+  @Test
+  public void testRouteWithPatternDELETE() {
+    testRouteWithPattern1("DELETE");
+  }
+
+  @Test
+  public void testRouteWithPatternHEAD() {
+    testRouteWithPattern1("HEAD");
+  }
+
+  @Test
+  public void testRouteWithPatternOPTIONS() {
+    testRouteWithPattern1("OPTIONS");
+  }
+
+  @Test
+  public void testRouteWithPatternTRACE() {
+    testRouteWithPattern1("TRACE");
+  }
+
+  @Test
+  public void testRouteWithPatternCONNECT() {
+    testRouteWithPattern1("CONNECT");
+  }
+
+  @Test
+  public void testRouteWithPatternPATCH() {
+    testRouteWithPattern1("PATCH");
+  }
+
+  @Test
+  public void testRouteWithRegexGET() {
+    testRouteWithRegex("GET");
+  }
+
+  @Test
+  public void testRouteWithRegexPUT() {
+    testRouteWithRegex("PUT");
+  }
+
+  @Test
+  public void testRouteWithRegexPOST() {
+    testRouteWithRegex("POST");
+  }
+
+  @Test
+  public void testRouteWithRegexDELETE() {
+    testRouteWithRegex("DELETE");
+  }
+
+  @Test
+  public void testRouteWithRegexHEAD() {
+    testRouteWithRegex("HEAD");
+  }
+
+  @Test
+  public void testRouteWithRegexOPTIONS() {
+    testRouteWithRegex("OPTIONS");
+  }
+
+  @Test
+  public void testRouteWithRegexTRACE() {
+    testRouteWithRegex("TRACE");
+  }
+
+  @Test
+  public void testRouteWithRegexCONNECT() {
+    testRouteWithRegex("CONNECT");
+  }
+
+  @Test
+  public void testRouteWithRegexPATCH() {
+    testRouteWithRegex("PATCH");
+  }
+
+  @Test
+  public void testRouteNoMatchPattern() {
+    Map<String, String> params = new HashMap<>();
+    testRoute(false, "foo", params, "GET", "bar", false, false);
+  }
+
+  @Test
+  public void testRouteNoMatchRegex() {
+    Map<String, String> params = new HashMap<>();
+    testRoute(true, "foo", params, "GET", "bar", false, false);
+  }
+
+  @Test
+  public void testRouteNoMatchHandlerPattern() {
+    Map<String, String> params = new HashMap<>();
+    testRoute(false, "foo", params, "GET", "bar", false, true);
+  }
+
+  @Test
+  public void testRouteNoMatchHandlerRegex() {
+    Map<String, String> params = new HashMap<>();
+    testRoute(true, "foo", params, "GET", "bar", false, true);
+  }
+
+  //----------- Private non test method ----------------------------
+
+  private void testRouteWithPattern1(String method) {
+    Map<String, String> params = new HashMap<>();
+    params.put("name", "foo");
+    params.put("version", "v0.1");
+    testRoute(false, "/:name/:version", params, method, "/foo/v0.1");
+  }
+
+  private void testRouteWithPattern2(String method) {
+    Map<String, String> params = new HashMap<>();
+    params.put("name", "foo");
+    params.put("version", "v0.1");
+    testRoute(false, "modules/:name/:version", params, method, "modules/foo/v0.1");
+  }
+
+  private void testRouteWithPattern3(String method) {
+    Map<String, String> params = new HashMap<>();
+    params.put("name", "foo");
+    params.put("version", "v0.1");
+    testRoute(false, "modules/:name/:version/", params, method, "modules/foo/v0.1/");
+  }
+
+  private void testRouteWithPattern4(String method) {
+    Map<String, String> params = new HashMap<>();
+    params.put("name", "foo");
+    params.put("version", "v0.1");
+    testRoute(false, "modules/:name/:version/whatever", params, method, "modules/foo/v0.1/whatever");
+  }
+
+  private void testRouteWithPattern5(String method) {
+    Map<String, String> params = new HashMap<>();
+    params.put("name", "foo");
+    params.put("version", "v0.1");
+    testRoute(false, "modules/:name/blah/:version/whatever", params, method, "modules/foo/blah/v0.1/whatever");
+  }
+
+  private void testRouteWithPattern6(String method) {
+    Map<String, String> params = new HashMap<>();
+    params.put("name", "foo");
+    testRoute(false, "/:name/", params, method, "/foo/");
+  }
+
+  private void testRouteWithRegex(String method) {
+    Map<String, String> params = new HashMap<>();
+    params.put("param0", "foo");
+    params.put("param1", "v0.1");
+    String regex = "\\/([^\\/]+)\\/([^\\/]+)";
+    testRoute(true, regex, params, method, "/foo/v0.1");
+  }
+
+
+  private void testRoute(final boolean regex, final String pattern, final Map<String, String> params,
+                         final String method, final String uri) {
+    testRoute(regex, pattern, params, method, uri, true, false);
+  }
+
+  private void testRoute(final boolean regex, final String pattern, final Map<String, String> params,
+                         final String method, final String uri, final boolean shouldPass, final boolean noMatchHandler) {
+
+    RouteMatcher matcher = new RouteMatcher();
+
+    Handler<HttpServerRequest> handler = req -> {
+      assertEquals(params.size(), req.params().size());
+      for (Map.Entry<String, String> entry : params.entrySet()) {
+        assertEquals(entry.getValue(), req.params().get(entry.getKey()));
+      }
+      req.response().end();
+    };
+
+    switch (method) {
+      case "GET":
+        if (regex) {
+          matcher.getWithRegEx(pattern, handler);
+        } else {
+          matcher.get(pattern, handler);
+        }
+        break;
+      case "PUT":
+        if (regex) {
+          matcher.putWithRegEx(pattern, handler);
+        } else {
+          matcher.put(pattern, handler);
+        }
+        break;
+      case "POST":
+        if (regex) {
+          matcher.postWithRegEx(pattern, handler);
+        } else {
+          matcher.post(pattern, handler);
+        }
+        break;
+      case "DELETE":
+        if (regex) {
+          matcher.deleteWithRegEx(pattern, handler);
+        } else {
+          matcher.delete(pattern, handler);
+        }
+        break;
+      case "OPTIONS":
+        if (regex) {
+          matcher.optionsWithRegEx(pattern, handler);
+        } else {
+          matcher.options(pattern, handler);
+        }
+        break;
+      case "HEAD":
+        if (regex) {
+          matcher.headWithRegEx(pattern, handler);
+        } else {
+          matcher.head(pattern, handler);
+        }
+        break;
+      case "TRACE":
+        if (regex) {
+          matcher.traceWithRegEx(pattern, handler);
+        } else {
+          matcher.trace(pattern, handler);
+        }
+        break;
+      case "PATCH":
+        if (regex) {
+          matcher.patchWithRegEx(pattern, handler);
+        } else {
+          matcher.patch(pattern, handler);
+        }
+        break;
+      case "CONNECT":
+        if (regex) {
+          matcher.connectWithRegEx(pattern, handler);
+        } else {
+          matcher.connect(pattern, handler);
+        }
+        break;
+    }
+
+    final String noMatchResponseBody = "oranges";
+
+    if (noMatchHandler) {
+      matcher.noMatch(req -> req.response().end(noMatchResponseBody));
+    }
+
+    server.requestHandler(matcher).listen(8080, "localhost", onSuccess(s -> {
+      Handler<HttpClientResponse> respHandler = resp -> {
+        if (shouldPass) {
+          assertEquals(200, resp.statusCode());
+          testComplete();
+        } else if (noMatchHandler) {
+          assertEquals(200, resp.statusCode());
+          resp.bodyHandler(body -> {
+            assertEquals(noMatchResponseBody, body.toString());
+            testComplete();
+          });
+        } else {
+          assertEquals(404, resp.statusCode());
+          testComplete();
+        }
+      };
+
+      final HttpClientRequest req;
+
+      switch (method) {
+        case "GET":
+          req = client.get(uri, respHandler);
+          break;
+        case "PUT":
+          req = client.put(uri, respHandler);
+          break;
+        case "POST":
+          req = client.post(uri, respHandler);
+          break;
+        case "DELETE":
+          req = client.delete(uri, respHandler);
+          break;
+        case "OPTIONS":
+          req = client.options(uri, respHandler);
+          break;
+        case "HEAD":
+          req = client.head(uri, respHandler);
+          break;
+        case "TRACE":
+          req = client.trace(uri, respHandler);
+          break;
+        case "PATCH":
+          req = client.patch(uri, respHandler);
+          break;
+        case "CONNECT":
+          req = client.connect(uri, respHandler);
+          break;
+        default:
+          throw new IllegalArgumentException("Invalid method:" + method);
+      }
+
+      req.end();
+    }));
+
+    await();
+  }
+}

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/newtests/HttpTestBase.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/newtests/HttpTestBase.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2011-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package org.vertx.java.tests.newtests;
+
+import org.junit.After;
+import org.junit.Before;
+import org.vertx.java.core.AsyncResult;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.http.HttpClient;
+import org.vertx.java.core.http.HttpServer;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
+ */
+public class HttpTestBase extends VertxTestBase {
+  private static final int DEFAULT_HTTP_PORT = Integer.getInteger("vertx.http.port", 8080);
+
+  protected HttpServer server;
+  protected HttpClient client;
+  protected int port = DEFAULT_HTTP_PORT;
+
+  @Before
+  public void beforeHttpTestBase() throws Exception {
+    server = vertx.createHttpServer();
+    client = vertx.createHttpClient().setPort(port);
+  }
+
+  @After
+  public void afterHttpTestBase() throws Exception {
+    client.close();
+    CountDownLatch latch = new CountDownLatch(1);
+    server.close((asyncResult) -> {
+      latch.countDown();
+    });
+    assertTrue(latch.await(10, TimeUnit.SECONDS));
+  }
+
+  protected <T> Handler<AsyncResult<T>> onSuccess(Consumer<T> consumer) {
+    return result -> {
+      assertTrue(result.succeeded());
+      consumer.accept(result.result());
+    };
+  }
+
+  protected <T> Handler<AsyncResult<T>> onFailure(Consumer<T> consumer) {
+    return result -> {
+      assertFalse(result.succeeded());
+      consumer.accept(result.result());
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  protected <E> Handler<E> noOpHandler() {
+    return noOp;
+  }
+
+  private static final Handler noOp = e -> {
+  };
+}


### PR DESCRIPTION
So some route matcher tests fails if I don't add an async vertx.stop method. If I run it separately (mvn test -Dtest=...) then it's fine. So obviously we have tests effecting each other, which is no good. I didn't add the latch and calling async vertx.stop to VertxTestBase so you can take a look. It also seems adding this slows down the tests quite a bit, by ~30 seconds on my machine.
