### PR TITLE
Bug 441760 - Allow Enums to be added to and getBinary from JsonArray

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/json/JsonArray.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/json/JsonArray.java
@@ -93,6 +93,15 @@ public class JsonArray extends JsonElement implements Iterable<Object> {
     return this;
   }
 
+  public byte[] getBinary(int index) {
+    Object item = list.get(index);
+    if (item instanceof String) {
+      return org.vertx.java.core.json.impl.Base64.decode((String) item);
+    } else {
+      throw new VertxException("Object at index " + index + " was not stored as a binary.");
+    }
+  }
+
   public JsonArray add(Object value) {
     if (value == null) {
       list.add(null);
@@ -108,6 +117,8 @@ public class JsonArray extends JsonElement implements Iterable<Object> {
       addBoolean((Boolean)value);
     } else if (value instanceof byte[]) {
       addBinary((byte[])value);
+    } else if (value instanceof Enum) {
+      addString(value.toString());
     } else {
       throw new VertxException("Cannot add objects of class " + value.getClass() +" to JsonArray");
     }

--- a/vertx-testsuite/src/test/java/org/vertx/java/tests/core/json/JavaJsonTest.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/tests/core/json/JavaJsonTest.java
@@ -17,6 +17,7 @@
 package org.vertx.java.tests.core.json;
 
 import org.junit.Test;
+import org.vertx.java.core.VertxException;
 import org.vertx.java.core.json.JsonArray;
 import org.vertx.java.core.json.JsonElement;
 import org.vertx.java.core.json.JsonObject;
@@ -24,6 +25,7 @@ import org.vertx.java.core.logging.Logger;
 import org.vertx.java.core.logging.impl.LoggerFactory;
 import org.vertx.java.testframework.TestBase;
 
+import java.util.Date;
 import java.util.Iterator;
 
 /**
@@ -246,7 +248,43 @@ public class JavaJsonTest extends TestBase {
     
     assertEquals(objElement.getString("foo"), testElement.asObject().getString("foo"));
   }
-  
+
+  @Test
+  public void testAddObjectToJsonArray() {
+
+    JsonObject testObject = new JsonObject().putString("test", "ok");
+    JsonArray testArray = new JsonArray().addString("test");
+    Integer testInt = 1;
+    Long testLong = 2L;
+    Double testDouble = 3.0;
+    Boolean testBool = true;
+    byte[] testBytes = "test".getBytes();
+    String testString = "test";
+
+    assertEquals(testObject, new JsonArray().add(testObject).get(0));
+    assertEquals(testArray,  new JsonArray().add(testArray).get(0));
+    assertEquals(testInt,    new JsonArray().add(testInt).get(0));
+    assertEquals(testLong,   new JsonArray().add(testLong).get(0));
+    assertEquals(testDouble, new JsonArray().add(testDouble).get(0));
+    assertEquals(testBool,   new JsonArray().add(testBool).get(0));
+    assertEquals("test",     new String(new JsonArray().add(testBytes).getBinary(0)));
+    assertEquals(testString, new JsonArray().add(testString).get(0));
+    assertEquals(TestEnum.TEST.toString(), new JsonArray().add(TestEnum.TEST).get(0));
+  }
+
+  @Test
+  public void testAddInvalidObjectToJsonArray() {
+    try {
+      new JsonArray().add(new Date());
+    } catch (VertxException e) {
+      assertEquals("Cannot add objects of class " + Date.class + " to JsonArray", e.getMessage());
+    }
+  }
+
+  private enum TestEnum {
+    TEST
+  }
+
   @Test
   public void testRetrieveJsonElementFromJsonObject2(){
     JsonArray arrayElement = new JsonArray().addString("foo");


### PR DESCRIPTION
Fix for bug 441760 for 2.x branch:
After switching to from Vertx 2.0.2 to 2.1.2 it was not possible anymore to add an Enum value to the JsonArray.
Please add back support for adding an Enum value.

In a JsonArray, a byte[] is stored in a Base64 encoded way, but it is only possible to retrieve the value as a String. Application should not need knowledge on the internals of Vertx so please add a method to get a binary value from the JsonArray.
