### PR TITLE
PROXY protocol support to HttpServer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
       <version>${netty.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-haproxy</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -286,50 +286,6 @@ Sets whether or not the current link is required.
 +++
 |===
 
-[[PfxOptions]]
-== PfxOptions
-
-++++
- Key or trust store options configuring private key and/or certificates based on PKCS#12 files.
- <p>
- When used as a key store, it should point to a store containing a private key and its certificate.
- When used as a trust store, it should point to a store containing a list of accepted certificates.
- <p>
-
- The store can either be loaded by Vert.x from the filesystem:
- <p>
- <pre>
- HttpServerOptions options = new HttpServerOptions();
- options.setPfxKeyCertOptions(new PfxOptions().setPath("/mykeystore.p12").setPassword("foo"));
- </pre>
-
- Or directly provided as a buffer:<p>
-
- <pre>
- Buffer store = vertx.fileSystem().readFileSync("/mykeystore.p12");
- options.setPfxKeyCertOptions(new PfxOptions().setValue(store).setPassword("foo"));
- </pre>
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[password]]`password`|`String`|
-+++
-Set the password
-+++
-|[[path]]`path`|`String`|
-+++
-Set the path
-+++
-|[[value]]`value`|`Buffer`|
-+++
-Set the store as a buffer
-+++
-|===
-
 [[NetClientOptions]]
 == NetClientOptions
 
@@ -434,6 +390,50 @@ Set the trust options in jks format, aka Java trustore
 |[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
 +++
 Set whether Netty pooled buffers are enabled
++++
+|===
+
+[[PfxOptions]]
+== PfxOptions
+
+++++
+ Key or trust store options configuring private key and/or certificates based on PKCS#12 files.
+ <p>
+ When used as a key store, it should point to a store containing a private key and its certificate.
+ When used as a trust store, it should point to a store containing a list of accepted certificates.
+ <p>
+
+ The store can either be loaded by Vert.x from the filesystem:
+ <p>
+ <pre>
+ HttpServerOptions options = new HttpServerOptions();
+ options.setPfxKeyCertOptions(new PfxOptions().setPath("/mykeystore.p12").setPassword("foo"));
+ </pre>
+
+ Or directly provided as a buffer:<p>
+
+ <pre>
+ Buffer store = vertx.fileSystem().readFileSync("/mykeystore.p12");
+ options.setPfxKeyCertOptions(new PfxOptions().setValue(store).setPassword("foo"));
+ </pre>
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[password]]`password`|`String`|
++++
+Set the password
++++
+|[[path]]`path`|`String`|
++++
+Set the path
++++
+|[[value]]`value`|`Buffer`|
++++
+Set the store as a buffer
 +++
 |===
 
@@ -622,25 +622,6 @@ Set whether Netty pooled buffers are enabled
 +++
 |===
 
-[[MetricsOptions]]
-== MetricsOptions
-
-++++
- Vert.x metrics base configuration, this class can be extended by provider implementations to configure
- those specific implementations.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[enabled]]`enabled`|`Boolean`|
-+++
-Set whether metrics will be enabled on the Vert.x instance.
-+++
-|===
-
 [[ClientOptionsBase]]
 == ClientOptionsBase
 
@@ -737,6 +718,25 @@ Set the trust options in jks format, aka Java trustore
 |[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
 +++
 Set whether Netty pooled buffers are enabled
++++
+|===
+
+[[MetricsOptions]]
+== MetricsOptions
+
+++++
+ Vert.x metrics base configuration, this class can be extended by provider implementations to configure
+ those specific implementations.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[enabled]]`enabled`|`Boolean`|
++++
+Set whether metrics will be enabled on the Vert.x instance.
 +++
 |===
 
@@ -951,6 +951,10 @@ Set the trust options in pfx format
 |[[port]]`port`|`Number (int)`|
 +++
 Set the port
