### PR TITLE
#3116 Added null handling in add0 that makes it work the same as set0

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -517,7 +517,10 @@ public final class VertxHttpHeaders extends HttpHeaders implements MultiMap {
     }
   }
 
-  private void add0(int h, int i, final CharSequence name, final CharSequence value) {
+  private VertxHttpHeaders add0(int h, int i, final CharSequence name, final CharSequence value) {
+    if (value == null) {
+      return this;
+    }
     if (!io.vertx.core.http.HttpHeaders.DISABLE_HTTP_HEADERS_VALIDATION) {
       HttpUtils.validateHeader(name, value);
     }
@@ -529,6 +532,7 @@ public final class VertxHttpHeaders extends HttpHeaders implements MultiMap {
 
     // Update the linked list.
     newEntry.addBefore(head);
+    return this;
   }
 
   private VertxHttpHeaders set0(final CharSequence name, final CharSequence strVal) {

--- a/src/test/java/io/vertx/core/http/CaseInsensitiveHeadersTest.java
+++ b/src/test/java/io/vertx/core/http/CaseInsensitiveHeadersTest.java
@@ -981,4 +981,5 @@ public class CaseInsensitiveHeadersTest {
     assertEquals("value1", mmap.get("header"));
     assertEquals(Arrays.asList("value1", "value2", "value3"), mmap.getAll("header"));
   }
+
 }

--- a/src/test/java/io/vertx/core/http/VertxHttpHeadersTest.java
+++ b/src/test/java/io/vertx/core/http/VertxHttpHeadersTest.java
@@ -16,8 +16,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -47,4 +46,23 @@ public class VertxHttpHeadersTest extends CaseInsensitiveHeadersTest {
   public void testHashMININT() {
     // Does not apply
   }
+
+  @Test
+  public void testSet0NullHeader() {
+    VertxHttpHeaders headers = new VertxHttpHeaders();
+    headers.set("Test-Header", (String) null);
+    String value = headers.get("Test-Header");
+    assertNull(value);
+    assertFalse(headers.contains("Test-Header"));
+  }
+
+  @Test
+  public void testAdd0NullHeader() {
+    VertxHttpHeaders headers = new VertxHttpHeaders();
+    headers.add("Test-Header", (String) null);
+    String value = headers.get("Test-Header");
+    assertNull(value);
+    assertFalse(headers.contains("Test-Header"));
+  }
+
 }


### PR DESCRIPTION
Signed-off-by: Leonard Broman <leonard.broman@gmail.com>

Added null-check to add0 that makes it behave the same as set0 and avoid a null pointerexception when validateHeader is called.