### PR TITLE
Breaking: Fix JSON types to correctly follow RFC7493

### DIFF
--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -122,4 +122,38 @@ public class Json {
   public static <T> T decodeValue(Buffer buf, Class<T> clazz) throws DecodeException {
     return CODEC.fromBuffer(buf, clazz);
   }
+
+  /**
+   * Convert a base64url encoded string to a base64 encoded string.
+   *
+   * Example:
+   * <code>
+   *     toBase64("qL8R4QIcQ_ZsRqOAbeRfcZhilN_MksRtDaErMA");
+   *     "qL8R4QIcQ/ZsRqOAbeRfcZhilN/MksRtDaErMA=="
+   * </code>
+   *
+   * JsonObject and JsonArray implement the RFC-7493 which defines how binary data is encoded. However
+   * the implementation on Vert.x 3.x was incorrect and did not use the correct encoding <code>base64url</code>.
+   *
+   * In order to interact with older Vert.x applications or other systems that use plain Base64 encoding this
+   * utility method will convert base64url strings to base64.
+   *
+   * @param base64url base64 url without padding string.
+   * @return base64 with padding encoded string.
+   */
+  public static String toBase64(String base64url) {
+    // padding is at most 3 '=' characters
+    final String padding = "===";
+    int stringLength = base64url.length();
+    int diff = stringLength % 4;
+    // if the modulus is 0 then no padding is needed
+    if (diff != 0) {
+      // padding needed, just append the difference to 4 of the modulus with '=' characters.
+      base64url = base64url + padding.substring(0, 4 - diff);
+    }
+    // replace the characters that are modified in the base64 alphabets.
+    return base64url
+      .replace('-', '+')
+      .replace('_', '/');
+  }
 }

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -36,6 +36,9 @@ import static java.time.format.DateTimeFormatter.ISO_INSTANT;
  */
 public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareable {
 
+  private static final Base64.Decoder B64DEC = Base64.getUrlDecoder();
+  private static final Base64.Encoder B64ENC = Base64.getUrlEncoder().withoutPadding();
+
   private List<Object> list;
 
   /**
@@ -233,7 +236,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
     if (val == null) {
       return null;
     } else {
-      return Base64.getDecoder().decode(val);
+      return B64DEC.decode(val);
     }
   }
 
@@ -418,7 +421,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
    * @return  a reference to this, so the API can be used fluently
    */
   public JsonArray add(byte[] value) {
-    list.add(value != null ? Base64.getEncoder().encodeToString(value) : null);
+    list.add(value != null ? B64ENC.encodeToString(value) : null);
     return this;
   }
 
@@ -612,7 +615,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
    * @return a reference to this, so the API can be used fluently
    */
   public JsonArray set(int pos, byte[] value) {
-    list.set(pos, value != null ? Base64.getEncoder().encodeToString(value) : null);
+    list.set(pos, value != null ? B64ENC.encodeToString(value) : null);
     return this;
   }
 

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -14,7 +14,6 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.Shareable;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
-import io.vertx.core.spi.json.JsonCodec;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -39,6 +38,9 @@ import static java.time.format.DateTimeFormatter.ISO_INSTANT;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterSerializable, Shareable {
+
+  private static final Base64.Decoder B64DEC = Base64.getUrlDecoder();
+  private static final Base64.Encoder B64ENC = Base64.getUrlEncoder().withoutPadding();
 
   private Map<String, Object> map;
 
@@ -273,7 +275,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   public byte[] getBinary(String key) {
     Objects.requireNonNull(key);
     String encoded = (String) map.get(key);
-    return encoded == null ? null : Base64.getDecoder().decode(encoded);
+    return encoded == null ? null : B64DEC.decode(encoded);
   }
 
   /**
@@ -464,7 +466,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   public byte[] getBinary(String key, byte[] def) {
     Objects.requireNonNull(key);
     Object val = map.get(key);
-    return val != null || map.containsKey(key) ? (val == null ? null : Base64.getDecoder().decode((String)val)) : def;
+    return val != null || map.containsKey(key) ? (val == null ? null : B64DEC.decode((String)val)) : def;
   }
 
   /**
@@ -670,7 +672,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
    */
   public JsonObject put(String key, byte[] value) {
     Objects.requireNonNull(key);
-    map.put(key, value == null ? null : Base64.getEncoder().encodeToString(value));
+    map.put(key, value == null ? null : B64ENC.encodeToString(value));
     return this;
   }
 
@@ -1068,7 +1070,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
         val = new JsonArray((List)val);
       }
     } else if (val instanceof byte[]) {
-      val = Base64.getEncoder().encodeToString((byte[])val);
+      val = B64ENC.encodeToString((byte[])val);
     } else if (val instanceof Instant) {
       val = ISO_INSTANT.format((Instant) val);
     } else {

--- a/src/main/java/io/vertx/core/json/jackson/ByteArrayDeserializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/ByteArrayDeserializer.java
@@ -22,11 +22,13 @@ import java.util.Base64;
 
 class ByteArrayDeserializer extends JsonDeserializer<byte[]> {
 
+  private static final Base64.Decoder B64DEC = Base64.getUrlDecoder();
+
   @Override
   public byte[] deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
     String text = p.getText();
     try {
-      return Base64.getDecoder().decode(text);
+      return B64DEC.decode(text);
     } catch (IllegalArgumentException e) {
       throw new InvalidFormatException(p, "Expected a base64 encoded byte array", text, Instant.class);
     }

--- a/src/main/java/io/vertx/core/json/jackson/ByteArraySerializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/ByteArraySerializer.java
@@ -19,8 +19,10 @@ import java.util.Base64;
 
 class ByteArraySerializer extends JsonSerializer<byte[]> {
 
+  private static final Base64.Encoder B64ENC = Base64.getUrlEncoder().withoutPadding();
+
   @Override
   public void serialize(byte[] value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-    jgen.writeString(Base64.getEncoder().encodeToString(value));
+    jgen.writeString(B64ENC.encodeToString(value));
   }
 }

--- a/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -50,6 +50,7 @@ import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 public class JacksonCodec implements JsonCodec {
 
   private static final JsonFactory factory = new JsonFactory();
+  private static final Base64.Encoder B64ENC = Base64.getUrlEncoder().withoutPadding();
 
   static {
     // Non-standard JSON but we allow C style comments in our JSON
@@ -295,7 +296,7 @@ public class JacksonCodec implements JsonCodec {
       } else if (json instanceof Instant) {
         generator.writeString((ISO_INSTANT.format((Instant)json)));
       } else if (json instanceof byte[]) {
-        generator.writeString(Base64.getEncoder().encodeToString((byte[]) json));
+        generator.writeString(B64ENC.encodeToString((byte[]) json));
       } else if (json == null) {
         generator.writeNull();
       } else {

--- a/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
@@ -85,7 +85,7 @@ public class JacksonDatabindTest extends VertxTestBase {
   public void testBytesDecoding() {
     Pojo original = new Pojo();
     original.bytes = TestUtils.randomByteArray(12);
-    Pojo decoded = Json.decodeValue("{\"bytes\":\"" + Base64.getEncoder().encodeToString(original.bytes) + "\"}", Pojo.class);
+    Pojo decoded = Json.decodeValue("{\"bytes\":\"" + Base64.getUrlEncoder().withoutPadding().encodeToString(original.bytes) + "\"}", Pojo.class);
     assertArrayEquals(original.bytes, decoded.bytes);
   }
 

--- a/src/test/java/io/vertx/core/json/JsonArrayTest.java
+++ b/src/test/java/io/vertx/core/json/JsonArrayTest.java
@@ -233,8 +233,8 @@ public class JsonArrayTest {
     byte[] bytes = TestUtils.randomByteArray(10);
     jsonArray.add(bytes);
     assertArrayEquals(bytes, jsonArray.getBinary(0));
-    assertEquals(Base64.getEncoder().encodeToString(bytes), jsonArray.getValue(0));
-    assertArrayEquals(bytes, Base64.getDecoder().decode(jsonArray.getString(0)));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bytes), jsonArray.getValue(0));
+    assertArrayEquals(bytes, Base64.getUrlDecoder().decode(jsonArray.getString(0)));
     try {
       jsonArray.getBinary(-1);
       fail();
@@ -381,7 +381,7 @@ public class JsonArrayTest {
     assertEquals(arr, jsonArray.getValue(8));
     byte[] bytes = TestUtils.randomByteArray(100);
     jsonArray.add(bytes);
-    assertEquals(Base64.getEncoder().encodeToString(bytes), jsonArray.getValue(9));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bytes), jsonArray.getValue(9));
     Instant now = Instant.now();
     jsonArray.add(now);
     assertEquals(now, jsonArray.getInstant(10));
@@ -519,7 +519,7 @@ public class JsonArrayTest {
     byte[] bytes = TestUtils.randomByteArray(10);
     assertSame(jsonArray, jsonArray.add(bytes));
     assertArrayEquals(bytes, jsonArray.getBinary(0));
-    assertEquals(Base64.getEncoder().encodeToString(bytes), jsonArray.getValue(0));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bytes), jsonArray.getValue(0));
     jsonArray.add((byte[])null);
     assertNull(jsonArray.getValue(1));
     assertEquals(2, jsonArray.size());
@@ -559,7 +559,7 @@ public class JsonArrayTest {
     assertEquals(Double.valueOf(1.23d), jsonArray.getDouble(4));
     assertEquals(true, jsonArray.getBoolean(5));
     assertArrayEquals(bytes, jsonArray.getBinary(6));
-    assertEquals(Base64.getEncoder().encodeToString(bytes), jsonArray.getValue(6));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bytes), jsonArray.getValue(6));
     assertEquals(now, jsonArray.getInstant(7));
     assertEquals(now.toString(), jsonArray.getValue(7));
     assertEquals(obj, jsonArray.getJsonObject(8));
@@ -1137,7 +1137,7 @@ public class JsonArrayTest {
     }
     jsonArray.add("bar");
     assertSame(jsonArray, jsonArray.set(0, bytes));
-    assertEquals(Base64.getEncoder().encodeToString(bytes), jsonArray.getValue(0));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bytes), jsonArray.getValue(0));
     assertEquals(1, jsonArray.size());
   }
 

