### PR TITLE
Delete invalid import class,Remove repeat ignore item,Fix 'javadoc' description error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ test-results
 test-tmp
 *.class
 *.swp
-.vertx

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -24,8 +24,6 @@ import io.vertx.core.tracing.TracingOptions;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import static io.vertx.core.file.FileSystemOptions.DEFAULT_FILE_CACHING_ENABLED;
-
 /**
  * Instances of this class are used to configure {@link io.vertx.core.Vertx} instances.
  *

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -111,7 +111,7 @@ public class VertxOptions {
   public static final long DEFAULT_BLOCKED_THREAD_CHECK_INTERVAL = 1000;
 
   /**
-   * The default value of blocked thread check interval unit = TimeUnit.NANOSECONDS
+   * The default value of blocked thread check interval unit = TimeUnit.MILLISECONDS
    */
   public static final TimeUnit DEFAULT_BLOCKED_THREAD_CHECK_INTERVAL_UNIT = TimeUnit.MILLISECONDS;
 


### PR DESCRIPTION
1.Delete invalid import class
2.Remove repeat ignore item
3.Fix 'DEFAULT_BLOCKED_THREAD_CHECK_INTERVAL_UNIT' constant 'javadoc' description error in VertxOptions Class.