### PR TITLE
Do not invoke exception handler with wrong exception for every response

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
@@ -456,7 +456,7 @@ public class Http2ServerResponseImpl implements HttpServerResponse {
           conn.metrics().responseEnd(metric, this);
         }
       }
-      if (exceptionHandler != null) {
+      if (failed && exceptionHandler != null) {
         conn.getContext().runOnContext(v -> exceptionHandler.handle(new VertxException("Connection was closed")));
       }
       if (endHandler != null) {


### PR DESCRIPTION
For every HTTP/2 connection response has been succesfully written then `handleEnded(false)` method is invoked.

Commit https://github.com/eclipse/vert.x/commit/fdd4c7bdd4cd34ad3e9005e9b94579dfb5035cdd changed added code to invoke the `exceptionHandler` unconditionally with message `"Connection was closed"`. This happens even if the response has been succesfully sent an the connection has not been closed.

The exception should be only generated and reported if `handleEnded` is invoked with `failed`=`true` argument.