### PR TITLE
SSL enabled DefaultHttpClient is properly set to the client mode (before...

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClient.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClient.java
@@ -716,12 +716,12 @@ public class DefaultHttpClient implements HttpClient {
           ChannelPipeline pipeline = ch.pipeline();
           if (tcpHelper.isSSL()) {
             SSLEngine engine = tcpHelper.getSSLContext().createSSLEngine(host, port);
+            engine.setUseClientMode(true); //We are on the client side of the connection
             if (tcpHelper.isVerifyHost()) {
               SSLParameters sslParameters = engine.getSSLParameters();
               sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
               engine.setSSLParameters(sslParameters);
             }
-            engine.setUseClientMode(true); //We are on the client side of the connection
             pipeline.addLast("ssl", new SslHandler(engine));
           }
 


### PR DESCRIPTION
After the SSLEngine creating, before the SSL parameters are set the engine should be set into the client mode. Otherwise the SSL parameters are configured as for a server. 

This causes following problems:
- communicating with servers which use SNI: The client and the server perform SSL handshanking using SSLv2 (since client is configured to support it), which doesn't support SSL server_name extension. Thus the server cannot find the proper certificate.
- certificates that are issued for wildcarded domains like (*.domain.com) are not accepted by the client

Location: DefaultHttpClient.internalConnect

Signed-off-by: Vladyslav Oleniuk vladyslav.oleniuk@kiwigrid.com
