### PR TITLE
Fix impossible cast and equals checks for incompatible operand

### DIFF
--- a/src/main/java/io/vertx/core/net/ProxyOptions.java
+++ b/src/main/java/io/vertx/core/net/ProxyOptions.java
@@ -202,7 +202,7 @@ public class ProxyOptions {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ClientOptionsBase)) return false;
+    if (!(o instanceof ProxyOptions)) return false;
     if (!super.equals(o)) return false;
 
     ProxyOptions that = (ProxyOptions) o;


### PR DESCRIPTION
FindBugs-3.0.1 ([http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)) reported BC_IMPOSSIBLE_CAST and EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS warnings on master:
```
BC_IMPOSSIBLE_CAST: Impossible cast from io.vertx.core.net.ClientOptionsBase to io.vertx.core.net.ProxyOptions in io.vertx.core.net.ProxyOptions.equals(Object) At ProxyOptions.java:[line 208]
EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS: io.vertx.core.net.ProxyOptions.equals(Object) checks for operand being a ClientOptionsBase At ProxyOptions.java:[line 205]
```
The descriptions of these bugs are as follows:
> BC: Impossible cast (BC_IMPOSSIBLE_CAST)
> This cast will always throw a ClassCastException. FindBugs tracks type information from instanceof checks, and also uses more precise information about the types of values returned from methods and loaded from fields. Thus, it may have more precise information that just the declared type of a variable, and can use this to determine that a cast will always throw an exception at runtime.
 [http://findbugs.sourceforge.net/bugDescriptions.html#BC_IMPOSSIBLE_CAST](http://findbugs.sourceforge.net/bugDescriptions.html#BC_IMPOSSIBLE_CAST)

> Eq: Equals checks for incompatible operand (EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS)
> This equals method is checking to see if the argument is some incompatible type (i.e., a class that is neither a supertype nor subtype of the class that defines the equals method). For example, the Foo class might have an equals method that looks like:
> ```
> public boolean equals(Object o) {
>   if (o instanceof Foo)
>     return name.equals(((Foo)o).name);
>   else if (o instanceof String)
>     return name.equals(o);
>   else return false;
> ```
> This is considered bad practice, as it makes it very hard to implement an equals method that is symmetric and transitive. Without those properties, very unexpected behavoirs are possible.
[http://findbugs.sourceforge.net/bugDescriptions.html#EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS](http://findbugs.sourceforge.net/bugDescriptions.html#EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS)