### PR TITLE
add message exception handler

### DIFF
--- a/src/main/java/io/vertx/core/Context.java
+++ b/src/main/java/io/vertx/core/Context.java
@@ -15,6 +15,7 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.eventbus.MessageError;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.json.JsonObject;
 
@@ -239,6 +240,24 @@ public interface Context {
   @GenIgnore
   @Nullable
   Handler<Throwable> exceptionHandler();
+
+  /**
+   * Set a message exception handler called when the context runs an action throwing an uncaught throwable.<p/>
+   *
+   * When this handler is called, {@link Vertx#currentContext()} will return this context.
+   *
+   * @param handler the exception handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  Context messageExceptionHandler(@Nullable Handler<MessageError> handler);
+
+  /**
+   * @return the current message exception handler of this context
+   */
+  @GenIgnore
+  @Nullable
+  Handler<MessageError> messageExceptionHandler();
 
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   void addCloseHook(Closeable hook);

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -18,6 +18,7 @@ import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.dns.DnsClient;
 import io.vertx.core.dns.DnsClientOptions;
 import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.MessageError;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
@@ -593,6 +594,21 @@ public interface Vertx extends Measured {
    */
   @GenIgnore
   @Nullable Handler<Throwable> exceptionHandler();
+
+  /**
+   * Set a default message exception handler for {@link Context}, set on {@link Context#messageExceptionHandler(Handler)} at creation.
+   *
+   * @param handler the exception handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  Vertx messageExceptionHandler(@Nullable Handler<MessageError> handler);
+
+  /**
+   * @return the current default message exception handler
+   */
+  @GenIgnore
+  @Nullable Handler<MessageError> messageExceptionHandler();
 
   @GenIgnore
   VertxFactory factory = ServiceHelper.loadFactory(VertxFactory.class);

--- a/src/main/java/io/vertx/core/eventbus/MessageError.java
+++ b/src/main/java/io/vertx/core/eventbus/MessageError.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.eventbus;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * @author Tom Fingerman 02/07/2019.
+ */
+@VertxGen
+public interface MessageError {
+  /**
+   * Message which handler caused an unaccepted exception
+   */
+  Message message();
+
+  /**
+   * Unaccepted exception that was thrown while processing a message
+   */
+  Throwable exception();
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -283,6 +283,7 @@ public class HandlerRegistration<T> implements MessageConsumer<T>, Handler<Messa
         metrics.endHandleMessage(metric, e);
       }
       context.reportException(e);
+      context.reportMessageException(message, e);
     }
     checkNextTick();
   }

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageErrorImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageErrorImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.eventbus.impl;
+
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageError;
+
+/**
+ * @author Tom Fingerman 02/07/2019.
+ */
+public class MessageErrorImpl implements MessageError {
+  private final Message message;
+  private final Throwable exception;
+
+  public MessageErrorImpl(Message message, Throwable exception) {
+    this.message = message;
+    this.exception = exception;
+  }
+
+  @Override
+  public Message message() {
+    return message;
+  }
+
+  @Override
+  public Throwable exception() {
+    return exception;
+  }
+}

--- a/src/main/java/io/vertx/core/impl/ContextInternal.java
+++ b/src/main/java/io/vertx/core/impl/ContextInternal.java
@@ -14,10 +14,10 @@ package io.vertx.core.impl;
 import io.netty.channel.EventLoop;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.Message;
 
 import java.util.concurrent.ConcurrentMap;
 
