### PR TITLE
Ability to reload CRL files/buffers at runtime

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -22,9 +22,13 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.metrics.Measured;
 import io.vertx.core.streams.ReadStream;
 
+import java.security.cert.CRLException;
+import java.security.cert.CertificateException;
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -1426,4 +1430,24 @@ public interface HttpClient extends Measured {
    * Clients should always be closed after use.
    */
   void close();
+
+  /**
+   * If HTTP Server was started with CRL options (see {@link HttpServerOptions#addCrlPath(String)}), then it allows to reload
+   * the CRL files at runtime. This is specifically useful when application has a new/updated CRLs from CA.
+   * <p>
+   * This will only re-load the CRL files with same name that were provided into {@link HttpServerOptions#addCrlPath}.
+   * <p>
+   * @throws CertificateException
+   * @throws CRLException
+   */
+  void reloadCrlFromPath() throws CertificateException, CRLException;
+
+  /**
+   * If HTTP Server was started with CRL options (see {@link HttpServerOptions#addCrlValue(Buffer)}), then it allows to reload
+   * the CRL buffer at runtime. This is specifically useful when application has a new/updated CRLs from CA.
+   * <p>
+   * @throws CertificateException
+   * @throws CRLException
+   */
+  void reloadCrlFromBuffer(List<Buffer> buffers) throws CertificateException, CRLException;
 }

--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -23,8 +23,13 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.metrics.Measured;
 import io.vertx.core.streams.ReadStream;
+
+import java.security.cert.CRLException;
+import java.security.cert.CertificateException;
+import java.util.List;
 
 /**
  * An HTTP and WebSockets server.
@@ -191,4 +196,25 @@ public interface HttpServer extends Measured {
    * @return the actual port the server is listening on.
    */
   int actualPort();
+
+  /**
+   * If HTTP Server was started with CRL options (see {@link HttpServerOptions#addCrlPath(String)}), then it allows to reload
+   * the CRL files at runtime. This is specifically useful when application has a new/updated CRLs from CA.
+   * <p>
+   * This will only re-load the CRL files with same name that were provided into {@link HttpServerOptions#addCrlPath}.
+   * <p>
+   * @throws CertificateException
+   * @throws CRLException
+   */
+  void reloadCrlFromPath() throws CertificateException, CRLException;
+
+  /**
+   * If HTTP Server was started with CRL options (see {@link HttpServerOptions#addCrlValue(Buffer)}), then it allows to reload
+   * the CRL buffer at runtime. This is specifically useful when application has a new/updated CRLs from CA.
+   * <p>
+   * @throws CertificateException
+   * @throws CRLException
+   */
+  void reloadCrlFromBuffer(List<Buffer> buffers) throws CertificateException, CRLException;
+
 }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -22,6 +22,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.VertxException;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
@@ -48,6 +49,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.security.cert.CRLException;
+import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -881,6 +884,26 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
   @Override
   public HttpClientRequest deleteAbs(String absoluteURI, Handler<HttpClientResponse> responseHandler) {
     return requestAbs(HttpMethod.DELETE, absoluteURI, responseHandler);
+  }
+
+  @Override
+  public void reloadCrlFromPath() throws CertificateException, CRLException {
+    if (closed) {
+      throwCrlReloadError();
+    }
+    sslHelper.reloadCrlFromPath(vertx);
+  }
+
+  @Override
+  public void reloadCrlFromBuffer(final List<Buffer> buffers) throws CertificateException, CRLException {
+    if (closed) {
+      throwCrlReloadError();
+    }
+    sslHelper.reloadCrlFromBuffer(buffers);
+  }
+
+  private void throwCrlReloadError() {
+    throw new VertxException("HTTP Client is closed. CRL can't be reloaded on closed client.");
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -234,7 +234,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
   @Override
   public void reloadCrlFromPath() throws CertificateException, CRLException {
     if (!listening) {
-      throwCrlError();
+      throwCrlReloadError();
     }
     sslHelper.reloadCrlFromPath(vertx);
   }
@@ -242,12 +242,12 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
   @Override
   public void reloadCrlFromBuffer(final List<Buffer> buffers) throws CertificateException, CRLException {
     if (!listening) {
-      throwCrlError();
+      throwCrlReloadError();
     }
     sslHelper.reloadCrlFromBuffer(buffers);
   }
 
-  private void throwCrlError() {
+  private void throwCrlReloadError() {
     throw new VertxException("Server not started yet! CRL reloading is only meant for runtime change.");
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -57,10 +57,7 @@ import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.GlobalEventExecutor;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Closeable;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpServer;
@@ -92,6 +89,8 @@ import io.vertx.core.streams.ReadStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.cert.CRLException;
+import java.security.cert.CertificateException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -230,6 +229,26 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
   @Override
   public HttpServer listen(int port, Handler<AsyncResult<HttpServer>> listenHandler) {
     return listen(port, "0.0.0.0", listenHandler);
+  }
+
+  @Override
+  public void reloadCrlFromPath() throws CertificateException, CRLException {
+    if (!listening) {
+      throwCrlError();
+    }
+    sslHelper.reloadCrlFromPath(vertx);
+  }
+
+  @Override
+  public void reloadCrlFromBuffer(final List<Buffer> buffers) throws CertificateException, CRLException {
+    if (!listening) {
+      throwCrlError();
+    }
+    sslHelper.reloadCrlFromBuffer(buffers);
+  }
+
+  private void throwCrlError() {
+    throw new VertxException("Server not started yet! CRL reloading is only meant for runtime change.");
   }
 
   public synchronized HttpServer listen(int port, String host, Handler<AsyncResult<HttpServer>> listenHandler) {


### PR DESCRIPTION
This PR contains following changes:

1 - Ability to reload CRL from file path or buffer at runtime in HttpClient
2 - Ability to reload CRL from file path or buffer at runtime in HttpServer

See - https://groups.google.com/forum/#!topic/vertx/fLQPPAxkftM