### PR TITLE
Remove timer callbacks from the metrics SPI

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -16,8 +16,8 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.concurrent.GenericFutureListener;
-import io.vertx.core.*;
 import io.vertx.core.Future;
+import io.vertx.core.*;
 import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.datagram.impl.DatagramSocketImpl;
@@ -868,9 +868,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
     boolean cancel() {
       if (cancelled.compareAndSet(false, true)) {
-        if (metrics != null) {
-          metrics.timerEnded(timerID, true);
-        }
         future.cancel(false);
         return true;
       } else {
@@ -891,9 +888,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       } else {
         future = el.schedule(toRun, delay, TimeUnit.MILLISECONDS);
       }
-      if (metrics != null) {
-        metrics.timerCreated(timerID);
-      }
     }
 
     public void handle(Void v) {
@@ -911,9 +905,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
     private void cleanupNonPeriodic() {
       VertxImpl.this.timeouts.remove(timerID);
-      if (metrics != null) {
-        metrics.timerEnded(timerID, false);
-      }
       ContextImpl context = getContext();
       if (context != null) {
         context.removeCloseHook(this);

--- a/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
@@ -55,27 +55,6 @@ public interface VertxMetrics extends Metrics, Measured {
   }
 
   /**
-   * Called when a timer is created
-   * <p>
-   * No specific thread and context can be expected when this method is called.
-   *
-   * @param id the id of the timer
-   */
-  default void timerCreated(long id) {
-  }
-
-  /**
-   * Called when a timer has ended (setTimer) or has been cancelled.<p/>
-   * <p>
-   * No specific thread and context can be expected when this method is called.
-   *
-   * @param id        the id of the timer
-   * @param cancelled if the timer was cancelled by the user
-   */
-  default void timerEnded(long id, boolean cancelled) {
-  }
-
-  /**
    * Provides the event bus metrics SPI when the event bus is created.<p/>
    * <p>
    * No specific thread and context can be expected when this method is called.<p/>

--- a/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
@@ -43,12 +43,6 @@ public class FakeVertxMetrics extends FakeMetricsBase implements VertxMetrics {
   public void verticleUndeployed(Verticle verticle) {
   }
 
-  public void timerCreated(long id) {
-  }
-
-  public void timerEnded(long id, boolean cancelled) {
-  }
-
   public EventBusMetrics createEventBusMetrics() {
     return new FakeEventBusMetrics();
   }


### PR DESCRIPTION
Closes #2352

Timer metrics hardly provide any meaningful information.
