### PR TITLE
provide empty object/array instance

### DIFF
--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -30,6 +30,7 @@ import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Collections;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -42,6 +43,9 @@ public class Json {
 
   public static ObjectMapper mapper = new ObjectMapper();
   public static ObjectMapper prettyMapper = new ObjectMapper();
+
+  private static final JsonObject EMPTY_JSON_OBJECT = new JsonObject(Collections.emptyMap());
+  private static final JsonArray EMPTY_JSON_ARRAY = new JsonArray(Collections.emptyList());
 
   static {
     // Non-standard JSON but we allow C style comments in our JSON
@@ -221,6 +225,22 @@ public class Json {
     } catch (Exception e) {
       throw new DecodeException("Failed to decode:" + e.getMessage(), e);
     }
+  }
+
+  /**
+   * Returns an empty jsonObject
+   * @return empty jsonObject
+   */
+  public static JsonObject emptyObject() {
+    return EMPTY_JSON_OBJECT;
+  }
+
+  /**
+   * Returns an empty jsonArray
+   * @return empty jsonArray
+   */
+  public static JsonArray emptyArray() {
+    return EMPTY_JSON_ARRAY;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/io/vertx/core/json/JsonArrayTest.java
+++ b/src/test/java/io/vertx/core/json/JsonArrayTest.java
@@ -1077,6 +1077,27 @@ public class JsonArrayTest {
     assertEquals(((JsonArray) removed).getDouble(0), 1.0, 0.0);
   }
 
+  @Test
+  public void testEmptyJsonObject() {
+    JsonArray emptyArray = Json.emptyArray();
+
+    try {
+      emptyArray.add("vertx"); // expect throw exception
+      fail();
+    } catch (Exception ignored) {
+      // OK
+    }
+
+    boolean empty = emptyArray.isEmpty();
+    assertTrue(empty);
+
+    int size = emptyArray.size();
+    assertEquals(size, 0);
+
+    assertSame(emptyArray, Json.emptyArray());
+  }
+
+
   private void testStreamCorrectTypes(JsonObject object) {
     object.getJsonArray("object1").stream().forEach(innerMap -> {
       assertTrue("Expecting JsonObject, found: " + innerMap.getClass().getCanonicalName(), innerMap instanceof JsonObject);

--- a/src/test/java/io/vertx/core/json/JsonObjectTest.java
+++ b/src/test/java/io/vertx/core/json/JsonObjectTest.java
@@ -1828,6 +1828,26 @@ public class JsonObjectTest {
     return obj;
   }
 
+  @Test
+  public void testEmptyJsonObject() {
+    JsonObject emptyObject = Json.emptyObject();
+
+    try {
+      emptyObject.put("key", "value"); // expect throw exception
+      fail();
+    } catch (Exception ignored) {
+      // OK
+    }
+
+    boolean empty = emptyObject.isEmpty();
+    assertTrue(empty);
+
+    int size = emptyObject.size();
+    assertEquals(size, 0);
+
+    assertSame(emptyObject, Json.emptyObject());
+  }
+
 }
 
 


### PR DESCRIPTION
To reduce JsonObject/JsonArray  instance creation
In some cases  we just want to return an 'empty object'. at present I had to create a new object/array 
**example:**

>   private JsonObject getJsonObjectByName(String name) {
    if (condition) {
      JsonObject entries = new JsonObject();
      // do something
      return entries;
    } else {
      return Json.emptyObject(); // reduce creation
    }
  }