### PR TITLE
Set file cache dir to tmp

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -578,6 +578,11 @@ Set the ALPN usage.
 When vert.x cannot find the file on the filesystem it tries to resolve the
  file from the class path when this is set to <code>true</code>.
 +++
+|[[fileCacheDir]]`@fileCacheDir`|`String`|+++
+When vert.x reads a file that is packaged with the application it gets
+ extracted to this directory first and subsequent reads will use the extracted
+ file to get better IO performance.
++++
 |[[fileCachingEnabled]]`@fileCachingEnabled`|`Boolean`|+++
 Set to <code>true</code> to cache files on the real file system
  when the filesystem performs class path resolving.

--- a/src/main/generated/io/vertx/core/file/FileSystemOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/file/FileSystemOptionsConverter.java
@@ -19,6 +19,11 @@ import java.time.format.DateTimeFormatter;
             obj.setClassPathResolvingEnabled((Boolean)member.getValue());
           }
           break;
+        case "fileCacheDir":
+          if (member.getValue() instanceof String) {
+            obj.setFileCacheDir((String)member.getValue());
+          }
+          break;
         case "fileCachingEnabled":
           if (member.getValue() instanceof Boolean) {
             obj.setFileCachingEnabled((Boolean)member.getValue());
@@ -34,6 +39,9 @@ import java.time.format.DateTimeFormatter;
 
    static void toJson(FileSystemOptions obj, java.util.Map<String, Object> json) {
     json.put("classPathResolvingEnabled", obj.isClassPathResolvingEnabled());
+    if (obj.getFileCacheDir() != null) {
+      json.put("fileCacheDir", obj.getFileCacheDir());
+    }
     json.put("fileCachingEnabled", obj.isFileCachingEnabled());
   }
 }

--- a/src/main/java/io/vertx/core/file/FileSystemOptions.java
+++ b/src/main/java/io/vertx/core/file/FileSystemOptions.java
@@ -15,6 +15,8 @@ package io.vertx.core.file;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
+import java.io.File;
+
 import static io.vertx.core.file.impl.FileResolver.DISABLE_CP_RESOLVING_PROP_NAME;
 import static io.vertx.core.file.impl.FileResolver.DISABLE_FILE_CACHING_PROP_NAME;
 
