### PR TITLE
Create additional write interface to NetSocket for notifications after socket writes are executed

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
@@ -203,19 +203,29 @@ class VertxHttp2ConnectionHandler<C extends Http2ConnectionBase> extends Http2Co
     encoder().writeHeaders(chctx, stream.id(), headers, 0, end, chctx.newPromise());
   }
 
-  void writeData(Http2Stream stream, ByteBuf chunk, boolean end) {
+  void writeData(Http2Stream stream, ByteBuf chunk, boolean end, Handler<AsyncResult<Void>> handler) {
     EventExecutor executor = chctx.executor();
+    ChannelPromise promise = chctx.newPromise();
+    if (handler != null) {
+      promise.addListener((future) -> {
+        if(future.isSuccess()) {
+          handler.handle(Future.succeededFuture());
+        } else {
+          handler.handle(Future.failedFuture(future.cause()));
+        }
+      });
+    }
     if (executor.inEventLoop()) {
-      _writeData(stream, chunk, end);
+      _writeData(stream, chunk, end, promise);
     } else {
       executor.execute(() -> {
-        _writeData(stream, chunk, end);
+        _writeData(stream, chunk, end, promise);
       });
     }
   }
 
-  private void _writeData(Http2Stream stream, ByteBuf chunk, boolean end) {
-    encoder().writeData(chctx, stream.id(), chunk, 0, end, chctx.newPromise());
+  private void _writeData(Http2Stream stream, ByteBuf chunk, boolean end, ChannelPromise promise) {
+    encoder().writeData(chctx, stream.id(), chunk, 0, end, promise);
     Http2RemoteFlowController controller = encoder().flowController();
     if (!controller.isWritable(stream) || end) {
       try {

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2NetSocket.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2NetSocket.java
@@ -217,6 +217,14 @@ class VertxHttp2NetSocket<C extends Http2ConnectionBase> extends VertxHttp2Strea
   }
 
   @Override
+  public NetSocket write(Buffer message, Handler<AsyncResult<Void>> handler) {
+    synchronized (conn) {
+      conn.handler.writeData(stream, message.getByteBuf(), false, handler);
+      return this;
+    }
+  }
+
+  @Override
   public NetSocket sendFile(String filename, long offset, long length) {
     return sendFile(filename, offset, length, null);
   }

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -128,7 +128,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
   }
 
   void writeData(ByteBuf chunk, boolean end) {
-    conn.handler.writeData(stream, chunk, end);
+    conn.handler.writeData(stream, chunk, end, null);
   }
 
   void writeReset(long code) {

--- a/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/src/main/java/io/vertx/core/net/NetSocket.java
@@ -97,6 +97,13 @@ public interface NetSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
   NetSocket write(String str, String enc);
 
   /**
+   * Like {@link #write(Object)} but with an {@code handler} called when the message has been written
+   * or failed to be written.
+   */
+  @Fluent
+  NetSocket write(Buffer message, Handler<AsyncResult<Void>> handler);
+
+  /**
    * Tell the operating system to stream a file as specified by {@code filename} directly from disk to the outgoing connection,
    * bypassing userspace altogether (where supported by the underlying operating system. This is a very efficient way to stream files.
    *

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -120,16 +120,14 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
   public NetSocketInternal writeMessage(Object message, Handler<AsyncResult<Void>> handler) {
     ChannelPromise promise = chctx.newPromise();
     super.writeToChannel(message, promise);
-    promise.addListener(new ChannelFutureListener() {
-      @Override
-      public void operationComplete(ChannelFuture future) throws Exception {
+    promise.addListener((future) -> {
         if (future.isSuccess()) {
           handler.handle(Future.succeededFuture());
         } else {
           handler.handle(Future.failedFuture(future.cause()));
         }
       }
-    });
+    );
     return this;
   }
 
@@ -158,6 +156,12 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
   private void write(ByteBuf buff) {
     reportBytesWritten(buff.readableBytes());
     writeMessage(buff);
+  }
+
+  @Override
+  public NetSocket write(Buffer message, Handler<AsyncResult<Void>> handler) {
+    writeMessage(message.getByteBuf(), handler);
+    return this;
   }
 
   @Override


### PR DESCRIPTION
Add writeHandler interface to NetSocket for notifications after socket writes are executed.  Since socket writes are asynchronous, this allows notifications for when they actually occur.

Signed-off-by: Hayden James <hayden.james@gmail.com>