### PR TITLE
Support retrieving X509 certificates CN since javax.naming package is unavailable in Android

### DIFF
--- a/src/test/java/io/vertx/test/core/TestUtils.java
+++ b/src/test/java/io/vertx/test/core/TestUtils.java
@@ -18,16 +18,15 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.Http2Settings;
 import io.vertx.core.net.*;
+import io.vertx.core.net.impl.KeyStoreHelper;
 import io.vertx.test.netty.TestLoggerFactory;
 
-import javax.naming.ldap.LdapName;
-import javax.naming.ldap.Rdn;
 import javax.security.cert.X509Certificate;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.net.InetAddress;
 import java.nio.file.Files;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.zip.GZIPOutputStream;
@@ -396,13 +395,8 @@ public class TestUtils {
 
   public static String cnOf(X509Certificate cert) throws Exception {
     String dn = cert.getSubjectDN().getName();
-    LdapName ldapDN = new LdapName(dn);
-    for (Rdn rdn : ldapDN.getRdns()) {
-      if (rdn.getType().equalsIgnoreCase("cn")) {
-        return rdn.getValue().toString();
-      }
-    }
-    return null;
+    List<String> names = KeyStoreHelper.getX509CertificateCommonNames(dn);
+    return names.isEmpty() ? null : names.get(0);
   }
 
   /**


### PR DESCRIPTION
…Support retrieving X509 certificates CN if javax.naming package is unavailable.  Android does not contain this package.

Signed-off-by: Hayden James <hayden.james@gmail.com>