@@ -35,8 +37,20 @@ public class FileSystemOptions {
    */
   public static final boolean DEFAULT_CLASS_PATH_RESOLVING_ENABLED = !Boolean.getBoolean(DISABLE_CP_RESOLVING_PROP_NAME);
 
+
+  // get the system default temp dir location (can be overriden by using the standard java system property)
+  // if not present default to the process start CWD
+  private static final String TMPDIR = System.getProperty("java.io.tmpdir", ".");
+  private static final String DEFAULT_CACHE_DIR_BASE = "vertx-cache";
+
+  /**
+   * The default caching directory /$tempdir/vertx-cache if the tmp dir is missing then defaults to $CWD/vertx-cache
+   */
+  public static final String DEFAULT_FILE_CACHING_DIR = TMPDIR + File.separator + DEFAULT_CACHE_DIR_BASE;
+
   private boolean classPathResolvingEnabled = DEFAULT_CLASS_PATH_RESOLVING_ENABLED;
   private boolean fileCachingEnabled = DEFAULT_FILE_CACHING_ENABLED;
+  private String fileCacheDir = DEFAULT_FILE_CACHING_DIR;
 
   /**
    * Default constructor
@@ -52,6 +66,7 @@ public class FileSystemOptions {
   public FileSystemOptions(FileSystemOptions other) {
     this.classPathResolvingEnabled = other.isClassPathResolvingEnabled();
     this.fileCachingEnabled = other.isFileCachingEnabled();
+    this.fileCacheDir = other.getFileCacheDir();
   }
 
   /**
@@ -114,6 +129,27 @@ public class FileSystemOptions {
     this.fileCachingEnabled = fileCachingEnabled;
     return this;
   }
+
+  /**
+   * @return the configured file cache dir
+   */
+  public String getFileCacheDir() {
+    return this.fileCacheDir;
+  }
+
+  /**
+   * When vert.x reads a file that is packaged with the application it gets
+   * extracted to this directory first and subsequent reads will use the extracted
+   * file to get better IO performance.
+   *
+   * @param fileCacheDir the value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public FileSystemOptions setFileCacheDir(String fileCacheDir) {
+    this.fileCacheDir = fileCacheDir;
+    return this;
+  }
+
 
   @Override
   public String toString() {

--- a/src/main/java/io/vertx/core/file/FileSystemOptions.java
+++ b/src/main/java/io/vertx/core/file/FileSystemOptions.java
@@ -17,8 +17,7 @@ import io.vertx.core.json.JsonObject;
 
 import java.io.File;
 
-import static io.vertx.core.file.impl.FileResolver.DISABLE_CP_RESOLVING_PROP_NAME;
-import static io.vertx.core.file.impl.FileResolver.DISABLE_FILE_CACHING_PROP_NAME;
+import static io.vertx.core.file.impl.FileResolver.*;
 
 /**
  * Vert.x file system base configuration, this class can be extended by provider implementations to configure
@@ -44,9 +43,10 @@ public class FileSystemOptions {
   private static final String DEFAULT_CACHE_DIR_BASE = "vertx-cache";
 
   /**
-   * The default caching directory /$tempdir/vertx-cache if the tmp dir is missing then defaults to $CWD/vertx-cache
+   * The default file caching dir. If the system property {@code "vertx.cacheDirBase"} is set, then this is the value
+   * If not, then the system property {@code java.io.tmpdir} is taken or {code .} if not set. suffixed with {@code vertx-cache}.
    */
-  public static final String DEFAULT_FILE_CACHING_DIR = TMPDIR + File.separator + DEFAULT_CACHE_DIR_BASE;
+  public static final String DEFAULT_FILE_CACHING_DIR = System.getProperty(CACHE_DIR_BASE_PROP_NAME, TMPDIR + File.separator + DEFAULT_CACHE_DIR_BASE);
 
   private boolean classPathResolvingEnabled = DEFAULT_CLASS_PATH_RESOLVING_ENABLED;
   private boolean fileCachingEnabled = DEFAULT_FILE_CACHING_ENABLED;
@@ -156,6 +156,7 @@ public class FileSystemOptions {
     return "FileSystemOptions{" +
     "classPathResolvingEnabled=" + classPathResolvingEnabled +
     ", fileCachingEnabled=" + fileCachingEnabled +
+    ", fileCacheDir=" + fileCacheDir +
     '}';
   }
 }

