### PR TITLE
Bug 439057 - FatJarStarter is assuming the fat Jar url is always at firs...

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/FatJarStarter.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/FatJarStarter.java
@@ -69,7 +69,8 @@ public class FatJarStarter implements Runnable {
   private void go(String[] args) throws Exception {
     URLClassLoader urlc = (URLClassLoader)FatJarStarter.class.getClassLoader();
 
-    String fileName = urlc.getURLs()[0].getFile();
+    final int totalUrlsCount = urlc.getURLs().length;
+    String fileName = urlc.getURLs()[totalUrlsCount-1].getFile();
 
     // Look for -cp or -classpath parameter
     String classpath = null;


### PR DESCRIPTION
...t location. If fat jar is launched with service wrapper like YAJSW, the process will fail.
