### PR TITLE
reproduce step for issue 2856 scenario 1(zero file)

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpServerFileUploadImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerFileUploadImpl.java
@@ -146,6 +146,7 @@ class HttpServerFileUploadImpl implements HttpServerFileUpload {
     context.owner().fileSystem().open(filename, new OpenOptions(), ar -> {
       if (ar.succeeded()) {
         file =  ar.result();
+        System.out.println("after streamToFileSystem succeeded, file=" + file);
         Pump p = Pump.pump(HttpServerFileUploadImpl.this, ar.result());
         p.start();
         resume();
@@ -187,6 +188,8 @@ class HttpServerFileUploadImpl implements HttpServerFileUpload {
 
   private void handleComplete() {
     lazyCalculateSize = false;
+    assert file != null : "Issue: 2856, if it's null for zero file, can not close the file";
+
     if (file == null) {
       notifyEndHandler();
     } else {

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -2767,6 +2767,11 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
+  public void testFormUploadZeroFile() throws Exception {
+    testFormUploadFile(TestUtils.randomAlphaString(0), true);
+  }
+
+  @Test
   public void testFormUploadSmallFile() throws Exception {
     testFormUploadFile(TestUtils.randomAlphaString(100), false);
   }


### PR DESCRIPTION
1. can not close the file handle if upload empty or zero size file
When my test:

```
Starting test: Http1xTest#testFormUploadZeroFile 
Unhandled exception 
java.lang.AssertionError: Issue: 2856, if it's null for zero file, can not close the file

....

after streamToFileSystem succeeded, file=io.vertx.core.file.impl.AsyncFileImpl@489d4a63

```

![image](https://user-images.githubusercontent.com/1870684/53626369-7e891f80-3c40-11e9-9a0c-33041e53e8bf.png)
