### PR TITLE
Use Netty DefaultHttpHeaders by default for performance

### DIFF
--- a/src/main/java/io/vertx/core/MultiMap.java
+++ b/src/main/java/io/vertx/core/MultiMap.java
@@ -22,6 +22,7 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.http.CaseInsensitiveHeaders;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -82,6 +83,61 @@ public interface MultiMap extends Iterable<Map.Entry<String, String>> {
    */
   @GenIgnore
   List<Map.Entry<String, String>> entries();
+
+  /**
+   * Returns an iterator for all entries in the multi-map.
+   *
+   * @return A immutable {@link java.util.List} of the name-value entries, which will be
+   *         empty if no pairs are found
+   */
+  @GenIgnore
+  default Iterator<Map.Entry<CharSequence, CharSequence>> iteratorCharSequence() {
+
+    class EntryAdapter implements Map.Entry<CharSequence, CharSequence> {
+
+      private final Map.Entry<String, String> entry;
+
+      EntryAdapter(Map.Entry<String, String> entry) {
+        this.entry = entry;
+      }
+
+      @Override
+      public CharSequence getKey() {
+        return entry.getKey();
+      }
+
+      @Override
+      public CharSequence getValue() {
+        return entry.getValue();
+      }
+
+      @Override
+      public CharSequence setValue(CharSequence value) {
+        return entry.setValue(value == null ? null : value.toString());
+      }
+    }
+
+    class IteratorAdapter implements Iterator<Map.Entry<CharSequence, CharSequence>> {
+
+      private final Iterator<Map.Entry<String, String>> iterator;
+
+      IteratorAdapter(Iterator<Map.Entry<String, String>> iterator){
+        this.iterator = iterator;
+      }
+
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public Map.Entry<CharSequence, CharSequence> next() {
+        return new EntryAdapter(iterator.next());
+      }
+    }
+
+    return new IteratorAdapter(iterator());
+  }
 
   /**
    * Checks to see if there is a value with the specified name

--- a/src/main/java/io/vertx/core/http/impl/HeadersAdaptor.java
+++ b/src/main/java/io/vertx/core/http/impl/HeadersAdaptor.java
@@ -22,6 +22,7 @@ import io.vertx.core.MultiMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -36,11 +37,13 @@ public class HeadersAdaptor implements MultiMap {
 
   @Override
   public String get(String name) {
+    Objects.requireNonNull(name, "name");
     return headers.get(name);
   }
 
   @Override
   public List<String> getAll(String name) {
+    Objects.requireNonNull(name, "name");
     return headers.getAll(name);
   }
 
@@ -66,12 +69,14 @@ public class HeadersAdaptor implements MultiMap {
 
   @Override
   public MultiMap add(String name, String value) {
+    Objects.requireNonNull(name, "name");
     headers.add(name, value);
     return this;
   }
 
   @Override
   public MultiMap add(String name, Iterable<String> values) {
+    Objects.requireNonNull(name, "name");
     headers.add(name, values);
     return this;
   }
@@ -94,12 +99,14 @@ public class HeadersAdaptor implements MultiMap {
 
   @Override
   public MultiMap set(String name, String value) {
+    Objects.requireNonNull(name, "name");
     headers.set(name, value);
     return this;
   }
 
   @Override
   public MultiMap set(String name, Iterable<String> values) {
+    Objects.requireNonNull(name, "name");
     headers.set(name, values);
     return this;
   }
@@ -115,6 +122,7 @@ public class HeadersAdaptor implements MultiMap {
 
   @Override
   public MultiMap remove(String name) {
+    Objects.requireNonNull(name, "name");
     headers.remove(name);
     return this;
   }
@@ -128,6 +136,11 @@ public class HeadersAdaptor implements MultiMap {
   @Override
   public Iterator<Map.Entry<String, String>> iterator() {
     return headers.iterator();
+  }
+
+  @Override
+  public Iterator<Map.Entry<CharSequence, CharSequence>> iteratorCharSequence() {
+    return headers.iteratorCharSequence();
   }
 
   @Override
@@ -145,6 +158,7 @@ public class HeadersAdaptor implements MultiMap {
 
   @Override
   public String get(CharSequence name) {
+    Objects.requireNonNull(name, "name");
     return headers.get(name);
   }
 
@@ -155,35 +169,41 @@ public class HeadersAdaptor implements MultiMap {
 
   @Override
   public boolean contains(CharSequence name) {
+    Objects.requireNonNull(name, "name");
     return headers.contains(name);
   }
 
   @Override
   public MultiMap add(CharSequence name, CharSequence value) {
+    Objects.requireNonNull(name, "name");
     headers.add(name, value);
     return this;
   }
 
   @Override
   public MultiMap add(CharSequence name, Iterable<CharSequence> values) {
+    Objects.requireNonNull(name, "name");
     headers.add(name, values);
     return this;
   }
 
   @Override
   public MultiMap set(CharSequence name, CharSequence value) {
+    Objects.requireNonNull(name, "name");
     headers.set(name, value);
     return this;
   }
 
   @Override
   public MultiMap set(CharSequence name, Iterable<CharSequence> values) {
+    Objects.requireNonNull(name, "name");
     headers.set(name, values);
     return this;
   }
 
   @Override
   public MultiMap remove(CharSequence name) {
+    Objects.requireNonNull(name, "name");
     headers.remove(name);
     return this;
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -42,6 +42,7 @@ import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
 
+import java.util.Iterator;
 import java.util.Map;
 
 import static io.vertx.core.http.HttpHeaders.DEFLATE_GZIP;
@@ -305,8 +306,10 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
           h.authority(hostHeader);
         }
       }
-      if (headers != null && headers.size() > 0) {
-        for (Map.Entry<String, String> header : headers) {
+      if (headers != null && !headers.isEmpty()) {
+        for (Iterator<Map.Entry<CharSequence, CharSequence>> it = headers.iteratorCharSequence(); it.hasNext(); ) {
+          Map.Entry<CharSequence, CharSequence> header = it.next();
+          // Todo : multi valued headers
           h.add(Http2HeadersAdaptor.toLowerCase(header.getKey()), header.getValue());
         }
       }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -19,11 +19,11 @@ package io.vertx.core.http.impl;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpConnection;
@@ -36,7 +36,7 @@ import io.vertx.core.net.NetSocket;
 import java.util.List;
 import java.util.Objects;
 
-import static io.vertx.core.http.HttpHeaders.*;
+import static io.vertx.core.http.HttpHeaders.CONTENT_LENGTH;
 
 /**
  * This class is optimised for performance when used on the same event loop that is was passed to the handler with.
@@ -70,7 +70,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   private boolean connecting;
   private boolean writeHead;
   private long written;
-  private CaseInsensitiveHeaders headers;
+  private MultiMap headers;
 
   HttpClientRequestImpl(HttpClientImpl client, io.vertx.core.http.HttpMethod method, String host, int port,
                         boolean ssl, String relativeURI, VertxInternal vertx) {
@@ -178,7 +178,8 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   public MultiMap headers() {
     synchronized (getLock()) {
       if (headers == null) {
-        headers = new CaseInsensitiveHeaders();
+        // defer the name/value validation until the write occurs.
+        headers = new HeadersAdaptor(new DefaultHttpHeaders(false));
       }
       return headers;
     }

--- a/src/test/java/io/vertx/test/core/CaseInsensitiveHeadersTest.java
+++ b/src/test/java/io/vertx/test/core/CaseInsensitiveHeadersTest.java
@@ -930,4 +930,14 @@ public class CaseInsensitiveHeadersTest {
       me.setValue(null);
     }
   }
+
+  @Test
+  public void testMultipleValues() {
+    MultiMap map = new CaseInsensitiveHeaders();
+    List<String> ts = Arrays.asList("1", "2", "3");
+    map.set("foo", ts);
+    assertEquals(1, map.size());
+    map.set("bar", "1");
+    assertEquals(2, map.size());
+  }
 }

--- a/src/test/java/io/vertx/test/core/Http2HeadersTest.java
+++ b/src/test/java/io/vertx/test/core/Http2HeadersTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
@@ -96,14 +97,41 @@ public class Http2HeadersTest {
   @Test
   public void testEntries() {
     map.set("foo", Arrays.<String>asList("foo_value_1", "foo_value_2"));
-    List<Map.Entry<String, String>> entries = map.entries();
-    assertEquals(entries.size(), 1);
-    assertEquals("foo", entries.get(0).getKey());
-    assertEquals("foo_value_1", entries.get(0).getValue());
+    List<Map.Entry<String, String>> entries1 = map.entries();
+    assertEquals(entries1.size(), 1);
+    assertEquals("foo", entries1.get(0).getKey());
+    assertEquals("foo_value_1", entries1.get(0).getValue());
     map.set("bar", "bar_value");
-    Map<String, String> collected = map.entries().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    List<Map.Entry<String, String>> entries2 = map.entries();
+    assertEquals(entries2.size(), 2);
+    Map<String, String> collected = entries2.stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     assertEquals("foo_value_1", collected.get("foo"));
     assertEquals("bar_value", collected.get("bar"));
+    map.remove("foo");
+    map.remove("bar");
+    List<Map.Entry<String, String>> entries3 = map.entries();
+    assertEquals(entries3.size(), 0);
+  }
+
+  @Test
+  public void testMultipleValues() {
+    List<String> ts = Arrays.asList("1", "2", "3");
+    map.set("foo", ts);
+    Set<String> names = map.names();
+    assertEquals(1, names.size());
+    assertTrue(names.contains("foo"));
+    assertEquals(1, map.size());
+    map.set("bar", "1");
+    Set<String> names2 = map.names();
+    assertEquals(2, names2.size());
+    assertTrue(names2.contains("foo"));
+    assertTrue(names2.contains("bar"));
+    assertEquals(2, map.size());
+    map.remove("foo");
+    map.remove("bar");
+    Set<String> names3 = map.names();
+    assertEquals(0, names3.size());
+    assertEquals(0, map.size());
   }
 
   private void assertHeaderNames(String... expected) {


### PR DESCRIPTION
Use DefaultHttpHeaders so that headers in HttpHeaders can be used directly. This helps Netty to serialize header name without having to encode. In addition to that, it can also use AsciiString.hashCode() for hash code for faster hash table lookup.
