### PR TITLE
Allow the ability to set status instead of just status code and status message

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/HttpServerResponse.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/HttpServerResponse.java
@@ -16,6 +16,7 @@
 
 package org.vertx.java.core.http;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.vertx.java.core.AsyncResult;
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.MultiMap;
@@ -51,6 +52,12 @@ public interface HttpServerResponse extends WriteStream<HttpServerResponse> {
    * @return A reference to this, so multiple method calls can be chained.
    */
   HttpServerResponse setStatusCode(int statusCode);
+
+  /**
+   * Set the full status. This sets both the status code and the status message.
+   * @return A reference to this, so multiple method calls can be chained.
+   */
+  HttpServerResponse setStatus(HttpResponseStatus status);
 
   /**
    * The HTTP status message of the response. If this is not specified a default value will be used depending on what

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServerResponse.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServerResponse.java
@@ -100,6 +100,12 @@ public class DefaultHttpServerResponse implements HttpServerResponse {
   }
 
   @Override
+  public HttpServerResponse setStatus(HttpResponseStatus status) {
+    this.response.setStatus(status);
+    return this;
+  }
+
+  @Override
   public String getStatusMessage() {
     return response.getStatus().reasonPhrase();
   }
@@ -339,7 +345,7 @@ public class DefaultHttpServerResponse implements HttpServerResponse {
     File file = new File(PathAdjuster.adjust(vertx, filename));
     if (!file.exists()) {
       if (notFoundResource != null) {
-        setStatusCode(HttpResponseStatus.NOT_FOUND.code());
+        setStatus(HttpResponseStatus.NOT_FOUND);
         sendFile(notFoundResource, (String) null, resultHandler);
       } else {
         sendNotFound();
@@ -421,13 +427,13 @@ public class DefaultHttpServerResponse implements HttpServerResponse {
   }
 
   private void sendForbidden() {
-    setStatusCode(HttpResponseStatus.FORBIDDEN.code());
+    setStatus(HttpResponseStatus.FORBIDDEN);
     putHeader(org.vertx.java.core.http.HttpHeaders.CONTENT_TYPE, org.vertx.java.core.http.HttpHeaders.TEXT_HTML);
     end(FORBIDDEN);
   }
 
   private void sendNotFound() {
-    setStatusCode(HttpResponseStatus.NOT_FOUND.code());
+    setStatus(HttpResponseStatus.NOT_FOUND);
     putHeader(org.vertx.java.core.http.HttpHeaders.CONTENT_TYPE, org.vertx.java.core.http.HttpHeaders.TEXT_HTML);
     end(NOT_FOUND);
   }


### PR DESCRIPTION
When sending a response and setting a status code, it usually returns "OK" in addition to the status code (example: "404 OK"). To remedy this, you have to type `setStatusCode(404).setStatusMessage("Not Found")` (or the equivalent using `HttpResponseStatus`).

In an effort to eliminate a lot of boilerplate code on the framework's users' side, I've added a `setStatus(HttpResponseStatus)` method that will set both the status code and status message.
