### PR TITLE
Add new CLI arg to support external JSON VertxOptions

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -913,10 +913,10 @@ vertx run groovy:io.vertx.example.MyGroovyVerticle
 
 The `vertx run` command can take a few optional parameters, they are:
 
- * `-vertx-options <options>` - Provides the Vert.x options. `options` is the name of a text file
- containing a JSON object that represents the Vert.x options, or a JSON string. This is optional.
- * `-conf <config>` - Provides some configuration to the verticle. `config` is the name of a text file
- containing a JSON object that represents the configuration for the verticle, or a JSON string. This is optional.
+ * `-options <options>` - Provides the Vert.x options.
+ `options` is the name of a JSON file that represents the Vert.x options, or a JSON string. This is optional.
+ * `-conf <config>` - Provides some configuration to the verticle.
+ `config` is the name of a JSON file that represents the configuration for the verticle, or a JSON string. This is optional.
  * `-cp <path>` - The path on which to search for the verticle and any other resources used by the verticle. This
  defaults to `.` (current directory). If your verticle references other scripts, classes or other resources
  (e.g. jar files) then make sure these are on this path. The path can contain multiple path entries separated by

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -913,8 +913,10 @@ vertx run groovy:io.vertx.example.MyGroovyVerticle
 
 The `vertx run` command can take a few optional parameters, they are:
 
- * `-conf <config_file>` - Provides some configuration to the verticle. `config_file` is the name of a text file
- containing a JSON object that represents the configuration for the verticle. This is optional.
+ * `-vertx-options <options>` - Provides the Vert.x options. `options` is the name of a text file
+ containing a JSON object that represents the Vert.x options, or a JSON string. This is optional.
+ * `-conf <config>` - Provides some configuration to the verticle. `config` is the name of a text file
+ containing a JSON object that represents the configuration for the verticle, or a JSON string. This is optional.
  * `-cp <path>` - The path on which to search for the verticle and any other resources used by the verticle. This
  defaults to `.` (current directory). If your verticle references other scripts, classes or other resources
  (e.g. jar files) then make sure these are on this path. The path can contain multiple path entries separated by

--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,11 +14,15 @@ package io.vertx.core.impl.launcher.commands;
 import io.vertx.core.*;
 import io.vertx.core.cli.annotations.*;
 import io.vertx.core.impl.launcher.VertxLifecycleHooks;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.spi.VertxMetricsFactory;
 import io.vertx.core.spi.launcher.ExecutionContext;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.lang.reflect.Method;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -26,6 +30,7 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.Enumeration;
 import java.util.Properties;
