### PR TITLE
Add address getter to MessageProducer.

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/MessageProducer.java
+++ b/src/main/java/io/vertx/core/eventbus/MessageProducer.java
@@ -50,4 +50,9 @@ public interface MessageProducer<T> extends WriteStream<T> {
   @Fluent
   MessageProducer<T> deliveryOptions(DeliveryOptions options);
 
+  /**
+   * @return The address to which the producer produces messages.
+   */
+  String address();
+
 }

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
@@ -75,4 +75,9 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
     return this;
   }
 
+  @Override
+  public String address() {
+    return address;
+  }
+
 }

--- a/src/test/java/io/vertx/test/core/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/test/core/LocalEventBusTest.java
@@ -125,6 +125,7 @@ public class LocalEventBusTest extends EventBusTestBase {
     String str = TestUtils.randomUnicodeString(100);
     Handler<Message<String>> handler = msg -> fail("Should not receive message");
     MessageConsumer reg = eb.<String>consumer(ADDRESS1).handler(handler);
+    assertEquals(ADDRESS1, reg.address());
     reg.unregister();
     eb.send(ADDRESS1, str);
     vertx.setTimer(1000, id -> testComplete());
@@ -1194,6 +1195,7 @@ public class LocalEventBusTest extends EventBusTestBase {
   public void testPublisher() {
     String str = TestUtils.randomUnicodeString(100);
     MessageProducer<String> publisher = eb.publisher(ADDRESS1);
+    assertEquals(ADDRESS1, publisher.address());
     AtomicInteger count = new AtomicInteger();
     int n = 2;
     for (int i = 0;i < n;i++) {
@@ -1211,6 +1213,7 @@ public class LocalEventBusTest extends EventBusTestBase {
   public void testPublisherWithOptions() {
     String str = TestUtils.randomUnicodeString(100);
     MessageProducer<String> publisher = eb.publisher(ADDRESS1, new DeliveryOptions().addHeader("foo", "foo_value"));
+    assertEquals(ADDRESS1, publisher.address());
     AtomicInteger count = new AtomicInteger();
     int n = 2;
     for (int i = 0;i < n;i++) {


### PR DESCRIPTION
`MessageConsumer` exposes an `address` getter which can be useful if the consumer is being passed to code that didn't create it. In the interest of consistency, this PR adds the same `address` getter to `MessageProducer`.

Signed-off-by: Jordan Halterman jordan.halterman@gmail.com
