### PR TITLE
Fixes vert.x-web 1146

### DIFF
--- a/src/test/java/io/vertx/core/http/CaseInsensitiveHeadersTest.java
+++ b/src/test/java/io/vertx/core/http/CaseInsensitiveHeadersTest.java
@@ -992,7 +992,6 @@ public class CaseInsensitiveHeadersTest {
 
     String json = Json.encode(mmap);
 
-
     assertEquals("{\"another-header\":[\"value1\",\"value2\",\"value3\"],\"header\":[\"value1\"]}", json);
   }
 

--- a/src/test/java/io/vertx/core/http/CaseInsensitiveHeadersTest.java
+++ b/src/test/java/io/vertx/core/http/CaseInsensitiveHeadersTest.java
@@ -12,6 +12,7 @@
 package io.vertx.core.http;
 
 import io.vertx.core.MultiMap;
+import io.vertx.core.json.Json;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -981,4 +982,32 @@ public class CaseInsensitiveHeadersTest {
     assertEquals("value1", mmap.get("header"));
     assertEquals(Arrays.asList("value1", "value2", "value3"), mmap.getAll("header"));
   }
+
+  @Test
+  public void testJacksonSerialization() {
+    MultiMap mmap = newMultiMap();
+
+    mmap.add("header", "value1");
+    mmap.add("another-header", Arrays.<CharSequence>asList("value1", "value2", "value3"));
+
+    String json = Json.encode(mmap);
+    assertEquals("{'header': ['value1'], 'another-header': ['value1', 'value2', 'value3']}", json); // suggested layout: {key: [values]}
+  }
+
+  @Test
+  public void testJacksonDeserialization() {
+    String json = "{'header': ['value1'], 'another-header': ['value2', 'value1', 'value3']}";
+
+    MultiMap mmap = Json.decodeValue(json, CaseInsensitiveHeaders.class);
+
+    CharSequence v1 = mmap.get("header");
+    assertEquals("value1", v1.toString());
+
+    CharSequence v2 = mmap.get("another-header");
+    assertEquals("value2", v1);
+
+    List<String> values = mmap.getAll("another-header");
+    assertEquals(Arrays.<String>asList("value2", "value1", "value3"), values);
+  }
+
 }

--- a/src/test/java/io/vertx/core/http/CaseInsensitiveHeadersTest.java
+++ b/src/test/java/io/vertx/core/http/CaseInsensitiveHeadersTest.java
@@ -991,20 +991,24 @@ public class CaseInsensitiveHeadersTest {
     mmap.add("another-header", Arrays.<CharSequence>asList("value1", "value2", "value3"));
 
     String json = Json.encode(mmap);
-    assertEquals("{'header': ['value1'], 'another-header': ['value1', 'value2', 'value3']}", json); // suggested layout: {key: [values]}
+
+
+    assertEquals("{\"another-header\":[\"value1\",\"value2\",\"value3\"],\"header\":[\"value1\"]}", json);
   }
 
   @Test
   public void testJacksonDeserialization() {
-    String json = "{'header': ['value1'], 'another-header': ['value2', 'value1', 'value3']}";
+    String json = "{\"header\": [\"value1\"], \"another-header\": [\"value2\", \"value1\", \"value3\"]}";
 
     MultiMap mmap = Json.decodeValue(json, CaseInsensitiveHeaders.class);
+
+    assertNotNull(mmap);
 
     CharSequence v1 = mmap.get("header");
     assertEquals("value1", v1.toString());
 
     CharSequence v2 = mmap.get("another-header");
-    assertEquals("value2", v1);
+    assertEquals("value2", v2);
 
     List<String> values = mmap.getAll("another-header");
     assertEquals(Arrays.<String>asList("value2", "value1", "value3"), values);

--- a/src/test/java/io/vertx/core/http/VertxHttpHeadersTest.java
+++ b/src/test/java/io/vertx/core/http/VertxHttpHeadersTest.java
@@ -47,4 +47,14 @@ public class VertxHttpHeadersTest extends CaseInsensitiveHeadersTest {
   public void testHashMININT() {
     // Does not apply
   }
+
+  @Override
+  public void testJacksonSerialization() {
+    // Does not apply
+  }
+
+  @Override
+  public void testJacksonDeserialization() {
+    // Does not apply
+  }
 }


### PR DESCRIPTION
Adds Jackson serializer and deserializer to the CaseInsensitiveHeaders class and the appropriate tests.

Fixes https://github.com/vert-x3/vertx-web/issues/1146