### PR TITLE
Event bus should be registered in the management registry only after the...

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/eventbus/impl/DefaultEventBus.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/eventbus/impl/DefaultEventBus.java
@@ -94,7 +94,6 @@ public class DefaultEventBus implements EventBus {
     this.clusterMgr = clusterManager;
     this.subs = clusterMgr.getAsyncMultiMap("subs");
     this.server = setServer(port, hostname, listenHandler);
-    ManagementRegistry.registerEventBus(serverID);
   }
 
   @Override
@@ -613,6 +612,7 @@ public class DefaultEventBus implements EventBus {
           int serverPort = (publicPort == -1) ? server.port() : publicPort;
           String serverHost = (publicHost == null) ? hostName : publicHost;
           DefaultEventBus.this.serverID = new ServerID(serverPort, serverHost);
+          ManagementRegistry.registerEventBus(serverID);
         }
         if (listenHandler != null) {
           if (asyncResult.succeeded()) {


### PR DESCRIPTION
... server has started (in the case of cluster)

Signed-off-by: Vladyslav Oleniuk vlad.oleniuk@gmail.com

There was sometimes a NullPointerException caused by the fact, that serverID was not always assigned its value when ManagementRegistry.registerEventBus(serverID) was called.
