### PR TITLE
Fix #3077 call endHandler for HttpServerResponse without keepalive

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -393,10 +393,6 @@ public class HttpServerResponseImpl implements HttpServerResponse {
         msg = new AssembledLastHttpContent(data, trailingHeaders);
       }
       conn.writeToChannel(msg, promise);
-      if (!keepAlive) {
-        closeConnAfterWrite();
-        closed = true;
-      }
       written = true;
       conn.responseComplete();
       if (bodyEndHandler != null) {
@@ -404,6 +400,10 @@ public class HttpServerResponseImpl implements HttpServerResponse {
       }
       if (!closed && endHandler != null) {
         endHandler.handle(null);
+      }
+      if (!keepAlive) {
+        closeConnAfterWrite();
+        closed = true;
       }
     }
   }


### PR DESCRIPTION
This is a possible fix for #3077.

We are not confident at all that this is the correct fix, so please review carefully.
Although the tests seem to accept it.