--- a/src/test/java/io/vertx/core/json/JsonCodecTest.java
+++ b/src/test/java/io/vertx/core/json/JsonCodecTest.java
@@ -81,7 +81,7 @@ public class JsonCodecTest {
     jsonObject.putNull("mynull");
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
-    String strBytes = Base64.getEncoder().encodeToString(bytes);
+    String strBytes = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     String expected = "{\"mystr\":\"foo\",\"mycharsequence\":\"oob\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
       "myboolean\":true,\"mybinary\":\"" + strBytes + "\",\"myinstant\":\"" + ISO_INSTANT.format(now) + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}";
     String json = mapper.toString(jsonObject);
@@ -102,7 +102,7 @@ public class JsonCodecTest {
     jsonArray.addNull();
     jsonArray.add(new JsonObject().put("foo", "bar"));
     jsonArray.add(new JsonArray().add("foo").add(123));
-    String strBytes = Base64.getEncoder().encodeToString(bytes);
+    String strBytes = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     String expected = "[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123]]";
     String json = mapper.toString(jsonArray);
     assertEquals(expected, json);
@@ -125,7 +125,7 @@ public class JsonCodecTest {
     jsonObject.putNull("mynull");
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
-    String strBytes = Base64.getEncoder().encodeToString(bytes);
+    String strBytes = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
 
     Buffer expected = Buffer.buffer("{\"mystr\":\"foo\",\"mycharsequence\":\"oob\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
       "myboolean\":true,\"mybinary\":\"" + strBytes + "\",\"myinstant\":\"" + ISO_INSTANT.format(now) + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}", "UTF-8");
@@ -148,7 +148,7 @@ public class JsonCodecTest {
     jsonArray.addNull();
     jsonArray.add(new JsonObject().put("foo", "bar"));
     jsonArray.add(new JsonArray().add("foo").add(123));
-    String strBytes = Base64.getEncoder().encodeToString(bytes);
+    String strBytes = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     Buffer expected = Buffer.buffer("[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123]]", "UTF-8");
     Buffer json = mapper.toBuffer(jsonArray);
     assertArrayEquals(expected.getBytes(), json.getBytes());
@@ -170,7 +170,7 @@ public class JsonCodecTest {
     jsonObject.put("myinstant", now);
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
-    String strBytes = Base64.getEncoder().encodeToString(bytes);
+    String strBytes = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     String strInstant = ISO_INSTANT.format(now);
     String expected = "{" + Utils.LINE_SEPARATOR +
       "  \"mystr\" : \"foo\"," + Utils.LINE_SEPARATOR +
@@ -204,7 +204,7 @@ public class JsonCodecTest {
     jsonArray.addNull();
     jsonArray.add(new JsonObject().put("foo", "bar"));
     jsonArray.add(new JsonArray().add("foo").add(123));
-    String strBytes = Base64.getEncoder().encodeToString(bytes);
+    String strBytes = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     String expected = "[ \"foo\", 123, 1234, 1.23, 2.34, true, \"" + strBytes + "\", null, {" + Utils.LINE_SEPARATOR +
       "  \"foo\" : \"bar\"" + Utils.LINE_SEPARATOR +
       "}, [ \"foo\", 123 ] ]";
@@ -215,7 +215,7 @@ public class JsonCodecTest {
   @Test
   public void testDecodeJsonObject() {
     byte[] bytes = TestUtils.randomByteArray(10);
-    String strBytes = Base64.getEncoder().encodeToString(bytes);
+    String strBytes = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     Instant now = Instant.now();
     String strInstant = ISO_INSTANT.format(now);
     String json = "{\"mystr\":\"foo\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
@@ -229,7 +229,7 @@ public class JsonCodecTest {
     assertEquals(Double.valueOf(2.34d), obj.getDouble("mydouble"));
     assertTrue(obj.getBoolean("myboolean"));
     assertArrayEquals(bytes, obj.getBinary("mybinary"));
-    assertEquals(Base64.getEncoder().encodeToString(bytes), obj.getValue("mybinary"));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bytes), obj.getValue("mybinary"));
     assertEquals(now, obj.getInstant("myinstant"));
     assertEquals(now.toString(), obj.getValue("myinstant"));
     assertTrue(obj.containsKey("mynull"));
@@ -243,7 +243,7 @@ public class JsonCodecTest {
   @Test
   public void testDecodeJsonArray() {
     byte[] bytes = TestUtils.randomByteArray(10);
-    String strBytes = Base64.getEncoder().encodeToString(bytes);
+    String strBytes = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     Instant now = Instant.now();
     String strInstant = ISO_INSTANT.format(now);
     String json = "[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",\"" + strInstant + "\",null,{\"foo\":\"bar\"},[\"foo\",123]]";
@@ -255,7 +255,7 @@ public class JsonCodecTest {
     assertEquals(Double.valueOf(2.34d), arr.getDouble(4));
     assertEquals(true, arr.getBoolean(5));
     assertArrayEquals(bytes, arr.getBinary(6));
-    assertEquals(Base64.getEncoder().encodeToString(bytes), arr.getValue(6));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bytes), arr.getValue(6));
     assertEquals(now, arr.getInstant(7));
     assertEquals(now.toString(), arr.getValue(7));
     assertTrue(arr.hasNull(8));
@@ -357,7 +357,7 @@ public class JsonCodecTest {
     String json = mapper.toString(data);
     assertNotNull(json);
     // base64 encoded hello
-    assertEquals("\"aGVsbG8=\"", json);
+    assertEquals("\"aGVsbG8\"", json);
   }
 
   @Test

--- a/src/test/java/io/vertx/core/json/JsonObjectTest.java
+++ b/src/test/java/io/vertx/core/json/JsonObjectTest.java
@@ -442,12 +442,12 @@ public class JsonObjectTest {
     byte[] bytes = TestUtils.randomByteArray(100);
     jsonObject.put("foo", bytes);
     assertArrayEquals(bytes, jsonObject.getBinary("foo"));
-    assertEquals(Base64.getEncoder().encodeToString(bytes), jsonObject.getValue("foo"));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bytes), jsonObject.getValue("foo"));
 
     // Can also get as string:
     String val = jsonObject.getString("foo");
     assertNotNull(val);
-    byte[] retrieved = Base64.getDecoder().decode(val);
+    byte[] retrieved = Base64.getUrlDecoder().decode(val);
     assertTrue(TestUtils.byteArraysEqual(bytes, retrieved));
 
     jsonObject.put("foo", 123);
@@ -535,9 +535,9 @@ public class JsonObjectTest {
     byte[] defBytes = TestUtils.randomByteArray(100);
     jsonObject.put("foo", bytes);
     assertArrayEquals(bytes, jsonObject.getBinary("foo", defBytes));
-    assertEquals(Base64.getEncoder().encodeToString(bytes), jsonObject.getValue("foo", Base64.getEncoder().encode(defBytes)));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bytes), jsonObject.getValue("foo", Base64.getUrlEncoder().withoutPadding().encode(defBytes)));
     assertArrayEquals(bytes, jsonObject.getBinary("foo", null));
-    assertEquals(Base64.getEncoder().encodeToString(bytes), jsonObject.getValue("foo", null));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bytes), jsonObject.getValue("foo", null));
 
     jsonObject.put("foo", 123);
     try {
@@ -732,7 +732,7 @@ public class JsonObjectTest {
     assertEquals(arr, jsonObject.getValue("foo"));
     byte[] bytes = TestUtils.randomByteArray(100);
     jsonObject.put("foo", bytes);
-    assertTrue(TestUtils.byteArraysEqual(bytes, Base64.getDecoder().decode((String) jsonObject.getValue("foo"))));
+    assertTrue(TestUtils.byteArraysEqual(bytes, Base64.getUrlDecoder().decode((String) jsonObject.getValue("foo"))));
     jsonObject.putNull("foo");
     assertNull(jsonObject.getValue("foo"));
     assertNull(jsonObject.getValue("absent"));
@@ -787,8 +787,8 @@ public class JsonObjectTest {
     assertEquals(arr, jsonObject.getValue("foo", null));
     byte[] bytes = TestUtils.randomByteArray(100);
     jsonObject.put("foo", bytes);
-    assertTrue(TestUtils.byteArraysEqual(bytes, Base64.getDecoder().decode((String) jsonObject.getValue("foo", "blah"))));
-    assertTrue(TestUtils.byteArraysEqual(bytes, Base64.getDecoder().decode((String)jsonObject.getValue("foo", null))));
+    assertTrue(TestUtils.byteArraysEqual(bytes, Base64.getUrlDecoder().decode((String) jsonObject.getValue("foo", "blah"))));
+    assertTrue(TestUtils.byteArraysEqual(bytes, Base64.getUrlDecoder().decode((String)jsonObject.getValue("foo", null))));
     jsonObject.putNull("foo");
     assertNull(jsonObject.getValue("foo", "blah"));
     assertNull(jsonObject.getValue("foo", null));
@@ -1044,15 +1044,15 @@ public class JsonObjectTest {
 
     assertSame(jsonObject, jsonObject.put("foo", bin1));
     assertArrayEquals(bin1, jsonObject.getBinary("foo"));
-    assertEquals(Base64.getEncoder().encodeToString(bin1), jsonObject.getValue("foo"));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bin1), jsonObject.getValue("foo"));
     jsonObject.put("quux", bin2);
     assertArrayEquals(bin2, jsonObject.getBinary("quux"));
-    assertEquals(Base64.getEncoder().encodeToString(bin2), jsonObject.getValue("quux"));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bin2), jsonObject.getValue("quux"));
     assertArrayEquals(bin1, jsonObject.getBinary("foo"));
-    assertEquals(Base64.getEncoder().encodeToString(bin1), jsonObject.getValue("foo"));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bin1), jsonObject.getValue("foo"));
     jsonObject.put("foo", bin3);
     assertArrayEquals(bin3, jsonObject.getBinary("foo"));
-    assertEquals(Base64.getEncoder().encodeToString(bin3), jsonObject.getValue("foo"));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bin3), jsonObject.getValue("foo"));
 
     jsonObject.put("foo", (byte[]) null);
     assertTrue(jsonObject.containsKey("foo"));
