### PR TITLE
Set verticle deployment completion handler early for blocking worker case

### DIFF
--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -485,7 +485,6 @@ public class DeploymentManager {
         try {
           verticle.init(vertx, context);
           Future<Void> startFuture = Future.future();
-          verticle.start(startFuture);
           startFuture.setHandler(ar -> {
             if (ar.succeeded()) {
               if (parent != null) {
@@ -509,6 +508,7 @@ public class DeploymentManager {
               deployment.rollback(callingContext, completionHandler, context, ar.cause());
             }
           });
+          verticle.start(startFuture);
         } catch (Throwable t) {
           if (failureReported.compareAndSet(false, true))
             deployment.rollback(callingContext, completionHandler, context, t);


### PR DESCRIPTION
Before, the handler for `startFuture` was only registered after `Verticle.start(startFuture)` returned. However in case the verticle is a worker verticle it should be allowed to block indefinitely and still communicate that it has started successfully (before it starts blocking).

There is the slight side-effect of this change that if the verticle start() method throws a *synchronous* exception *after* already having reported successful startup (through `startFuture`), the success will now get propagated to the initiator, when before it wasn't.