### PR TITLE
Add `query(Object... path)` method for simple JSON querying

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -259,6 +259,50 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
   }
 
   /**
+   * Recursively query into nested {@link JsonObject} / {@link JsonArray} objects.
+   * 
+   * @param pathIdx The current position in the query path.
+   * @param path The query path.
+   * @return The object at the query path, or null if not found.
+   * @throws IllegalArgumentException if the query path has extra unused parameters when a value is reached, or an attempt
+   *         is made to index a {@link JsonArray} using a non-{@link Integer} value. 
+   */
+  protected Object query(int pathIdx, Object[] path) {
+      if (pathIdx >= path.length) {
+          return null;
+      }
+      Object queryObj = path[pathIdx];
+      if (!(queryObj instanceof Integer)) {
+          throw new IllegalArgumentException("Tried to index a JsonArray with a non-Integer query object");
+      }
+      Integer queryIdx = (Integer) queryObj;
+      Object obj = getValue(queryIdx);
+      if (obj == null || pathIdx == path.length - 1) {
+          return obj;
+      } else if (obj instanceof JsonObject) {
+          return ((JsonObject) obj).query(pathIdx + 1, path);
+      } else if (obj instanceof JsonArray) {
+          return ((JsonArray) obj).query(pathIdx + 1, path);
+      } else {
+          throw new IllegalArgumentException("Reached a terminal value before the end of the query parameters");
+      }
+  }
+
+  /**
+   * Recursively query into nested {@link JsonObject} / {@link JsonArray} objects. Objects in the path should be of type
+   * {@link String} for {@link JsonObject} keys (if they are not {@link String}, their {@link Object#toString()} method
+   * will be called to convert them to a {@link String}), and {@link Integer} for indexes into a {@link JsonArray}.
+   * 
+   * @param path The query path, consisting of {@link JsonObject} keys and {@link JsonArray} indices.
+   * @return The object at the query path, or null if an object was not found at the requested path.
+   * @throws IllegalArgumentException if the query path has extra unused parameters when a value is reached, or an attempt
+   *         is made to index a {@link JsonArray} using a non-{@link Integer} value. 
+   */
+  public Object query(Object... path) {
+      return query(0, path);
+  }
+
+  /**
    * Is there a null value at position pos?
    *
    * @param pos  the position in the array


### PR DESCRIPTION
This PR adds `JsonObject::query(Object... path)` and `JsonArray::query(Object... path)` methods for simple query of `JsonObject` / `JsonArray` structures, e.g.:

```
Object age = myDoc.query("users", userId, "age");
```