### PR TITLE
Use FQCN for logging when possible, fix JUL logger to pick correct source class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
     <netty.version>4.0.21.Final</netty.version>
     <jackson.version>2.2.2</jackson.version>
     <hazelcast.version>3.2.1</hazelcast.version>
-    <log4j.version>1.2.16</log4j.version>
-    <slf4j.version>1.6.2</slf4j.version>
+    <log4j.version>1.2.17</log4j.version>
+    <slf4j.version>1.7.7</slf4j.version>
     <junit.version>4.11</junit.version>
     <apacheds-protocol-dns.version>1.5.7</apacheds-protocol-dns.version>
   </properties>
@@ -169,7 +169,7 @@
                 <exclude>**/HazelcastClusteredEventbusTest.java</exclude>
               </excludes>
             <systemPropertyVariables>
-              <java.util.logging.SimpleFormatter.format>%4$s: %2$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+              <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
             </systemPropertyVariables>
           </configuration>
         </plugin>

--- a/vertx-core/src/main/java/io/vertx/core/logging/impl/JULLogDelegate.java
+++ b/vertx-core/src/main/java/io/vertx/core/logging/impl/JULLogDelegate.java
@@ -16,7 +16,10 @@
 
 package io.vertx.core.logging.impl;
 
+import io.vertx.core.logging.Logger;
+
 import java.util.logging.Level;
