### PR TITLE
fixed connection hanging bug for unidentified request methods

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/RouteMatcher.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/RouteMatcher.java
@@ -82,6 +82,8 @@ public class RouteMatcher implements Handler<HttpServerRequest> {
       case "CONNECT":
         route(request, connectBindings);
         break;
+      default:
+        notFound(request);
     }
   }
 
@@ -356,6 +358,10 @@ public class RouteMatcher implements Handler<HttpServerRequest> {
         return;
       }
     }
+    notFound(request);
+  }
+
+  private void notFound(HttpServerRequest request) {
     if (noMatchHandler != null) {
       noMatchHandler.handle(request);
     } else {


### PR DESCRIPTION
Signed-off-by: Burak Emre Kabakcı emrekabakci@gmail.com

If the request method is not one of the listed methods in switch statement connection hangs because RouteMatcher doesn't close it.
