### PR TITLE
Port the utils removeDots and normalizePath from web to core, as they…

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -88,12 +88,18 @@ public final class HttpUtils {
    *
    * double slash // will be converted to single slash and the path will always start with slash.
    *
+   * Null paths are not normalized as nothing can be said about them.
+   *
    * @param pathname raw path
    * @return normalized path
    */
   public static String normalizePath(String pathname) {
+    if (pathname == null) {
+      return null;
+    }
+
     // add trailing slash if not set
-    if (pathname == null || pathname.length() == 0) {
+    if (pathname.length() == 0) {
       return "/";
     }
 
@@ -163,9 +169,9 @@ public final class HttpUtils {
   /**
    * Removed dots as per <a href="http://tools.ietf.org/html/rfc3986#section-5.2.4>rfc3986</a>.
    *
-   * There are 2 extra transformations that are not part of the spec but kept for backwards compatibility:
+   * There is 1 extra transformation that are not part of the spec but kept for backwards compatibility:
    *
-   * double slash // will be converted to single slash and the path will always start with slash.
+   * double slash // will be converted to single slash.
    *
    * @param path raw path
    * @return normalized path

--- a/src/test/java/io/vertx/core/http/HttpUtilsTest.java
+++ b/src/test/java/io/vertx/core/http/HttpUtilsTest.java
@@ -15,8 +15,7 @@ import org.junit.Test;
 
 import java.net.URI;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class HttpUtilsTest {
 
@@ -81,7 +80,7 @@ public class HttpUtilsTest {
 
   @Test
   public void testNullPath() throws Exception {
-    assertEquals("/", HttpUtils.normalizePath(null));
+    assertNull(HttpUtils.normalizePath(null));
   }
 
   @Test


### PR DESCRIPTION
… are usefull not just to web routing but HTTP in general

Signed-off-by: Paulo Lopes <paulo@mlopes.net>

Follow up from: https://github.com/vert-x3/vertx-web/pull/1040

Once this is merged, the Utils on web can be clean as most of it's code is now on core.