### PR TITLE
Fix native BSD transport dependency

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1431,7 +1431,7 @@ You need to add the following dependency in your classpath:
 ----
 <dependency>
   <groupId>io.netty</groupId>
-  <artifactId>netty-transport-native-epoll</artifactId>
+  <artifactId>netty-transport-native-kqueue</artifactId>
   <version>4.1.15.Final</version>
   <classifier>osx-x86_64</classifier>
 </dependency>


### PR DESCRIPTION
# Change Description

I fixed a copy paste error in the native transport documentation. `epoll` is only available on Linux and on BSD it should be `kqueue`.

# Before

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileKotlin'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not find netty-transport-native-epoll-osx-x86_64.jar (io.netty:netty-transport-native-epoll:4.1.15.Final).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-epoll/4.1.15.Final/netty-transport-native-epoll-4.1.15.Final-osx-x86_64.jar

BUILD FAILED in 1s
1 actionable task: 1 executed
```

# After

```
Download https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-kqueue/4.1.15.Final/netty-transport-native-kqueue-4.1.15.Final.pom
Download https://repo.maven.apache.org/maven2/io/netty/netty-parent/4.1.15.Final/netty-parent-4.1.15.Final.pom
Download https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-kqueue/4.1.15.Final/netty-transport-native-kqueue-4.1.15.Final-osx-x86_64.jar

BUILD SUCCESSFUL in 7s
1 actionable task: 1 executed
```