### PR TITLE
fix logging to system out and err

### DIFF
--- a/src/main/java/io/vertx/core/Starter.java
+++ b/src/main/java/io/vertx/core/Starter.java
@@ -238,8 +238,7 @@ public class Starter {
         return null;
       }
       if (result.get().failed()) {
-        log.error("Failed to form cluster");
-        result.get().cause().printStackTrace();
+        log.error("Failed to form cluster", result.get().cause());
         return null;
       }
       vertx = result.get().result();

--- a/src/main/java/io/vertx/core/dns/impl/decoder/RecordDecoder.java
+++ b/src/main/java/io/vertx/core/dns/impl/decoder/RecordDecoder.java
@@ -19,6 +19,8 @@ import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.util.CharsetUtil;
 import io.vertx.core.dns.impl.MxRecordImpl;
 import io.vertx.core.dns.impl.SrvRecordImpl;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -34,6 +36,7 @@ import java.util.function.Function;
  */
 public class RecordDecoder {
 
+    private static final Logger log = LoggerFactory.getLogger(RecordDecoder.class);
 
     /**
      * Decodes MX (mail exchanger) resource records.
@@ -223,7 +226,7 @@ public class RecordDecoder {
         try {
             result = (T) decoder.apply(record);
         } catch (Exception e) {
-            throw new IllegalStateException(e.getMessage(), e.getCause());
+          log.error(e.getMessage(), e.getCause());
         }
         return result;
     }

--- a/src/main/java/io/vertx/core/dns/impl/decoder/RecordDecoder.java
+++ b/src/main/java/io/vertx/core/dns/impl/decoder/RecordDecoder.java
@@ -223,7 +223,7 @@ public class RecordDecoder {
         try {
             result = (T) decoder.apply(record);
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new IllegalStateException(e.getMessage(), e.getCause());
         }
         return result;
     }

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradedClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradedClientConnection.java
@@ -24,6 +24,8 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.impl.pool.ConnectionListener;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 
@@ -35,6 +37,8 @@ import javax.security.cert.X509Certificate;
  * An HTTP/2 connection in clear text that upgraded from an HTTP/1 upgrade.
  */
 public class Http2UpgradedClientConnection implements HttpClientConnection {
+
+  private static final Logger log = LoggerFactory.getLogger(Http2UpgradedClientConnection.class);
 
   private HttpClientImpl client;
   private HttpClientConnection current;
@@ -151,7 +155,7 @@ public class Http2UpgradedClientConnection implements HttpClientConnection {
                 listener.onConcurrencyChange(concurrency);
               } else {
                 // Handle me
-                ar.cause().printStackTrace();
+                log.error(ar.cause().getMessage(), ar.cause());
               }
             });
           });

--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
@@ -267,8 +267,7 @@ public class BareCommand extends ClasspathHandler {
         return null;
       }
       if (result.get().failed()) {
-        log.error("Failed to form cluster");
-        result.get().cause().printStackTrace();
+        log.error("Failed to form cluster", result.get().cause());
         return null;
       }
       instance = result.get().result();
@@ -296,8 +295,7 @@ public class BareCommand extends ClasspathHandler {
           conf = new JsonObject(jsonFileOrString);
         } catch (DecodeException e2) {
           // The configuration is not printed for security purpose, it can contain sensitive data.
-          log.error("The -" + argName + " argument does not point to an existing file or is not a valid JSON object");
-          e2.printStackTrace();
+          log.error("The -" + argName + " argument does not point to an existing file or is not a valid JSON object", e2);
           return null;
         }
       }

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -402,7 +402,6 @@ public class RunCommand extends BareCommand {
   protected void deploy() {
     deploy(mainVerticle, vertx, deploymentOptions, res -> {
       if (res.failed()) {
-        res.cause().printStackTrace();
         handleDeployFailed(res.cause());
       }
     });

--- a/src/main/java/io/vertx/core/impl/launcher/commands/VertxIsolatedDeployer.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/VertxIsolatedDeployer.java
@@ -66,12 +66,12 @@ public class VertxIsolatedDeployer {
     return res -> {
       if (res.failed()) {
         Throwable cause = res.cause();
-        cause.printStackTrace();
         if (cause instanceof VertxException) {
           VertxException ve = (VertxException) cause;
-          log.error(ve.getMessage());
-          if (ve.getCause() != null) {
-            log.error(ve.getCause());
+          if (ve.getCause() == null) {
+            log.error(ve.getMessage());
+          } else {
+            log.error(ve.getMessage(), ve.getCause());
           }
         } else {
           log.error("Failed in " + message, cause);

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -292,7 +292,7 @@ public abstract class ConnectionBase {
         if (future.isSuccess()) {
           sendFileRegion(file, offset + MAX_REGION_SIZE, length - MAX_REGION_SIZE, writeFuture);
         } else {
-          future.cause().printStackTrace();
+          log.error(future.cause().getMessage(), future.cause());
           writeFuture.setFailure(future.cause());
         }
       });


### PR DESCRIPTION
there were several places where e.printStackTrace() was used, which messed up the logging for docker containers (e.g. if you change the logging pattern with the used logging framework)