### PR TITLE
Move to use lowercase header name instead

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -15,6 +15,10 @@
  */
 package io.vertx.core.http;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.util.AsciiString;
+
 /**
  * Contains often used Header names.
  * <p>
@@ -28,289 +32,337 @@ public final class HttpHeaders {
   /**
    * Accept header name
    */
-  public static final CharSequence ACCEPT = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCEPT);
+  public static final CharSequence ACCEPT = HttpHeaderNames.ACCEPT;
 
   /**
    * Accept-Charset header name
    */
-  public static final CharSequence ACCEPT_CHARSET = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCEPT_CHARSET);
+  public static final CharSequence ACCEPT_CHARSET = HttpHeaderNames.ACCEPT_CHARSET;
 
   /**
    * Accept-Encoding header name
    */
-  public static final CharSequence ACCEPT_ENCODING = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCEPT_ENCODING);
+  public static final CharSequence ACCEPT_ENCODING = HttpHeaderNames.ACCEPT_ENCODING;
 
   /**
    * Accept-Language header name
    */
-  public static final CharSequence ACCEPT_LANGUAGE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCEPT_LANGUAGE);
+  public static final CharSequence ACCEPT_LANGUAGE = HttpHeaderNames.ACCEPT_LANGUAGE;
 
   /**
    * Accept-Ranges header name
    */
-  public static final CharSequence ACCEPT_RANGES = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCEPT_RANGES);
+  public static final CharSequence ACCEPT_RANGES = HttpHeaderNames.ACCEPT_RANGES;
 
   /**
    * Accept-Patch header name
    */
-  public static final CharSequence ACCEPT_PATCH = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCEPT_PATCH);
+  public static final CharSequence ACCEPT_PATCH = HttpHeaderNames.ACCEPT_PATCH;
 
   /**
    * Access-Control-Allow-Credentials header name
    */
-  public static final CharSequence ACCESS_CONTROL_ALLOW_CREDENTIALS = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS);
+  public static final CharSequence ACCESS_CONTROL_ALLOW_CREDENTIALS = HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS;
 
   /**
    * Access-Control-Allow-Headers header name
    */
-  public static final CharSequence ACCESS_CONTROL_ALLOW_HEADERS = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS);
+  public static final CharSequence ACCESS_CONTROL_ALLOW_HEADERS = HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS;
 
   /**
    * Access-Control-Allow-Methods header name
    */
-  public static final CharSequence ACCESS_CONTROL_ALLOW_METHODS = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_METHODS);
+  public static final CharSequence ACCESS_CONTROL_ALLOW_METHODS = HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS;
 
   /**
    * Access-Control-Allow-Origin header name
    */
-  public static final CharSequence ACCESS_CONTROL_ALLOW_ORIGIN = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN);
+  public static final CharSequence ACCESS_CONTROL_ALLOW_ORIGIN = HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN;
 
   /**
    * Access-Control-Expose-Headers header name
    */
-  public static final CharSequence ACCESS_CONTROL_EXPOSE_HEADERS = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_EXPOSE_HEADERS);
+  public static final CharSequence ACCESS_CONTROL_EXPOSE_HEADERS = HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS;
 
   /**
    * Access-Control-Max-Age header name
    */
-  public static final CharSequence ACCESS_CONTROL_MAX_AGE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_MAX_AGE);
+  public static final CharSequence ACCESS_CONTROL_MAX_AGE = HttpHeaderNames.ACCESS_CONTROL_MAX_AGE;
 
   /**
    * Access-Control-Request-Headers header name
    */
-  public static final CharSequence ACCESS_CONTROL_REQUEST_HEADERS = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_REQUEST_HEADERS);
+  public static final CharSequence ACCESS_CONTROL_REQUEST_HEADERS = HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS;
 
   /**
    * Access-Control-Request-Method header name
    */
-  public static final CharSequence ACCESS_CONTROL_REQUEST_METHOD = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ACCESS_CONTROL_REQUEST_METHOD);
+  public static final CharSequence ACCESS_CONTROL_REQUEST_METHOD = HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD;
 
   /**
    *  Age header name
    */
-  public static final CharSequence AGE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.AGE);
+  public static final CharSequence AGE = HttpHeaderNames.AGE;
 
   /**
    * Allow header name
    */