+import java.util.logging.LogRecord;
 
 /**
  * A {@link LogDelegate} which delegates to java.util.logging
@@ -24,6 +27,8 @@ import java.util.logging.Level;
  * @author <a href="kenny.macleod@kizoom.com">Kenny MacLeod</a>
  */
 public class JULLogDelegate implements LogDelegate {
+  private static final String FQCN = Logger.class.getCanonicalName();
+
   private final java.util.logging.Logger logger;
 
   JULLogDelegate(final String name) {
@@ -43,51 +48,82 @@ public class JULLogDelegate implements LogDelegate {
   }
 
   public void fatal(final Object message) {
-    logger.log(Level.SEVERE, message == null ? "NULL" : message.toString());
+    log(Level.SEVERE, message);
   }
 
   public void fatal(final Object message, final Throwable t) {
-    logger.log(Level.SEVERE, message == null ? "NULL" : message.toString(), t);
+    log(Level.SEVERE, message, t);
   }
 
   public void error(final Object message) {
-    logger.log(Level.SEVERE, message == null ? "NULL" : message.toString());
+    log(Level.SEVERE, message);
   }
 
   public void error(final Object message, final Throwable t) {
-    logger.log(Level.SEVERE, message == null ? "NULL" : message.toString(), t);
+    log(Level.SEVERE, message, t);
   }
 
   public void warn(final Object message) {
-    logger.log(Level.WARNING, message == null ? "NULL" : message.toString());
+    log(Level.WARNING, message);
   }
 
   public void warn(final Object message, final Throwable t) {
-    logger.log(Level.WARNING, message == null ? "NULL" : message.toString(), t);
+    log(Level.WARNING, message, t);
   }
 
   public void info(final Object message) {
-    logger.log(Level.INFO, message == null ? "NULL" : message.toString());
+    log(Level.INFO, message);
   }
 
   public void info(final Object message, final Throwable t) {
-    logger.log(Level.INFO, message == null ? "NULL" : message.toString(), t);
+    log(Level.INFO, message, t);
   }
 
   public void debug(final Object message) {
-    logger.log(Level.FINE, message == null ? "NULL" : message.toString());
+    log(Level.FINE, message);
   }
 
   public void debug(final Object message, final Throwable t) {
-    logger.log(Level.FINE, message == null ? "NULL" : message.toString(), t);
+    log(Level.FINE, message, t);
   }
 
   public void trace(final Object message) {
-    logger.log(Level.FINEST, message == null ? "NULL" : message.toString());
+    log(Level.FINEST, message);
   }
 
   public void trace(final Object message, final Throwable t) {
-    logger.log(Level.FINEST, message == null ? "NULL" : message.toString(), t);
+    log(Level.FINEST, message, t);
   }
 
+  private void log(Level level, Object message) {
+    log(level, message, null);
+  }
+
+  private void log(Level level, Object message, Throwable t) {
+    if (!logger.isLoggable(level)) {
+      return;
+    }
+    String msg = (message == null) ? "NULL" : message.toString();
+    LogRecord record = new LogRecord(level, msg);
+    record.setLoggerName(logger.getName());
+    record.setThrown(t);
+    // Find FQCN of calling class
+    boolean found = false;
+    for (StackTraceElement ste : new Throwable().getStackTrace()) {
+      if (FQCN.equals(ste.getClassName())) {
+        found = true;
+      } else if (found && !FQCN.equals(ste.getClassName())) {
+        record.setSourceClassName(ste.getClassName());
+        record.setSourceMethodName(ste.getMethodName());
+        break;
+      }
+    }
+    // If not found, set it to null, which will default to use logger name. Otherwise it will be incorrect and
+    // use this class.
+    if (!found) {
+      record.setSourceClassName(null);
+    }
+
+    logger.log(record);
+  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/logging/impl/Log4jLogDelegate.java
+++ b/vertx-core/src/main/java/io/vertx/core/logging/impl/Log4jLogDelegate.java
@@ -16,12 +16,17 @@
 
 package io.vertx.core.logging.impl;
 
+import io.vertx.core.logging.Logger;
+import org.apache.log4j.Level;
+
 /**
  * A {@link LogDelegate} which delegates to Apache Log4j
  *
  * @author <a href="kenny.macleod@kizoom.com">Kenny MacLeod</a>
  */
 public class Log4jLogDelegate implements LogDelegate {
+  private static final String FQCN = Logger.class.getCanonicalName();
+
   private final org.apache.log4j.Logger logger;
 
   Log4jLogDelegate(final String name) {
@@ -41,51 +46,58 @@ public class Log4jLogDelegate implements LogDelegate {
   }
 
   public void fatal(final Object message) {
-    logger.fatal(message);
+    log(Level.FATAL, message);
   }
 
   public void fatal(final Object message, final Throwable t) {
-    logger.fatal(message, t);
+    log(Level.FATAL, message, t);
   }
 
   public void error(final Object message) {
-    logger.error(message);
+    log(Level.ERROR, message);
   }
 
   public void error(final Object message, final Throwable t) {
-    logger.error(message, t);
+    log(Level.ERROR, message, t);
   }
 
   public void warn(final Object message) {
-    logger.warn(message);
+    log(Level.WARN, message);
   }
 
   public void warn(final Object message, final Throwable t) {
-    logger.warn(message, t);
+    log(Level.WARN, message, t);
   }
 
   public void info(final Object message) {
-    logger.info(message);
+    log(Level.INFO, message);
   }
 
   public void info(final Object message, final Throwable t) {
-    logger.info(message, t);
+    log(Level.INFO, message, t);
   }
 
   public void debug(final Object message) {
-    logger.debug(message);
+    log(Level.DEBUG, message);
   }
 
   public void debug(final Object message, final Throwable t) {
-    logger.debug(message, t);
+    log(Level.DEBUG, message, t);
   }
 
   public void trace(final Object message) {
-    logger.trace(message);
+    log(Level.TRACE, message);
   }
 
   public void trace(final Object message, final Throwable t) {
-    logger.trace(message, t);
+    log(Level.TRACE, message, t);
   }
 
+  private void log(Level level, Object message) {
+    log(level, message, null);
+  }
+
+  private void log(Level level, Object message, Throwable t) {
+    logger.log(FQCN, level, message, t);
+  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/logging/impl/SLF4JLogDelegate.java
+++ b/vertx-core/src/main/java/io/vertx/core/logging/impl/SLF4JLogDelegate.java
@@ -19,11 +19,15 @@ package io.vertx.core.logging.impl;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.spi.LocationAwareLogger;
+
+import static org.slf4j.spi.LocationAwareLogger.*;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class SLF4JLogDelegate implements LogDelegate{
+  private static final String FQCN = io.vertx.core.logging.Logger.class.getCanonicalName();
 
   private final Logger logger;
 
@@ -44,50 +48,83 @@ public class SLF4JLogDelegate implements LogDelegate{
   }
 
   public void fatal(final Object message) {
-    logger.error(message.toString());
+    log(ERROR_INT, message);
   }
 
   public void fatal(final Object message, final Throwable t) {
-    logger.error(message.toString(), t);
+    log(ERROR_INT, message, t);
   }
 
   public void error(final Object message) {
-    logger.error(message.toString());
+    log(ERROR_INT, message);
   }
 
   public void error(final Object message, final Throwable t) {
-    logger.error(message.toString(), t);
+    log(ERROR_INT, message, t);
   }
 
   public void warn(final Object message) {
-    logger.warn(message.toString());
+    log(WARN_INT, message);
   }
 
   public void warn(final Object message, final Throwable t) {
-    logger.warn(message.toString(), t);
+    log(WARN_INT, message, t);
   }
 
   public void info(final Object message) {
-    logger.info(message.toString());
+    log(INFO_INT, message);
   }
 
   public void info(final Object message, final Throwable t) {
-    logger.info(message.toString(), t);
+    log(INFO_INT, message, t);
   }
 
   public void debug(final Object message) {
-    logger.debug(message.toString());
+    log(DEBUG_INT, message);
   }
 
   public void debug(final Object message, final Throwable t) {
-    logger.debug(message.toString(), t);
+    log(DEBUG_INT, message, t);
   }
 
   public void trace(final Object message) {
-    logger.trace(message.toString());
+    log(TRACE_INT, message);
   }
 
   public void trace(final Object message, final Throwable t) {
-    logger.trace(message.toString(), t);
+    log(TRACE_INT, message, t);
+  }
+
+  private void log(int level, Object message) {
+    log(level, message, null);
+  }
+
+  private void log(int level, Object message, Throwable t) {
+    String msg = (message == null) ? "NULL" : message.toString();
+
+    if (logger instanceof LocationAwareLogger) {
+      LocationAwareLogger l = (LocationAwareLogger) logger;
+      l.log(null, FQCN, level, msg, null, t);
+    } else {
+      switch (level) {
+        case TRACE_INT:
+          logger.trace(msg, t);
+          break;
+        case DEBUG_INT:
+          logger.debug(msg, t);
+          break;
+        case INFO_INT:
+          logger.info(msg, t);
+          break;
+        case WARN_INT:
+          logger.warn(msg, t);
+          break;
+        case ERROR_INT:
+          logger.error(msg, t);
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown log level " + level);
+      }
+    }
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -17,6 +17,7 @@
 package io.vertx.core.net.impl;
 
 import io.netty.handler.ssl.SslHandler;
+import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.impl.PathAdjuster;
 import io.vertx.core.http.HttpClientOptions;
@@ -144,9 +145,7 @@ public class SSLHelper {
       context.init(keyMgrs, trustMgrs, new SecureRandom());
       return context;
     } catch (Exception e) {
-      //TODO better logging
-      log.error("Failed to create context", e);
-      throw new RuntimeException(e.getMessage());
+      throw new VertxException(e);
     }
   }
 

--- a/vertx-core/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/test/core/HttpTest.java
@@ -24,6 +24,7 @@ import io.vertx.core.Context;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
+import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.Registration;
@@ -2472,8 +2473,9 @@ public class HttpTest extends HttpTestBase {
     try {
       server.listen();
       fail("Was expecting a failure");
-    } catch (RuntimeException e) {
-      assertEquals(expectedMessage, e.getMessage());
+    } catch (VertxException e) {
+      assertNotNull(e.getCause());
+      assertEquals(expectedMessage, e.getCause().getMessage());
     }
   }
 
@@ -2488,8 +2490,9 @@ public class HttpTest extends HttpTestBase {
     try {
       req.end();
       fail("Was expecting a failure");
-    } catch (Exception e) {
-      assertEquals("java.nio.file.NoSuchFileException: /invalid.pem", e.getMessage());
+    } catch (VertxException e) {
+      assertNotNull(e.getCause());
+      assertEquals("java.nio.file.NoSuchFileException: /invalid.pem", e.getCause().getMessage());
     }
   }
 


### PR DESCRIPTION
Not sure what we want ultimately for logging, but wanted to fix minor annoyance (especially when running tests) of JULLogDelegate always being displayed as source class. 

Just double check as I did this a little late.
