### PR TITLE
In order to remove a ServerId it must be wrapped in the same way as it w...

### DIFF
--- a/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/HazelcastAsyncMultiMap.java
+++ b/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/HazelcastAsyncMultiMap.java
@@ -66,9 +66,10 @@ class HazelcastAsyncMultiMap<K, V> implements AsyncMultiMap<K, V>, EntryListener
   public void removeAllForValue(final V val, final Handler<AsyncResult<Void>> completionHandler) {
     vertx.executeBlocking(new Action<Void>() {
       public Void perform() {
+        V wrappedVal = HazelcastServerID.convertServerID(val);
         for (Map.Entry<K, V> entry : map.entrySet()) {
           V v = entry.getValue();
-          if (val.equals(v)) {
+          if (wrappedVal.equals(v)) {
             map.remove(entry.getKey(), v);
           }
         }


### PR DESCRIPTION
...as wrapped when it was put into the map

When vert.x runs in the cluster mode, and the last handler for a specific address is unregistered, the appropriate Address -> ServerId entry should be removed from the subs multi map. But since the removal passes not wrapped ServerId (while it was wrapped during putting it in) it is not removed from the map (and as the result from the cache). This leads to the situation when a message is sent to the cluster node, that does not have a handler any more

Signed-off-by: Vladyslav Oleniuk vlad.oleniuk@gmail.com
