### PR TITLE
Avoid an unnecessary extra copy when constructing JsonArray's.

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/json/JsonArray.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/json/JsonArray.java
@@ -36,7 +36,7 @@ public class JsonArray extends JsonElement implements Iterable<Object> {
   }
 
   public JsonArray(Object[] array) {
-    this(new ArrayList<>(Arrays.asList(array)), true);
+    this(Arrays.asList(array), true);
   }
 
   protected JsonArray(List list, boolean copy) {


### PR DESCRIPTION
Signed-off-by: Benoit Sigoure tsunanet@gmail.com
