### PR TITLE
add support for sslHandshakeTimeout in NetServer and NetClient Options

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -232,6 +232,10 @@ Set whether SO_linger keep alive is enabled
 +++
 Set whether SSL/TLS is enabled
 +++
+|[[sslHandshakeTimeout]]`sslHandshakeTimeout`|`Number (long)`|
++++
+Set the SSL handshake timeout, in milliseconds.
++++
 |[[tcpCork]]`tcpCork`|`Boolean`|
 +++
 Enable the <code>TCP_CORK</code> option - only with linux native transport.
@@ -623,6 +627,10 @@ Set whether SO_linger keep alive is enabled
 +++
 Set whether SSL/TLS is enabled
 +++
+|[[sslHandshakeTimeout]]`sslHandshakeTimeout`|`Number (long)`|
++++
+Set the SSL handshake timeout, in milliseconds.
++++
 |[[tcpCork]]`tcpCork`|`Boolean`|
 +++
 Enable the <code>TCP_CORK</code> option - only with linux native transport.
@@ -947,6 +955,10 @@ Set whether SO_linger keep alive is enabled
 +++
 Set whether SSL/TLS is enabled
 +++
+|[[sslHandshakeTimeout]]`sslHandshakeTimeout`|`Number (long)`|
++++
+Set the SSL handshake timeout, in milliseconds.
++++
 |[[tcpCork]]`tcpCork`|`Boolean`|
 +++
 Enable the <code>TCP_CORK</code> option - only with linux native transport.
@@ -1189,6 +1201,10 @@ Set whether SO_linger keep alive is enabled
 +++
 Set whether SSL/TLS is enabled
 +++
+|[[sslHandshakeTimeout]]`sslHandshakeTimeout`|`Number (long)`|
++++
+Set the SSL handshake timeout, in milliseconds.
++++
 |[[tcpCork]]`tcpCork`|`Boolean`|
 +++
 Enable the <code>TCP_CORK</code> option - only with linux native transport.
@@ -1424,6 +1440,10 @@ Set whether SO_linger keep alive is enabled
 +++
 Set whether SSL/TLS is enabled
 +++
+|[[sslHandshakeTimeout]]`sslHandshakeTimeout`|`Number (long)`|
++++
+Set the SSL handshake timeout, in milliseconds.
++++
 |[[tcpCork]]`tcpCork`|`Boolean`|
 +++
 Enable the <code>TCP_CORK</code> option - only with linux native transport.
@@ -1574,6 +1594,10 @@ Set whether SO_linger keep alive is enabled
 |[[ssl]]`ssl`|`Boolean`|
 +++
 Set whether SSL/TLS is enabled
++++
+|[[sslHandshakeTimeout]]`sslHandshakeTimeout`|`Number (long)`|
++++
+Set the SSL handshake timeout, in milliseconds.
 +++
 |[[tcpCork]]`tcpCork`|`Boolean`|
 +++
@@ -2153,6 +2177,10 @@ Set whether SO_linger keep alive is enabled
 |[[ssl]]`ssl`|`Boolean`|
 +++
 Set whether SSL/TLS is enabled
++++
+|[[sslHandshakeTimeout]]`sslHandshakeTimeout`|`Number (long)`|
++++
+Set the SSL handshake timeout, in milliseconds.
 +++
 |[[tcpCork]]`tcpCork`|`Boolean`|
 +++

