### PR TITLE
Allow Enums to put in JsonObject/JsonArray (converting to String)

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -139,6 +139,12 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable {
     return list.get(pos) == null;
   }
 
+  public JsonArray add(Enum value) {
+    Objects.requireNonNull(value);
+    list.add(value.toString());
+    return this;
+  }
+
   public JsonArray add(CharSequence value) {
     Objects.requireNonNull(value);
     list.add(value.toString());

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -250,6 +250,12 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
     return map.keySet();
   }
 
+  public JsonObject put(String key, Enum value) {
+    Objects.requireNonNull(key);
+    map.put(key, value == null ? null : value.toString());
+    return this;
+  }
+
   public JsonObject put(String key, CharSequence value) {
     Objects.requireNonNull(key);
     map.put(key, value == null ? null : value.toString());

--- a/src/test/java/io/vertx/test/core/JsonArrayTest.java
+++ b/src/test/java/io/vertx/test/core/JsonArrayTest.java
@@ -382,6 +382,22 @@ public class JsonArrayTest {
     assertEquals("blah", arr.getString(0));
   }
 
+  enum SomeEnum {
+    FOO, BAR
+  }
+
+  @Test
+  public void testAddEnum() {
+    assertSame(jsonArray, jsonArray.add(JsonObjectTest.SomeEnum.FOO));
+    assertEquals(JsonObjectTest.SomeEnum.FOO.toString(), jsonArray.getString(0));
+    try {
+      jsonArray.add((JsonObjectTest.SomeEnum)null);
+      fail();
+    } catch (NullPointerException e) {
+      // OK
+    }
+  }
+
   @Test
   public void testAddString() {
     assertSame(jsonArray, jsonArray.add("foo"));

--- a/src/test/java/io/vertx/test/core/JsonObjectTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectTest.java
@@ -751,6 +751,23 @@ public class JsonObjectTest {
     assertEquals(0, jsonObject.size());
   }
 
+  enum SomeEnum {
+    FOO, BAR
+  }
+
+  @Test
+  public void testPutEnum() {
+    assertSame(jsonObject, jsonObject.put("foo", SomeEnum.FOO));
+    assertEquals(SomeEnum.FOO.toString(), jsonObject.getString("foo"));
+    assertTrue(jsonObject.containsKey("foo"));
+    try {
+      jsonObject.put(null, SomeEnum.FOO);
+      fail();
+    } catch (NullPointerException e) {
+      // OK
+    }
+  }
+
   @Test
   public void testPutString() {
     assertSame(jsonObject, jsonObject.put("foo", "bar"));


### PR DESCRIPTION
This is mainly as a convenience so users can put properties as Enums, e.g. for service configuration, e.g.

JsonObject config = new JsonObject().put(AuthRealmTypeFieldName, AuthRealmType.JDBC);
AuthService service = AuthService.create(vertx, config);
