### PR TITLE
Write buffer text message #2756

### DIFF
--- a/src/main/java/io/vertx/core/http/WebSocketBase.java
+++ b/src/main/java/io/vertx/core/http/WebSocketBase.java
@@ -138,6 +138,16 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
   WebSocketBase writeTextMessage(String text);
 
   /**
+   * Writes a (potentially large) piece of binary text data to the connection.
+   * This data might be written as multiple frames if it exceeds the maximum WebSocket frame size.
+   *
+   * @param textBuffer  the data to write
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  WebSocketBase writeBinaryTextMessage(Buffer textBuffer);
+
+  /**
    * Writes a ping to the connection. This will be written in a single frame. Ping frames may be at most 125 bytes (octets).
    * <p>
    * This method should not be used to write application data and should only be used for implementing a keep alive or

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -187,6 +187,15 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
   }
 
   @Override
+  public S writeBinaryTextMessage(Buffer textBuffer) {
+    synchronized (conn) {
+      checkClosed();
+      writePartialMessage(FrameType.TEXT, textBuffer, 0);
+      return (S) this;
+    }
+  }
+
+  @Override
   public S write(Buffer data) {
     synchronized (conn) {
       checkClosed();


### PR DESCRIPTION
It's for performance. In our case we already have a `Buffer`, it will be wasted to convert it to String then Vertx convert the String to Buffer again before sending out.