### PR TITLE
Properly convert a URL to a Path in ClasspathPathResolver

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/file/impl/ClasspathPathResolver.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/file/impl/ClasspathPathResolver.java
@@ -54,12 +54,10 @@ public class ClasspathPathResolver implements PathResolver {
 
   public static Path urlToPath(URL url) {
     if (FILE_SEP == '/') {
-      // *nix - a bit quicker than pissing around with URIs
-      String sfile = url.getFile();
-      if (sfile != null) {
-        return Paths.get(url.getFile());
-      } else {
-        return null;
+      try {
+        return Paths.get(url.toURI());
+      } catch (Exception e) {
+        throw new VertxException(e);
       }
     } else {
       // E.g. windows


### PR DESCRIPTION
@purplefox Please have a look. Not entirely sure about the possible consequences of this change.

For starters the only way for this issue to happen is to have ClasspathPathResolver resolve the path. And the only way I could figure this out (outside of running the Yoke test mentioned in the BZ below) is this:

https://gist.github.com/nscavell/28b89b19738ccfdb7fe4

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=441428 for reference