--- a/src/main/asciidoc/java/cli-for-java.adoc
+++ b/src/main/asciidoc/java/cli-for-java.adoc
@@ -1,0 +1,108 @@
+=== Typed options and arguments
+
+The described `link:../../apidocs/io/vertx/core/cli/Option.html[Option]` and `link:../../apidocs/io/vertx/core/cli/Argument.html[Argument]` classes are _untyped_,
+meaning that the only get String values.
+`link:../../apidocs/io/vertx/core/cli/TypedOption.html[TypedOption]` and `link:../../apidocs/io/vertx/core/cli/TypedArgument.html[TypedArgument]` let you specify a _type_, so the
+(String) raw value is converted to the specified type.
+
+Instead of
+`link:../../apidocs/io/vertx/core/cli/Option.html[Option]` and `link:../../apidocs/io/vertx/core/cli/Argument.html[Argument]`, use `link:../../apidocs/io/vertx/core/cli/TypedOption.html[TypedOption]`
+and `link:../../apidocs/io/vertx/core/cli/TypedArgument.html[TypedArgument]` in the `link:../../apidocs/io/vertx/core/cli/CLI.html[CLI]` definition:
+
+[source,java]
+----
+CLI cli = CLI.create("copy")
+    .setSummary("A command line interface to copy files.")
+    .addOption(new TypedOption<Boolean>()
+        .setType(Boolean.class)
+        .setLongName("directory")
+        .setShortName("R")
+        .setDescription("enables directory support")
+        .setFlag(true))
+    .addArgument(new TypedArgument<File>()
+        .setType(File.class)
+        .setIndex(0)
+        .setDescription("The source")
+        .setArgName("source"))
+    .addArgument(new TypedArgument<File>()
+        .setType(File.class)
+        .setIndex(0)
+        .setDescription("The destination")
+        .setArgName("target"));
+----
+
+Then you can retrieve the converted values as follows:
+
+[source,java]
+----
+CommandLine commandLine = cli.parse(userCommandLineArguments);
+boolean flag = commandLine.getOptionValue("R");
+File source = commandLine.getArgumentValue("source");
+File target = commandLine.getArgumentValue("target");
+----
+
+The vert.x CLI is able to convert to classes:
+
+* having a constructor with a single
+`link:../../apidocs/java/lang/String.html[String]` argument, such as `link:../../apidocs/java/io/File.html[File]` or `link:../../apidocs/io/vertx/core/json/JsonObject.html[JsonObject]`
+* with a static `from` or `fromString` method
+* with a static `valueOf` method, such as primitive types and enumeration
+
+In addition, you can implement your own `link:../../apidocs/io/vertx/core/cli/converters/Converter.html[Converter]` and instruct the CLI to use
+this converter:
+
+[source,java]
+----
+CLI cli = CLI.create("some-name")
+    .addOption(new TypedOption<Person>()
+        .setType(Person.class)
+        .setConverter(new PersonConverter())
+        .setLongName("person"));
+----
+
+For booleans, the boolean values are evaluated to `true`: `on`, `yes`, `1`, `true`.
+
+If one of your option has an `enum` as type, it computes the set of choices automatically.
+
+=== Using annotations
+
+You can also define your CLI using annotations. Definition is done using annotation on the class and on _setter_
+methods:
+
+[source, java]
+----
+@Name("some-name")
+@Summary("some short summary.")
+@Description("some long description")
+public class AnnotatedCli {
+
+  private boolean flag;
+  private String name;
+  private String arg;
+
+ @Option(shortName = "f", flag = true)
+ public void setFlag(boolean flag) {
+   this.flag = flag;
+ }
+
+ @Option(longName = "name")
+ public void setName(String name) {
+   this.name = name;
+ }
+
+ @Argument(index = 0)
+ public void setArg(String arg) {
+  this.arg = arg;
+ }
+}
+----
+
+Once annotated, you can define the `link:../../apidocs/io/vertx/core/cli/CLI.html[CLI]` and inject the values using:
+
+[source,java]
+----
+CLI cli = CLI.create(AnnotatedCli.class);
+CommandLine commandLine = cli.parse(userCommandLineArguments);
+AnnotatedCli instance = new AnnotatedCli();
+CLIConfigurator.inject(commandLine, instance);
+----

--- a/src/main/generated/io/vertx/core/eventbus/EventBusOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/eventbus/EventBusOptionsConverter.java
@@ -134,6 +134,9 @@ import io.vertx.core.json.JsonArray;
     if (json.getValue("ssl") instanceof Boolean) {
       obj.setSsl((Boolean)json.getValue("ssl"));
     }
+    if (json.getValue("sslHandshakeTimeout") instanceof Number) {
+      obj.setSslHandshakeTimeout(((Number)json.getValue("sslHandshakeTimeout")).longValue());
+    }
     if (json.getValue("tcpCork") instanceof Boolean) {
       obj.setTcpCork((Boolean)json.getValue("tcpCork"));
     }
@@ -234,6 +237,7 @@ import io.vertx.core.json.JsonArray;
     json.put("sendBufferSize", obj.getSendBufferSize());
     json.put("soLinger", obj.getSoLinger());
     json.put("ssl", obj.isSsl());
+    json.put("sslHandshakeTimeout", obj.getSslHandshakeTimeout());
     json.put("tcpCork", obj.isTcpCork());
     json.put("tcpFastOpen", obj.isTcpFastOpen());
     json.put("tcpKeepAlive", obj.isTcpKeepAlive());

--- a/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
@@ -83,6 +83,9 @@ import io.vertx.core.json.JsonArray;
     if (json.getValue("ssl") instanceof Boolean) {
       obj.setSsl((Boolean)json.getValue("ssl"));
     }
+    if (json.getValue("sslHandshakeTimeout") instanceof Number) {
+      obj.setSslHandshakeTimeout(((Number)json.getValue("sslHandshakeTimeout")).longValue());
+    }
     if (json.getValue("tcpCork") instanceof Boolean) {
       obj.setTcpCork((Boolean)json.getValue("tcpCork"));
     }
