### PR TITLE
Fix native BSD transport dependency

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1462,7 +1462,7 @@ You need to add the following dependency in your classpath:
 ----
 <dependency>
   <groupId>io.netty</groupId>
-  <artifactId>netty-transport-native-epoll</artifactId>
+  <artifactId>netty-transport-native-kqueue</artifactId>
   <version>4.1.15.Final</version>
   <classifier>osx-x86_64</classifier>
 </dependency>


### PR DESCRIPTION
3.7 version of https://github.com/eclipse-vertx/vert.x/pull/2860