### PR TITLE
provide fix and test for #2790

### DIFF
--- a/src/main/java/io/vertx/core/parsetools/impl/JsonParserImpl.java
+++ b/src/main/java/io/vertx/core/parsetools/impl/JsonParserImpl.java
@@ -224,6 +224,7 @@ public class JsonParserImpl implements JsonParser {
             if (endHandler != null) {
               endHandler.handle(null);
             }
+            return;
           }
           break;
         } else {

--- a/src/test/java/io/vertx/core/parsetools/FakeStream.java
+++ b/src/test/java/io/vertx/core/parsetools/FakeStream.java
@@ -24,6 +24,8 @@ class FakeStream implements ReadStream<Buffer> {
   private Handler<Buffer> eventHandler;
   private Handler<Void> endHandler;
   private Handler<Throwable> exceptionHandler;
+  private volatile int pauseCount;
+  private volatile int resumeCount;
 
   @Override
   public ReadStream<Buffer> exceptionHandler(Handler<Throwable> handler) {
@@ -50,11 +52,13 @@ class FakeStream implements ReadStream<Buffer> {
   @Override
   public ReadStream<Buffer> pause() {
     demand = 0L;
+    pauseCount++;
     return this;
   }
 
   @Override
   public ReadStream<Buffer> resume() {
+    resumeCount++;
     return fetch(Long.MAX_VALUE);
   }
 
@@ -88,5 +92,13 @@ class FakeStream implements ReadStream<Buffer> {
 
   void end() {
     endHandler.handle(null);
+  }
+
+  public int pauseCount() {
+    return pauseCount;
+  }
+
+  public int resumeCount() {
+    return resumeCount;
   }
 }

--- a/src/test/java/io/vertx/core/parsetools/JsonParserTest.java
+++ b/src/test/java/io/vertx/core/parsetools/JsonParserTest.java
@@ -789,6 +789,9 @@ public class JsonParserTest {
     stream.end();
     assertEquals(0, events.size());
     assertEquals(1, ended.get());
+    //regression check for #2790 - ensure that by accident resume method is not called.
+    assertEquals(0, stream.pauseCount());
+    assertEquals(0, stream.resumeCount());
   }
 
   @Test


### PR DESCRIPTION
Hi, 
that is initial bug-fix for #2790.

I have one problem with test - because of closing file is asynchronous I had to handle exception in Vert.x exception handler 
```java
 vertx.exceptionHandler(exception -> fail());
```
and also schedule completion to allow vert.x first catch exception and fail test.
```java
vertx.setTimer(10, val -> complete());
```

do you maybe have other idea how to test that case with file-closed case (my seems really ... bad)  ?