### PR TITLE
Support of MessageCodec for event bus serialization

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/EventBus.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/EventBus.java
@@ -105,6 +105,10 @@ public interface EventBus {
    */
   Registration registerLocalHandler(String address, Handler<? extends Message> handler);
 
+  <T> EventBus registerCodec(Class<T> type, MessageCodec<T> codec);
+
+  <T> EventBus unregisterCodec(Class<T> type);
+
   /**
    * Sets a default timeout, in ms, for replies. If a messages is sent specify a reply handler
    * but without specifying a timeout, then the reply handler is timed out, i.e. it is automatically unregistered

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/MessageCodec.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/MessageCodec.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2011-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.eventbus;
+
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
+ */
+public interface MessageCodec<T> {
+  Buffer encode(T object);
+
+  T decode(Buffer buffer);
+}

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageFactory.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageFactory.java
@@ -17,6 +17,9 @@
 package io.vertx.core.eventbus.impl;
 
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+
+import java.util.Map;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -37,9 +40,10 @@ public class MessageFactory {
   static final byte TYPE_STRING = 11;
   static final byte TYPE_JSON_OBJECT = 12;
   static final byte TYPE_JSON_ARRAY = 13;
+  static final byte TYPE_OBJECT = 14;
   static final byte TYPE_REPLY_FAILURE = 100;
 
-  static BaseMessage read(Buffer buff) {
+  static BaseMessage read(Buffer buff, Map<String, MessageCodec<?>> codecMap) {
     byte type = buff.getByte(0);
     switch (type) {
       case TYPE_PING:
@@ -70,6 +74,10 @@ public class MessageFactory {
         return new JsonObjectMessage(buff);
       case TYPE_JSON_ARRAY:
         return new JsonArrayMessage(buff);
+      case TYPE_OBJECT:
+        @SuppressWarnings("unchecked")
+        ObjectMessage<?> om = new ObjectMessage(buff, codecMap);
+        return om;
       case TYPE_REPLY_FAILURE:
         return new ReplyFailureMessage(buff);
       default:

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/ObjectMessage.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/ObjectMessage.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2011-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.eventbus.impl;
+
+import io.netty.util.CharsetUtil;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.core.shareddata.Shareable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
+ */
+public class ObjectMessage<T> extends BaseMessage<T> {
+
+  private String decodedType;
+  private MessageCodec<T> codec;
+  private boolean encoded;
+  private Buffer encodedData;
+
+  public ObjectMessage(boolean send, String address, T object, String decodedType, MessageCodec<T> codec) {
+    super(send, address, object);
+    this.decodedType = decodedType;
+    this.codec = codec;
+  }
+
+  public ObjectMessage(Buffer readBuff, Map<String, MessageCodec<T>> codecMap) {
+    super(readBuff, codecMap);
+  }
+
+  @Override
+  protected byte type() {
+    return MessageFactory.TYPE_OBJECT;
+  }
+
+  @Override
+  protected Message<T> copy() {
+    if (body instanceof Shareable) {
+      return this;
+    } else if (body instanceof Cloneable) {
+      Class<?> c = body.getClass();
+      try {
+        Method method = c.getMethod("clone");
+        @SuppressWarnings("unchecked")
+        T clone = (T) method.invoke(body);
+        return new ObjectMessage<>(send, address, clone, decodedType, codec);
+      } catch (NoSuchMethodException e) {
+        throw new IllegalArgumentException("No public clone() method for cloneable class " + c);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        throw new IllegalArgumentException("Could not invoke clone method for class " + c, e);
+      }
+    } else {
+      throw new IllegalArgumentException(body.getClass() + " does not implement Cloneable or Shareable.");
+    }
+  }
+
+  @Override
+  protected void readBody(int pos, Buffer readBuff) {
+    throw new UnsupportedOperationException("ObjectMessage does not support reading of body w/out codec map");
+  }
+
+  @Override
+  protected void readBody(int pos, Buffer readBuff, Map<String, MessageCodec<T>> codecMap) {
+    // decodedType
+    int decodedTypeLength = readBuff.getInt(pos);
+    pos += 4;
+    if (decodedTypeLength > 0) {
+      byte[] bytes = readBuff.getBytes(pos, pos + decodedTypeLength);
+      pos += decodedTypeLength;
+      decodedType = new String(bytes, CharsetUtil.UTF_8);
+    } else {
+      throw new IllegalArgumentException("Could not parse decoded type from buffer");
+    }
+
+    codec = codecMap.get(decodedType);
+    if (codec == null) {
+      throw new RuntimeException("Unable to retrieve message codec for type " + decodedType);
+    }
+
+    boolean isNull = readBuff.getByte(pos) == (byte) 0;
+    if (!isNull) {
+      pos++;
+      int buffLength = readBuff.getInt(pos);
+      pos += 4;
+      byte[] bytes = readBuff.getBytes(pos, pos + buffLength);
+      encodedData = new Buffer(bytes);
+      encoded = true;
+    }
+    body = codec.decode(encodedData);
+  }
+
+  @Override
+  protected void writeBody(Buffer buff) {
+    writeString(buff, decodedType);
+
+    encode();
+    if (encodedData == null) {
+      buff.appendByte((byte) 0);
+    } else {
+      buff.appendByte((byte) 1);
+      buff.appendInt(encodedData.length());
+      buff.appendBuffer(encodedData);
+    }
+  }
+
+  @Override
+  protected int getBodyLength() {
+    encode();
+    return 1 + (encodedData == null ? 0 : 4 + encodedData.length());
+  }
+
+  private Buffer encode() {
+    if (!encoded) {
+      encodedData = codec.encode(body);
+      encoded = true;
+    }
+
+    return encodedData;
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/test/core/ClusteredEventBusTest.java
+++ b/vertx-core/src/test/java/io/vertx/test/core/ClusteredEventBusTest.java
@@ -68,6 +68,8 @@ public class ClusteredEventBusTest extends EventBusTestBase {
   @Override
   protected <T> void testSend(T val, Consumer<T> consumer) {
     startNodes(2);
+    registerCodecs();
+
     Registration reg = vertices[1].eventBus().registerHandler(ADDRESS1, (Message<T> msg) -> {
       if (consumer == null) {
         assertEquals(val, msg.body());
@@ -86,6 +88,7 @@ public class ClusteredEventBusTest extends EventBusTestBase {
   @Override
   protected <T> void testReply(T val, Consumer<T> consumer) {
     startNodes(2);
+    registerCodecs();
     String str = TestUtils.randomUnicodeString(1000);
     Registration reg = vertices[1].eventBus().registerHandler(ADDRESS1, msg -> {
       assertEquals(str, msg.body());
@@ -110,6 +113,8 @@ public class ClusteredEventBusTest extends EventBusTestBase {
   protected <T> void testPublish(T val, Consumer<T> consumer) {
     int numNodes = 3;
     startNodes(numNodes);
+    registerCodecs();
+
     AtomicInteger count = new AtomicInteger();
     class MyHandler implements Handler<Message<T>> {
       @Override
@@ -169,6 +174,12 @@ public class ClusteredEventBusTest extends EventBusTestBase {
       assertTrue(latch.await(30, TimeUnit.SECONDS));
     } catch (InterruptedException e) {
       fail(e.getMessage());
+    }
+  }
+
+  private void registerCodecs() {
+    for (Vertx vertx : vertices) {
+      registerCodecs(vertx.eventBus());
     }
   }
 


### PR DESCRIPTION
2nd pass at message codec. I still don't like how we are mapping type to codec. We could map which codec was used, and ask each codec if it should encode, but I think this is better with a proper interceptor approach.
