### PR TITLE
Simplify Message reply methods

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/eventbus/EventBus.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/eventbus/EventBus.java
@@ -62,7 +62,7 @@ public interface EventBus {
    * @param address The address to send it to
    * @param message The message
    */
-  <T> EventBus send(String address, T message);
+  EventBus send(String address, Object message);
 
   /**
    * Send a message
@@ -70,7 +70,7 @@ public interface EventBus {
    * @param message The message
    * @param replyHandler Reply handler will be called when any reply from the recipient is received
    */
-  <T, R> EventBus send(String address, T message, Handler<Message<R>> replyHandler);
+  <T> EventBus send(String address, Object message, Handler<Message<T>> replyHandler);
 
   /**
    * Send an object as a message
@@ -79,14 +79,14 @@ public interface EventBus {
    * @param timeout - Timeout in ms. If no reply received within the timeout then the reply handler will be unregistered
    * @param replyHandler Reply handler will be called when any reply from the recipient is received
    */
-  <T, R> EventBus sendWithTimeout(String address, T message, long timeout, Handler<AsyncResult<Message<R>>> replyHandler);
+  <T> EventBus sendWithTimeout(String address, Object message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
 
   /**
    * Publish a message
    * @param address The address to publish it to
    * @param message The message
    */
-  <T> EventBus publish(String address, T message);
+  EventBus publish(String address, Object message);
 
   /**
    * Registers a handler against the specified address

--- a/vertx-core/src/main/java/org/vertx/java/core/eventbus/Message.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/eventbus/Message.java
@@ -18,9 +18,6 @@ package org.vertx.java.core.eventbus;
 
 import org.vertx.java.core.AsyncResult;
 import org.vertx.java.core.Handler;
-import org.vertx.java.core.buffer.Buffer;
-import org.vertx.java.core.json.JsonArray;
-import org.vertx.java.core.json.JsonObject;
 
 /**
  * Represents a message on the event bus.<p>
@@ -47,7 +44,7 @@ public interface Message<T> {
   String replyAddress();
 
   /**
-   * Same as {@code reply(T message)} but with an empty body
+   * Same as {@code reply(Object message)} but with a null body
    */
   void reply();
 
@@ -59,242 +56,26 @@ public interface Message<T> {
   void reply(Object message);
 
   /**
-   * Reply to this message. If the message was sent specifying a reply handler, that handler will be
-   * called when it has received a reply. If the message wasn't sent specifying a receipt handler
-   * this method does nothing.
-   */
-  void reply(JsonObject message);
-
-  /**
-   * Reply to this message. If the message was sent specifying a reply handler, that handler will be
-   * called when it has received a reply. If the message wasn't sent specifying a receipt handler
-   * this method does nothing.
-   */
-  void reply(JsonArray message);
-
-  /**
-   * Reply to this message. If the message was sent specifying a reply handler, that handler will be
-   * called when it has received a reply. If the message wasn't sent specifying a receipt handler
-   * this method does nothing.
-   */
-  void reply(String message);
-
-  /**
-   * Reply to this message. If the message was sent specifying a reply handler, that handler will be
-   * called when it has received a reply. If the message wasn't sent specifying a receipt handler
-   * this method does nothing.
-   */
-  void reply(Buffer message);
-
-  /**
-   * Reply to this message. If the message was sent specifying a reply handler, that handler will be
-   * called when it has received a reply. If the message wasn't sent specifying a receipt handler
-   * this method does nothing.
-   */
-  void reply(byte[] message);
-
-  /**
-   * Reply to this message. If the message was sent specifying a reply handler, that handler will be
-   * called when it has received a reply. If the message wasn't sent specifying a receipt handler
-   * this method does nothing.
-   */
-  void reply(Integer message);
-
-  /**
-   * Reply to this message. If the message was sent specifying a reply handler, that handler will be
-   * called when it has received a reply. If the message wasn't sent specifying a receipt handler
-   * this method does nothing.
-   */
-  void reply(Long message);
-
-  /**
-   * Reply to this message. If the message was sent specifying a reply handler, that handler will be
-   * called when it has received a reply. If the message wasn't sent specifying a receipt handler
-   * this method does nothing.
-   */
-  void reply(Short message);
-
-  /**
-   * Reply to this message. If the message was sent specifying a reply handler, that handler will be
-   * called when it has received a reply. If the message wasn't sent specifying a receipt handler
-   * this method does nothing.
-   */
-  void reply(Character message);
-
-  /**
-   * Reply to this message. If the message was sent specifying a reply handler, that handler will be
-   * called when it has received a reply. If the message wasn't sent specifying a receipt handler
-   * this method does nothing.
-   */
-  void reply(Boolean message);
-
-  /**
-   * Reply to this message. If the message was sent specifying a reply handler, that handler will be
-   * called when it has received a reply. If the message wasn't sent specifying a receipt handler
-   * this method does nothing.
-   */
-  void reply(Float message);
-
-  /**
-   * Reply to this message. If the message was sent specifying a reply handler, that handler will be
-   * called when it has received a reply. If the message wasn't sent specifying a receipt handler
-   * this method does nothing.
-   */
-  void reply(Double message);
-
-  /**
    * The same as {@code reply()} but you can specify handler for the reply - i.e.
    * to receive the reply to the reply.
    */
-  <T> void reply(Handler<Message<T>> replyHandler);
+  <R> void reply(Handler<Message<R>> replyHandler);
 
   /**
    * Reply to this message. Specifying a timeout and a reply handler
    */
-  <T> void replyWithTimeout(long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
+  <R> void replyWithTimeout(long timeout, Handler<AsyncResult<Message<R>>> replyHandler);
 
   /**
-   * The same as {@code reply(JsonObject message)} but you can specify handler for the reply - i.e.
+   * The same as {@code reply(R message)} but you can specify handler for the reply - i.e.
    * to receive the reply to the reply.
    */
-  <T> void reply(Object message, Handler<Message<T>> replyHandler);
+  <R> void reply(Object message, Handler<Message<R>> replyHandler);
 
   /**
    * Reply to this message. Specifying a timeout and a reply handler
    */
-  <T> void replyWithTimeout(Object message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
-
-  /**
-   * The same as {@code reply(JsonObject message)} but you can specify handler for the reply - i.e.
-   * to receive the reply to the reply.
-   */
-  <T> void reply(JsonObject message, Handler<Message<T>> replyHandler);
-
-  /**
-   * Reply to this message. Specifying a timeout and a reply handler
-   */
-  <T> void replyWithTimeout(JsonObject message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
-
-  /**
-   * The same as {@code reply(JsonArray message)} but you can specify handler for the reply - i.e.
-   * to receive the reply to the reply.
-   */
-  <T> void reply(JsonArray message, Handler<Message<T>> replyHandler);
-
-  /**
-   * Reply to this message. Specifying a timeout and a reply handler
-   */
-  <T> void replyWithTimeout(JsonArray message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
-
-  /**
-   * The same as {@code reply(String message)} but you can specify handler for the reply - i.e.
-   * to receive the reply to the reply.
-   */
-  <T> void reply(String message, Handler<Message<T>> replyHandler);
-
-  /**
-   * Reply to this message. Specifying a timeout and a reply handler
-   */
-  <T> void replyWithTimeout(String message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
-
-  /**
-   * The same as {@code reply(Buffer message)} but you can specify handler for the reply - i.e.
-   * to receive the reply to the reply.
-   */
-  <T> void reply(Buffer message, Handler<Message<T>> replyHandler);
-
-  /**
-   * Reply to this message. Specifying a timeout and a reply handler
-   */
-  <T> void replyWithTimeout(Buffer message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
-
-  /**
-   * The same as {@code reply(byte[] message)} but you can specify handler for the reply - i.e.
-   * to receive the reply to the reply.
-   */
-  <T> void reply(byte[] message, Handler<Message<T>> replyHandler);
-
-  /**
-   * Reply to this message. Specifying a timeout and a reply handler
-   */
-  <T> void replyWithTimeout(byte[] message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
-
-  /**
-   * The same as {@code reply(Integer message)} but you can specify handler for the reply - i.e.
-   * to receive the reply to the reply.
-   */
-  <T> void reply(Integer message, Handler<Message<T>> replyHandler);
-
-  /**
-   * Reply to this message. Specifying a timeout and a reply handler
-   */
-  <T> void replyWithTimeout(Integer message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
-
-  /**
-   * The same as {@code reply(Long message)} but you can specify handler for the reply - i.e.
-   * to receive the reply to the reply.
-   */
-  <T> void reply(Long message, Handler<Message<T>> replyHandler);
-
-  /**
-   * Reply to this message. Specifying a timeout and a reply handler
-   */
-  <T> void replyWithTimeout(Long message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
-
-  /**
-   * The same as {@code reply(Short message)} but you can specify handler for the reply - i.e.
-   * to receive the reply to the reply.
-   */
-  <T> void reply(Short message, Handler<Message<T>> replyHandler);
-
-  /**
-   * Reply to this message. Specifying a timeout and a reply handler
-   */
-  <T> void replyWithTimeout(Short message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
-
-  /**
-   * The same as {@code reply(Character message)} but you can specify handler for the reply - i.e.
-   * to receive the reply to the reply.
-   */
-  <T> void reply(Character message, Handler<Message<T>> replyHandler);
-
-  /**
-   * Reply to this message. Specifying a timeout and a reply handler
-   */
-  <T> void replyWithTimeout(Character message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
-
-  /**
-   * The same as {@code reply(Boolean message)} but you can specify handler for the reply - i.e.
-   * to receive the reply to the reply.
-   */
-  <T> void reply(Boolean message, Handler<Message<T>> replyHandler);
-
-  /**
-   * Reply to this message. Specifying a timeout and a reply handler
-   */
-  <T> void replyWithTimeout(Boolean message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
-
-  /**
-   * The same as {@code reply(Float message)} but you can specify handler for the reply - i.e.
-   * to receive the reply to the reply.
-   */
-  <T> void reply(Float message, Handler<Message<T>> replyHandler);
-
-  /**
-   * Reply to this message. Specifying a timeout and a reply handler
-   */
-  <T> void replyWithTimeout(Float message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
-
-  /**
-   * The same as {@code reply(Double message)} but you can specify handler for the reply - i.e.
-   * to receive the reply to the reply.
-   */
-  <T> void reply(Double message, Handler<Message<T>> replyHandler);
-
-  /**
-   * Reply to this message. Specifying a timeout and a reply handler
-   */
-  <T> void replyWithTimeout(Double message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler);
+  <R> void replyWithTimeout(Object message, long timeout, Handler<AsyncResult<Message<R>>> replyHandler);
 
   /**
    * Signal that processing of this message failed. If the message was sent specifying a result handler

--- a/vertx-core/src/main/java/org/vertx/java/core/eventbus/impl/BaseMessage.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/eventbus/impl/BaseMessage.java
@@ -23,24 +23,22 @@ import org.vertx.java.core.buffer.Buffer;
 import org.vertx.java.core.eventbus.Message;
 import org.vertx.java.core.eventbus.ReplyException;
 import org.vertx.java.core.eventbus.ReplyFailure;
-import org.vertx.java.core.json.JsonArray;
-import org.vertx.java.core.json.JsonObject;
 import org.vertx.java.core.net.NetSocket;
 import org.vertx.java.core.net.impl.ServerID;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public abstract class BaseMessage<U> implements Message<U> {
+public abstract class BaseMessage<T> implements Message<T> {
 
-  protected U body;
+  protected T body;
   protected ServerID sender;
   protected EventBusImpl bus;
   protected String address;
   protected String replyAddress;
   protected boolean send; // Is it a send or a publish?
 
-  protected BaseMessage(boolean send, String address, U body) {
+  protected BaseMessage(boolean send, String address, T body) {
     this.send = send;
     this.body = body;
     this.address = address;
@@ -52,7 +50,7 @@ public abstract class BaseMessage<U> implements Message<U> {
   }
 
   @Override
-  public U body() {
+  public T body() {
     return body;
   }
 
@@ -72,203 +70,23 @@ public abstract class BaseMessage<U> implements Message<U> {
   }
 
   @Override
-  public void reply(JsonObject message) {
-    reply(message, null);
-  }
-
-  @Override
-  public void reply(JsonArray message) {
-    reply(message, null);
-  }
-
-  @Override
-  public void reply(String message) {
-    reply(message, null);
-  }
-
-  @Override
-  public void reply(Buffer message) {
-    reply(message, null);
-  }
-
-  @Override
-  public void reply(byte[] message) {
-    reply(message, null);
-  }
-
-  @Override
-  public void reply(Integer message) {
-    reply(message, null);
-  }
-
-  @Override
-  public void reply(Long message) {
-    reply(message, null);
-  }
-
-  @Override
-  public void reply(Short message) {
-    reply(message, null);
-  }
-
-  @Override
-  public void reply(Character message) {
-    reply(message, null);
-  }
-
-  @Override
-  public void reply(Boolean message) {
-    reply(message, null);
-  }
-
-  @Override
-  public void reply(Float message) {
-    reply(message, null);
-  }
-
-  @Override
-  public void reply(Double message) {
-    reply(message, null);
-  }
-
-  @Override
-  public <T> void reply(Handler<Message<T>> replyHandler) {
+  public <R> void reply(Handler<Message<R>> replyHandler) {
     sendReply(EventBusImpl.createMessage(true, replyAddress, null), replyHandler);
   }
 
   @Override
-  public <T> void replyWithTimeout(long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
+  public <R> void replyWithTimeout(long timeout, Handler<AsyncResult<Message<R>>> replyHandler) {
     sendReplyWithTimeout(EventBusImpl.createMessage(true, replyAddress, null), timeout, replyHandler);
   }
 
   @Override
-  public <T> void reply(Object message, Handler<Message<T>> replyHandler) {
+  public <R> void reply(Object message, Handler<Message<R>> replyHandler) {
     sendReply(EventBusImpl.createMessage(true, replyAddress, message), replyHandler);
   }
 
   @Override
-  public <T> void replyWithTimeout(Object message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
+  public <R> void replyWithTimeout(Object message, long timeout, Handler<AsyncResult<Message<R>>> replyHandler) {
     sendReplyWithTimeout(EventBusImpl.createMessage(true, replyAddress, message), timeout, replyHandler);
-  }
-
-  @Override
-  public <T> void reply(JsonObject message, Handler<Message<T>> replyHandler) {
-    sendReply(new JsonObjectMessage(true, replyAddress, message), replyHandler);
-  }
-
-  @Override
-  public <T> void replyWithTimeout(JsonObject message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
-    sendReplyWithTimeout(new JsonObjectMessage(true, replyAddress, message), timeout, replyHandler);
-  }
-
-  @Override
-  public <T> void reply(JsonArray message, Handler<Message<T>> replyHandler) {
-    sendReply(new JsonArrayMessage(true, replyAddress, message), replyHandler);
-  }
-
-  @Override
-  public <T> void replyWithTimeout(JsonArray message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
-    sendReplyWithTimeout(new JsonArrayMessage(true, replyAddress, message), timeout, replyHandler);
-  }
-
-  @Override
-  public <T> void reply(String message, Handler<Message<T>> replyHandler) {
-    sendReply(new StringMessage(true, replyAddress, message), replyHandler);
-  }
-
-  @Override
-  public <T> void replyWithTimeout(String message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
-    sendReplyWithTimeout(new StringMessage(true, replyAddress, message), timeout, replyHandler);
-  }
-
-  @Override
-  public <T> void reply(Buffer message, Handler<Message<T>> replyHandler) {
-    sendReply(new BufferMessage(true, replyAddress, message), replyHandler);
-  }
-
-  @Override
-  public <T> void replyWithTimeout(Buffer message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
-    sendReplyWithTimeout(new BufferMessage(true, replyAddress, message), timeout, replyHandler);
-  }
-
-  @Override
-  public <T> void reply(byte[] message, Handler<Message<T>> replyHandler) {
-    sendReply(new ByteArrayMessage(true, replyAddress, message),  replyHandler);
-  }
-
-  @Override
-  public <T> void replyWithTimeout(byte[] message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
-    sendReplyWithTimeout(new ByteArrayMessage(true, replyAddress, message), timeout, replyHandler);
-  }
-
-  @Override
-  public <T> void reply(Integer message, Handler<Message<T>> replyHandler) {
-    sendReply(new IntMessage(true, replyAddress, message), replyHandler);
-  }
-
-  @Override
-  public <T> void replyWithTimeout(Integer message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
-    sendReplyWithTimeout(new IntMessage(true, replyAddress, message), timeout, replyHandler);
-  }
-
-  @Override
-  public <T> void reply(Long message, Handler<Message<T>> replyHandler) {
-    sendReply(new LongMessage(true, replyAddress, message), replyHandler);
-  }
-
-  @Override
-  public <T> void replyWithTimeout(Long message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
-    sendReplyWithTimeout(new LongMessage(true, replyAddress, message), timeout, replyHandler);
-  }
-
-  @Override
-  public <T> void reply(Short message, Handler<Message<T>> replyHandler) {
-    sendReply(new ShortMessage(true, replyAddress, message), replyHandler);
-  }
-
-  @Override
-  public <T> void replyWithTimeout(Short message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
-    sendReplyWithTimeout(new ShortMessage(true, replyAddress, message), timeout, replyHandler);
-  }
-
-  @Override
-  public <T> void reply(Character message, Handler<Message<T>> replyHandler) {
-    sendReply(new CharacterMessage(true, replyAddress, message), replyHandler);
-  }
-
-  @Override
-  public <T> void replyWithTimeout(Character message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
-    sendReplyWithTimeout(new CharacterMessage(true, replyAddress, message), timeout, replyHandler);
-  }
-
-  @Override
-  public <T> void reply(Boolean message, Handler<Message<T>> replyHandler) {
-    sendReply(new BooleanMessage(true, replyAddress, message), replyHandler);
-  }
-
-  @Override
-  public <T> void replyWithTimeout(Boolean message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
-    sendReplyWithTimeout(new BooleanMessage(true, replyAddress, message), timeout, replyHandler);
-  }
-
-  @Override
-  public <T> void reply(Float message, Handler<Message<T>> replyHandler) {
-    sendReply(new FloatMessage(true, replyAddress, message), replyHandler);
-  }
-
-  @Override
-  public <T> void replyWithTimeout(Float message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
-    sendReplyWithTimeout(new FloatMessage(true, replyAddress, message), timeout, replyHandler);
-  }
-
-  @Override
-  public <T> void reply(Double message, Handler<Message<T>> replyHandler) {
-    sendReply(new DoubleMessage(true, replyAddress, message), replyHandler);
-  }
-
-  @Override
-  public <T> void replyWithTimeout(Double message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
-    sendReplyWithTimeout(new DoubleMessage(true, replyAddress, message), timeout, replyHandler);
   }
 
   @Override
@@ -335,7 +153,7 @@ public abstract class BaseMessage<U> implements Message<U> {
 
   protected abstract byte type();
 
-  protected abstract Message<U> copy();
+  protected abstract Message<T> copy();
 
   protected abstract void readBody(int pos, Buffer readBuff);
 

--- a/vertx-core/src/main/java/org/vertx/java/core/eventbus/impl/EventBusImpl.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/eventbus/impl/EventBusImpl.java
@@ -100,24 +100,24 @@ public class EventBusImpl implements EventBus {
   }
 
   @Override
-  public <T> EventBus send(String address, T message) {
+  public EventBus send(String address, Object message) {
     return send(address, message, null);
   }
 
   @Override
-  public <T, R> EventBus send(String address, T message, Handler<Message<R>> replyHandler) {
+  public <T> EventBus send(String address, Object message, Handler<Message<T>> replyHandler) {
     sendOrPub(createMessage(true, address, message), replyHandler);
     return this;
   }
 
   @Override
-  public <T, R> EventBus sendWithTimeout(String address, T message, long timeout, Handler<AsyncResult<Message<R>>> replyHandler) {
+  public <T> EventBus sendWithTimeout(String address, Object message, long timeout, Handler<AsyncResult<Message<T>>> replyHandler) {
     sendOrPubWithTimeout(createMessage(true, address, message), replyHandler, timeout);
     return this;
   }
 
   @Override
-  public <T> EventBus publish(String address, T message) {
+  public EventBus publish(String address, Object message) {
     sendOrPub(createMessage(false, address, message), null);
     return this;
   }


### PR DESCRIPTION
No need to use generics for the message on send, publish, and reply.
