### PR TITLE
Add Object Array Message Codec for Vertx Service Proxy

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
@@ -21,6 +21,8 @@ import io.vertx.core.json.JsonObject;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -53,6 +55,7 @@ public class CodecManager {
     this.systemCodecs = codecs(NULL_MESSAGE_CODEC, PING_MESSAGE_CODEC, STRING_MESSAGE_CODEC, BUFFER_MESSAGE_CODEC, JSON_OBJECT_MESSAGE_CODEC, JSON_ARRAY_MESSAGE_CODEC,
       BYTE_ARRAY_MESSAGE_CODEC, INT_MESSAGE_CODEC, LONG_MESSAGE_CODEC, FLOAT_MESSAGE_CODEC, DOUBLE_MESSAGE_CODEC,
       BOOLEAN_MESSAGE_CODEC, SHORT_MESSAGE_CODEC, CHAR_MESSAGE_CODEC, BYTE_MESSAGE_CODEC, REPLY_EXCEPTION_MESSAGE_CODEC);
+    this.registerDefaultCodec(Object[].class, new InnerObjectArrayMessageCodec());
   }
 
   public MessageCodec lookupCodec(Object body, String codecName) {
@@ -60,7 +63,11 @@ public class CodecManager {
     if (codecName != null) {
       codec = userCodecMap.get(codecName);
       if (codec == null) {
-        throw new IllegalArgumentException("No message codec for name: " + codecName);
+        codec = Stream.of(systemCodecs())
+          .filter(c -> c.name().equals(codecName))
+          .findAny()
+          .orElseThrow(() -> new IllegalArgumentException("No message codec for name: " + codecName));
+
       }
     } else if (body == null) {
       codec = NULL_MESSAGE_CODEC;
@@ -158,10 +165,17 @@ public class CodecManager {
 
   private MessageCodec[] codecs(MessageCodec... codecs) {
     MessageCodec[] arr = new MessageCodec[codecs.length];
-    for (MessageCodec codec: codecs) {
+    for (MessageCodec codec : codecs) {
       arr[codec.systemCodecID()] = codec;
     }
     return arr;
+  }
+
+  private class InnerObjectArrayMessageCodec extends ObjectArrayMessageCodec {
+
+    private InnerObjectArrayMessageCodec() {
+      super(CodecManager.this::lookupCodec, CodecManager.this.systemCodecs());
+    }
   }
 
 

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/ObjectArrayMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/ObjectArrayMessageCodec.java
@@ -1,0 +1,92 @@
+package io.vertx.core.eventbus.impl.codecs;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+
+import java.util.function.BiFunction;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Binary codec for Object Array. Uses delegate codec for every element.
+ *
+ * <p>
+ * <strong>Support only System and Default Codecs!</strong>
+ *
+ * @author <a href="https://github.com/eutkin">Eugene Utkin</a>
+ */
+public class ObjectArrayMessageCodec implements MessageCodec<Object[], Object[]> {
+
+  private final BiFunction<Object, String, MessageCodec> codecSearcher;
+  private final MessageCodec[] systemCodecs;
+
+  public ObjectArrayMessageCodec(BiFunction<Object, String, MessageCodec> codecSearcher, MessageCodec[] systemCodecs) {
+    this.codecSearcher = requireNonNull(codecSearcher, "Codec Searcher must not be null");
+    this.systemCodecs = requireNonNull(systemCodecs, "System Codec must not be null");
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void encodeToWire(Buffer buffer, Object[] objects) {
+    buffer.appendInt(objects.length);
+    for (Object object : objects) {
+      MessageCodec messageCodec = codecSearcher.apply(object, null);
+      buffer.appendByte(messageCodec.systemCodecID());
+      if (messageCodec.systemCodecID() == -1) {
+        buffer.appendInt(messageCodec.name().length());
+        buffer.appendString(messageCodec.name());
+      }
+      Buffer tempBuf = Buffer.buffer();
+      messageCodec.encodeToWire(tempBuf, object);
+      buffer.appendInt(tempBuf.length());
+      buffer.appendBuffer(tempBuf);
+    }
+  }
+
+  @Override
+  public Object[] decodeFromWire(int pos, Buffer buffer) {
+    int arrayLength = buffer.getInt(pos);
+    pos += 4;
+    Object[] result = new Object[arrayLength];
+    for (int i = 0; i < arrayLength; i++) {
+      int codeSystemId = buffer.getByte(pos);
+      pos += 1;
+      MessageCodec codec;
+      if (codeSystemId > -1) {
+        codec = systemCodecs[codeSystemId];
+      } else {
+        int codecNameLength = buffer.getInt(pos);
+        pos += 4;
+        int endPos = pos + codecNameLength;
+        String codecName = buffer.getString(pos, endPos);
+        codec = codecSearcher.apply(null, codecName);
+        pos = endPos;
+      }
+      int dataLength = buffer.getInt(pos);
+      pos += 4;
+      int endPos = pos + dataLength;
+      Buffer data = buffer.getBuffer(pos, endPos);
+      pos = endPos;
+      Object o = codec.decodeFromWire(0, data);
+      result[i] = o;
+    }
+    return result;
+  }
+
+  @Override
+  public Object[] transform(Object[] objects) {
+    Object[] copied = new Object[objects.length];
+    System.arraycopy(objects, 0, copied, 0, objects.length);
+    return copied;
+  }
+
+  @Override
+  public String name() {
+    return "object-array";
+  }
+
+  @Override
+  public byte systemCodecID() {
+    return -1;
+  }
+}

--- a/src/test/java/io/vertx/core/eventbus/impl/codecs/ObjectArrayMessageCodecTest.java
+++ b/src/test/java/io/vertx/core/eventbus/impl/codecs/ObjectArrayMessageCodecTest.java
@@ -1,0 +1,152 @@
+package io.vertx.core.eventbus.impl.codecs;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.core.eventbus.impl.codecs.StringMessageCodec;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.test.core.VertxTestBase;
+import io.vertx.test.fakecluster.FakeClusterManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Arrays.asList;
+
+@RunWith(Parameterized.class)
+public class ObjectArrayMessageCodecTest extends VertxTestBase {
+
+
+  private final Object[] message;
+
+  public ObjectArrayMessageCodecTest(Object[] message) {
+    this.message = message;
+  }
+
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> parameters() {
+    return asList(new Object[][]{
+      {new Object[]{1L, new JsonObject().put("mes", "text")}},
+      {new Object[]{new Example("Hello"), Buffer.buffer("World!")}}
+    });
+  }
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+  }
+
+  @Override
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+  }
+
+  @Override
+  protected ClusterManager getClusterManager() {
+    return new FakeClusterManager();
+  }
+
+  @Test
+  public void case1() {
+    startNodes(2);
+
+    vertices[0].eventBus().registerDefaultCodec(Example.class, new ExampleMessageCodec());
+    vertices[1].eventBus().registerDefaultCodec(Example.class, new ExampleMessageCodec());
+    vertices[0].exceptionHandler(this::fail);
+    vertices[1].exceptionHandler(this::fail);
+
+    vertices[0].eventBus().<Object[]>consumer("a").handler(m -> assertArrayEquals("Array not equals", message, m.body()))
+      .exceptionHandler(this::fail)
+      .completionHandler(ar -> {
+        assertTrue(ar.succeeded());
+        vertices[1].eventBus().send("a", message);
+        testComplete();
+      });
+    await(30, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void case2() {
+    startNodes(2);
+
+    ExampleMessageCodec messageCodec = new ExampleMessageCodec();
+    vertices[0].eventBus().registerDefaultCodec(Example.class,messageCodec);
+    vertices[1].eventBus().registerDefaultCodec(Example.class, messageCodec);
+    vertices[0].exceptionHandler(this::fail);
+    vertices[1].exceptionHandler(this::fail);
+
+    vertices[0].eventBus().<Object[]>consumer("a").handler(m -> assertArrayEquals("Array not equals", message, m.body()))
+      .exceptionHandler(this::fail)
+      .completionHandler(ar -> {
+        assertTrue(ar.succeeded());
+        vertices[1].eventBus().publish("a", message);
+        testComplete();
+      });
+    await(30, TimeUnit.SECONDS);
+  }
+
+  private static class Example {
+    private final String value;
+
+    private Example(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Example example = (Example) o;
+      return Objects.equals(value, example.value);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+  }
+
+  private static class ExampleMessageCodec implements MessageCodec<Example, Example> {
+
+    MessageCodec<String, String> delegate = new StringMessageCodec();
+
+    @Override
+    public void encodeToWire(Buffer buffer, Example example) {
+      delegate.encodeToWire(buffer, example.value);
+    }
+
+    @Override
+    public Example decodeFromWire(int pos, Buffer buffer) {
+      return new Example(delegate.decodeFromWire(pos, buffer));
+    }
+
+    @Override
+    public Example transform(Example example) {
+      return example;
+    }
+
+    @Override
+    public String name() {
+      return "example";
+    }
+
+    @Override
+    public byte systemCodecID() {
+      return -1;
+    }
+  }
+}


### PR DESCRIPTION
I would like to add new message codec for vert.x.

Vert.x is an actor model based system in which actors interact via databus.
A message is serialized (only cluster vert.x) before transporting into databus and deserialized upon receiving.
Default implementation allows using primitive types and json as well as custom message codecs.

What I propose new message codec for Object[].
By default, vert.x would’ve used Json Array, serializing every element first into
String then into bytes. My codec will iterate through the array of objects,
finds existing system and default codecs for each element and use them for serialization.
It provides straightforward binary serialization and uses flexibility of other custom codecs.

This feature will allow you to implement another feature in the vertx-service-proxy project
, namely "Pluggable marshallers".

This codec is needed to serialize the array of method arguments not into JsonObject, and then into bytes, but immediately into bytes. This will remove some limitations in the Service Proxy and improve performance.

Example:

```java
public class VerticleOnNode1 extends AbstractVerticle {
    public void start() {
        vertx.eventBus()
             .registerDefaultCodec(SampleDataObject.class, new SampleDataObjectMessageCodec());
        vertx.eventBus().send("address", new Object[] { "textValue", new SampleDataObject() });
    }
}

public class VerticleOnNode2 extends AbstractVerticle {
    public void start() {
        vertx.eventBus()
             .registerDefaultCodec(SampleDataObject.class, new SampleDataObjectMessageCodec());
        vertx.eventBus().consumer("address")
             .handler(mes -> {
                  String textValue = mes.body()[0];
                  SampleDataObject sample = mes.body()[1];
             });
    }
}
```

Service Proxy:

```java
public class SomeDatabaseServiceVertxEBProxy implements SomeDatabaseService {
  @Override
  public  void save(String collection, JsonObject document, Handler<AsyncResult<Void>> result){
    if (closed) {
      result.handle(Future.failedFuture(new IllegalStateException("Proxy is closed")));
      return;
    }
   /* Serialize data in text format
    JsonObject args = new JsonObject();
    args .put("collection", collection);
    args .put("document", document);
   */
  // now, serialize data in binary format, supporting user's codecs.
  // and DataObject may not have Constructor(JsonObject json) and toJson method.
   Object[] args = new Object[] {collection, document};

    DeliveryOptions _deliveryOptions = (_options != null) ? new DeliveryOptions(_options) : new DeliveryOptions();
    _deliveryOptions.addHeader("action", "save");
    _vertx.eventBus().<Void>send(_address, args, _deliveryOptions, res -> {
      if (res.failed()) {
        result.handle(Future.failedFuture(res.cause()));
      } else {
        result.handle(Future.succeededFuture(res.result().body()));
      }
    });
  }
}
```

