### PR TITLE
Message forwarding in eventbus interceptors

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/DeliveryContext.java
+++ b/src/main/java/io/vertx/core/eventbus/DeliveryContext.java
@@ -43,4 +43,11 @@ public interface DeliveryContext<T> {
    * @return the value delivered by the message (before or after being processed by the codec)
    */
   Object body();
+  
+  /**
+    * Forwards a message to another address
+    * @param address  the address to forward it to
+    */
+  void forward(String address);
+  
 }

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -33,11 +33,12 @@ public class MessageImpl<U, V> implements Message<V> {
   protected EventBusImpl bus;
   protected String address;
   protected String replyAddress;
+  protected long replyTimeout;
   protected MultiMap headers;
   protected U sentBody;
   protected V receivedBody;
   protected boolean send;
-
+  
   public MessageImpl() {
   }
 
@@ -158,5 +159,9 @@ public class MessageImpl<U, V> implements Message<V> {
 
   protected boolean isLocal() {
     return true;
+  }
+
+  public void setReplyTimeout(long timeout) {
+    this.replyTimeout = timeout;
   }
 }


### PR DESCRIPTION
This commit adds ability to forward message in eventbus interceptor to different address. 
You can route messages according to theirs headers or body content.

This is very useful feature, notably in multi tenant applications.

You can for example:
* have multiple implementations of same service, choose them by header
* deploy different number of target Verticle instances for diferrent tenants (based on their size), choose target address dynamicaly by tenant identification in header
* make asynchronous and clustered interceptors/proxies - against the code directly in interceptor you can forward message to diferrent address that somehow modify it, set flag in headers to not forward it again and forward it to original address
All behavior is transparent to original sender.

It's better than listen on target address in some other verticle and forward it manually because:
* can proxy existing library which have listen address hard coded
* don't break contract between sender and receiver, i.e:
  * don't break Backpressure handling, pause, resume etc. which can otherwise be very hard to implement
  * don't change request timeout and codec - this information can't be determined in message receiver
  * even if you choose dynamic forward address based on message headers (ie multiple forward addresses for same original address) producer communicate directly with consumer

Keep up this contract is very effective in clustered environment. If you use some proxy verticle instead, you must collocate this proxy instances with target verticles to minimize unnecessary inter node communication and forwarding, which can be very inefficient and difficult to implement.


We currently use all this use cases do this in interceptor via java reflection, which of course is very ugly. 