### PR TITLE
improve http parse url performance for #path #query #params

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
@@ -344,7 +344,7 @@ public class Http2ServerRequestImpl extends Http2ServerStream implements HttpSer
   
   @Override
   public String path() {
-    if (path == null) {
+    if (path == null && uri != null) {
       synchronized (conn) {
           final Object o =  HttpUtils.parsePathAndQueryStartIf(uri);
           if (o instanceof Object[]) {
@@ -362,7 +362,7 @@ public class Http2ServerRequestImpl extends Http2ServerStream implements HttpSer
 
   @Override
   public String query() {
-    if (query == null) {
+    if (query == null && uri != null) {
           query = path() == uri || queryStart == -1 ? null : queryStart > 0 && uri.length() > queryStart
             ? uri.substring(queryStart + 1) : HttpUtils.parseQuery(uri);
     }

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
@@ -68,10 +68,9 @@ public class Http2ServerRequestImpl extends Http2ServerStream implements HttpSer
   private final String serverOrigin;
   private final MultiMap headersMap;
   private final String scheme;
-  //add volatile for fix Double-Checked Locking
-  private volatile String path;
-  private volatile String query;
-  private volatile MultiMap params;
+  private String path;
+  private String query;
+  private MultiMap params;
   private String absoluteURI;
   private MultiMap attributes;
   private Object trace;
@@ -347,7 +346,6 @@ public class Http2ServerRequestImpl extends Http2ServerStream implements HttpSer
   public String path() {
     if (path == null) {
       synchronized (conn) {
-        if (path == null) {
           final Object o =  HttpUtils.parsePathAndQueryStartIf(uri);
           if (o instanceof Object[]) {
             final Object[] arr =  (Object[])o;
@@ -357,7 +355,6 @@ public class Http2ServerRequestImpl extends Http2ServerStream implements HttpSer
             path = (String)o;
             queryStart = -1;
           }
-         }
        }
     }
     return path;
@@ -367,10 +364,8 @@ public class Http2ServerRequestImpl extends Http2ServerStream implements HttpSer
   public String query() {
     if (query == null) {
       synchronized (conn) {
-        if (query == null) {
           query = path() == uri || queryStart == -1 ? null : queryStart > 0 && uri.length() > queryStart
             ? uri.substring(queryStart + 1) : HttpUtils.parseQuery(uri);
-        }
       }
     }
     return query;
@@ -415,9 +410,7 @@ public class Http2ServerRequestImpl extends Http2ServerStream implements HttpSer
   public MultiMap params() {
      if (params == null) {
        synchronized (conn) {
-         if (params == null) {
            params = HttpUtils.params(query(), false);
-         }
        }
      }
      return params;

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
@@ -363,10 +363,8 @@ public class Http2ServerRequestImpl extends Http2ServerStream implements HttpSer
   @Override
   public String query() {
     if (query == null) {
-      synchronized (conn) {
           query = path() == uri || queryStart == -1 ? null : queryStart > 0 && uri.length() > queryStart
             ? uri.substring(queryStart + 1) : HttpUtils.parseQuery(uri);
-      }
     }
     return query;
   }
@@ -409,9 +407,7 @@ public class Http2ServerRequestImpl extends Http2ServerStream implements HttpSer
   @Override
   public MultiMap params() {
      if (params == null) {
-       synchronized (conn) {
-           params = HttpUtils.params(query(), false);
-       }
+       params = HttpUtils.params(query(), false);
      }
      return params;
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -20,6 +20,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.StreamResetException;
 import io.vertx.core.net.SocketAddress;
 
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -46,8 +47,16 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
     this.server = server;
     this.host = host;
     this.port = port;
-    this.path = uri.length() > 0 ? HttpUtils.parsePath(uri) : "";
-    this.query = HttpUtils.parseQuery(uri);
+    final Object o = uri.length() > 0 ? HttpUtils.parsePathAndQueryStartIf(uri) :  "";
+    if (o instanceof Object[]) {
+      final Object[] arr = (Object[])o;
+      this.path = (String)arr[0];
+      final int queryStart = (Integer)arr[1];
+      this.query = queryStart != -1 &&  uri.length() > queryStart ? uri.substring(queryStart + 1) : null;
+    } else {
+      this.path = (String)o;
+      this.query = null;
+    }
     this.ssl = ssl;
     this.responsePromise = Promise.promise();
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -424,7 +424,15 @@ public final class HttpUtils {
   /**
    * Extract the path out of the uri.
    */
-  static String parsePath(String uri) {
+  static String parsePath(final String uri) {
+    final Object o = parsePathAndQueryStartIf(uri);
+    return (String) ( o instanceof Object[] ? ((Object[])o)[0] : o );
+  }
+
+  /**
+   * Extract the path out of the uri and queryStart
+   */
+  static Object parsePathAndQueryStartIf(final String uri) {
     int i;
     if (uri.charAt(0) == '/') {
       i = 0;
@@ -443,9 +451,12 @@ public final class HttpUtils {
 
     int queryStart = uri.indexOf('?', i);
     if (queryStart == -1) {
+      if (i == 0) {
+        return uri;
+      }
       queryStart = uri.length();
     }
-    return uri.substring(i, queryStart);
+    return new Object[] {uri.substring(i, queryStart), queryStart};
   }
 
   /**
@@ -478,10 +489,13 @@ public final class HttpUtils {
     return absoluteURI;
   }
 
-  static MultiMap params(String uri) {
-    QueryStringDecoder queryStringDecoder = new QueryStringDecoder(uri);
+  static MultiMap params(final String uri, final boolean hasPath) {
+    final MultiMap params = new CaseInsensitiveHeaders();
+    if ( uri == null ) {
+      return params;
+    }
+    QueryStringDecoder queryStringDecoder = new QueryStringDecoder(uri, hasPath);
     Map<String, List<String>> prms = queryStringDecoder.parameters();
-    MultiMap params = new CaseInsensitiveHeaders();
     if (!prms.isEmpty()) {
       for (Map.Entry<String, List<String>> entry: prms.entrySet()) {
         params.add(entry.getKey(), entry.getValue());


### PR DESCRIPTION
less gc (reduce create unncessary object) for #params
(if queryString == null, no need QueryStringDecoder)

no need repeat parse path for #query and #params

Signed-off-by: qxo <qxodream@gmail.com>