### PR TITLE
Support setting local port for http and tcp clients

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -176,6 +176,12 @@ Set the key/cert options in jks format, aka Java keystore.
 Set the local interface to bind for network connections. When the local address is null,
  it will pick any local address, the default local address is null.
 +++
+|[[localPort]]`localPort`|`Number (int)`|
++++
+Set the local port to bind for network connections.
+ When the port is set to 0, it will pick a random port by os,
+ the default local port is 0.
++++
 |[[logActivity]]`logActivity`|`Boolean`|
 +++
 Set to true to enabled network activity logging: Netty's pipeline is configured for logging on Netty's logger.
@@ -840,6 +846,12 @@ Set the key/cert options in jks format, aka Java keystore.
 Set the local interface to bind for network connections. When the local address is null,
  it will pick any local address, the default local address is null.
 +++
+|[[localPort]]`localPort`|`Number (int)`|
++++
+Set the local port to bind for network connections.
+ When the port is set to 0, it will pick a random port by os,
+ the default local port is 0.
++++
 |[[logActivity]]`logActivity`|`Boolean`|
 +++
 Set to true to enabled network activity logging: Netty's pipeline is configured for logging on Netty's logger.
@@ -1359,6 +1371,12 @@ Set the key/cert options in jks format, aka Java keystore.
 +++
 Set the local interface to bind for network connections. When the local address is null,
  it will pick any local address, the default local address is null.
++++
+|[[localPort]]`localPort`|`Number (int)`|
++++
+Set the local port to bind for network connections.
+ When the port is set to 0, it will pick a random port by os,
+ the default local port is 0.
 +++
 |[[logActivity]]`logActivity`|`Boolean`|
 +++

--- a/src/main/generated/io/vertx/core/net/ClientOptionsBaseConverter.java
+++ b/src/main/generated/io/vertx/core/net/ClientOptionsBaseConverter.java
@@ -33,6 +33,9 @@ import io.vertx.core.json.JsonArray;
     if (json.getValue("localAddress") instanceof String) {
       obj.setLocalAddress((String)json.getValue("localAddress"));
     }
+    if (json.getValue("localPort") instanceof Number) {
+      obj.setLocalPort(((Number)json.getValue("localPort")).intValue());
+    }
     if (json.getValue("metricsName") instanceof String) {
       obj.setMetricsName((String)json.getValue("metricsName"));
     }
@@ -49,6 +52,7 @@ import io.vertx.core.json.JsonArray;
     if (obj.getLocalAddress() != null) {
       json.put("localAddress", obj.getLocalAddress());
     }
+    json.put("localPort", obj.getLocalPort());
     if (obj.getMetricsName() != null) {
       json.put("metricsName", obj.getMetricsName());
     }

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -959,6 +959,11 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public HttpClientOptions setLocalPort(int localPort) {
+    return (HttpClientOptions) super.setLocalPort(localPort);
+  }
+
+  @Override
   public HttpClientOptions setLogActivity(boolean logEnabled) {
     return (HttpClientOptions) super.setLogActivity(logEnabled);
   }

--- a/src/main/java/io/vertx/core/net/ClientOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/ClientOptionsBase.java
@@ -45,6 +45,7 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
   private String metricsName;
   private ProxyOptions proxyOptions;
   private String localAddress;
+  private int localPort;
 
   /**
    * Default constructor
@@ -66,6 +67,7 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
     this.metricsName = other.metricsName;
     this.proxyOptions = other.proxyOptions != null ? new ProxyOptions(other.proxyOptions) : null;
     this.localAddress = other.localAddress;
+    this.localPort = other.localPort;
   }
 
   /**
@@ -96,6 +98,7 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
     this.metricsName = DEFAULT_METRICS_NAME;
     this.proxyOptions = null;
     this.localAddress = null;
+    this.localPort = 0;
   }
 
   /**
@@ -185,6 +188,11 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
   }
 
   /**
+   * @return the local port to bind for network connections.
+   */
+  public int getLocalPort() { return localPort; }
+
+  /**
    * Set the local interface to bind for network connections. When the local address is null,
    * it will pick any local address, the default local address is null.
    *
@@ -193,6 +201,19 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
    */
   public ClientOptionsBase setLocalAddress(String localAddress) {
     this.localAddress = localAddress;
+    return this;
+  }
+
+  /**
+   * Set the local port to bind for network connections.
+   * When the port is set to 0, it will pick a random port by os,
+   * the default local port is 0.
+   *
+   * @param localPort the local port
+   * @return a reference to this, so the API can be used fluently
+   */
+  public ClientOptionsBase setLocalPort(int localPort) {
+    this.localPort = localPort;
     return this;
   }
 
@@ -369,6 +390,7 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
     if (!Objects.equals(metricsName, that.metricsName)) return false;
     if (!Objects.equals(proxyOptions, that.proxyOptions)) return false;
     if (!Objects.equals(localAddress, that.localAddress)) return false;
+    if (localPort != that.localPort) return false;
 
     return true;
   }
@@ -381,6 +403,7 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
     result = 31 * result + (metricsName != null ? metricsName.hashCode() : 0);
     result = 31 * result + (proxyOptions != null ? proxyOptions.hashCode() : 0);
     result = 31 * result + (localAddress != null ? localAddress.hashCode() : 0);
