### PR TITLE
Rename Headers back to MultiMap.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/MultiMap.java
+++ b/vertx-core/src/main/java/io/vertx/core/MultiMap.java
@@ -29,7 +29,7 @@ import java.util.Set;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
-public interface Headers extends Iterable<Map.Entry<String, String>> {
+public interface MultiMap extends Iterable<Map.Entry<String, String>> {
 
   @GenIgnore
   String get(CharSequence name);
@@ -98,10 +98,10 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
    * @return {@code this}
    */
   @Fluent
-  Headers add(String name, String value);
+  MultiMap add(String name, String value);
 
   @GenIgnore
-  Headers add(CharSequence name, CharSequence value);
+  MultiMap add(CharSequence name, CharSequence value);
 
   /**
    * Adds a new values under the specified name
@@ -112,10 +112,10 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
    * @return {@code this}
    */
   @GenIgnore
-  Headers add(String name, Iterable<String> values);
+  MultiMap add(String name, Iterable<String> values);
 
   @GenIgnore
-  Headers add(CharSequence name, Iterable<CharSequence> values);
+  MultiMap add(CharSequence name, Iterable<CharSequence> values);
 
   /**
    * Adds all the entries from another MultiMap to this one
@@ -123,7 +123,7 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
    * @return {@code this}
    */
   @Fluent
-  Headers addAll(Headers headers);
+  MultiMap addAll(MultiMap map);
 
   /**
    * Adds all the entries from a Map to this
@@ -131,7 +131,7 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
    * @return {@code this}
    */
   @GenIgnore
-  Headers addAll(Map<String, String> headers);
+  MultiMap addAll(Map<String, String> headers);
 
   /**
    * Sets a value under the specified name.
@@ -143,10 +143,10 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
    * @return {@code this}
    */
   @Fluent
-  Headers set(String name, String value);
+  MultiMap set(String name, String value);
 
   @GenIgnore
-  Headers set(CharSequence name, CharSequence value);
+  MultiMap set(CharSequence name, CharSequence value);
 
   /**
    * Sets values for the specified name.
@@ -156,10 +156,10 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
    * @return {@code this}
    */
   @GenIgnore
-  Headers set(String name, Iterable<String> values);
+  MultiMap set(String name, Iterable<String> values);
 
   @GenIgnore
-  Headers set(CharSequence name, Iterable<CharSequence> values);
+  MultiMap set(CharSequence name, Iterable<CharSequence> values);
 
 
   /**
@@ -168,7 +168,7 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
    * @return {@code this}
    */
   @Fluent
-  Headers setAll(Headers headers);
+  MultiMap setAll(MultiMap map);
 
   /**
    * Cleans and set all values of the given instance
@@ -176,7 +176,7 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
    * @return {@code this}
    */
   @GenIgnore
-  Headers setAll(Map<String, String> headers);
+  MultiMap setAll(Map<String, String> headers);
 
  /**
   * Removes the value with the given name
@@ -185,10 +185,10 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
   * @return {@code this}
   */
   @Fluent
-  Headers remove(String name);
+  MultiMap remove(String name);
 
   @GenIgnore
-  Headers remove(CharSequence name);
+  MultiMap remove(CharSequence name);
 
 
   /**
@@ -197,7 +197,7 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
    * @return {@code this}
    */
   @Fluent
-  Headers clear();
+  MultiMap clear();
 
   /**
    * Return the number of names.

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/DeliveryOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/DeliveryOptions.java
@@ -17,7 +17,7 @@
 package io.vertx.core.eventbus;
 
 import io.vertx.codegen.annotations.Options;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.ServiceHelper;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.DeliveryOptionsFactory;
@@ -50,9 +50,9 @@ public interface DeliveryOptions {
 
   DeliveryOptions addHeader(String key, String value);
 
-  DeliveryOptions setHeaders(Headers headers);
+  DeliveryOptions setHeaders(MultiMap headers);
 
-  Headers getHeaders();
+  MultiMap getHeaders();
 
   static final DeliveryOptionsFactory factory = ServiceHelper.loadFactory(DeliveryOptionsFactory.class);
 

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/Message.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/Message.java
@@ -20,7 +20,7 @@ import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -33,7 +33,7 @@ public interface Message<T> {
    */
   String address();
 
-  Headers headers();
+  MultiMap headers();
 
   /**
    * The body of the message

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/DeliveryOptionsImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/DeliveryOptionsImpl.java
@@ -16,7 +16,7 @@
 
 package io.vertx.core.eventbus.impl;
 
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.json.JsonObject;
@@ -32,7 +32,7 @@ public class DeliveryOptionsImpl implements DeliveryOptions {
 
   private long timeout = DEFAULT_TIMEOUT;
   private String codecName;
-  private Headers headers;
+  private MultiMap headers;
 
   DeliveryOptionsImpl() {
   }
@@ -91,13 +91,13 @@ public class DeliveryOptionsImpl implements DeliveryOptions {
   }
 
   @Override
-  public DeliveryOptions setHeaders(Headers headers) {
+  public DeliveryOptions setHeaders(MultiMap headers) {
     this.headers = headers;
     return this;
   }
 
   @Override
-  public Headers getHeaders() {
+  public MultiMap getHeaders() {
     return headers;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -19,7 +19,7 @@ package io.vertx.core.eventbus.impl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
@@ -270,7 +270,7 @@ public class EventBusImpl implements EventBus {
     }
   }
 
-  MessageImpl createMessage(boolean send, String address, Headers headers, Object body, String codecName) {
+  MessageImpl createMessage(boolean send, String address, MultiMap headers, Object body, String codecName) {
     MessageCodec codec;
     if (codecName != null) {
       codec = userCodecMap.get(codecName);

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -19,7 +19,7 @@ package io.vertx.core.eventbus.impl;
 import io.netty.util.CharsetUtil;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.Message;
@@ -47,7 +47,7 @@ public class MessageImpl<U, V> implements Message<V> {
   private ServerID sender;
   private String address;
   private String replyAddress;
-  private Headers headers;
+  private MultiMap headers;
   private U sentBody;
   private V receivedBody;
   private MessageCodec<U, V> messageCodec;
@@ -59,7 +59,7 @@ public class MessageImpl<U, V> implements Message<V> {
   public MessageImpl() {
   }
 
-  public MessageImpl(ServerID sender, String address, String replyAddress, Headers headers, U sentBody,
+  public MessageImpl(ServerID sender, String address, String replyAddress, MultiMap headers, U sentBody,
                      MessageCodec<U, V> messageCodec, boolean send) {
     this.sender = sender;
     this.address = address;
@@ -105,7 +105,7 @@ public class MessageImpl<U, V> implements Message<V> {
   }
 
   @Override
-  public Headers headers() {
+  public MultiMap headers() {
     // Lazily decode headers
     if (headers == null) {
       // The message has been read from the wire

--- a/vertx-core/src/main/java/io/vertx/core/http/CaseInsensitiveHeaders.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/CaseInsensitiveHeaders.java
@@ -17,7 +17,7 @@
 package io.vertx.core.http;
 
 
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -32,7 +32,7 @@ import java.util.TreeSet;
  *
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-public final class CaseInsensitiveHeaders implements Headers {
+public final class CaseInsensitiveHeaders implements MultiMap {
   private static final int BUCKET_SIZE = 17;
 
   private static int hash(String name) {
@@ -54,7 +54,7 @@ public final class CaseInsensitiveHeaders implements Headers {
     }
   }
 
-  private Headers set0(Iterable<Map.Entry<String, String>> map) {
+  private MultiMap set0(Iterable<Map.Entry<String, String>> map) {
     clear();
     for (Map.Entry<String, String> entry: map) {
       add(entry.getKey(), entry.getValue());
@@ -63,12 +63,12 @@ public final class CaseInsensitiveHeaders implements Headers {
   }
 
   @Override
-  public Headers setAll(Headers headers) {
+  public MultiMap setAll(MultiMap headers) {
     return set0(headers);
   }
 
   @Override
-  public Headers setAll(Map<String, String> headers) {
+  public MultiMap setAll(Map<String, String> headers) {
     return set0(headers.entrySet());
   }
 
@@ -113,7 +113,7 @@ public final class CaseInsensitiveHeaders implements Headers {
   }
 
   @Override
-  public Headers add(final String name, final String strVal) {
+  public MultiMap add(final String name, final String strVal) {
     int h = hash(name);
     int i = index(h);
     add0(h, i, name, strVal);
@@ -121,7 +121,7 @@ public final class CaseInsensitiveHeaders implements Headers {
   }
 
   @Override
-  public Headers add(String name, Iterable<String> values) {
+  public MultiMap add(String name, Iterable<String> values) {
     int h = hash(name);
     int i = index(h);
     for (String vstr: values) {
@@ -131,7 +131,7 @@ public final class CaseInsensitiveHeaders implements Headers {
   }
 
   @Override
-  public Headers addAll(Headers headers) {
+  public MultiMap addAll(MultiMap headers) {
     for (Map.Entry<String, String> entry: headers.entries()) {
       add(entry.getKey(), entry.getValue());
     }
@@ -139,7 +139,7 @@ public final class CaseInsensitiveHeaders implements Headers {
   }
 
   @Override
-  public Headers addAll(Map<String, String> map) {
+  public MultiMap addAll(Map<String, String> map) {
     for (Map.Entry<String, String> entry: map.entrySet()) {
       add(entry.getKey(), entry.getValue());
     }
@@ -158,7 +158,7 @@ public final class CaseInsensitiveHeaders implements Headers {
   }
 
   @Override
-  public Headers remove(final String name) {
+  public MultiMap remove(final String name) {
     if (name == null) {
       throw new NullPointerException("name");
     }
@@ -205,7 +205,7 @@ public final class CaseInsensitiveHeaders implements Headers {
   }
 
   @Override
-  public Headers set(final String name, final String strVal) {
+  public MultiMap set(final String name, final String strVal) {
     int h = hash(name);
     int i = index(h);
     remove0(h, i, name);
@@ -214,7 +214,7 @@ public final class CaseInsensitiveHeaders implements Headers {
   }
 
   @Override
-  public Headers set(final String name, final Iterable<String> values) {
+  public MultiMap set(final String name, final Iterable<String> values) {
     if (values == null) {
       throw new NullPointerException("values");
     }
@@ -234,7 +234,7 @@ public final class CaseInsensitiveHeaders implements Headers {
   }
 
   @Override
-  public Headers clear() {
+  public MultiMap clear() {
     for (int i = 0; i < entries.length; i ++) {
       entries[i] = null;
     }
@@ -338,12 +338,12 @@ public final class CaseInsensitiveHeaders implements Headers {
   }
 
   @Override
-  public Headers add(CharSequence name, CharSequence value) {
+  public MultiMap add(CharSequence name, CharSequence value) {
     return add(name.toString(), value.toString());
   }
 
   @Override
-  public Headers add(CharSequence name, Iterable<CharSequence> values) {
+  public MultiMap add(CharSequence name, Iterable<CharSequence> values) {
     String n = name.toString();
     for (CharSequence seq: values) {
       add(n, seq.toString());
@@ -352,12 +352,12 @@ public final class CaseInsensitiveHeaders implements Headers {
   }
 
   @Override
-  public Headers set(CharSequence name, CharSequence value) {
+  public MultiMap set(CharSequence name, CharSequence value) {
     return set(name.toString(), value.toString());
   }
 
   @Override
-  public Headers set(CharSequence name, Iterable<CharSequence> values) {
+  public MultiMap set(CharSequence name, Iterable<CharSequence> values) {
     remove(name);
     String n = name.toString();
     for (CharSequence seq: values) {
@@ -367,7 +367,7 @@ public final class CaseInsensitiveHeaders implements Headers {
   }
 
   @Override
-  public Headers remove(CharSequence name) {
+  public MultiMap remove(CharSequence name) {
     return remove(name.toString());
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -17,7 +17,7 @@
 package io.vertx.core.http;
 
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.Fluent;
@@ -82,7 +82,7 @@ public interface HttpClientRequest extends WriteStream<HttpClientRequest> {
    * @return The HTTP headers
    */
   @CacheReturn
-  Headers headers();
+  MultiMap headers();
 
   /**
    * Put an HTTP header - fluent API

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientResponse.java
@@ -17,7 +17,7 @@
 package io.vertx.core.http;
 
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.Fluent;
@@ -56,13 +56,13 @@ public interface HttpClientResponse extends ReadStream<HttpClientResponse> {
    * @return The HTTP headers
    */
   @CacheReturn
-  Headers headers();
+  MultiMap headers();
 
   /**
    * @return The HTTP trailers
    */
   @CacheReturn
-  Headers trailers();
+  MultiMap trailers();
 
   /**
    * @return The Set-Cookie headers (including trailers)

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -17,7 +17,7 @@
 package io.vertx.core.http;
 
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.Fluent;
@@ -86,13 +86,13 @@ public interface HttpServerRequest extends ReadStream<HttpServerRequest> {
    * The headers will be automatically lower-cased when they reach the server
    */
   @CacheReturn
-  Headers headers();
+  MultiMap headers();
 
   /**
    * Returns a map of all the parameters in the request
    */
   @CacheReturn
-  Headers params();
+  MultiMap params();
 
   /**
    * Return the remote (client side) address of the request
@@ -161,6 +161,6 @@ public interface HttpServerRequest extends ReadStream<HttpServerRequest> {
    * {@link #setExpectMultipart(boolean)} must be called first before trying to get the formAttributes
    */
   @CacheReturn
-  Headers formAttributes();
+  MultiMap formAttributes();
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -18,7 +18,7 @@ package io.vertx.core.http;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.Fluent;
@@ -95,7 +95,7 @@ public interface HttpServerResponse extends WriteStream<HttpServerResponse> {
    * @return The HTTP headers
    */
   @CacheReturn
-  Headers headers();
+  MultiMap headers();
 
   /**
    * Put an HTTP header - fluent API
@@ -126,7 +126,7 @@ public interface HttpServerResponse extends WriteStream<HttpServerResponse> {
    * @return The HTTP trailers
    */
   @CacheReturn
-  Headers trailers();
+  MultiMap trailers();
 
   /**
    * Put an HTTP trailer - fluent API

--- a/vertx-core/src/main/java/io/vertx/core/http/RequestOptionsBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/RequestOptionsBase.java
@@ -16,7 +16,7 @@
 
 package io.vertx.core.http;
 
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -31,9 +31,9 @@ public interface RequestOptionsBase<T extends RequestOptionsBase> {
 
   T setHost(String host);
 
-  Headers getHeaders();
+  MultiMap getHeaders();
 
-  T setHeaders(Headers headers);
+  T setHeaders(MultiMap headers);
 
   String getRequestURI();
 

--- a/vertx-core/src/main/java/io/vertx/core/http/ServerWebSocket.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/ServerWebSocket.java
@@ -16,7 +16,7 @@
 
 package io.vertx.core.http;
 
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
@@ -49,7 +49,7 @@ public interface ServerWebSocket extends WebSocketBase<ServerWebSocket> {
    * A map of all headers in the request to upgrade to websocket
    */
   @CacheReturn
-  Headers headers();
+  MultiMap headers();
 
   /**
    * Reject the WebSocket<p>

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HeadersAdaptor.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HeadersAdaptor.java
@@ -17,7 +17,7 @@
 package io.vertx.core.http.impl;
 
 import io.netty.handler.codec.http.HttpHeaders;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 
 import java.util.Iterator;
 import java.util.List;
@@ -27,7 +27,7 @@ import java.util.Set;
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-public class HeadersAdaptor implements Headers {
+public class HeadersAdaptor implements MultiMap {
   private final HttpHeaders headers;
 
   public HeadersAdaptor(HttpHeaders headers) {
@@ -65,19 +65,19 @@ public class HeadersAdaptor implements Headers {
   }
 
   @Override
-  public Headers add(String name, String value) {
+  public MultiMap add(String name, String value) {
     headers.add(name, value);
     return this;
   }
 
   @Override
-  public Headers add(String name, Iterable<String> values) {
+  public MultiMap add(String name, Iterable<String> values) {
     headers.add(name, values);
     return this;
   }
 
   @Override
-  public Headers addAll(Headers headers) {
+  public MultiMap addAll(MultiMap headers) {
     for (Map.Entry<String, String> entry: headers.entries()) {
       add(entry.getKey(), entry.getValue());
     }
@@ -85,7 +85,7 @@ public class HeadersAdaptor implements Headers {
   }
 
   @Override
-  public Headers addAll(Map<String, String> map) {
+  public MultiMap addAll(Map<String, String> map) {
     for (Map.Entry<String, String> entry: map.entrySet()) {
       add(entry.getKey(), entry.getValue());
     }
@@ -93,19 +93,19 @@ public class HeadersAdaptor implements Headers {
   }
 
   @Override
-  public Headers set(String name, String value) {
+  public MultiMap set(String name, String value) {
     headers.set(name, value);
     return this;
   }
 
   @Override
-  public Headers set(String name, Iterable<String> values) {
+  public MultiMap set(String name, Iterable<String> values) {
     headers.set(name, values);
     return this;
   }
 
   @Override
-  public Headers setAll(Headers httpHeaders) {
+  public MultiMap setAll(MultiMap httpHeaders) {
     clear();
     for (Map.Entry<String, String> entry: httpHeaders) {
       add(entry.getKey(), entry.getValue());
@@ -114,13 +114,13 @@ public class HeadersAdaptor implements Headers {
   }
 
   @Override
-  public Headers remove(String name) {
+  public MultiMap remove(String name) {
     headers.remove(name);
     return this;
   }
 
   @Override
-  public Headers clear() {
+  public MultiMap clear() {
     headers.clear();
     return this;
   }
@@ -136,7 +136,7 @@ public class HeadersAdaptor implements Headers {
   }
 
   @Override
-  public Headers setAll(Map<String, String> headers) {
+  public MultiMap setAll(Map<String, String> headers) {
     for (Map.Entry<String, String> entry: headers.entrySet()) {
       add(entry.getKey(), entry.getValue());
     }
@@ -159,31 +159,31 @@ public class HeadersAdaptor implements Headers {
   }
 
   @Override
-  public Headers add(CharSequence name, CharSequence value) {
+  public MultiMap add(CharSequence name, CharSequence value) {
     headers.add(name, value);
     return this;
   }
 
   @Override
-  public Headers add(CharSequence name, Iterable<CharSequence> values) {
+  public MultiMap add(CharSequence name, Iterable<CharSequence> values) {
     headers.add(name, values);
     return this;
   }
 
   @Override
-  public Headers set(CharSequence name, CharSequence value) {
+  public MultiMap set(CharSequence name, CharSequence value) {
     headers.set(name, value);
     return this;
   }
 
   @Override
-  public Headers set(CharSequence name, Iterable<CharSequence> values) {
+  public MultiMap set(CharSequence name, Iterable<CharSequence> values) {
     headers.set(name, values);
     return this;
   }
 
   @Override
-  public Headers remove(CharSequence name) {
+  public MultiMap remove(CharSequence name) {
     headers.remove(name);
     return this;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -35,7 +35,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
@@ -388,12 +388,12 @@ public class HttpClientImpl implements HttpClient {
           }
 
           @Override
-          public Headers headers() {
+          public MultiMap headers() {
             return resp.headers();
           }
 
           @Override
-          public Headers trailers() {
+          public MultiMap trailers() {
             return resp.trailers();
           }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -28,7 +28,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
@@ -65,7 +65,7 @@ public class HttpClientRequestImpl implements HttpClientRequest {
   private boolean writeHead;
   private long written;
   private long currentTimeoutTimerId = -1;
-  private Headers headers;
+  private MultiMap headers;
   private boolean exceptionOccurred;
   private long lastDataReceived;
 
@@ -95,7 +95,7 @@ public class HttpClientRequestImpl implements HttpClientRequest {
   }
 
   @Override
-  public Headers headers() {
+  public MultiMap headers() {
     if (headers == null) {
       headers = new HeadersAdaptor(request.headers());
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
@@ -20,7 +20,7 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.VoidHandler;
 import io.vertx.core.buffer.Buffer;
@@ -57,8 +57,8 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
   private NetSocket netSocket;
 
   // Cache these for performance
-  private Headers headers;
-  private Headers trailers;
+  private MultiMap headers;
+  private MultiMap trailers;
   private List<String> cookies;
 
   HttpClientResponseImpl(Vertx vertx, HttpClientRequestImpl request, ClientConnection conn, HttpResponse response) {
@@ -81,7 +81,7 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
   }
 
   @Override
-  public Headers headers() {
+  public MultiMap headers() {
     if (headers == null) {
       headers = new HeadersAdaptor(response.headers());
     }
@@ -89,7 +89,7 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
   }
 
   @Override
-  public Headers trailers() {
+  public MultiMap trailers() {
     if (trailers == null) {
       trailers = new HeadersAdaptor(new DefaultHttpHeaders());
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -30,7 +30,7 @@ import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty.util.CharsetUtil;
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpServerFileUpload;
@@ -74,14 +74,14 @@ public class HttpServerRequestImpl implements HttpServerRequest {
   private Handler<Throwable> exceptionHandler;
 
   //Cache this for performance
-  private Headers params;
-  private Headers headers;
+  private MultiMap params;
+  private MultiMap headers;
   private String absoluteURI;
 
   private NetSocket netSocket;
   private Handler<HttpServerFileUpload> uploadHandler;
   private Handler<Void> endHandler;
-  private Headers attributes;
+  private MultiMap attributes;
   private HttpPostRequestDecoder decoder;
   private boolean isURLEncoded;
 
@@ -146,7 +146,7 @@ public class HttpServerRequestImpl implements HttpServerRequest {
   }
 
   @Override
-  public Headers headers() {
+  public MultiMap headers() {
     if (headers == null) {
       headers = new HeadersAdaptor(request.headers());
     }
@@ -154,7 +154,7 @@ public class HttpServerRequestImpl implements HttpServerRequest {
   }
 
   @Override
-  public Headers params() {
+  public MultiMap params() {
     if (params == null) {
       QueryStringDecoder queryStringDecoder = new QueryStringDecoder(uri());
       Map<String, List<String>> prms = queryStringDecoder.parameters();
@@ -249,7 +249,7 @@ public class HttpServerRequestImpl implements HttpServerRequest {
   }
 
   @Override
-  public Headers formAttributes() {
+  public MultiMap formAttributes() {
     if (decoder == null) {
       throw new IllegalStateException("Call expectMultiPart(true) before request body is received to receive form attributes");
     }
@@ -333,7 +333,7 @@ public class HttpServerRequestImpl implements HttpServerRequest {
     }
   }
 
-  private Headers attributes() {
+  private MultiMap attributes() {
     // Create it lazily
     if (attributes == null) {
       attributes = new CaseInsensitiveHeaders();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -32,7 +32,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.impl.PathAdjuster;
 import io.vertx.core.http.HttpHeaders;
@@ -63,9 +63,9 @@ public class HttpServerResponseImpl implements HttpServerResponse {
   private boolean chunked;
   private boolean closed;
   private ChannelFuture channelFuture;
-  private Headers headers;
+  private MultiMap headers;
   private LastHttpContent trailing;
-  private Headers trailers;
+  private MultiMap trailers;
   private String statusMessage;
 
   HttpServerResponseImpl(final VertxInternal vertx, ServerConnection conn, HttpRequest request) {
@@ -78,7 +78,7 @@ public class HttpServerResponseImpl implements HttpServerResponse {
   }
 
   @Override
-  public Headers headers() {
+  public MultiMap headers() {
     if (headers == null) {
       headers = new HeadersAdaptor(response.headers());
     }
@@ -86,7 +86,7 @@ public class HttpServerResponseImpl implements HttpServerResponse {
   }
 
   @Override
-  public Headers trailers() {
+  public MultiMap trailers() {
     if (trailers == null) {
       if (trailing == null) {
         trailing = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, false);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/RequestOptionsImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/RequestOptionsImpl.java
@@ -16,7 +16,7 @@
 
 package io.vertx.core.http.impl;
 
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.RequestOptionsBase;
@@ -33,7 +33,7 @@ public class RequestOptionsImpl implements RequestOptions {
 
   private int port ;
   private String host;
-  private Headers headers;
+  private MultiMap headers;
   private String requestURI;
 
   RequestOptionsImpl() {
@@ -90,12 +90,12 @@ public class RequestOptionsImpl implements RequestOptions {
   }
 
   @Override
-  public Headers getHeaders() {
+  public MultiMap getHeaders() {
     return headers;
   }
 
   @Override
-  public RequestOptions setHeaders(Headers headers) {
+  public RequestOptions setHeaders(MultiMap headers) {
     this.headers = headers;
     return this;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -17,7 +17,7 @@
 package io.vertx.core.http.impl;
 
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.WebSocketFrame;
@@ -32,9 +32,9 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocket> impl
   private final Runnable connectRunnable;
   private boolean connected;
   private boolean rejected;
-  private final Headers headers;
+  private final MultiMap headers;
 
-  public ServerWebSocketImpl(VertxInternal vertx, String uri, String path, String query, Headers headers,
+  public ServerWebSocketImpl(VertxInternal vertx, String uri, String path, String query, MultiMap headers,
                              ConnectionBase conn, boolean supportsContinuation, Runnable connectRunnable) {
     super(vertx, conn, supportsContinuation);
 
@@ -61,7 +61,7 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocket> impl
   }
 
   @Override
-  public Headers headers() {
+  public MultiMap headers() {
     return headers;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketConnectOptionsImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketConnectOptionsImpl.java
@@ -16,7 +16,7 @@
 
 package io.vertx.core.http.impl;
 
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.json.JsonArray;
@@ -39,7 +39,7 @@ public class WebSocketConnectOptionsImpl implements WebSocketConnectOptions {
 
   private int port ;
   private String host;
-  private Headers headers;
+  private MultiMap headers;
   private String requestURI;
   private int maxWebsocketFrameSize;
   private int version;
@@ -111,12 +111,12 @@ public class WebSocketConnectOptionsImpl implements WebSocketConnectOptions {
   }
 
   @Override
-  public Headers getHeaders() {
+  public MultiMap getHeaders() {
     return headers;
   }
 
   @Override
-  public WebSocketConnectOptions setHeaders(Headers headers) {
+  public WebSocketConnectOptions setHeaders(MultiMap headers) {
     this.headers = headers;
     return this;
   }

--- a/vertx-core/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/test/core/HttpTest.java
@@ -23,7 +23,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.Message;
@@ -945,7 +945,7 @@ public class HttpTest extends HttpTestBase {
       req.response().end();
     });
     server.listen(onSuccess(server -> {
-      Headers headers = new CaseInsensitiveHeaders();
+      MultiMap headers = new CaseInsensitiveHeaders();
       headers.add("foo", "bar");
       client.getNow(RequestOptions.options().setPort(DEFAULT_HTTP_PORT).setRequestURI(DEFAULT_TEST_URI).setHeaders(headers), resp -> {
         assertEquals(200, resp.statusCode());
@@ -1205,7 +1205,7 @@ public class HttpTest extends HttpTestBase {
   }
 
   private void testRequestHeaders(boolean individually) {
-    Headers headers = getHeaders(10);
+    MultiMap headers = getHeaders(10);
 
     server.requestHandler(req -> {
       assertEquals(headers.size() + 1, req.headers().size());
@@ -1241,7 +1241,7 @@ public class HttpTest extends HttpTestBase {
   }
 
   private void testResponseHeaders(boolean individually) {
-    Headers headers = getHeaders(10);
+    MultiMap headers = getHeaders(10);
 
     server.requestHandler(req -> {
       if (individually) {
@@ -1678,7 +1678,7 @@ public class HttpTest extends HttpTestBase {
   }
 
   private void testResponseTrailers(boolean individually) {
-    Headers trailers = getHeaders(10);
+    MultiMap trailers = getHeaders(10);
 
     server.requestHandler(req -> {
       req.response().setChunked(true);
@@ -3320,7 +3320,7 @@ public class HttpTest extends HttpTestBase {
           });
         });
         req.endHandler(v -> {
-          Headers attrs = req.formAttributes();
+          MultiMap attrs = req.formAttributes();
           attributeCount.set(attrs.size());
           req.response().end();
         });
@@ -3369,7 +3369,7 @@ public class HttpTest extends HttpTestBase {
           fail("Should get here");
         }));
         req.endHandler(v -> {
-          Headers attrs = req.formAttributes();
+          MultiMap attrs = req.formAttributes();
           attributeCount.set(attrs.size());
           assertEquals("vert x", attrs.get("framework"));
           assertEquals("jvm", attrs.get("runson"));
@@ -3414,7 +3414,7 @@ public class HttpTest extends HttpTestBase {
           fail("Should not get here");
         }));
         req.endHandler(v -> {
-          Headers attrs = req.formAttributes();
+          MultiMap attrs = req.formAttributes();
           attributeCount.set(attrs.size());
           assertEquals("junit-testUserAlias", attrs.get("origin"));
           assertEquals("admin@foo.bar", attrs.get("login"));
@@ -3670,7 +3670,7 @@ public class HttpTest extends HttpTestBase {
     String randString = TestUtils.randomUnicodeString(100);
     assertEquals(options, options.setHost(randString));
     assertEquals(randString, options.getHost());
-    Headers headers = new CaseInsensitiveHeaders();
+    MultiMap headers = new CaseInsensitiveHeaders();
     assertNull(options.getHeaders());
     assertEquals(options, options.setHeaders(headers));
     assertSame(headers, options.getHeaders());
@@ -3688,7 +3688,7 @@ public class HttpTest extends HttpTestBase {
   public void testCopyRequestOptions() {
     int port = 4523;
     String host = TestUtils.randomAlphaString(100);
-    Headers headers = new CaseInsensitiveHeaders();
+    MultiMap headers = new CaseInsensitiveHeaders();
     headers.add("foo", "bar");
     String uri = TestUtils.randomAlphaString(100);
     RequestOptions options = RequestOptions.options().setPort(port).setHost(host).setHeaders(headers).setRequestURI(uri);
@@ -3712,7 +3712,7 @@ public class HttpTest extends HttpTestBase {
   public void testCopyRequestOptionsJson() {
     int port = 4523;
     String host = TestUtils.randomAlphaString(100);
-    Headers headers = new CaseInsensitiveHeaders();
+    MultiMap headers = new CaseInsensitiveHeaders();
     headers.add("foo", "bar");
     String uri = TestUtils.randomAlphaString(100);
     JsonObject json = new JsonObject();
@@ -3958,9 +3958,9 @@ public class HttpTest extends HttpTestBase {
     server.listen(onSuccess(consumer));
   }
 
-  private static Headers getHeaders(int num) {
+  private static MultiMap getHeaders(int num) {
     Map<String, String> map = genMap(num);
-    Headers headers = new HeadersAdaptor(new DefaultHttpHeaders());
+    MultiMap headers = new HeadersAdaptor(new DefaultHttpHeaders());
     for (Map.Entry<String, String> entry : map.entrySet()) {
       headers.add(entry.getKey(), entry.getValue());
     }

--- a/vertx-core/src/test/java/io/vertx/test/core/LocalEventBusTest.java
+++ b/vertx-core/src/test/java/io/vertx/test/core/LocalEventBusTest.java
@@ -21,7 +21,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Handler;
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
@@ -646,7 +646,7 @@ public class LocalEventBusTest extends EventBusTestBase {
 
   @Test
   public void testHeadersCopiedAfterSend() throws Exception {
-    Headers headers = new CaseInsensitiveHeaders();
+    MultiMap headers = new CaseInsensitiveHeaders();
     headers.add("foo", "bar");
     vertx.eventBus().registerHandler(ADDRESS1, msg -> {
       assertNotSame(headers, msg.headers());

--- a/vertx-core/src/test/java/io/vertx/test/core/WebsocketTest.java
+++ b/vertx-core/src/test/java/io/vertx/test/core/WebsocketTest.java
@@ -17,7 +17,7 @@
 package io.vertx.test.core;
 
 
-import io.vertx.core.Headers;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpClient;
@@ -535,7 +535,7 @@ public class WebsocketTest extends NetTestBase {
     String randString = TestUtils.randomUnicodeString(100);
     assertEquals(options, options.setHost(randString));
     assertEquals(randString, options.getHost());
-    Headers headers = new CaseInsensitiveHeaders();
+    MultiMap headers = new CaseInsensitiveHeaders();
     assertNull(options.getHeaders());
     assertEquals(options, options.setHeaders(headers));
     assertSame(headers, options.getHeaders());
@@ -578,7 +578,7 @@ public class WebsocketTest extends NetTestBase {
   public void testCopyOptions() {
     int port = 4523;
     String host = TestUtils.randomAlphaString(100);
-    Headers headers = new CaseInsensitiveHeaders();
+    MultiMap headers = new CaseInsensitiveHeaders();
     headers.add("foo", "bar");
     String uri = TestUtils.randomAlphaString(100);
     int websocketFrameSize = TestUtils.randomPositiveInt();
@@ -612,7 +612,7 @@ public class WebsocketTest extends NetTestBase {
   public void testCopyOptionsJson() {
     int port = 4523;
     String host = TestUtils.randomAlphaString(100);
-    Headers headers = new CaseInsensitiveHeaders();
+    MultiMap headers = new CaseInsensitiveHeaders();
     headers.add("foo", "bar");
     String uri = TestUtils.randomAlphaString(100);
     int websocketFrameSize = TestUtils.randomPositiveInt();


### PR DESCRIPTION
I think the change to rename MultiMap to Headers was unnecessary. It's especially confusing when you use it for query parameters: 

   `Headers params = req.params()`