-  public static final CharSequence ALLOW = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ALLOW);
+  public static final CharSequence ALLOW = HttpHeaderNames.ALLOW;
 
   /**
    * Authorization header name
    */
-  public static final CharSequence AUTHORIZATION = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.AUTHORIZATION);
+  public static final CharSequence AUTHORIZATION = HttpHeaderNames.AUTHORIZATION;
 
   /**
    * Cache-Control header name
    */
-  public static final CharSequence CACHE_CONTROL = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.CACHE_CONTROL);
+  public static final CharSequence CACHE_CONTROL = HttpHeaderNames.CACHE_CONTROL;
 
   /**
    * Connection header name
    */
-  public static final CharSequence CONNECTION = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION);
+  public static final CharSequence CONNECTION = HttpHeaderNames.CONNECTION;
 
   /**
    * Content-Base header name
    */
-  public static final CharSequence CONTENT_BASE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_BASE);
+  public static final CharSequence CONTENT_BASE = HttpHeaderNames.CONTENT_BASE;
 
   /**
    * Content-Encoding header name
    */
-  public static final CharSequence CONTENT_ENCODING = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_ENCODING);
+  public static final CharSequence CONTENT_ENCODING = HttpHeaderNames.CONTENT_ENCODING;
 
   /**
    * Content-Language header name
    */
-  public static final CharSequence CONTENT_LANGUAGE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LANGUAGE);
+  public static final CharSequence CONTENT_LANGUAGE = HttpHeaderNames.CONTENT_LANGUAGE;
 
   /**
    * Content-Length header name
    */
-  public static final CharSequence CONTENT_LENGTH = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH);
+  public static final CharSequence CONTENT_LENGTH = HttpHeaderNames.CONTENT_LENGTH;
 
   /**
    * Content-Location header name
    */
-  public static final CharSequence CONTENT_LOCATION = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LOCATION);
-
-  /**
-   * Content-Transfer-Encoding header name
-   */
-  public static final CharSequence CONTENT_TRANSFER_ENCODING = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TRANSFER_ENCODING);
+  public static final CharSequence CONTENT_LOCATION = HttpHeaderNames.CONTENT_LOCATION;
 
   /**
    * Content-MD5 header name
    */
-  public static final CharSequence CONTENT_MD5 = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_MD5);
+  public static final CharSequence CONTENT_MD5 = HttpHeaderNames.CONTENT_MD5;
 
   /**
    * Content-Rage header name
    */
-  public static final CharSequence CONTENT_RANGE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_RANGE);
+  public static final CharSequence CONTENT_RANGE = HttpHeaderNames.CONTENT_RANGE;
+
+  /**
+   * Content-Transfer-Encoding header name
+   */
+  public static final CharSequence CONTENT_TRANSFER_ENCODING = HttpHeaderNames.CONTENT_TRANSFER_ENCODING;
 
   /**
    * Content-Type header name
    */
-  public static final CharSequence CONTENT_TYPE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE);
+  public static final CharSequence CONTENT_TYPE = HttpHeaderNames.CONTENT_TYPE;
 
   /**
    * Content-Cookie header name
    */
-  public static final CharSequence COOKIE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.COOKIE);
+  public static final CharSequence COOKIE = HttpHeaderNames.COOKIE;
 
   /**
    * Date header name
    */
-  public static final CharSequence DATE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.DATE);
+  public static final CharSequence DATE = HttpHeaderNames.DATE;
 
   /**
    * Etag header name
    */
-  public static final CharSequence ETAG = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ETAG);
+  public static final CharSequence ETAG = HttpHeaderNames.ETAG;
 
   /**
    * Expect header name
    */
-  public static final CharSequence EXPECT = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.EXPECT);
+  public static final CharSequence EXPECT = HttpHeaderNames.EXPECT;
 
   /**
    * Expires header name
    */
-  public static final CharSequence EXPIRES = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.EXPIRES);
+  public static final CharSequence EXPIRES = HttpHeaderNames.EXPIRES;
 
   /**
    * From header name
    */
-  public static final CharSequence FROM = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.FROM);
+  public static final CharSequence FROM = HttpHeaderNames.FROM;
 
   /**
    * Host header name
    */
-  public static final CharSequence HOST = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.HOST);
+  public static final CharSequence HOST = HttpHeaderNames.HOST;
 
   /**
    * If-Match header name
    */
