### PR TITLE
Enable isolation groups for Java 9+

### DIFF
--- a/src/test/java/io/vertx/core/impl/DeploymentManagerTest.java
+++ b/src/test/java/io/vertx/core/impl/DeploymentManagerTest.java
@@ -1,0 +1,43 @@
+package io.vertx.core.impl;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.junit.Test;
+import org.assertj.core.util.Arrays;
+import org.junit.Assert;
+
+public class DeploymentManagerTest {
+
+  private static boolean isJarOrZip(File file) {
+    String fileName = file.getName().toLowerCase();
+    if (fileName.endsWith(".jar") || fileName.endsWith(".zip")) {
+      return true;
+    }
+    return false;
+  }
+
+  @Test
+  public void extractClasspathTest() throws URISyntaxException{
+    for(URL cpURL : DeploymentManager.extractClasspath(getClass().getClassLoader())) {
+      File cpEntry = new File(cpURL.toURI());
+      Assert.assertTrue("Classpath entry does not exist: " + cpURL, cpEntry.exists());
+      if (cpEntry.isFile()) {
+        // If classpath entry is a file, it must be a jar or zip
+        Assert.assertTrue("Classpath entry is a file but not a zip or jar: " + cpURL, isJarOrZip(cpEntry));
+      }
+    }
+  }
+
+  @Test
+  public void extractClasspathWithExplodedJarTest() throws MalformedURLException{
+    URL cp = new File("src/test/resources/cpExtraction/exploded").toURI().toURL();
+    URLClassLoader ucl = new URLClassLoader(Arrays.array(cp), null);
+    for (URL cpURL : DeploymentManager.extractCPByManifest(ucl)) {
+      Assert.assertEquals("extractCPByManifest does not handle exploded JARs correct", cp, cpURL);
+    }
+  }
+}

--- a/src/test/resources/cpExtraction/exploded/META-INF/MANIFEST.MF
+++ b/src/test/resources/cpExtraction/exploded/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+


### PR DESCRIPTION
The current implementation of isolation groups [1] requires the
instantiation of a new IsolatingClassLoader, which contains all JARs
from the class path of the SystemClassLoader. Before Java 9, this was
solved by casting the SystemClassLoader to an URLClassLoader to extract
JARs on the class path of the SystemClassLoader.

Due to the fact, that the SystemClassLoader is not longer an
URLClassLoader in Java 9, this approach will not longer work.

This patch implements a way to extract the class path of the
SystemClassLoader which does not require the SystemClassLoader to be an
instance of URLClassLoader.

WARNING: This approach will not work for modules, which were introduces
in Java 9, because modules are living in the "runtime image" [2]. Due to
this, it is not possible to pass the module classes into the current
implementation of IsolatingClassLoader.


[1] https://github.com/eclipse-vertx/vert.x/blob/4bbced9e8ac173ab73c4b4d1ef0bee99c6322a89/src/main/asciidoc/index.adoc#verticle-isolation-groups
[2] https://openjdk.java.net/jeps/220


Signed-off-by: Pascal Krause <pascal.krause@sap.com>