### PR TITLE
Disable SSLv3 in DefaultHttpServer

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServer.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServer.java
@@ -169,23 +169,8 @@ public class DefaultHttpServer implements HttpServer, Closeable {
             protected void initChannel(Channel ch) throws Exception {
               ChannelPipeline pipeline = ch.pipeline();
               if (tcpHelper.isSSL()) {
-                SSLEngine engine = tcpHelper.getSSLContext().createSSLEngine();
-                engine.setUseClientMode(false);
-                switch (tcpHelper.getClientAuth()) {
-                  case REQUEST: {
-                    engine.setWantClientAuth(true);
-                    break;
-                  }
-                  case REQUIRED: {
-                    engine.setNeedClientAuth(true);
-                    break;
-                  }
-                  case NONE: {
-                    engine.setNeedClientAuth(false);
-                    break;
-                  }
-                }
-                pipeline.addLast("ssl", new SslHandler(engine));
+                SslHandler sslHandler = tcpHelper.createSslHandler(vertx, false);
+                pipeline.addLast("ssl", sslHandler);
               }
               pipeline.addLast("flashpolicy", new FlashPolicyHandler());
               pipeline.addLast("httpDecoder", new HttpRequestDecoder(4096, 8192, 8192, false));


### PR DESCRIPTION
The 2.1.3 release disabled SSLv3 in DefaultHttpClient.  This pull request did the work for the server side.
