### PR TITLE
Disable strack trace lookup for JUL logging

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/logging/impl/JULLogDelegate.java
+++ b/vertx-core/src/main/java/io/vertx/core/logging/impl/JULLogDelegate.java
@@ -16,8 +16,6 @@
 
 package io.vertx.core.logging.impl;
 
-import io.vertx.core.logging.Logger;
-
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -27,8 +25,6 @@ import java.util.logging.LogRecord;
  * @author <a href="kenny.macleod@kizoom.com">Kenny MacLeod</a>
  */
 public class JULLogDelegate implements LogDelegate {
-  private static final String FQCN = Logger.class.getCanonicalName();
-
   private final java.util.logging.Logger logger;
 
   JULLogDelegate(final String name) {
@@ -107,22 +103,9 @@ public class JULLogDelegate implements LogDelegate {
     LogRecord record = new LogRecord(level, msg);
     record.setLoggerName(logger.getName());
     record.setThrown(t);
-    // Find FQCN of calling class
-    boolean found = false;
-    for (StackTraceElement ste : new Throwable().getStackTrace()) {
-      if (FQCN.equals(ste.getClassName())) {
-        found = true;
-      } else if (found && !FQCN.equals(ste.getClassName())) {
-        record.setSourceClassName(ste.getClassName());
-        record.setSourceMethodName(ste.getMethodName());
-        break;
-      }
-    }
-    // If not found, set it to null, which will default to use logger name. Otherwise it will be incorrect and
-    // use this class.
-    if (!found) {
-      record.setSourceClassName(null);
-    }
+    // This will disable stack trace lookup inside JUL. If someone wants location info, they can use their own formatter
+    // or use a different logging framework like sl4j, or log4j
+    record.setSourceClassName(null);
 
     logger.log(record);
   }

--- a/vertx-core/src/main/java/io/vertx/core/logging/impl/VertxLoggerFormatter.java
+++ b/vertx-core/src/main/java/io/vertx/core/logging/impl/VertxLoggerFormatter.java
@@ -32,7 +32,7 @@ public class VertxLoggerFormatter extends java.util.logging.Formatter {
   public String format(final LogRecord record) {
     Date date = new Date();
     SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     // Minimize memory allocations here.
     date.setTime(record.getMillis());
     sb.append("[").append(Thread.currentThread().getName()).append("] ");


### PR DESCRIPTION
Since the proper way to format JUL is to provide a custom formatter like we've done with VertxLoggerFormatter, I propose we just disable stacktrace lookup altogether (since it's slow) and use the logger name by default. 

If anyone wants location information in their logs, it would be fairly trivial to do so with a custom formatter. Or maybe even better, we provide another formatter in vertx that does it ?