+import java.util.Scanner;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -53,6 +58,7 @@ public class BareCommand extends ClasspathHandler {
 
   protected String haGroup;
 
+  protected String vertxOptions;
   protected VertxOptions options;
 
   protected Runnable finalAction;
@@ -108,6 +114,25 @@ public class BareCommand extends ClasspathHandler {
   }
 
   /**
+   * The Vert.x options, it can be a json file or a json string.
+   *
+   * @param vertxOptions the configuration
+   */
+  @Option(longName = "vertx-options", argName = "options")
+  @Description("Specifies the Vert.x options. It should reference either a " +
+    "text file containing a valid JSON object which represents the options OR be a JSON string.")
+  public void setVertxOptions(String vertxOptions) {
+    if (vertxOptions != null) {
+      // For inlined configuration remove first and end single and double quotes if any
+      this.vertxOptions = vertxOptions.trim()
+        .replaceAll("^\"|\"$", "")
+        .replaceAll("^'|'$", "");
+    } else {
+      this.vertxOptions = null;
+    }
+  }
+
+  /**
    * @return whether or not the vert.x instance should be clustered. This implementation
    * returns {@code true}.
    */
@@ -148,8 +173,15 @@ public class BareCommand extends ClasspathHandler {
    */
   @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
   protected Vertx startVertx() {
-    MetricsOptions metricsOptions = getMetricsOptions();
-    options = new VertxOptions().setMetricsOptions(metricsOptions);
+    JsonObject optionsJson = getJsonFromFileOrString(vertxOptions, "vertx-options");
+    if (optionsJson == null) {
+      MetricsOptions metricsOptions = getMetricsOptions();
+      options = new VertxOptions().setMetricsOptions(metricsOptions);
+    } else {
+      MetricsOptions metricsOptions = getMetricsOptions(optionsJson.getJsonObject("metricsOptions"));
+      options = new VertxOptions(optionsJson).setMetricsOptions(metricsOptions);
+    }
+
     configureFromSystemProperties(options, VERTX_OPTIONS_PROP_PREFIX);
     beforeStartingVertx(options);
     Vertx instance;
@@ -212,6 +244,33 @@ public class BareCommand extends ClasspathHandler {
     return instance;
   }
 
+  protected JsonObject getJsonFromFileOrString(String jsonFileOrString, String argName) {
+    JsonObject conf;
+    if (jsonFileOrString != null) {
+      try (Scanner scanner = new Scanner(new File(jsonFileOrString), "UTF-8").useDelimiter("\\A")) {
+        String sconf = scanner.next();
+        try {
+          conf = new JsonObject(sconf);
+        } catch (DecodeException e) {
+          log.error("Configuration file " + sconf + " does not contain a valid JSON object");
+          return null;
+        }
+      } catch (FileNotFoundException e) {
+        try {
+          conf = new JsonObject(jsonFileOrString);
+        } catch (DecodeException e2) {
+          // The configuration is not printed for security purpose, it can contain sensitive data.
+          log.error("The -" + argName + " argument does not point to an existing file or is not a valid JSON object");
+          e2.printStackTrace();
+          return null;
+        }
+      }
+    } else {
+      conf = null;
+    }
+    return conf;
+  }
+
   /**
    * Hook called after starting vert.x.
    *
@@ -240,12 +299,19 @@ public class BareCommand extends ClasspathHandler {
    * @return the metric options.
    */
   protected MetricsOptions getMetricsOptions() {
+    return getMetricsOptions(null);
+  }
+
+  /**
+   * @return the metric options.
+   */
+  protected MetricsOptions getMetricsOptions(JsonObject jsonObject) {
     MetricsOptions metricsOptions;
     VertxMetricsFactory factory = ServiceHelper.loadFactoryOrNull(VertxMetricsFactory.class);
     if (factory != null) {
-      metricsOptions = factory.newOptions();
+      metricsOptions = jsonObject == null ? factory.newOptions() : factory.newOptions(jsonObject);
     } else {
-      metricsOptions = new MetricsOptions();
+      metricsOptions = jsonObject == null ? new MetricsOptions() : new MetricsOptions(jsonObject);
     }
     configureFromSystemProperties(metricsOptions, METRICS_OPTIONS_PROP_PREFIX);
     return metricsOptions;

--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
@@ -118,9 +118,8 @@ public class BareCommand extends ClasspathHandler {
    *
    * @param vertxOptions the configuration
    */
-  @Option(longName = "vertx-options", argName = "options")
-  @Description("Specifies the Vert.x options. It should reference either a " +
-    "text file containing a valid JSON object which represents the options OR be a JSON string.")
+  @Option(longName = "options", argName = "options")
+  @Description("Specifies the Vert.x options. It should reference either a JSON file which represents the options OR be a JSON string.")
   public void setVertxOptions(String vertxOptions) {
     if (vertxOptions != null) {
       // For inlined configuration remove first and end single and double quotes if any
@@ -173,7 +172,7 @@ public class BareCommand extends ClasspathHandler {
    */
   @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
   protected Vertx startVertx() {
-    JsonObject optionsJson = getJsonFromFileOrString(vertxOptions, "vertx-options");
+    JsonObject optionsJson = getJsonFromFileOrString(vertxOptions, "options");
     if (optionsJson == null) {
       MetricsOptions metricsOptions = getMetricsOptions();
       options = new VertxOptions().setMetricsOptions(metricsOptions);

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,21 +11,21 @@
 
 package io.vertx.core.impl.launcher.commands;
 
-import io.vertx.core.*;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.cli.CLIException;
 import io.vertx.core.cli.CommandLine;
 import io.vertx.core.cli.annotations.*;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.launcher.VertxLifecycleHooks;
-import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.launcher.ExecutionContext;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Scanner;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -411,30 +411,7 @@ public class RunCommand extends BareCommand {
   }
 
   protected JsonObject getConfiguration() {
-    JsonObject conf;
-    if (config != null) {
-      try (Scanner scanner = new Scanner(new File(config), "UTF-8").useDelimiter("\\A")) {
-        String sconf = scanner.next();
-        try {
-          conf = new JsonObject(sconf);
-        } catch (DecodeException e) {
-          log.error("Configuration file " + sconf + " does not contain a valid JSON object");
-          return null;
-        }
-      } catch (FileNotFoundException e) {
-        try {
-          conf = new JsonObject(config);
-        } catch (DecodeException e2) {
-          // The configuration is not printed for security purpose, it can contain sensitive data.
-          log.error("The -conf option does not point to an existing file or is not a valid JSON object");
-          e2.printStackTrace();
-          return null;
-        }
-      }
-    } else {
-      conf = null;
-    }
-    return conf;
+    return getJsonFromFileOrString(config, "conf");
   }
 
   protected void beforeDeployingVerticle(DeploymentOptions deploymentOptions) {

--- a/src/main/java/io/vertx/core/spi/VertxMetricsFactory.java
+++ b/src/main/java/io/vertx/core/spi/VertxMetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,7 @@
 package io.vertx.core.spi;
 
 import io.vertx.core.VertxOptions;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.spi.metrics.VertxMetrics;
 
@@ -33,9 +34,9 @@ public interface VertxMetricsFactory {
   VertxMetrics metrics(VertxOptions options);
 
   /**
-   * Create an empty metrics options. Providers can override this method to provide a custom metrics options subclass
-   * that exposes custom configuration. It is used by the {@link io.vertx.core.Starter} class when
-   * creating new options when building a CLI vert.x
+   * Create an empty metrics options.
+   * Providers can override this method to provide a custom metrics options subclass that exposes custom configuration.
+   * It is used by the {@link io.vertx.core.Launcher} class when creating new options when building a CLI Vert.x.
    *
    * @return new metrics options
    */
@@ -43,4 +44,15 @@ public interface VertxMetricsFactory {
     return new MetricsOptions();
   }
 
+  /**
+   * Create metrics options from the provided {@code jsonObject}.
+   * Providers can override this method to provide a custom metrics options subclass that exposes custom configuration.
+   * It is used by the {@link io.vertx.core.Launcher} class when creating new options when building a CLI Vert.x.
+   *
+   * @param jsonObject json provided by the user
+   * @return new metrics options
+   */
+  default MetricsOptions newOptions(JsonObject jsonObject) {
+    return new MetricsOptions(jsonObject);
+  }
 }

--- a/src/test/java/io/vertx/core/CustomMetricsFactory.java
+++ b/src/test/java/io/vertx/core/CustomMetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,6 +11,7 @@
 
 package io.vertx.core;
 
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.metrics.impl.DummyVertxMetrics;
 import io.vertx.core.spi.VertxMetricsFactory;
@@ -29,5 +30,10 @@ public class CustomMetricsFactory implements VertxMetricsFactory {
   @Override
   public MetricsOptions newOptions() {
     return new CustomMetricsOptions();
+  }
+
+  @Override
+  public MetricsOptions newOptions(JsonObject jsonObject) {
+    return new CustomMetricsOptions(jsonObject);
   }
 }

--- a/src/test/java/io/vertx/core/CustomMetricsOptions.java
+++ b/src/test/java/io/vertx/core/CustomMetricsOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,6 +11,7 @@
 
 package io.vertx.core;
 
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;
 
 /**
@@ -19,6 +20,16 @@ import io.vertx.core.metrics.MetricsOptions;
 public class CustomMetricsOptions extends MetricsOptions {
 
   private String value;
+  private NestedMetricsOptions nestedOptions;
+
+  public CustomMetricsOptions() {
+  }
+
+  public CustomMetricsOptions(JsonObject json) {
+    value = json.getString("customProperty");
+    JsonObject nestedOptionsJson = json.getJsonObject("nestedOptions");
+    this.nestedOptions = nestedOptionsJson == null ? null : new NestedMetricsOptions(nestedOptionsJson);
+  }
 
   public String getCustomProperty() {
     return value;
@@ -26,5 +37,13 @@ public class CustomMetricsOptions extends MetricsOptions {
 
   public void setCustomProperty(String value) {
     this.value = value;
+  }
+
+  public NestedMetricsOptions getNestedOptions() {
+    return nestedOptions;
+  }
+
+  public void setNestedOptions(NestedMetricsOptions nestedOptions) {
+    this.nestedOptions = nestedOptions;
   }
 }

--- a/src/test/java/io/vertx/core/LauncherTest.java
+++ b/src/test/java/io/vertx/core/LauncherTest.java
@@ -483,7 +483,7 @@ public class LauncherTest extends VertxTestBase {
     }
 
     MyLauncher launcher = new MyLauncher();
-    String[] args = new String[]{"run", "java:" + TestVerticle.class.getCanonicalName(), "-vertx-options", optionsArg};
+    String[] args = new String[]{"run", "java:" + TestVerticle.class.getCanonicalName(), "-options", optionsArg};
     launcher.dispatch(args);
     assertWaitUntil(() -> TestVerticle.instanceCount.get() == 1);
 
@@ -584,7 +584,7 @@ public class LauncherTest extends VertxTestBase {
     }
 
     MyLauncher launcher = new MyLauncher();
-    String[] args = {"run", "java:" + TestVerticle.class.getCanonicalName(), "-vertx-options", optionsArg};
+    String[] args = {"run", "java:" + TestVerticle.class.getCanonicalName(), "-options", optionsArg};
     ClassLoader oldCL = Thread.currentThread().getContextClassLoader();
     Thread.currentThread().setContextClassLoader(MetricsOptionsTest.createMetricsFromMetaInfLoader("io.vertx.core.CustomMetricsFactory"));
     try {

--- a/src/test/java/io/vertx/core/LauncherTest.java
+++ b/src/test/java/io/vertx/core/LauncherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,11 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
+import java.io.*;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -443,7 +439,6 @@ public class LauncherTest extends VertxTestBase {
     assertEquals(true, opts.getMetricsOptions().isEnabled());
     assertEquals("somegroup", opts.getHAGroup());
     assertEquals(TimeUnit.SECONDS, opts.getMaxEventLoopExecuteTimeUnit());
-
   }
 
   private void clearProperties() {
@@ -457,6 +452,50 @@ public class LauncherTest extends VertxTestBase {
       }
     }
     toClear.forEach(System::clearProperty);
+  }
+
+  @Test
+  public void testConfigureFromJsonFile() throws Exception {
+    testConfigureFromJson(true);
+  }
+
+  @Test
+  public void testConfigureFromJsonString() throws Exception {
+    testConfigureFromJson(false);
+  }
+
+  private void testConfigureFromJson(boolean jsonFile) throws Exception {
+    JsonObject json = new JsonObject()
+      .put("eventLoopPoolSize", 123)
+      .put("maxEventLoopExecuteTime", 123767667)
+      .put("metricsOptions", new JsonObject().put("enabled", true))
+      .put("eventBusOptions", new JsonObject().put("clustered", true).put("clusterPublicHost", "mars"))
+      .put("haGroup", "somegroup")
+      .put("maxEventLoopExecuteTimeUnit", "SECONDS");
+
+    String optionsArg;
+    if (jsonFile) {
+      File file = testFolder.newFile();
+      Files.write(file.toPath(), json.toBuffer().getBytes());
+      optionsArg = file.getPath();
+    } else {
+      optionsArg = json.toString();
+    }
+
+    MyLauncher launcher = new MyLauncher();
+    String[] args = new String[]{"run", "java:" + TestVerticle.class.getCanonicalName(), "-vertx-options", optionsArg};
+    launcher.dispatch(args);
+    assertWaitUntil(() -> TestVerticle.instanceCount.get() == 1);
+
+    VertxOptions opts = launcher.getVertxOptions();
+
+    assertEquals(123, opts.getEventLoopPoolSize(), 0);
+    assertEquals(123767667L, opts.getMaxEventLoopExecuteTime());
+    assertEquals(true, opts.getMetricsOptions().isEnabled());
+    assertEquals(true, opts.isClustered());
+    assertEquals("mars", opts.getClusterPublicHost());
+    assertEquals("somegroup", opts.getHAGroup());
+    assertEquals(TimeUnit.SECONDS, opts.getMaxEventLoopExecuteTimeUnit());
   }
 
   @Test
@@ -516,6 +555,49 @@ public class LauncherTest extends VertxTestBase {
       def.getMetricsOptions().setEnabled(true);
     }
     assertEquals(def, opts);
+  }
+
+  @Test
+  public void testCustomMetricsOptionsFromJsonFile() throws Exception {
+    testCustomMetricsOptionsFromJson(true);
+  }
+
+  @Test
+  public void testCustomMetricsOptionsFromJsonString() throws Exception {
+    testCustomMetricsOptionsFromJson(false);
+  }
+
+  private void testCustomMetricsOptionsFromJson(boolean jsonFile) throws Exception {
+    JsonObject json = new JsonObject()
+      .put("metricsOptions", new JsonObject()
+        .put("enabled", true)
+        .put("customProperty", "customPropertyValue")
+        .put("nestedOptions", new JsonObject().put("nestedProperty", "nestedValue")));
+
+    String optionsArg;
+    if (jsonFile) {
+      File file = testFolder.newFile();
+      Files.write(file.toPath(), json.toBuffer().getBytes());
+      optionsArg = file.getPath();
+    } else {
+      optionsArg = json.toString();
+    }
+
+    MyLauncher launcher = new MyLauncher();
+    String[] args = {"run", "java:" + TestVerticle.class.getCanonicalName(), "-vertx-options", optionsArg};
+    ClassLoader oldCL = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(MetricsOptionsTest.createMetricsFromMetaInfLoader("io.vertx.core.CustomMetricsFactory"));
+    try {
+      launcher.dispatch(args);
+    } finally {
+      Thread.currentThread().setContextClassLoader(oldCL);
+    }
+    assertWaitUntil(() -> TestVerticle.instanceCount.get() == 1);
+
+    VertxOptions opts = launcher.getVertxOptions();
+    CustomMetricsOptions custom = (CustomMetricsOptions) opts.getMetricsOptions();
+    assertEquals("customPropertyValue", custom.getCustomProperty());
+    assertEquals("nestedValue", custom.getNestedOptions().getNestedProperty());
   }
 
   @Test

--- a/src/test/java/io/vertx/core/NestedMetricsOptions.java
+++ b/src/test/java/io/vertx/core/NestedMetricsOptions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.metrics.MetricsOptions;
+
+/**
+ * @author Thomas Segismont
+ */
+public class NestedMetricsOptions extends MetricsOptions {
+
+  private String nestedProperty;
+
+  public NestedMetricsOptions() {
+  }
+
+  public NestedMetricsOptions(JsonObject jsonObject) {
+    nestedProperty = jsonObject.getString("nestedProperty");
+  }
+
+  public String getNestedProperty() {
+    return nestedProperty;
+  }
+
+  public void setNestedProperty(String nestedProperty) {
+    this.nestedProperty = nestedProperty;
+  }
+}


### PR DESCRIPTION
Resolves #1729

This allows a user to configure:
- metrics options
- clustering and event bus options
- any base Vert.x options

It relieves users from implementing their own `Launcher` class, only for overriding `beforeStartingVertx` and manipulating options. 