+    result = 31 * result + localPort;
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -350,6 +350,11 @@ public class NetClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public NetClientOptions setLocalPort(int localPort) {
+    return (NetClientOptions) super.setLocalPort(localPort);
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (!(o instanceof NetClientOptions)) return false;

--- a/src/main/java/io/vertx/core/net/impl/transport/Transport.java
+++ b/src/main/java/io/vertx/core/net/impl/transport/Transport.java
@@ -214,7 +214,9 @@ public class Transport {
     setOption("TCK_FASTOPEN", options.isTcpFastOpen(), setter);
     setOption("SO_REUSEPORT", options.isReusePort(), setter);
     if (options.getLocalAddress() != null) {
-      bootstrap.localAddress(options.getLocalAddress(), 0);
+      bootstrap.localAddress(options.getLocalAddress(), options.getLocalPort());
+    } else if (options.getLocalPort() != 0) {
+      bootstrap.localAddress(options.getLocalPort());
     }
     bootstrap.option(ChannelOption.TCP_NODELAY, options.isTcpNoDelay());
     if (options.getSendBufferSize() != -1) {

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -463,6 +463,7 @@ public class Http1xTest extends HttpTest {
     boolean openSslSessionCacheEnabled = rand.nextBoolean();
     boolean sendUnmaskedFrame = rand.nextBoolean();
     String localAddress = TestUtils.randomAlphaString(10);
+    int localPort = TestUtils.randomInt();
     int decoderInitialBufferSize = TestUtils.randomPositiveInt();
 
     options.setSendBufferSize(sendBufferSize);
@@ -502,6 +503,7 @@ public class Http1xTest extends HttpTest {
     options.setAlpnVersions(alpnVersions);
     options.setHttp2ClearTextUpgrade(h2cUpgrade);
     options.setLocalAddress(localAddress);
+    options.setLocalPort(localPort);
     options.setSendUnmaskedFrames(sendUnmaskedFrame);
     options.setDecoderInitialBufferSize(decoderInitialBufferSize);
     HttpClientOptions copy = new HttpClientOptions(options);

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -3321,6 +3321,44 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
+  public void testClientLocalPort() throws Exception {
+    int expectedPort = TestUtils.randomHighPortInt();
+    client.close();
+    client = vertx.createHttpClient(createBaseClientOptions().setLocalPort(expectedPort));
+    server.requestHandler(req -> {
+      assertEquals(expectedPort, req.remoteAddress().port());
+      req.response().end();
+    });
+    startServer();
+    client.getNow(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath", resp -> {
+      assertEquals(200, resp.statusCode());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testClientLocalAddrAndPort() throws Exception {
+    String expectedAddress = InetAddress.getLocalHost().getHostAddress();
+    int expectedPort = TestUtils.randomHighPortInt();
+    client.close();
+    client = vertx.createHttpClient(createBaseClientOptions()
+                                      .setLocalAddress(expectedAddress)
+                                      .setLocalPort(expectedPort));
+    server.requestHandler(req -> {
+      assertEquals(expectedAddress, req.remoteAddress().host());
+      assertEquals(expectedPort, req.remoteAddress().port());
+      req.response().end();
+    });
+    startServer();
+    client.getNow(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath", resp -> {
+      assertEquals(200, resp.statusCode());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
   public void testFollowRedirectGetOn301() throws Exception {
     testFollowRedirect(HttpMethod.GET, HttpMethod.GET, 301, 200, 2, "http://localhost:8080/redirected", "http://localhost:8080/redirected");
   }

--- a/src/test/java/io/vertx/test/core/NetTest.java
+++ b/src/test/java/io/vertx/test/core/NetTest.java
@@ -3061,6 +3061,52 @@ public class NetTest extends VertxTestBase {
   }
 
   @Test
+  public void testClientLocalPort() throws Exception {
+    int expectedPort = TestUtils.randomHighPortInt();
+    NetClientOptions clientOptions = new NetClientOptions().setLocalPort(expectedPort);
+    client.close();
+    client = vertx.createNetClient(clientOptions);
+    server.connectHandler(sock -> {
+      assertEquals(expectedPort, sock.remoteAddress().port());
+      sock.close();
+    });
+    int serverListenPort = TestUtils.randomHighPortInt();
+    server.listen(serverListenPort, "localhost", onSuccess(v -> {
+      client.connect(serverListenPort, "localhost", onSuccess(socket -> {
+        socket.closeHandler(v2 -> {
+          testComplete();
+        });
+      }));
+    }));
+    await();
+  }
+
+  @Test
+  public void testClientLocalAddrAndPort() throws Exception {
+    String expectedAddress = InetAddress.getLocalHost().getHostAddress();
+    int expectedPort = TestUtils.randomHighPortInt();
+    NetClientOptions clientOptions = new NetClientOptions()
+                                        .setLocalAddress(expectedAddress)
+                                        .setLocalPort(expectedPort);
+    client.close();
+    client = vertx.createNetClient(clientOptions);
+    server.connectHandler(sock -> {
+      assertEquals(expectedAddress, sock.remoteAddress().host());
+      assertEquals(expectedPort, sock.remoteAddress().port());
+      sock.close();
+    });
+    int serverListenPort = TestUtils.randomHighPortInt();
+    server.listen(serverListenPort, "localhost", onSuccess(v -> {
+      client.connect(serverListenPort, "localhost", onSuccess(socket -> {
+        socket.closeHandler(v2 -> {
+          testComplete();
+        });
+      }));
+    }));
+    await();
+  }
+
+  @Test
   public void testSelfSignedCertificate() throws Exception {
     CountDownLatch latch = new CountDownLatch(2);
 


### PR DESCRIPTION
In current version vert, the local port is randomly picked by the OS, (in `io.vertx.core.net.impl.transport.Transport`, the port is set to `0`), however some company strictly restricts the use of ports, which requires the developer to specify local port even in clients.
This pr adds a `localPort` field in `XXOptions` classes, and sets the port into netty bootstrap instance. Test cases are added as well.