-  public static final CharSequence IF_MATCH = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.IF_MATCH);
+  public static final CharSequence IF_MATCH = HttpHeaderNames.IF_MATCH;
 
   /**
    * If-Modified-Since header name
    */
-  public static final CharSequence IF_MODIFIED_SINCE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.IF_MODIFIED_SINCE);
+  public static final CharSequence IF_MODIFIED_SINCE = HttpHeaderNames.IF_MODIFIED_SINCE;
 
   /**
    * If-None-Match header name
    */
-  public static final CharSequence IF_NONE_MATCH = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.IF_NONE_MATCH);
+  public static final CharSequence IF_NONE_MATCH = HttpHeaderNames.IF_NONE_MATCH;
+
+  /**
+   * If-Unmodified-Since header name
+   */
+  public static final CharSequence IF_UNMODIFIED_SINCE = HttpHeaderNames.IF_UNMODIFIED_SINCE;
 
   /**
    * Last-Modified header name
    */
-  public static final CharSequence LAST_MODIFIED = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.LAST_MODIFIED);
+  public static final CharSequence LAST_MODIFIED = HttpHeaderNames.LAST_MODIFIED;
 
   /**
    * Location header name
    */
-  public static final CharSequence LOCATION = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.LOCATION);
+  public static final CharSequence LOCATION = HttpHeaderNames.LOCATION;
 
   /**
    * Origin header name
    */
-  public static final CharSequence ORIGIN = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.ORIGIN);
+  public static final CharSequence ORIGIN = HttpHeaderNames.ORIGIN;
+
+  /**
+   * Pragma header name
+   */
+  public static final CharSequence PRAGMA = HttpHeaderNames.PRAGMA;
 
   /**
    * Proxy-Authenticate header name
    */
-  public static final CharSequence PROXY_AUTHENTICATE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.PROXY_AUTHENTICATE);
+  public static final CharSequence PROXY_AUTHENTICATE = HttpHeaderNames.PROXY_AUTHENTICATE;
 
   /**
    * Proxy-Authorization header name
    */
-  public static final CharSequence PROXY_AUTHORIZATION = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.PROXY_AUTHORIZATION);
+  public static final CharSequence PROXY_AUTHORIZATION = HttpHeaderNames.PROXY_AUTHORIZATION;
+
+  /**
+   * Range header name
+   */
+  public static final CharSequence RANGE = HttpHeaderNames.RANGE;
 
   /**
    * Referer header name
    */
-  public static final CharSequence REFERER = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.REFERER);
+  public static final CharSequence REFERER = HttpHeaderNames.REFERER;
 
   /**
    * Retry-After header name
    */
-  public static final CharSequence RETRY_AFTER = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.RETRY_AFTER);
+  public static final CharSequence RETRY_AFTER = HttpHeaderNames.RETRY_AFTER;
 
   /**
    * Server header name
    */
-  public static final CharSequence SERVER = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.SERVER);
+  public static final CharSequence SERVER = HttpHeaderNames.SERVER;
+
+  /**
+   * TE header name
+   */
+  public static final CharSequence TE = HttpHeaderNames.TE;
+
+  /**
+   * Trailer header name
+   */
+  public static final CharSequence TRAILER = HttpHeaderNames.TRAILER;
 
   /**
    * Transfer-Encoding header name
    */
-  public static final CharSequence TRANSFER_ENCODING = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.TRANSFER_ENCODING);
+  public static final CharSequence TRANSFER_ENCODING = HttpHeaderNames.TRANSFER_ENCODING;
 
   /**
    * User-Agent header name
    */
-  public static final CharSequence USER_AGENT = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.USER_AGENT);
+  public static final CharSequence USER_AGENT = HttpHeaderNames.USER_AGENT;
+
+  /**
+   * Vary header name
+   */
+  public static final CharSequence VARY = HttpHeaderNames.VARY;
+
+  /**
+   * Via header name
+   */
+  public static final CharSequence VIA = HttpHeaderNames.VIA;
+
+  /**
+   * Warning header name
+   */
+  public static final CharSequence WARNING = HttpHeaderNames.WARNING;
 
   /**
    * Set-Cookie header name
    */
