### PR TITLE
Future will fail when the handler which is passed to `Future.future` throws an Exception.

### DIFF
--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -36,10 +36,10 @@ public interface Future<T> extends AsyncResult<T> {
    */
   static <T> Future<T> future(Handler<Promise<T>> handler) {
     Promise<T> promise = Promise.promise();
-    try{
+    try {
       handler.handle(promise);
-    }catch (Exception e){
-      promise.fail(e);
+    } catch (Exception e){
+      promise.tryFail(e);
     }
     return promise.future();
   }

--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -36,7 +36,11 @@ public interface Future<T> extends AsyncResult<T> {
    */
   static <T> Future<T> future(Handler<Promise<T>> handler) {
     Promise<T> promise = Promise.promise();
-    handler.handle(promise);
+    try{
+      handler.handle(promise);
+    }catch (Exception e){
+      promise.fail(e);
+    }
     return promise.future();
   }
 

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -65,14 +65,10 @@ public class FutureTest extends VertxTestBase {
     assertSame(f2, ref.get().future());
     assertEquals(1, count.get());
     new Checker<>(f2).assertFailed(cause);
-    try {
-      Future.future(f -> {
-        throw cause;
-      });
-      fail();
-    } catch (Exception e) {
-      assertSame(cause, e);
-    }
+    Future f3 = Future.future(f -> {
+      throw cause;
+    });
+    assertSame(cause, f3.cause());
   }
 
   @Test


### PR DESCRIPTION
I means Future can auto fail when handler which is passed to `Future.future` throws an Exception.
This is my first PR. 
See also: #3056 
Thank you.
