### PR TITLE
Rename startFuture parameters to startPromise

### DIFF
--- a/src/main/java/io/vertx/core/AbstractVerticle.java
+++ b/src/main/java/io/vertx/core/AbstractVerticle.java
@@ -98,13 +98,13 @@ public abstract class AbstractVerticle implements Verticle {
    * This is called by Vert.x when the verticle instance is deployed. Don't call it yourself.<p>
    * If your verticle does things in its startup which take some time then you can override this method
    * and call the startFuture some time later when start up is complete.
-   * @param startFuture  a future which should be called when verticle start-up is complete.
+   * @param startPromise  a promise which should be called when verticle start-up is complete.
    * @throws Exception
    */
   @Override
-  public void start(Promise<Void> startFuture) throws Exception {
+  public void start(Promise<Void> startPromise) throws Exception {
     start();
-    startFuture.complete();
+    startPromise.complete();
   }
 
   /**
@@ -112,13 +112,13 @@ public abstract class AbstractVerticle implements Verticle {
    * This is called by Vert.x when the verticle instance is un-deployed. Don't call it yourself.<p>
    * If your verticle does things in its shut-down which take some time then you can override this method
    * and call the stopFuture some time later when clean-up is complete.
-   * @param stopFuture  a future which should be called when verticle clean-up is complete.
+   * @param stopPromise  a promise which should be called when verticle clean-up is complete.
    * @throws Exception
    */
   @Override
-  public void stop(Promise<Void> stopFuture) throws Exception {
+  public void stop(Promise<Void> stopPromise) throws Exception {
     stop();
-    stopFuture.complete();
+    stopPromise.complete();
   }
 
   /**

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -303,8 +303,8 @@ public class ContextTest extends VertxTestBase {
     ctx.runOnContext(v -> {
       vertx.deployVerticle(new AbstractVerticle() {
         @Override
-        public void start(Promise<Void> startFuture) throws Exception {
-          context.runOnContext(startFuture::complete);
+        public void start(Promise<Void> startPromise) throws Exception {
+          context.runOnContext(startPromise::complete);
         }
       }, ar -> {
         throw failure;

--- a/src/test/java/io/vertx/core/DeploymentTest.java
+++ b/src/test/java/io/vertx/core/DeploymentTest.java
@@ -741,7 +741,7 @@ public class DeploymentTest extends VertxTestBase {
     AtomicInteger childUndeployed = new AtomicInteger();
     vertx.deployVerticle(new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> startFuture) throws Exception {
+      public void start(Promise<Void> startPromise) throws Exception {
         vertx.deployVerticle(new AbstractVerticle() {
           @Override
           public void start() throws Exception {
@@ -752,7 +752,7 @@ public class DeploymentTest extends VertxTestBase {
             childUndeployed.incrementAndGet();
           }
         }, onSuccess(child -> {
-          startFuture.fail("Undeployed");
+          startPromise.fail("Undeployed");
         }));
       }
     }, onFailure(expected -> {
@@ -769,7 +769,7 @@ public class DeploymentTest extends VertxTestBase {
     AtomicInteger childUndeployed = new AtomicInteger();
     vertx.deployVerticle(new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> startFuture) throws Exception {
+      public void start(Promise<Void> startPromise) throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         vertx.deployVerticle(new AbstractVerticle() {
           @Override
@@ -798,12 +798,12 @@ public class DeploymentTest extends VertxTestBase {
     AtomicInteger parentFailed = new AtomicInteger();
     vertx.deployVerticle(new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> startFuture) throws Exception {
+      public void start(Promise<Void> startPromise) throws Exception {
         vertx.deployVerticle(new AbstractVerticle() {
           @Override
-          public void start(Promise<Void> fut) throws Exception {
+          public void start(Promise<Void> startPromise) throws Exception {
             vertx.setTimer(100, id -> {
-              fut.complete();
+              startPromise.complete();
             });
           }
           @Override
@@ -947,12 +947,12 @@ public class DeploymentTest extends VertxTestBase {
   public void testChildUndeployedDirectly() throws Exception {
     Verticle parent = new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> startFuture) throws Exception {
+      public void start(Promise<Void> startPromise) throws Exception {
 
         Verticle child = new AbstractVerticle() {
           @Override
-          public void start(Promise<Void> startFuture) throws Exception {
-            startFuture.complete();
+          public void start(Promise<Void> startPromise) throws Exception {
+            startPromise.complete();
 
             // Undeploy it directly
             vertx.runOnContext(v -> vertx.undeploy(context.deploymentID()));
@@ -960,7 +960,7 @@ public class DeploymentTest extends VertxTestBase {
         };
 
         vertx.deployVerticle(child, onSuccess(depID -> {
-          startFuture.complete();
+          startPromise.complete();
         }));
 
       }
@@ -1160,10 +1160,10 @@ public class DeploymentTest extends VertxTestBase {
   public static class ParentVerticle extends AbstractVerticle {
 
     @Override
-    public void start(Promise<Void> startFuture) throws Exception {
+    public void start(Promise<Void> startPromise) throws Exception {
       vertx.deployVerticle("java:" + ChildVerticle.class.getName(), ar -> {
         if (ar.succeeded()) {
-          startFuture.complete(null);
+          startPromise.complete(null);
         } else {
           ar.cause().printStackTrace();
         }
@@ -1276,8 +1276,8 @@ public class DeploymentTest extends VertxTestBase {
   public void testFailedVerticleStopNotCalled() {
     Verticle verticleChild = new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> startFuture) throws Exception {
-        startFuture.fail("wibble");
+      public void start(Promise<Void> startPromise) throws Exception {
+        startPromise.fail("wibble");
       }
       @Override
       public void stop() {
@@ -1287,9 +1287,9 @@ public class DeploymentTest extends VertxTestBase {
     };
     Verticle verticleParent = new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> startFuture) throws Exception {
+      public void start(Promise<Void> startPromise) throws Exception {
         vertx.deployVerticle(verticleChild, onFailure(v -> {
-          startFuture.complete();
+          startPromise.complete();
         }));
       }
     };
@@ -1438,9 +1438,9 @@ public class DeploymentTest extends VertxTestBase {
     };
     Verticle v = new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> startFuture) throws Exception {
+      public void start(Promise<Void> startPromise) throws Exception {
         this.context.addCloseHook(closeable);
-        startFuture.fail("Fail to deploy.");
+        startPromise.fail("Fail to deploy.");
       }
     };
     vertx.deployVerticle(v, asyncResult -> {
@@ -1463,8 +1463,8 @@ public class DeploymentTest extends VertxTestBase {
     vertx.deployVerticle(() -> {
       Verticle v = new AbstractVerticle() {
         @Override
-        public void start(final Promise<Void> startFuture) throws Exception {
-          startFuture.fail("Fail to deploy.");
+        public void start(final Promise<Void> startPromise) throws Exception {
+          startPromise.fail("Fail to deploy.");
         }
       };
       return v;
@@ -1616,16 +1616,16 @@ public class DeploymentTest extends VertxTestBase {
     }
 
     @Override
-    public void start(Promise<Void> startFuture) throws Exception {
+    public void start(Promise<Void> startPromise) throws Exception {
       if (startConsumer != null) {
-        startConsumer.accept(startFuture);
+        startConsumer.accept(startPromise);
       }
     }
 
     @Override
-    public void stop(Promise<Void> stopFuture) throws Exception {
+    public void stop(Promise<Void> stopPromise) throws Exception {
       if (stopConsumer != null) {
-        stopConsumer.accept(stopFuture);
+        stopConsumer.accept(stopPromise);
       }
     }
   }

--- a/src/test/java/io/vertx/core/NamedWorkerPoolTest.java
+++ b/src/test/java/io/vertx/core/NamedWorkerPoolTest.java
@@ -53,7 +53,7 @@ public class NamedWorkerPoolTest extends VertxTestBase {
       .setMaxWorkerExecuteTime(maxWorkerExecuteTime);
     vertx.deployVerticle(new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> startFuture) throws Exception {
+      public void start(Promise<Void> startPromise) throws Exception {
         vertx.executeBlocking(fut -> {
           try {
             SECONDS.sleep(5);
@@ -61,7 +61,7 @@ public class NamedWorkerPoolTest extends VertxTestBase {
           } catch (InterruptedException e) {
             fut.fail(e);
           }
-        }, startFuture);
+        }, startPromise);
       }
     }, deploymentOptions, onSuccess(did -> {
       testComplete();

--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTestBase.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTestBase.java
@@ -220,7 +220,7 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
       boolean unregisterCalled;
 
       @Override
-      public void start(Promise<Void> startFuture) throws Exception {
+      public void start(Promise<Void> startPromise) throws Exception {
         EventBus eventBus = getVertx().eventBus();
         MessageConsumer<String> consumer = eventBus.consumer("whatever");
         consumer.handler(m -> {
@@ -229,7 +229,7 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
             unregisterCalled = true;
           }
           m.reply("ok");
-        }).completionHandler(startFuture);
+        }).completionHandler(startPromise);
       }
     };
 

--- a/src/test/java/io/vertx/core/http/HttpServerCloseHookTest.java
+++ b/src/test/java/io/vertx/core/http/HttpServerCloseHookTest.java
@@ -34,7 +34,7 @@ public class HttpServerCloseHookTest extends VertxTestBase {
   private static class TestVerticle extends AbstractVerticle {
 
     @Override
-    public void start(Promise<Void> startFuture) {
+    public void start(Promise<Void> startPromise) {
       HttpServerOptions invalidOptions = new HttpServerOptions()
         .setSsl(true)
         .setPfxTrustOptions(new PfxOptions().setValue(Buffer.buffer("boom")));
@@ -43,9 +43,9 @@ public class HttpServerCloseHookTest extends VertxTestBase {
         req.response().end("Hello World!");
       }).listen(8443, ar -> {
         if (ar.succeeded()) {
-          startFuture.complete();
+          startPromise.complete();
         } else {
-          startFuture.fail(ar.cause());
+          startPromise.fail(ar.cause());
         }
       });
     }

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -3092,7 +3092,7 @@ public class NetTest extends VertxTestBase {
     String expected = TestUtils.randomAlphaString(2000);
     vertx.deployVerticle(new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> startFuture) throws Exception {
+      public void start(Promise<Void> startPromise) throws Exception {
         NetServer server = vertx.createNetServer();
         server.connectHandler(so -> {
           Buffer received = Buffer.buffer();
@@ -3107,7 +3107,7 @@ public class NetTest extends VertxTestBase {
             Thread.currentThread().interrupt();
           }
         });
-        server.listen(testAddress, ar -> startFuture.handle(ar.mapEmpty()));
+        server.listen(testAddress, ar -> startPromise.handle(ar.mapEmpty()));
       }
     }, new DeploymentOptions().setWorker(true), onSuccess(v -> {
       client.connect(testAddress, onSuccess(so -> {

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -977,7 +977,7 @@ public class MetricsTest extends VertxTestBase {
     CountDownLatch latch = new CountDownLatch(1);
     Verticle worker = new AbstractVerticle() {
       @Override
-      public void start(Promise<Void> done) throws Exception {
+      public void start(Promise<Void> startPromise) throws Exception {
         vertx.eventBus().localConsumer("message", d -> {
             msg.incrementAndGet();
             try {
@@ -1002,7 +1002,7 @@ public class MetricsTest extends VertxTestBase {
             }
           }
         );
-        done.complete();
+        startPromise.complete();
       }
     };
 

--- a/src/test/java/io/vertx/test/verticles/SimpleServer.java
+++ b/src/test/java/io/vertx/test/verticles/SimpleServer.java
@@ -22,14 +22,14 @@ import io.vertx.core.http.HttpServerOptions;
 public class SimpleServer extends AbstractVerticle {
 
   @Override
-  public void start(Promise<Void> startFuture) throws Exception {
+  public void start(Promise<Void> startPromise) throws Exception {
     HttpServer server = vertx.createHttpServer(new HttpServerOptions().setPort(8080));
     server.requestHandler(req -> req.response().end());
     server.listen(res -> {
       if (res.succeeded()) {
-        startFuture.complete();
+        startPromise.complete();
       } else {
-        startFuture.fail(res.cause());
+        startPromise.fail(res.cause());
       }
     });
   }

--- a/src/test/java/io/vertx/test/verticles/sourceverticle/SourceVerticle.java
+++ b/src/test/java/io/vertx/test/verticles/sourceverticle/SourceVerticle.java
@@ -23,10 +23,10 @@ public class SourceVerticle extends AbstractVerticle {
 
 
   @Override
-  public void start(Promise<Void> startFuture) throws Exception {
+  public void start(Promise<Void> startPromise) throws Exception {
     vertx.deployVerticle("java:" + OtherSourceVerticle.class.getName().replace('.', '/') + ".java", new DeploymentOptions(), ar -> {
       if (ar.succeeded()) {
-        startFuture.complete((Void) null);
+        startPromise.complete((Void) null);
       } else {
         ar.cause().printStackTrace();
       }


### PR DESCRIPTION
I found this while playing with 4.0.0-milestone and my IDE completed with a wrong name.
