### PR TITLE
Change JsonObjectMessageCodec to use a Buffer for deep copy for local delivery of messages. Fixes #3154.

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/JsonObjectMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/JsonObjectMessageCodec.java
@@ -36,7 +36,7 @@ public class JsonObjectMessageCodec implements MessageCodec<JsonObject, JsonObje
 
   @Override
   public JsonObject transform(JsonObject jsonObject) {
-    return jsonObject.copy();
+    return new JsonObject(jsonObject.toBuffer());
   }
 
   @Override


### PR DESCRIPTION
Change JsonObjectMessageCodec to use a Buffer for deep copy for local delivery of messages. This makes local messaging behavior more consistent with remote messaging. Fixes #3154.

---

`JsonObjectMessageCodec` has inconsistent support for JsonObjects depending on whether they are being passed through the event bus **locally** or **remotely** (through the wire).

If a `JsonObject` contains a `BigDecimal` or `List` field, it will encounter issues when going through the event bus **locally**. For `BigDecimal` fields, an error will be thrown. For `List` fields, it will be converted into a `JsonArray` instead. This is inconsistent from the behavior if the same JsonObject is passed through the wire/remotely.

For **remote** sending/receiving of messages, the `JsonObject` is encoded into a byte buffer and decoded back into a new `JsonObject`, which results in a byte-perfect copy of the message.

For **local** sending/receiving of messages, `JsonObject.copy()` is used to create a deep copy of the object instead. This, however, has some side effects that result in the above highlighted issues with certain field types, resulting in either an error, or an inconsistent copy of the original message.

Digging further, the issue seems to be that `JsonObject.copy()` in turn uses `Json.checkAndCopy()`, which has processing logic that affects the List & BigDecimal handling.

Based on this, `BigDecimal` values will throw an `IllegalStateException`, `Map` becomes `JsonObject` and `List` becomes a `JsonArray`. I can understand the rationale here, as Vert.x is meant to be a polyglot framework and these types are Java-specific.

**However, this results in `JsonObjectMessageCodec` having behavior that is inconsistent, depending on if the verticles are co-located locally or are clustered remotely.**

The reason why we discovered this is because we went through a refactoring exercise to consolidate certain related services together, and the first step was to combine previously-remote verticles into a group of child verticles under the same main verticle. Suddenly, event bus calls that used to be working fine were throwing errors.

Signed-off-by: Jensen Ching <jensen.ching@gmail.com>