--- a/src/main/java/io/vertx/core/file/impl/FileResolver.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolver.java
@@ -52,12 +52,20 @@ public class FileResolver {
   public static final String DISABLE_FILE_CACHING_PROP_NAME = "vertx.disableFileCaching";
   public static final String DISABLE_CP_RESOLVING_PROP_NAME = "vertx.disableFileCPResolving";
 
-
+  /**
+   * Deprecated since setting the standard "java.io.tmpdir" is a better solution that adding another property
+   * that provides the same result.
+   * @deprecated to be removed on 4.0, use "java.io.tmpdir" instead.
+   */
+  @Deprecated
   public static final String CACHE_DIR_BASE_PROP_NAME = "vertx.cacheDirBase";
-  private static final String DEFAULT_CACHE_DIR_BASE = ".vertx";
+  // get the system default temp dir location (can be overriden by using the standard java system property)
+  // if not present default to the process start CWD
+  private static final String TMPDIR = System.getProperty("java.io.tmpdir", ".");
+  private static final String DEFAULT_CACHE_DIR_BASE = "vertx-cache";
   private static final String FILE_SEP = System.getProperty("file.separator");
   private static final boolean NON_UNIX_FILE_SEP = !FILE_SEP.equals("/");
-  private static final String CACHE_DIR_BASE = System.getProperty(CACHE_DIR_BASE_PROP_NAME, DEFAULT_CACHE_DIR_BASE);
+  private static final String CACHE_DIR_BASE = TMPDIR + File.separator + System.getProperty(CACHE_DIR_BASE_PROP_NAME, DEFAULT_CACHE_DIR_BASE);
   private static final String JAR_URL_SEP = "!/";
   private static final Pattern JAR_URL_SEP_PATTERN = Pattern.compile(JAR_URL_SEP);
 

--- a/src/main/java/io/vertx/core/file/impl/FileResolver.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolver.java
@@ -51,13 +51,6 @@ public class FileResolver {
 
   public static final String DISABLE_FILE_CACHING_PROP_NAME = "vertx.disableFileCaching";
   public static final String DISABLE_CP_RESOLVING_PROP_NAME = "vertx.disableFileCPResolving";
-
-  /**
-   * Deprecated since setting the standard "java.io.tmpdir" is a better solution that adding another property
-   * that provides the same result.
-   * @deprecated to be removed on 4.0, use "java.io.tmpdir" instead.
-   */
-  @Deprecated
   public static final String CACHE_DIR_BASE_PROP_NAME = "vertx.cacheDirBase";
   private static final String FILE_SEP = System.getProperty("file.separator");
   private static final boolean NON_UNIX_FILE_SEP = !FILE_SEP.equals("/");
@@ -82,8 +75,7 @@ public class FileResolver {
   public FileResolver(FileSystemOptions fileSystemOptions) {
     this.enableCaching = fileSystemOptions.isFileCachingEnabled();
     this.enableCpResolving = fileSystemOptions.isClassPathResolvingEnabled();
-    // todo: remove the system.getProperty() and leave just the fs options value in 4.0 when the deprecated field is removed
-    this.fileCacheDir = System.getProperty(CACHE_DIR_BASE_PROP_NAME, fileSystemOptions.getFileCacheDir());
+    this.fileCacheDir = fileSystemOptions.getFileCacheDir();
 
     String cwdOverride = System.getProperty("vertx.cwd");
     if (cwdOverride != null) {

--- a/src/test/java/io/vertx/core/file/FileResolverTestBase.java
+++ b/src/test/java/io/vertx/core/file/FileResolverTestBase.java
@@ -41,6 +41,8 @@ import java.util.stream.Collectors;
  */
 public abstract class FileResolverTestBase extends VertxTestBase {
 
+  private final String cacheBaseDir = System.getProperty("java.io.tmpdir", ".") + File.separator + "vertx-cache";
+
   protected FileResolver resolver;
 
   protected String webRoot;
@@ -94,7 +96,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile("afile.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(".vertx" + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>afile</body></html>", readFile(file));
     }
@@ -107,7 +109,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
       for (int i = 0; i < 2; i++) {
         File file = vertx.resolveFile("afile.html");
         assertTrue(file.exists());
-        assertTrue(file.getPath().startsWith(".vertx" + File.separator + "file-cache-"));
+        assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
         assertFalse(file.isDirectory());
         assertEquals("<html><body>afile</body></html>", readFile(file));
       }
@@ -121,7 +123,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile("afile with spaces.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(".vertx" + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>afile with spaces</body></html>", readFile(file));
     }
@@ -132,7 +134,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot);
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(".vertx" + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
       assertTrue(file.isDirectory());
     }
   }
@@ -142,7 +144,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot + "/somefile.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(".vertx" + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>blah</body></html>", readFile(file));
     }
@@ -153,7 +155,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot + "/subdir");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(".vertx" + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
       assertTrue(file.isDirectory());
     }
   }
@@ -163,7 +165,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot + "/subdir/subfile.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(".vertx" + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>subfile</body></html>", readFile(file));
     }


### PR DESCRIPTION
As discussed on the thread: https://groups.google.com/forum/#!topic/vertx-dev/Gj_it5N7m34

Less pollution of working directory and make vert.x applications more container friendly where writing is usually not allowed, except on system temp dir.