### PR TITLE
Introduce local methods in SharedData for async map, counter and lock

### DIFF
--- a/src/main/asciidoc/shareddata.adoc
+++ b/src/main/asciidoc/shareddata.adoc
@@ -35,11 +35,14 @@ Here's an example of using a shared local map:
 
 === Asynchronous shared maps
 
-Asynchronous shared maps allow data to be put in the map and retrieved locally when Vert.x is not clustered.
-When clustered, data can be put from any node and retrieved from the same node or any other node.
+{@link io.vertx.core.shareddata.AsyncMap Asynchronous shared maps} allow data to be put in the map and retrieved locally
+when Vert.x is not clustered. When clustered, data can be put from any node and retrieved from the same node or any other node.
 
 IMPORTANT: In clustered mode, asynchronous shared maps rely on distributed data structures provided by the cluster manager.
 Beware that the latency relative to asynchronous shared map operations can be much higher in clustered than in local mode.
+
+In case that Vert.x is clustered, but a local asynchronous map is needed, you can call
+{@link io.vertx.core.shareddata.SharedData#getLocalAsyncMap(java.lang.String,io.vertx.core.Handler)}.
 
 This makes them really useful for things like storing session state in a farm of servers hosting a Vert.x web
 application.
@@ -84,8 +87,9 @@ See the {@link io.vertx.core.shareddata.AsyncMap API docs} for more information.
 
 === Asynchronous locks
 
-{@link io.vertx.core.shareddata.Lock Asynchronous locks} allow you to obtain exclusive locks locally or across the cluster -
-this is useful when you want to do something or access a resource on only one node of a cluster at any one time.
+{@link io.vertx.core.shareddata.Lock Asynchronous locks} allow data you to obtain exclusive locks locally when Vert.x is not clustered.
+When clustered, exclusive locks can be obtained from any node and checked or released from the same node or any other node.
+This is useful when you want to do something or access a resource on only one node of a cluster at any one time.
 
 Asynchronous locks have an asynchronous API unlike most lock APIs which block the calling thread until the lock
 is obtained.
@@ -94,6 +98,12 @@ To obtain a lock use {@link io.vertx.core.shareddata.SharedData#getLock(java.lan
 
 This won't block, but when the lock is available, the handler will be called with an instance of {@link io.vertx.core.shareddata.Lock},
 signifying that you now own the lock.
+
+IMPORTANT: In clustered mode, asynchronous locks maps rely on distributed data structures provided by the cluster manager.
+Beware that the latency relative to asynchronous lock operations can be much higher in clustered than in local mode.
+
+In case that Vert.x is clustered, but only a local lock should be obtained you can call
+{@link io.vertx.core.shareddata.SharedData#getLocalLock(java.lang.String,io.vertx.core.Handler)}.
 
 While you own the lock no other caller, anywhere on the cluster will be able to obtain the lock.
 
@@ -115,18 +125,23 @@ with a failure:
 
 === Asynchronous counters
 
+{@link io.vertx.core.shareddata.Counter Asynchronous counters} allow data you to obtain an instance of an atomic counter
+locally when Vert.x is not clustered. When clustered, an instance of atomic counters can be obtained from any node and
+you can retrieve the current count, atomically increment it, decrement it and add a value to it from the same node or any other node.
+
 It's often useful to maintain an atomic counter locally or across the different nodes of your application.
 
-You can do this with {@link io.vertx.core.shareddata.Counter}.
-
-You obtain an instance with {@link io.vertx.core.shareddata.SharedData#getCounter(java.lang.String,io.vertx.core.Handler)}:
+To obtain a counter use {@link io.vertx.core.shareddata.SharedData#getCounter(java.lang.String,io.vertx.core.Handler)}.
 
 [source,$lang]
 ----
 {@link examples.SharedDataExamples#example7}
 ----
 
-Once you have an instance you can retrieve the current count, atomically increment it, decrement and add a value to
-it using the various methods.
+IMPORTANT: In clustered mode, asynchronous counters rely on distributed data structures provided by the cluster manager.
+Beware that the latency relative to asynchronous counter operations can be much higher in clustered than in local mode.
+
+In case that Vert.x is clustered, but only a local counter should be obtained you can call
+{@link io.vertx.core.shareddata.SharedData#getLocalCounter(java.lang.String,io.vertx.core.Handler)}.
 
 See the {@link io.vertx.core.shareddata.Counter API docs} for more information.

--- a/src/main/java/io/vertx/core/shareddata/SharedData.java
+++ b/src/main/java/io/vertx/core/shareddata/SharedData.java
@@ -61,6 +61,15 @@ public interface SharedData {
   <K, V> void getAsyncMap(String name, Handler<AsyncResult<AsyncMap<K, V>>> resultHandler);
 
   /**
+   * Get the {@link AsyncMap} with the specified name. When clustered, the map is <b>NOT</b> accessible to all nodes in the cluster only the
+   * instance which created the map can put and retrieve data from this map.
+   *
+   * @param name the name of the map
+   * @param resultHandler the map will be returned asynchronously in this handler
+   */
+  <K, V> void getLocalAsyncMap(String name, Handler<AsyncResult<AsyncMap<K, V>>> resultHandler);
+
+  /**
    * Get an asynchronous lock with the specified name. The lock will be passed to the handler when it is available.
    * <p>
    *   In general lock acquision is unordered, so that sequential attempts to acquire a lock,
@@ -87,12 +96,46 @@ public interface SharedData {
   void getLockWithTimeout(String name, long timeout, Handler<AsyncResult<Lock>> resultHandler);
 
   /**
+   * Get an asynchronous local lock with the specified name. The lock will be passed to the handler when it is available.
+   * <p>
+   *   In general lock acquision is unordered, so that sequential attempts to acquire a lock,
+   *   even from a single thread, can happen in non-sequential order.
+   * </p>
+   *
+   * @param name  the name of the lock
+   * @param resultHandler  the handler
+   */
+  void getLocalLock(String name, Handler<AsyncResult<Lock>> resultHandler);
+
+  /**
+   * Like {@link #getLocalLock(String, Handler)} but specifying a timeout. If the lock is not obtained within the timeout
+   * a failure will be sent to the handler.
+   * <p>
+   *   In general lock acquision is unordered, so that sequential attempts to acquire a lock,
+   *   even from a single thread, can happen in non-sequential order.
+   * </p>
+   *
+   * @param name  the name of the lock
+   * @param timeout  the timeout in ms
+   * @param resultHandler  the handler
+   */
+  void getLocalLockWithTimeout(String name, long timeout, Handler<AsyncResult<Lock>> resultHandler);
+
+  /**
    * Get an asynchronous counter. The counter will be passed to the handler.
    *
    * @param name  the name of the counter.
    * @param resultHandler  the handler
    */
   void getCounter(String name, Handler<AsyncResult<Counter>> resultHandler);
+
+  /**
+   * Get an asynchronous local counter. The counter will be passed to the handler.
+   *
+   * @param name  the name of the counter.
+   * @param resultHandler  the handler
+   */
+  void getLocalCounter(String name, Handler<AsyncResult<Counter>> resultHandler);
 
   /**
    * Return a {@code LocalMap} with the specific {@code name}.

--- a/src/test/java/io/vertx/core/shareddata/ClusteredAsynchronousLockTest.java
+++ b/src/test/java/io/vertx/core/shareddata/ClusteredAsynchronousLockTest.java
@@ -11,6 +11,8 @@
 
 package io.vertx.core.shareddata;
 
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.shareddata.AsynchronousLockTest;
@@ -20,6 +22,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -52,6 +55,38 @@ public class ClusteredAsynchronousLockTest extends AsynchronousLockTest {
   private int mod(int idx, int size) {
     int i = idx % size;
     return i < 0 ? i + size : i;
+  }
+
+  @Test
+  public void testGetLocalLock() {
+    final Vertx node1 = getVertx();
+    final Vertx node2 = getVertx();
+    assertNotSame(node1, node2);
+    AtomicInteger checkpoint = new AtomicInteger(1);
+
+    CompositeFuture.all(Future.<Lock>future(fut -> {
+      node1.sharedData().getLocalLock("lock", fut);
+    }), Future.<Lock>future(fut -> {
+      node2.sharedData().getLocalLock("lock", fut);
+    })).compose(compFuture -> {
+      Lock lockNode1 = compFuture.result().resultAt(0);
+      Lock lockNode2 = compFuture.result().resultAt(1);
+      lockNode1.release();
+
+      return Future.<Lock>future(fut -> {
+        node2.sharedData().getLocalLockWithTimeout("lock", 250, fut);
+      }).otherwise(t -> {
+        assertEquals("Acquire lock should fail", "Timed out waiting to get lock", t.getMessage());
+        checkpoint.decrementAndGet();
+        return lockNode2;
+      });
+    }).setHandler(asyncLock -> {
+      assertTrue(asyncLock.succeeded());
+      assertEquals(0, checkpoint.get());
+      asyncLock.result().release();
+      testComplete();
+    });
+    await();
   }
 
   /**

--- a/src/test/java/io/vertx/core/shareddata/ClusteredSharedCounterTest.java
+++ b/src/test/java/io/vertx/core/shareddata/ClusteredSharedCounterTest.java
@@ -11,8 +11,11 @@
 
 package io.vertx.core.shareddata;
 
+import org.junit.Test;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.shareddata.SharedCounterTest;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.test.fakecluster.FakeClusterManager;
 
@@ -31,6 +34,36 @@ public class ClusteredSharedCounterTest extends SharedCounterTest {
   public void setUp() throws Exception {
     super.setUp();
     startNodes(numNodes);
+  }
+
+  @Test
+  public void testGetLocalCounter() {
+    final Vertx node1 = getVertx();
+    final Vertx node2 = getVertx();
+    assertNotSame(node1, node2);
+
+    CompositeFuture.all(Future.<Counter>future(fut -> {
+      node1.sharedData().getLocalCounter("counter", fut);
+    }), Future.<Counter>future(fut -> {
+      node2.sharedData().getLocalCounter("counter", fut);
+    })).compose(compFuture -> {
+      Counter counterNode1 = compFuture.result().resultAt(0);
+      Counter counterNode2 = compFuture.result().resultAt(1);
+
+      return CompositeFuture.all(Future.<Long>future(fut -> {
+        counterNode1.addAndGet(1, fut);
+      }), Future.<Long>future(fut -> {
+        counterNode2.addAndGet(2, fut);
+      }));
+    }).setHandler(asyncCompFuture -> {
+      assertTrue(asyncCompFuture.succeeded());
+      long valueCounterNode1 = asyncCompFuture.result().resultAt(0);
+      long valueCounterNode2 = asyncCompFuture.result().resultAt(1);
+      assertEquals(valueCounterNode1, 1);
+      assertEquals(valueCounterNode2, 2);
+      testComplete();
+    });
+    await();
   }
 
   int pos;


### PR DESCRIPTION
Closes #2654

In the current implementation of SharedData it is not possible to get a
local lock, counter or async map if a cluster manager is used.
Fortunately all the necessary logic is already in place, so that this
change is minimal invasive.