### PR TITLE
Correctly close connection and trigger exception on malformed HTTP reque...

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/VertxHttpHandler.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/VertxHttpHandler.java
@@ -22,8 +22,10 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.websocketx.*;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
@@ -53,6 +55,13 @@ public abstract class VertxHttpHandler<C extends ConnectionBase> extends VertxHa
 
   @Override
   protected void channelRead(final C connection, final DefaultContext context, final ChannelHandlerContext chctx, final Object msg) throws Exception {
+    if (msg instanceof HttpObject) {
+        DecoderResult result = ((HttpObject) msg).getDecoderResult();
+        if (result.isFailure()) {
+            chctx.pipeline().fireExceptionCaught(result.cause());
+            return;
+        }
+    }
     if (connection != null) {
       // we are reading from the channel
       Channel ch = chctx.channel();

--- a/vertx-core/src/main/java/org/vertx/java/core/net/impl/VertxHandler.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/impl/VertxHandler.java
@@ -105,8 +105,7 @@ public abstract class VertxHandler<C extends ConnectionBase> extends ChannelDupl
         }
       });
     } else {
-      // Ignore - any exceptions before a channel exists will be passed manually via the failed(...) method
-      // Any exceptions after a channel is closed can be ignored
+      ch.close();
     }
   }
 

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/http/JavaHttpTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/http/JavaHttpTest.java
@@ -691,6 +691,11 @@ public class JavaHttpTest extends TestBase {
     startTest(getMethodName());
   }
 
+  @Test
+  public void testRequestHandlerNotCalledInvalidRequest() {
+    startTest(getMethodName());
+  }
+
   void sharedServers(String testName, boolean multipleInstances, int numInstances, int initialServers, int initialToStop) throws Exception {
 
     //We initially start then stop them to make sure the shared server cleanup code works ok


### PR DESCRIPTION
...st

Correctly handle malformated HTTP requests by trigger the exceptionHandler and close the Channel.

This is related to https://groups.google.com/forum/#!topic/vertx/0pwAPktltHg
