### PR TITLE
Websocket Client HTTP response headers

### DIFF
--- a/src/main/java/io/vertx/core/http/WebSocketBase.java
+++ b/src/main/java/io/vertx/core/http/WebSocketBase.java
@@ -13,6 +13,7 @@ package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.*;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.ReadStream;
@@ -89,6 +90,15 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
    * handshake will not be completed yet.
    */
   String subProtocol();
+
+  /**
+   *  Returns the HTTP response headers during the websocket connection handler.
+   *  <p/>
+   *  After the completion handler callback has completed the response headers will be {@code null}
+   *
+   * @return the response headers
+   */
+  MultiMap headers();
 
   /**
    * Write a WebSocket frame to the connection

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -814,7 +814,9 @@ class Http1xClientConnection extends Http1xConnectionBase implements HttpClientC
           webSocket.setMetric(metrics.connected(endpointMetric, metric(), webSocket));
         }
         webSocket.registerHandler(vertx.eventBus());
+        webSocket.headers(new HeadersAdaptor(response.headers()));
         wsConnect.handle(webSocket);
+        webSocket.headers(null);
       });
     }
   }

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -13,6 +13,7 @@ package io.vertx.core.http.impl;
 
 import io.netty.buffer.ByteBuf;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
@@ -59,7 +60,7 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
   private Handler<Void> endHandler;
   protected final Http1xConnectionBase conn;
   protected boolean closed;
-
+  private MultiMap headers;
 
   WebSocketImplBase(VertxInternal vertx, Http1xConnectionBase conn, boolean supportsContinuation,
                               int maxWebSocketFrameSize, int maxWebSocketMessageSize) {
@@ -163,6 +164,19 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
   void subProtocol(String subProtocol) {
     synchronized (conn) {
       this.subProtocol = subProtocol;
+    }
+  }
+
+  @Override
+  public MultiMap headers() {
+    synchronized(conn) {
+      return headers;
+    }
+  }
+
+  void headers(MultiMap responseHeaders) {
+    synchronized(conn) {
+      this.headers = responseHeaders;
     }
   }
 

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -16,14 +16,7 @@ import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocket13FrameDecoder;
 import io.netty.handler.codec.http.websocketx.WebSocket13FrameEncoder;
 import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
-import io.vertx.core.AbstractVerticle;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.impl.FrameType;
 import io.vertx.core.http.impl.ws.WebSocketFrameImpl;
@@ -1558,6 +1551,34 @@ public class WebSocketTest extends VertxTestBase {
   }
 
   @Test
+  public void testReceiveHttpResponseHeadersOnClient() {
+    server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).requestHandler(req -> {
+      handshakeWithCookie(req);
+    });
+    AtomicReference<WebSocket> websocketRef = new AtomicReference();
+    server.listen(ar -> {
+      assertTrue(ar.succeeded());
+      client.websocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/some/path", ws -> {
+        MultiMap entries = ws.headers();
+        assertNotNull(entries);
+        assertFalse(entries.isEmpty());
+        assertEquals("websocket".toLowerCase(), entries.get("Upgrade").toLowerCase());
+        assertEquals("upgrade".toLowerCase(), entries.get("Connection").toLowerCase());
+        Set<String> cookiesToSet = new HashSet(entries.getAll("Set-Cookie"));
+        assertEquals(2, cookiesToSet.size());
+        assertTrue(cookiesToSet.contains("SERVERID=test-server-id"));
+        assertTrue(cookiesToSet.contains("JSONID=test-json-id"));
+        websocketRef.set(ws);
+        vertx.runOnContext(v -> {
+          assertNull(ws.headers());
+          testComplete();
+        });
+      }, failure -> fail("connection should succeed"));
+    });
+    await();
+  }
+
+  @Test
   public void testUpgrade() {
     testUpgrade(false);
   }
@@ -1701,6 +1722,31 @@ public class WebSocketTest extends VertxTestBase {
       }
     });
     testRaceConditionWithWebsocketClient(fut.get());
+  }
+
+  private NetSocket handshakeWithCookie(HttpServerRequest req) {
+    NetSocket so = req.netSocket();
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-1");
+      byte[] inputBytes = (req.getHeader("Sec-WebSocket-Key") + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").getBytes();
+      digest.update(inputBytes);
+      byte[] hashedBytes = digest.digest();
+      byte[] accept = Base64.getEncoder().encode(hashedBytes);
+      Buffer data = Buffer.buffer();
+      data.appendString("HTTP/1.1 101 Switching Protocols\r\n");
+      data.appendString("Upgrade: websocket\r\n");
+      data.appendString("Connection: upgrade\r\n");
+      data.appendString("Sec-WebSocket-Accept: " + new String(accept) + "\r\n");
+      data.appendString("Set-Cookie: SERVERID=test-server-id\r\n");
+      data.appendString("Set-Cookie: JSONID=test-json-id\r\n");
+      data.appendString("\r\n");
+      so.write(data);
+      return so;
+    } catch (NoSuchAlgorithmException e) {
+      req.response().setStatusCode(500).end();
+      fail(e.getMessage());
+      return null;
+    }
   }
 
   private NetSocket handshake(HttpServerRequest req) {


### PR DESCRIPTION
expose http response headers to websocketBase during the connection handler.  Clear headers after handler to prevent resource useage when the user does not care about the headers

#2662