-  public static final CharSequence SET_COOKIE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Names.SET_COOKIE);
+  public static final CharSequence SET_COOKIE = HttpHeaderNames.SET_COOKIE;
 
   /**
    * application/x-www-form-urlencoded header value
    */
-  public static final CharSequence APPLICATION_X_WWW_FORM_URLENCODED = createOptimized(io.netty.handler.codec.http.HttpHeaders.Values.APPLICATION_X_WWW_FORM_URLENCODED);
+  public static final CharSequence APPLICATION_X_WWW_FORM_URLENCODED = HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED;
 
   /**
    * chunked header value
    */
-  public static final CharSequence CHUNKED =  createOptimized(io.netty.handler.codec.http.HttpHeaders.Values.CHUNKED);
+  public static final CharSequence CHUNKED =  HttpHeaderValues.CHUNKED;
   /**
    * close header value
    */
-  public static final CharSequence CLOSE =  createOptimized(io.netty.handler.codec.http.HttpHeaders.Values.CLOSE);
+  public static final CharSequence CLOSE =  HttpHeaderValues.CLOSE;
 
   /**
    * 100-continue header value
    */
-  public static final CharSequence CONTINUE =  createOptimized(io.netty.handler.codec.http.HttpHeaders.Values.CONTINUE);
+  public static final CharSequence CONTINUE =  HttpHeaderValues.CONTINUE;
 
   /**
    * identity header value
    */
-  public static final CharSequence IDENTITY =  createOptimized(io.netty.handler.codec.http.HttpHeaders.Values.IDENTITY);
+  public static final CharSequence IDENTITY =  HttpHeaderValues.IDENTITY;
   /**
    * keep-alive header value
    */
-  public static final CharSequence KEEP_ALIVE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Values.KEEP_ALIVE);
+  public static final CharSequence KEEP_ALIVE = HttpHeaderValues.KEEP_ALIVE;
 
   /**
    * Upgrade header value
    */
-  public static final CharSequence UPGRADE = createOptimized(io.netty.handler.codec.http.HttpHeaders.Values.UPGRADE);
+  public static final CharSequence UPGRADE = HttpHeaderValues.UPGRADE;
   /**
    * WebSocket header value
    */
-  public static final CharSequence WEBSOCKET = createOptimized(io.netty.handler.codec.http.HttpHeaders.Values.WEBSOCKET);
+  public static final CharSequence WEBSOCKET = HttpHeaderValues.WEBSOCKET;
 
   /**
    * deflate,gzip header value
+   *
+   * Deprecated: use {@link #GZIP_DEFLATE} instead.
    */
+  @Deprecated
   public static final CharSequence DEFLATE_GZIP = createOptimized("deflate, gzip");
+
+  /**
+   * gzip,deflate header value
+   */
+  public static final CharSequence GZIP_DEFLATE = HttpHeaderValues.GZIP_DEFLATE;
 
   /**
    * text/html header value
@@ -328,7 +380,7 @@ public final class HttpHeaders {
    * for multiple responses or requests.
    */
   public static CharSequence createOptimized(String value) {
-    return io.netty.handler.codec.http.HttpHeaders.newEntity(value);
+    return new AsciiString(value);
   }
 
   private HttpHeaders() {

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -44,7 +44,7 @@ import io.vertx.core.spi.metrics.HttpClientMetrics;
 
 import java.util.Map;
 
-import static io.vertx.core.http.HttpHeaders.DEFLATE_GZIP;
+import static io.vertx.core.http.HttpHeaders.GZIP_DEFLATE;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -311,7 +311,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
         }
       }
       if (conn.http2Pool.client.getOptions().isTryUseCompression() && h.get(HttpHeaderNames.ACCEPT_ENCODING) == null) {
-        h.set(HttpHeaderNames.ACCEPT_ENCODING, DEFLATE_GZIP);
+        h.set(HttpHeaderNames.ACCEPT_ENCODING, GZIP_DEFLATE);
       }
       if (conn.metrics.isEnabled()) {
         request.metric(conn.metrics.requestBegin(conn.queueMetric, conn.metric, conn.localAddress(), conn.remoteAddress(), request));


### PR DESCRIPTION
With HTTP/2, all the headers should be in lowercase form. By making all the headers to be lowercase, it will reduce the need for Netty/Vert.x to perform any conversion

Signed-off-by: Testo Nakada test1@doramail.com
