### PR TITLE
Adding IANA HTTP Methods

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpMethod.java
+++ b/src/main/java/io/vertx/core/http/HttpMethod.java
@@ -25,5 +25,11 @@ import io.vertx.codegen.annotations.VertxGen;
  */
 @VertxGen
 public enum HttpMethod {
-  OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, CONNECT, PATCH, OTHER
+  // http://www.iana.org/assignments/http-methods/http-methods.xhtml
+  ACL, BIND, CHECKIN, CHECKOUT, CONNECT, COPY, DELETE, GET, HEAD,
+  LABEL, LINK, LOCK, MERGE, MKACTIVITY, MKCALENDAR, MKCOL, MKREDIRECTREF,
+  MKWORKSPACE, MOVE, OPTIONS, ORDERPATCH, PATCH, POST, PRI, PROPFIND, PROPPATCH,
+  PUT, REBIND, REPORT, SEARCH, TRACE, UNBIND, UNCHECKOUT, UNLINK, UNLOCK, UPDATE, UPDATEREDIRECTREF,
+  // https://stackoverflow.com/questions/25857508/what-is-the-http-method-purge
+  PURGE
 }


### PR DESCRIPTION
I hereby add all methods which are listed under http://www.iana.org/assignments/http-methods/http-methods.xhtml, that do not pose problems (e.g. BASELINE-CONTROL and VERSION-CONTROL with a hyphen) as well as the PURGE method (https://stackoverflow.com/questions/25857508/what-is-the-http-method-purge).

Those can be used within the `Route.allowedMethod(...)` to register them as an acceptables CORS method.