### PR TITLE
updated groovy mod version from 2.1.0-final to 2.1.1

### DIFF
--- a/vertx-platform/src/main/resources/default-langs.properties
+++ b/vertx-platform/src/main/resources/default-langs.properties
@@ -23,7 +23,7 @@
 
 rhino=io.vertx~lang-rhino~2.1.1:org.vertx.java.platform.impl.RhinoVerticleFactory
 jruby=io.vertx~lang-jruby~2.1.0-final:org.vertx.java.platform.impl.JRubyVerticleFactory
-groovy=io.vertx~lang-groovy~2.1.0-final:org.vertx.groovy.platform.impl.GroovyVerticleFactory
+groovy=io.vertx~lang-groovy~2.1.1:org.vertx.groovy.platform.impl.GroovyVerticleFactory
 jython=io.vertx~lang-jython~2.1.1:org.vertx.java.platform.impl.JythonVerticleFactory
 scala=io.vertx~lang-scala~1.0.0:org.vertx.scala.platform.impl.ScalaVerticleFactory
 clojure=io.vertx~lang-clojure~1.0.4:io.vertx.lang.clojure.ClojureVerticleFactory

--- a/vertx-testsuite/src/test/resources/langs.properties
+++ b/vertx-testsuite/src/test/resources/langs.properties
@@ -23,7 +23,7 @@
 
 rhino=io.vertx~lang-rhino~2.1.1:org.vertx.java.platform.impl.RhinoVerticleFactory
 jruby=io.vertx~lang-jruby~2.1.0-final:org.vertx.java.platform.impl.JRubyVerticleFactory
-groovy=io.vertx~lang-groovy~2.1.0-final:org.vertx.groovy.platform.impl.GroovyVerticleFactory
+groovy=io.vertx~lang-groovy~2.1.1:org.vertx.groovy.platform.impl.GroovyVerticleFactory
 jython=io.vertx~lang-jython~2.1.1:org.vertx.java.platform.impl.JythonVerticleFactory
 scala=io.vertx~lang-scala~1.0.0:org.vertx.scala.platform.impl.ScalaVerticleFactory
 clojure=io.vertx~lang-clojure~1.0.1:io.vertx.lang.clojure.ClojureVerticleFactory


### PR DESCRIPTION
Groovy mod 2.1.0-final is using the older groovy version 2.1.1.

The latest stable groovy version is 2.3.7.
As soon vertx is using a groovy class compiled > version 2.3.0, you get
11.11.2014 13:55:33.145 [SCHWERWIEGEND] Failed to instantiate verticle factory 
11.11.2014 13:55:33.147 [SCHWERWIEGEND] java.lang.NoClassDefFoundError: org/codehaus/groovy/runtime/typehandling/ShortTypeHandling 

see http://glaforge.appspot.com/article/groovy-2-3-5-out-with-upward-compatibility

Groovy mod 2.1.1 is using groovy version 2.3.3.
