### PR TITLE
Fix for failed vert.x-3-hazelcast-tests

### DIFF
--- a/vertx-core/src/test/java/io/vertx/test/core/SharedCounterTest.java
+++ b/vertx-core/src/test/java/io/vertx/test/core/SharedCounterTest.java
@@ -35,18 +35,6 @@ public class SharedCounterTest extends VertxTestBase {
   public void testIllegalArguments() throws Exception {
     assertNullPointerException(() -> getVertx().sharedData().getCounter(null, ar -> {}));
     assertNullPointerException(() -> getVertx().sharedData().getCounter("foo", null));
-    getVertx().sharedData().getCounter("foo", ar -> {
-      Counter counter = ar.result();
-      assertNullPointerException(() -> counter.get(null));
-      assertNullPointerException(() -> counter.incrementAndGet(null));
-      assertNullPointerException(() -> counter.getAndIncrement(null));
-      assertNullPointerException(() -> counter.decrementAndGet(null));
-      assertNullPointerException(() -> counter.addAndGet(1, null));
-      assertNullPointerException(() -> counter.getAndAdd(1, null));
-      assertNullPointerException(() -> counter.compareAndSet(1, 1, null));
-      testComplete();
-    });
-    await();
   }
 
   @Test


### PR DESCRIPTION
- Refactored handling of `null` `resultHandlers` in `AsynchronousCounter` and `HazelcastCounter` consistently.

Sorry, I derived the (inconsistent) nullability of the argument from only one class and executed only the core test before check-in. The latter won't happen again.
