### PR TITLE
Inbound exception handler

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -77,6 +77,11 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
     pending.drainHandler(v -> {
       conn.doResume();
     });
+    pending.exceptionHandler(t -> {
+      if (exceptionHandler != null) {
+        exceptionHandler.handle(t);
+      }
+    });
   }
 
   void registerHandler(EventBus eventBus) {

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -102,6 +102,14 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
         }
       }
     });
+    pending.exceptionHandler(t -> {
+      Handler<Throwable> handler = exceptionHandler();
+      if (handler != null) {
+        handler.handle(t);
+      } else {
+        log.error("Unhandled exception", t);
+      }
+    });
   }
 
   synchronized void registerEventBusHandler() {

--- a/src/main/java/io/vertx/core/streams/impl/InboundBuffer.java
+++ b/src/main/java/io/vertx/core/streams/impl/InboundBuffer.java
@@ -246,7 +246,6 @@ public class InboundBuffer<E> {
     Handler<Throwable> handler;
     synchronized (this) {
       if ((handler = exceptionHandler) == null) {
-        log.error("Unhandled exception", err);
         return;
       }
     }

--- a/src/main/java/io/vertx/core/streams/impl/InboundBuffer.java
+++ b/src/main/java/io/vertx/core/streams/impl/InboundBuffer.java
@@ -14,6 +14,8 @@ import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.Arguments;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 import java.util.ArrayDeque;
 import java.util.Objects;
@@ -69,6 +71,7 @@ public class InboundBuffer<E> {
    * A reusable sentinel for signaling the end of a stream.
    */
   public static final Object END_SENTINEL = new Object();
+  private static final Logger log = LoggerFactory.getLogger(InboundBuffer.class);
 
   private final Context context;
   private final ArrayDeque<E> pending;
@@ -243,6 +246,7 @@ public class InboundBuffer<E> {
     Handler<Throwable> handler;
     synchronized (this) {
       if ((handler = exceptionHandler) == null) {
+        log.error("Unhandled exception", err);
         return;
       }
     }


### PR DESCRIPTION
Fixes an issue reported in https://github.com/eclipse-vertx/vert.x/issues/2973 . Some of the other modules that depend on `InboundBuffer` still need to be fixed(the rest of them have `try/catch` in the corresponding handlers).