### PR TITLE
Created andThen methods for Future

### DIFF
--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -480,7 +480,7 @@ public interface Future<T> extends AsyncResult<T>, Handler<AsyncResult<T>> {
    * @param mapper the mapper function
    * @return the composed future
    */
-  default <U> Future<U> andThen(Function<AsyncResult<T>, Future<U>> mapper) {
+  default <U> Future<U> andThen(Function<Future<T>, Future<U>> mapper) {
     if (mapper == null) {
       throw new NullPointerException();
     }
@@ -488,7 +488,7 @@ public interface Future<T> extends AsyncResult<T>, Handler<AsyncResult<T>> {
     setHandler(ar -> {
       Future<U> apply;
       try {
-        apply = mapper.apply(ar);
+        apply = mapper.apply(this);
       } catch (Throwable e) {
         ret.fail(e);
         return;

--- a/src/test/java/io/vertx/test/core/FutureTest.java
+++ b/src/test/java/io/vertx/test/core/FutureTest.java
@@ -1233,6 +1233,39 @@ public class FutureTest extends VertxTestBase {
     testOtherwiseEmpty(f, f);
   }
 
+  private final Function<AsyncResult<String>, Future<String>> FUTURE_INVERTER =
+    ar -> (ar.succeeded()) ? Future.failedFuture("bla") : Future.succeededFuture("bla");
+
+  @Test
+  public void testAndThenCombinedCompleted() {
+    Future<String> completed = Future.succeededFuture("foo");
+    Future<String> f = completed.andThen(FUTURE_INVERTER);
+    assertEquals(true, f.failed());
+  }
+
+  @Test
+  public void testAndThenCombinedFailure() {
+    Future<String> failed = Future.failedFuture("foo");
+    Future<String> f = failed.andThen(FUTURE_INVERTER);
+    assertEquals(true, f.isComplete());
+  }
+
+  @Test
+  public void testAndThenCompleted() {
+    Future<String> completed = Future.succeededFuture("foo");
+    Future<Integer> f = completed.andThen(r -> Future.succeededFuture(r.length()), e -> Future.succeededFuture(0));
+    assertEquals(true, f.isComplete());
+    assertEquals(3, f.result().intValue());
+  }
+
+  @Test
+  public void testAndThenFailure() {
+    Future<String> failed = Future.failedFuture("foo");
+    Future<String> f = failed.andThen(r -> Future.succeededFuture("error"), e -> Future.succeededFuture(e.getMessage()));
+    assertEquals(true, f.isComplete());
+    assertEquals("foo", f.result());
+  }
+
   @Test
   public void testToString() {
     assertEquals("Future{unresolved}", Future.future().toString());

--- a/src/test/java/io/vertx/test/core/FutureTest.java
+++ b/src/test/java/io/vertx/test/core/FutureTest.java
@@ -1233,7 +1233,7 @@ public class FutureTest extends VertxTestBase {
     testOtherwiseEmpty(f, f);
   }
 
-  private final Function<AsyncResult<String>, Future<String>> FUTURE_INVERTER =
+  private final Function<Future<String>, Future<String>> FUTURE_INVERTER =
     ar -> (ar.succeeded()) ? Future.failedFuture("bla") : Future.succeededFuture("bla");
 
   @Test


### PR DESCRIPTION
I've created two new methods for Future, inspired to Scala one. This is useful when you need to handle both completed and failure state of Future at same time (for example inverting a future state from completed to failed)