### PR TITLE
When setting a null handler on the MesssageConsumer, the register method...

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -1030,6 +1030,7 @@ public class EventBusImpl implements EventBus {
         };
       }
       if (registered) {
+        registered = false;
         unregisterHandler(address, this, completionHandler);
         metrics.handlerUnregistered(address);
       } else {
@@ -1082,8 +1083,8 @@ public class EventBusImpl implements EventBus {
         registered = true;
         registerHandler(address, this, replyHandler, localOnly, timeoutID);
       } else if (this.handler == null && registered) {
-        registered = false;
-        unregister();
+        // This will set registered to false
+        this.unregister();
       }
       return this;
     }


### PR DESCRIPTION
... should set registered flag to false otherwise registration won't effectively happen

Signed-off-by: Julien Viet julien@julienviet.com
