### PR TITLE
Bug 441627 - Having spaces in fat jar path is failing to launch vertx module

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/FatJarStarter.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/FatJarStarter.java
@@ -70,7 +70,7 @@ public class FatJarStarter implements Runnable {
     URLClassLoader urlc = (URLClassLoader)FatJarStarter.class.getClassLoader();
 
     final int totalUrlsCount = urlc.getURLs().length;
-    String fileName = urlc.getURLs()[totalUrlsCount - 1].getFile();
+    String fileName = urlc.getURLs()[totalUrlsCount - 1].toURI().getPath();
 
     // Look for -cp or -classpath parameter
     String classpath = null;


### PR DESCRIPTION
Failed to run fat jar
java.io.FileNotFoundException: C:\Users\ansharma\Desktop\temp\mag%20root%20test\Mag\magroot-1.1.51-release\kerberos\kerberosproxy.jar (The system cannot find the path specified)
    at java.io.FileInputStream.open(Native Method)
    at java.io.FileInputStream.<init>(Unknown Source)
    at java.io.FileInputStream.<init>(Unknown Source)
    at org.vertx.java.platform.impl.FatJarStarter.unzipJar(FatJarStarter.java:245)
    at org.vertx.java.platform.impl.FatJarStarter.unzipIntoTmpDir(FatJarStarter.java:240)
    at org.vertx.java.platform.impl.FatJarStarter.go(FatJarStarter.java:89)
    at org.vertx.java.platform.impl.FatJarStarter.main(FatJarStarter.java:59)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at org.rzo.yajsw.app.WrapperJVMMain.executeMain(WrapperJVMMain.java:53)
    at org.rzo.yajsw.app.WrapperJVMMain.main(WrapperJVMMain.java:36)