@@ -1130,7 +1130,7 @@ public class JsonObjectTest {
     assertEquals(Float.valueOf(1.23f), jsonObject.getFloat("float"));
     assertEquals(Double.valueOf(1.23d), jsonObject.getDouble("double"));
     assertArrayEquals(bytes, jsonObject.getBinary("binary"));
-    assertEquals(Base64.getEncoder().encodeToString(bytes), jsonObject.getValue("binary"));
+    assertEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(bytes), jsonObject.getValue("binary"));
     assertEquals(now, jsonObject.getInstant("instant"));
     assertEquals(now.toString(), jsonObject.getValue("instant"));
     assertEquals(obj, jsonObject.getJsonObject("obj"));

--- a/src/test/java/io/vertx/core/json/JsonTest.java
+++ b/src/test/java/io/vertx/core/json/JsonTest.java
@@ -1,0 +1,18 @@
+package io.vertx.core.json;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JsonTest {
+
+  @Test
+  public void testBase64Conversion() {
+    // demo string
+    assertEquals("qL8R4QIcQ/ZsRqOAbeRfcZhilN/MksRtDaErMA==", Json.toBase64("qL8R4QIcQ_ZsRqOAbeRfcZhilN_MksRtDaErMA"));
+    // verify if 1 pad is added
+    assertEquals("SGVsbG8gVmVydC54ISE=", Json.toBase64("SGVsbG8gVmVydC54ISE"));
+    // verify if 2 pads is added
+    assertEquals("SGVsbG8gVmVydC54IQ==", Json.toBase64("SGVsbG8gVmVydC54IQ"));
+  }
+}


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

This is a breaking change, which properly follows the RFC7493 when dealing with base64 (binary data) in json.

The fix also adds a utility function to `Json` class to convert from the new format (base64url) to the old format (plain base64).

The utility has 2 functions:

* help users handle integration between vert.x 3 and vert.x 4 projects
* help the interop with other systems that expect base64 strings