### PR TITLE
Reply status on socket bridge

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/EventBusBridge.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/EventBusBridge.java
@@ -324,6 +324,19 @@ public class EventBusBridge implements Handler<SockJSSocket> {
     sock.write(new Buffer(envelope.encode()));
   }
 
+  /**
+    * Method too reply a status to the caller of the socket
+    *
+    * @param sock
+    * @param replyAddress
+    * @param status
+    */
+  private static void replyStatus(SockJSSocket sock, String replyAddress, String status) {
+    JsonObject body = new JsonObject().putString("status", status);
+    JsonObject envelope = new JsonObject().putString("address", replyAddress).putValue("body", body);
+    sock.write(new Buffer(envelope.encode()));
+  }
+
   private void doSendOrPub(final boolean send, final SockJSSocket sock, final String address,
                            final JsonObject message) {
     final Object body = message.getValue("body");
@@ -352,16 +365,19 @@ public class EventBusBridge implements Handler<SockJSSocket> {
                 // invalid session id
                 if (debug) {
                   log.debug("Inbound message for address " + address + " rejected because sessionID is not authorised");
+                  replyStatus(sock, replyAddress, "access_denied");
                 }
               }
             } else {
               log.error("Error in performing authorisation", res.cause());
+              replyStatus(sock, replyAddress, "auth_error");
             }
           });
         } else {
           // session id null
           if (debug) {
             log.debug("Inbound message for address " + address + " rejected because it requires auth and sessionID is missing");
+            replyStatus(sock, replyAddress, "auth_required");
           }
         }
       } else {
@@ -371,6 +387,7 @@ public class EventBusBridge implements Handler<SockJSSocket> {
       // inbound match failed
       if (debug) {
         log.debug("Inbound message for address " + address + " rejected because there is no match");
+        replyStatus(sock, replyAddress, "access_denied");
       }
     }
   }


### PR DESCRIPTION
Hi,

As I said in a previous PR, congratulation for your nice work, I enjoy your application !
This is a up to date of this feature from master the previous was from branch.2.0.x.

This pull pull request concern only the bridge socket. As far as I understand it, if a person is not authenticated or allow to access to a eventbus address, the message is juste ignore and lost. The client doesn't even know that it request need an authentication. For my understanding, I think It would be interesting to send that information :
- access_denied : when the user is authenticated but not allow
- auth_required : when the user is not authenticated
- auth_error : when we are enable to get user authentication information
- This a suggestion of implementation because I really don't know if the I reply is a good or the best way.

Best regards,
Maneau
