### PR TITLE
improve netty HttpMethod to vert.x HttpMethod performance for http GET/POST/HEAD

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -219,11 +219,20 @@ public class HttpServerRequestImpl implements HttpServerRequest {
   @Override
   public io.vertx.core.http.HttpMethod method() {
     if (method == null) {
-      String sMethod = request.method().toString();
-      try {
-        method = io.vertx.core.http.HttpMethod.valueOf(sMethod);
-      } catch (IllegalArgumentException e) {
-        method = io.vertx.core.http.HttpMethod.OTHER;
+      final HttpMethod nettyHttpMethod = request.method();
+      if (io.netty.handler.codec.http.HttpMethod.GET == nettyHttpMethod) {
+        method = io.vertx.core.http.HttpMethod.GET;
+      } else if(io.netty.handler.codec.http.HttpMethod.POST == nettyHttpMethod) {
+        method = io.vertx.core.http.HttpMethod.POST;
+      } else if(io.netty.handler.codec.http.HttpMethod.HEAD == nettyHttpMethod) {
+        method = io.vertx.core.http.HttpMethod.HEAD;
+      }else {
+        String sMethod = nettyHttpMethod.toString();
+        try {
+          method = io.vertx.core.http.HttpMethod.valueOf(sMethod);
+        } catch (IllegalArgumentException e) {
+          method = io.vertx.core.http.HttpMethod.OTHER;
+        }
       }
     }
     return method;


### PR DESCRIPTION
On my jmh benchmark faster 200%(2X)
ref: https://github.com/qxo/vertx-jmh-benchmark/blob/master/src/main/java/test/Vertx4httpMethodBenchmark.java
```
 # JMH version: 1.21

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

 Benchmark                               Mode  Cnt    Score    Error   Units  Score/min
Vertx4httpMethodBenchmark.newWay4GET   thrpt   10  982.649 ± 29.455  ops/us      2.231
Vertx4httpMethodBenchmark.newWay4HEAD  thrpt   10  979.842 ± 29.272  ops/us      2.224
Vertx4httpMethodBenchmark.newWay4PUT   thrpt   10  452.905 ± 17.113  ops/us      1.028
Vertx4httpMethodBenchmark.oldWay4GET   thrpt   10  463.152 ± 22.043  ops/us      1.051
Vertx4httpMethodBenchmark.oldWay4HEAD  thrpt   10  443.467 ± 19.277  ops/us      1.007
Vertx4httpMethodBenchmark.oldWay4PUT   thrpt   10  440.537 ± 11.307  ops/us      1.000
```