### PR TITLE
Added handling from Connection: close header in HttpClient

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClientRequest.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClientRequest.java
@@ -270,6 +270,10 @@ public class DefaultHttpClientRequest implements HttpClientRequest {
     }
   }
 
+  boolean hasExceptionOccurred() {
+      return exceptionOccurred;
+  }
+
   void handleResponse(DefaultHttpClientResponse resp) {
     // If an exception occurred (e.g. a timeout fired) we won't receive the response.
     if (!exceptionOccurred) {
@@ -332,6 +336,7 @@ public class DefaultHttpClientRequest implements HttpClientRequest {
             // The connection has been closed - closed connections can be in the pool
             // Get another connection - Note that we DO NOT call connectionClosed() on the pool at this point
             // that is done asynchronously in the connection closeHandler()
+            connecting = false;
             connect();
           }
         }

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/http/JavaHttpTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/http/JavaHttpTest.java
@@ -451,6 +451,31 @@ public class JavaHttpTest extends TestBase {
     startTest(getMethodName());
   }
 
+  public void testPoolingNoKeepAliveNoPipelining() throws Exception {
+    startApp(CountServer.class.getName());
+    startTest(getMethodName());
+  }
+
+  public void testPoolingNoPipeliningWithConnectionClosingServer() throws Exception {
+    startApp(ConnectionCloseCountServer.class.getName());
+    startTest(getMethodName());
+  }
+
+  public void testPoolingWithConnectionClosingServer() throws Exception {
+    startApp(ConnectionCloseCountServer.class.getName());
+    startTest(getMethodName());
+  }
+
+  public void testPoolingNoPipeliningWithClosingServer() throws Exception {
+    startApp(ClosingServer.class.getName());
+    startTest(getMethodName());
+  }
+
+  public void testPoolingWithClosingServer() throws Exception {
+    startApp(ClosingServer.class.getName());
+    startTest(getMethodName());
+  }
+
   public void testConnectionErrorsGetReportedToRequest() {
     startTest(getMethodName());
   }

--- a/vertx-testsuite/src/test/java/vertx/tests/core/http/ConnectionCloseCountServer.java
+++ b/vertx-testsuite/src/test/java/vertx/tests/core/http/ConnectionCloseCountServer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package vertx.tests.core.http;
+
+import org.vertx.java.core.AsyncResult;
+import org.vertx.java.core.AsyncResultHandler;
+import org.vertx.java.core.Future;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.http.HttpServer;
+import org.vertx.java.core.http.HttpServerRequest;
+import org.vertx.java.platform.Verticle;
+import org.vertx.java.testframework.TestUtils;
+
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public class ConnectionCloseCountServer extends Verticle {
+
+  protected TestUtils tu;
+
+  private HttpServer server;
+
+  public void start(final Future<Void> startedResult) {
+    tu = new TestUtils(vertx);
+
+    server = vertx.createHttpServer().requestHandler(new Handler<HttpServerRequest>() {
+      public void handle(final HttpServerRequest req) {
+        tu.checkThread();
+        String cnt = req.headers().get("count");
+        req.response().headers().set("count", cnt);
+        req.response().headers().set("Connection", "close");
+        req.response().end();
+        req.response().close();
+      }
+    });
+    server.listen(8080, new AsyncResultHandler<HttpServer>() {
+      @Override
+      public void handle(AsyncResult<HttpServer> ar) {
+        tu.azzert(ar.succeeded());
+        tu.appReady();
+        startedResult.setResult(null);
+      }
+    });
+  }
+
+  public void stop() {
+    server.close(new AsyncResultHandler<Void>() {
+      public void handle(AsyncResult<Void> result) {
+        tu.checkThread();
+        tu.appStopped();
+      }
+    });
+  }
+
+}


### PR DESCRIPTION
This PR is a super set of https://github.com/eclipse/vert.x/pull/875

This adds handling of the 'Connection: close' header that can be returned by a server that wishes for an HTTP/1.1 connection to be treated as non-persistent.  In that case the http client should not reuse the connection for subsequent requests and should remove it from the pool.

In addition handling was added for cases where the server closes the connection, without issuing a Connection: close header, that would inform the HttpClientRequests exception handler that the connection was closed.  This only happens if a request timeout exception hasn't already occurred and gives the caller a better chance to handle these cases gracefully.  Although the correct behavior for pipelining according to the RFC is to resend requests on the closed connection it would be a much larger change as the DefaultHttpClientRequest class would need the ability to retain and reset some of it's state.  Since that seemed a little too invasive at this point it seemed like the next best solution would be to give the caller the opportunity to decided to resend rather than simply treating this as a request timeout.

Finally, because of the new connection close handling and associated exception when there are pending requests, several tests needed to be updated so that the server side of the test properly ended the response.  The tests wouldn't fail but would print the ClosedChannelException to stdout when running tests.
