### PR TITLE
fix for maven build Error message on windows

### DIFF
--- a/src/main/assembly/docs.xml
+++ b/src/main/assembly/docs.xml
@@ -9,7 +9,7 @@
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}/asciidoc</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>./</outputDirectory>
     </fileSet>
   </fileSets>
 </assembly>


### PR DESCRIPTION
[ERROR] OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /