### PR TITLE
Enable isolation groups for Java 9+

### DIFF
--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -25,6 +25,7 @@ import io.vertx.core.spi.VerticleFactory;
 import io.vertx.core.spi.metrics.VertxMetrics;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -32,11 +33,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.WeakHashMap;
@@ -380,10 +383,73 @@ public class DeploymentManager {
     return factoryList;
   }
 
+  private static URL mapToURL(String path) {
+    try {
+      File file = new File(path);
+      return file.toURI().toURL();
+    } catch (MalformedURLException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static List<URL> extractCPFromProperty() {
+    List<URL> classpathURLs = new ArrayList<>();
+    String classpath = System.getProperty("java.class.path");
+    if (Objects.nonNull(classpath)) {
+      for (String path : classpath.split(File.pathSeparator)) {
+        classpathURLs.add(mapToURL(path));
+      }
+    }
+    return classpathURLs;
+  }
+
+  // VisibleForTesting
+  static List<URL> extractCPByManifest(ClassLoader current) {
+    List<URL> classpathURLs = new ArrayList<>();
+    String searchFile = "META-INF/MANIFEST.MF";
+    Enumeration<URL> urls;
+    try {
+      urls = current.getResources(searchFile);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+    for (URL url : Collections.list(urls)) {
+      String urlString = url.toExternalForm();
+      if ("jar".equals(url.getProtocol().toLowerCase())) {
+        String prefix = "jar:";
+        String suffix = "!/" + searchFile;
+        urlString = urlString.replace(prefix, "").replace(suffix, "").trim();
+      }
+      // handle exploded jars
+      urlString = urlString.replace(searchFile, "").trim();
+      try {
+        classpathURLs.add(new URL(urlString));
+      } catch (MalformedURLException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+    return classpathURLs;
+  }
+
+  // VisibleForTesting
+  static List<URL> extractClasspath(ClassLoader current) {
+    if (current instanceof URLClassLoader) {
+      URLClassLoader urlc = (URLClassLoader)current;
+      return Arrays.asList(urlc.getURLs());
+    } else {
+      List<URL> classpathURLs = extractCPFromProperty();
+      for (URL url : extractCPByManifest(current)) {
+        if (!classpathURLs.contains(url)) {
+          classpathURLs.add(url); 
+        }
+      }
+      return classpathURLs;
+    }
+  }
+
   /**
-   * <strong>IMPORTANT</strong> - Isolation groups are not supported on Java 9+ because the application classloader is not
-   * an URLClassLoader anymore. Thus we can't extract the list of jars to configure the IsolatedClassLoader.
-   *
+   * <strong>IMPORTANT</strong> - Isolation groups are not supported if modules are used. Because modules are living
+   * in the runtime image and there is no way, to extract these modules.
    */
   private ClassLoader getClassLoader(DeploymentOptions options) {
     String isolationGroup = options.getIsolationGroup();
@@ -391,32 +457,20 @@ public class DeploymentManager {
     if (isolationGroup == null) {
       cl = getCurrentClassLoader();
     } else {
-      // IMPORTANT - Isolation groups are not supported on Java 9+, because the system classloader is not an URLClassLoader
-      // anymore. Thus we can't extract the paths from the classpath and isolate the loading.
       synchronized (this) {
         cl = classloaders.get(isolationGroup);
         if (cl == null) {
           ClassLoader current = getCurrentClassLoader();
-          if (!(current instanceof URLClassLoader)) {
-            throw new IllegalStateException("Current classloader must be URLClassLoader");
-          }
           List<URL> urls = new ArrayList<>();
           // Add any extra URLs to the beginning of the classpath
           List<String> extraClasspath = options.getExtraClasspath();
           if (extraClasspath != null) {
             for (String pathElement: extraClasspath) {
-              File file = new File(pathElement);
-              try {
-                URL url = file.toURI().toURL();
-                urls.add(url);
-              } catch (MalformedURLException e) {
-                throw new IllegalStateException(e);
-              }
+              urls.add(mapToURL(pathElement));
             }
           }
           // And add the URLs of the Vert.x classloader
-          URLClassLoader urlc = (URLClassLoader)current;
-          urls.addAll(Arrays.asList(urlc.getURLs()));
+          urls.addAll(extractClasspath(current));
 
           // Create an isolating cl with the urls
           cl = new IsolatingClassLoader(urls.toArray(new URL[urls.size()]), getCurrentClassLoader(),

--- a/src/test/java/io/vertx/core/impl/DeploymentManagerTest.java
+++ b/src/test/java/io/vertx/core/impl/DeploymentManagerTest.java
@@ -1,0 +1,43 @@
+package io.vertx.core.impl;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.junit.Test;
+import org.assertj.core.util.Arrays;
+import org.junit.Assert;
+
+public class DeploymentManagerTest {
+
+  private static boolean isJarOrZip(File file) {
+    String fileName = file.getName().toLowerCase();
+    if (fileName.endsWith(".jar") || fileName.endsWith(".zip")) {
+      return true;
+    }
+    return false;
+  }
+
+  @Test
+  public void extractClasspathTest() throws URISyntaxException{
+    for(URL cpURL : DeploymentManager.extractClasspath(getClass().getClassLoader())) {
+      File cpEntry = new File(cpURL.toURI());
+      Assert.assertTrue("Classpath entry does not exist: " + cpURL, cpEntry.exists());
+      if (cpEntry.isFile()) {
+        // If classpath entry is a file, it must be a jar or zip
+        Assert.assertTrue("Classpath entry is a file but not a zip or jar: " + cpURL, isJarOrZip(cpEntry));
+      }
+    }
+  }
+
+  @Test
+  public void extractClasspathWithExplodedJarTest() throws MalformedURLException{
+    URL cp = new File("src/test/resources/cpExtraction/exploded").toURI().toURL();
+    URLClassLoader ucl = new URLClassLoader(Arrays.array(cp), null);
+    for (URL cpURL : DeploymentManager.extractCPByManifest(ucl)) {
+      Assert.assertEquals("extractCPByManifest does not handle exploded JARs correct", cp, cpURL);
+    }
+  }
+}

--- a/src/test/resources/cpExtraction/exploded/META-INF/MANIFEST.MF
+++ b/src/test/resources/cpExtraction/exploded/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+


### PR DESCRIPTION
The current implementation of isolation groups [1] requires the
instantiation of a new IsolatingClassLoader, which contains all JARs
from the class path of the SystemClassLoader. Before Java 9, this was
solved by casting the SystemClassLoader to an URLClassLoader to extract
JARs on the class path of the SystemClassLoader.

Due to the fact, that the SystemClassLoader is not longer an
URLClassLoader in Java 9, this approach will not longer work.

This patch implements a way to extract the class path of the
SystemClassLoader which does not require the SystemClassLoader to be an
instance of URLClassLoader.

WARNING: This approach will not work for modules, which were introduces
in Java 9, because modules are living in the "runtime image" [2]. Due to
this, it is not possible to pass the module classes into the current
implementation of IsolatingClassLoader.


[1] https://github.com/eclipse-vertx/vert.x/blob/4bbced9e8ac173ab73c4b4d1ef0bee99c6322a89/src/main/asciidoc/index.adoc#verticle-isolation-groups
[2] https://openjdk.java.net/jeps/220


Signed-off-by: Pascal Krause <pascal.krause@sap.com>