@@ -154,6 +157,7 @@ import io.vertx.core.json.JsonArray;
     }
     json.put("soLinger", obj.getSoLinger());
     json.put("ssl", obj.isSsl());
+    json.put("sslHandshakeTimeout", obj.getSslHandshakeTimeout());
     json.put("tcpCork", obj.isTcpCork());
     json.put("tcpFastOpen", obj.isTcpFastOpen());
     json.put("tcpKeepAlive", obj.isTcpKeepAlive());

--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -350,6 +350,11 @@ public class NetClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public NetClientOptions setSslHandshakeTimeout(long sslHandshakeTimeout) {
+    return (NetClientOptions) super.setSslHandshakeTimeout(sslHandshakeTimeout);
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (!(o instanceof NetClientOptions)) return false;

--- a/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -275,6 +275,11 @@ public class NetServerOptions extends TCPSSLOptions {
     return (NetServerOptions) super.addCrlValue(crlValue);
   }
 
+  @Override
+  public NetServerOptions setSslHandshakeTimeout(long sslHandshakeTimeout) {
+    return (NetServerOptions) super.setSslHandshakeTimeout(sslHandshakeTimeout);
+  }
+
   /**
    * @return the value of accept backlog
    */

--- a/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -90,12 +90,18 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    */
   public static final boolean DEFAULT_TCP_QUICKACK = false;
 
+  /**
+   * The default value of SSL handshakeTimeout (in milliseconds) = 10000L
+   */
+  public static final long DEFAULT_SSL_HANDSHAKE_TIMEOUT = 10000L;
+
   private boolean tcpNoDelay;
   private boolean tcpKeepAlive;
   private int soLinger;
   private boolean usePooledBuffers;
   private int idleTimeout;
   private boolean ssl;
+  private long sslHandshakeTimeout;
   private KeyCertOptions keyCertOptions;
   private TrustOptions trustOptions;
   private Set<String> enabledCipherSuites;
@@ -129,6 +135,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     this.usePooledBuffers = other.isUsePooledBuffers();
     this.idleTimeout = other.getIdleTimeout();
     this.ssl = other.isSsl();
+    this.sslHandshakeTimeout = other.sslHandshakeTimeout;
     this.keyCertOptions = other.getKeyCertOptions() != null ? other.getKeyCertOptions().clone() : null;
     this.trustOptions = other.getTrustOptions() != null ? other.getTrustOptions().clone() : null;
     this.enabledCipherSuites = other.getEnabledCipherSuites() == null ? new LinkedHashSet<>() : new LinkedHashSet<>(other.getEnabledCipherSuites());
@@ -172,6 +179,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     idleTimeout = DEFAULT_IDLE_TIMEOUT;
     ssl = DEFAULT_SSL;
     enabledCipherSuites = new LinkedHashSet<>();
+    sslHandshakeTimeout = DEFAULT_SSL_HANDSHAKE_TIMEOUT;
     crlPaths = new ArrayList<>();
     crlValues = new ArrayList<>();
     useAlpn = DEFAULT_USE_ALPN;
@@ -655,6 +663,27 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     return new LinkedHashSet<>(enabledSecureTransportProtocols);
   }
 