@@ -96,6 +96,16 @@ public interface ContextInternal extends Context {
    * @param t the exception to report
    */
   void reportException(Throwable t);
+
+  /**
+   * Report a message exception to this context synchronously.
+   * <p>
+   * The message exception handler will be called when there is one, otherwise will do nothing.
+   *
+   * @param message the message from the consumer that caused the exception
+   * @param t       the exception to report
+   */
+  void reportMessageException(Message message, Throwable t);
 
   /**
    * @return the {@link ConcurrentMap} used to store context data

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -26,6 +26,7 @@ import io.vertx.core.dns.DnsClient;
 import io.vertx.core.dns.DnsClientOptions;
 import io.vertx.core.dns.impl.DnsClientImpl;
 import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.MessageError;
 import io.vertx.core.eventbus.impl.EventBusImpl;
 import io.vertx.core.eventbus.impl.clustered.ClusteredEventBus;
 import io.vertx.core.file.FileSystem;
@@ -121,6 +122,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   private volatile HAManager haManager;
   private boolean closed;
   private volatile Handler<Throwable> exceptionHandler;
+  private volatile Handler<MessageError> messageExceptionHandler;
   private final Map<String, SharedWorkerPool> namedWorkerPools;
   private final int defaultWorkerPoolSize;
   private final long maxWorkerExecTime;
@@ -1116,6 +1118,17 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   @Override
   public Handler<Throwable> exceptionHandler() {
     return exceptionHandler;
+  }
+
+  @Override
+  public Vertx messageExceptionHandler(Handler<MessageError> handler) {
+    messageExceptionHandler = handler;
+    return this;
+  }
+
+  @Override
+  public Handler<MessageError> messageExceptionHandler() {
+    return messageExceptionHandler;
   }
 
   @Override

--- a/src/test/java/io/vertx/core/eventbus/EventBusMessageExceptionTest.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusMessageExceptionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.eventbus;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+/**
+ * @author Tom Fingerman 03/07/2019.
+ */
+public class EventBusMessageExceptionTest extends VertxTestBase {
+
+  @Test
+  public void testMessageExceptionHandler() {
+    vertx.messageExceptionHandler(event ->
+      event.message().fail(500, event.exception().getMessage()));
+
+    String unexpectedExceptionAddress = "unexpected-exception-address";
+    String errorMessage = "the-exception-should-be-this!";
+
+    vertx.eventBus().consumer(unexpectedExceptionAddress, message -> {
+      throw new RuntimeException(errorMessage);
+    });
+
+    vertx.eventBus().request(unexpectedExceptionAddress, new JsonObject(), message -> {
+      if (message.failed()) {
+        assertEquals(errorMessage, message.cause().getMessage());
+        testComplete();
+      } else {
+        fail("The message should have failed with exception");
+      }
+    });
+
+    await();
+  }
+
+}


### PR DESCRIPTION
Hi, this is my first attempt to contribute to Vert.x and to open source in general :)

I have been working with Vert.x for quite some time, and i got to say i love this framework. I mainly use Kotlin as i find it very hard to work with async libraries without async/await (coroutines) features and Java does not comply to it.

While working with Vert.x i found a big problem and while searching the web i saw that others saw it to but it was never addressed.

When i create a `consumer` in vert.x and some unexpected exception occur inside of it (like NumberFormatException, RuntimeException, anything that was not catched properly) the only thing i can do is register an `exceptionHandler` that allows me to log the problem, and vert.x will wait for a timeout before dropping the message.

I found it very troubling, sometimes in tests i would wait for 30 seconds before seeing that the problem was an unexpected exception.

In kotlin i created the following to mitigate it but i believe it should be solved inside the framework:
```kotlin
/**
 * Same as [EventBus.consumer] but wraps the handler execution with try-catch to make sure uncaught exceptions
 * will always be handled in case something unexpected happened.
 *
 * By default Vert.x swallow uncaught exceptions and it might cause an hang to consumers so this makes sure that if
 * something like that happens, the code will never hang and always return a response as fast as possible.
 *
 * @param address the address that will register it at
 * @param messageHandler the handler that will process the received messages
 *
 * @author Tom Fingerman 06/05/2019.
 */
fun <T> EventBus.safeConsumer(address: String, messageHandler: (Message<T>) -> Unit): MessageConsumer<T> {
  return consumer<T>(address).apply {
    this.handler { message ->
      try {
        messageHandler(message)
      } catch (e: Throwable) {
        message.fail(500, e.message)
      }
    }
  }
}
```

This PR include a suggestion and a question at the same time. If you run the test i created without my new `messageExceptionHandler`, the event will be stuck until timeout is reached.

I believe that adding the ability to create a global exception handler that actually sends a failure is safer and allows to create safer code with Vert.x.

Please let me know what you think, or if there is a better way to achieve what i tried to do.

**EDIT:** i would also consider putting a default `messageExceptionHandler` that does `message.fail(500, e.message)` to make sure it is safe by default but allows others to change it.