++++
+|[[proxyProtocolEnabled]]`proxyProtocolEnabled`|`Boolean`|
++++
+Set whether proxy protocol is enabled
 +++
 |[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
 +++

--- a/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
@@ -45,6 +45,9 @@ public class HttpServerOptionsConverter {
     if (json.getValue("maxWebsocketFrameSize") instanceof Number) {
       obj.setMaxWebsocketFrameSize(((Number)json.getValue("maxWebsocketFrameSize")).intValue());
     }
+    if (json.getValue("proxyProtocolEnabled") instanceof Boolean) {
+      obj.setProxyProtocolEnabled((Boolean)json.getValue("proxyProtocolEnabled"));
+    }
     if (json.getValue("websocketSubProtocols") instanceof String) {
       obj.setWebsocketSubProtocols((String)json.getValue("websocketSubProtocols"));
     }
@@ -57,6 +60,7 @@ public class HttpServerOptionsConverter {
     json.put("maxHeaderSize", obj.getMaxHeaderSize());
     json.put("maxInitialLineLength", obj.getMaxInitialLineLength());
     json.put("maxWebsocketFrameSize", obj.getMaxWebsocketFrameSize());
+    json.put("proxyProtocolEnabled", obj.isProxyProtocolEnabled());
     if (obj.getWebsocketSubProtocols() != null) {
       json.put("websocketSubProtocols", obj.getWebsocketSubProtocols());
     }

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -64,6 +64,11 @@ public class HttpServerOptions extends NetServerOptions {
    */
   public static final boolean DEFAULT_HANDLE_100_CONTINE_AUTOMATICALLY = false;
 
+  /**
+   * Default value of whether proxy protocol is enabled = false
+   */
+  public static final boolean DEFAULT_PROXY_PROTOCOL_ENABLED = false;
+
   private boolean compressionSupported;
   private int maxWebsocketFrameSize;
   private String websocketSubProtocols;
@@ -71,6 +76,7 @@ public class HttpServerOptions extends NetServerOptions {
   private int maxChunkSize;
   private int maxInitialLineLength;
   private int maxHeaderSize;
+  private boolean proxyProtocolEnabled;
 
   /**
    * Default constructor
@@ -95,6 +101,7 @@ public class HttpServerOptions extends NetServerOptions {
     this.maxChunkSize = other.getMaxChunkSize();
     this.maxInitialLineLength = other.getMaxInitialLineLength();
     this.maxHeaderSize = other.getMaxHeaderSize();
+    this.proxyProtocolEnabled = other.isProxyProtocolEnabled();
   }
 
   /**
@@ -116,6 +123,7 @@ public class HttpServerOptions extends NetServerOptions {
     maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
     maxInitialLineLength = DEFAULT_MAX_INITIAL_LINE_LENGTH;
     maxHeaderSize = DEFAULT_MAX_HEADER_SIZE;
+    proxyProtocolEnabled = DEFAULT_PROXY_PROTOCOL_ENABLED;
   }
 
   @Override
@@ -387,6 +395,24 @@ public class HttpServerOptions extends NetServerOptions {
     return this;
   }
 
+  /**
+   * @return whether proxy protocol is enabled
+   */
+  public boolean isProxyProtocolEnabled() {
+    return proxyProtocolEnabled;
+  }
+
+  /**
+   * Set whether proxy protocol is enabled
+   *
+   * @param proxyProtocolEnabled true if proxy protocol is enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setProxyProtocolEnabled(boolean proxyProtocolEnabled) {
+    this.proxyProtocolEnabled = proxyProtocolEnabled;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -401,6 +427,7 @@ public class HttpServerOptions extends NetServerOptions {
     if (maxChunkSize != that.maxChunkSize) return false;
     if (maxInitialLineLength != that.maxInitialLineLength) return false;
     if (maxHeaderSize != that.maxHeaderSize) return false;
+    if (proxyProtocolEnabled != that.proxyProtocolEnabled) return false;
     return !(websocketSubProtocols != null ? !websocketSubProtocols.equals(that.websocketSubProtocols) : that.websocketSubProtocols != null);
 
   }
@@ -415,6 +442,7 @@ public class HttpServerOptions extends NetServerOptions {
     result = 31 * result + maxChunkSize;
     result = 31 * result + maxInitialLineLength;
     result = 31 * result + maxHeaderSize;
+    result = 31 * result + (proxyProtocolEnabled ? 1 : 0);
     return result;
   }
 }

--- a/src/test/asciidoc/dataobjects.adoc
+++ b/src/test/asciidoc/dataobjects.adoc
@@ -30,21 +30,6 @@
 ^|Name | Type ^| Description
 |===
 
-[[ParentDataObject]]
-== ParentDataObject
-
-++++
- @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[parentProperty]]`parentProperty`|`String`|-
-|===
-
 [[TestDataObject]]
 == TestDataObject
 
@@ -120,6 +105,21 @@
 |[[stringValue]]`stringValue`|`String`|-
 |[[stringValueMap]]`stringValueMap`|`String`|-
 |[[stringValues]]`stringValues`|`Array of String`|-
+|===
+
+[[ParentDataObject]]
+== ParentDataObject
+
+++++
+ @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[parentProperty]]`parentProperty`|`String`|-
 |===
 
 [[AggregatedDataObject]]


### PR DESCRIPTION
This PR adds support for the PROXY protocol (http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt) to the HttpServer.

Signed-off-by: Jon Keys jon.keys@gmail.com