+  /**
+   * @return the SSL handshake timeout, in milliseconds.
+   */
+  public long getSslHandshakeTimeout() {
+    return sslHandshakeTimeout;
+  }
+
+  /**
+   * Set the SSL handshake timeout, in milliseconds.
+   *
+   * @param sslHandshakeTimeout the SSL handshake timeout to set, in milliseconds
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TCPSSLOptions setSslHandshakeTimeout(long sslHandshakeTimeout) {
+    if (sslHandshakeTimeout < 0) {
+      throw new IllegalArgumentException("sslHandshakeTimeout must be >= 0");
+    }
+    this.sslHandshakeTimeout = sslHandshakeTimeout;
+    return this;
+  }
+
   @Override
   public TCPSSLOptions setLogActivity(boolean logEnabled) {
     return (TCPSSLOptions) super.setLogActivity(logEnabled);
@@ -696,6 +725,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     if (idleTimeout != that.idleTimeout) return false;
     if (soLinger != that.soLinger) return false;
     if (ssl != that.ssl) return false;
+    if (sslHandshakeTimeout != that.sslHandshakeTimeout) return false;
     if (tcpKeepAlive != that.tcpKeepAlive) return false;
     if (tcpNoDelay != that.tcpNoDelay) return false;
     if (tcpFastOpen != that.tcpFastOpen) return false;
@@ -727,6 +757,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     result = 31 * result + (usePooledBuffers ? 1 : 0);
     result = 31 * result + idleTimeout;
     result = 31 * result + (ssl ? 1 : 0);
+    result = 31 * result + (int) sslHandshakeTimeout;
     result = 31 * result + (keyCertOptions != null ? keyCertOptions.hashCode() : 0);
     result = 31 * result + (trustOptions != null ? trustOptions.hashCode() : 0);
     result = 31 * result + (enabledCipherSuites != null ? enabledCipherSuites.hashCode() : 0);

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -199,6 +199,7 @@ public class NetClientImpl implements MetricsProvider, NetClient {
         if (sslHelper.isSSL()) {
           // TCP connected, so now we must do the SSL handshake
           SslHandler sslHandler = (SslHandler) ch.pipeline().get("ssl");
+          sslHandler.setHandshakeTimeoutMillis(options.getSslHandshakeTimeout());
 
           io.netty.util.concurrent.Future<Channel> fut = sslHandler.handshakeFuture();
           fut.addListener(future2 -> {

--- a/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
@@ -187,6 +187,7 @@ public class NetServerImpl implements Closeable, MetricsProvider, NetServer {
                   ch.pipeline().addFirst("ssl", sniHandler);
                 } else {
                   SslHandler sslHandler = new SslHandler(sslHelper.createEngine(vertx));
+                  sslHandler.setHandshakeTimeoutMillis(options.getSslHandshakeTimeout());
                   handshakeFuture = sslHandler.handshakeFuture();
                   ch.pipeline().addFirst("ssl", sslHandler);
                 }

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -300,11 +300,13 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
     if (sslHandler == null) {
       if (remoteAddress != null) {
         sslHandler = new SslHandler(helper.createEngine(vertx, remoteAddress, serverName));
+        ((SslHandler)sslHandler).setHandshakeTimeoutMillis(helper.getSslHandshakeTimeout());
       } else {
         if (helper.isSNI()) {
           sslHandler = new VertxSniHandler(helper, vertx);
         } else {
           sslHandler = new SslHandler(helper.createEngine(vertx));
+          ((SslHandler)sslHandler).setHandshakeTimeoutMillis(helper.getSslHandshakeTimeout());
         }
       }
       chctx.pipeline().addFirst("ssl", sslHandler);

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -121,6 +121,7 @@ public class SSLHelper {
 
   private boolean ssl;
   private boolean sni;
+  private long sslHandshakeTimeout;
   private KeyCertOptions keyCertOptions;
   private TrustOptions trustOptions;
   private boolean trustAll;
@@ -179,6 +180,7 @@ public class SSLHelper {
   public SSLHelper(NetClientOptions options, KeyCertOptions keyCertOptions, TrustOptions trustOptions) {
     SSLEngineOptions sslEngineOptions = resolveEngineOptions(options);
     this.ssl = options.isSsl();
+    this.sslHandshakeTimeout = options.getSslHandshakeTimeout();
     this.keyCertOptions = keyCertOptions;
     this.trustOptions = trustOptions;
     this.trustAll = options.isTrustAll();
@@ -196,6 +198,7 @@ public class SSLHelper {
   public SSLHelper(NetServerOptions options, KeyCertOptions keyCertOptions, TrustOptions trustOptions) {
     SSLEngineOptions sslEngineOptions = resolveEngineOptions(options);
     this.ssl = options.isSsl();
+    this.sslHandshakeTimeout = options.getSslHandshakeTimeout();
     this.keyCertOptions = keyCertOptions;
     this.trustOptions = trustOptions;
     this.clientAuth = options.getClientAuth();
@@ -517,5 +520,9 @@ public class SSLHelper {
     SSLEngine engine = getContext(vertx, null).newEngine(ByteBufAllocator.DEFAULT);
     configureEngine(engine, null);
     return engine;
+  }
+
+  public long getSslHandshakeTimeout() {
+    return sslHandshakeTimeout;
   }
 }

--- a/src/main/java/io/vertx/core/net/impl/VertxSniHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxSniHandler.java
@@ -70,6 +70,7 @@ public class VertxSniHandler extends SniHandler {
     try {
       SSLEngine engine = helper.createEngine(sslContext);
       sslHandler = new SslHandler(engine);
+      sslHandler.setHandshakeTimeoutMillis(helper.getSslHandshakeTimeout());
       ctx.pipeline().replace(this, "ssl", sslHandler);
       Future<Channel> fut = sslHandler.handshakeFuture();
       fut.addListener(future -> {


### PR DESCRIPTION
Fix Issue #2118 
add implement and some unit tests for sslHandshakeTimeout in NetClient Options
add an API to expose netty's SSL Handshake Timeout
Signed-off-by: BillyYccc <billy112487983@gmail.com>