### PR TITLE
Event bus improvements

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/EventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBus.java
@@ -17,7 +17,6 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.metrics.Measured;
 
 /**
@@ -70,15 +69,15 @@ public interface EventBus extends Measured {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  <T> EventBus request(String address, Object message, Handler<AsyncResult<Message<T>>> replyHandler);
+  default <T> EventBus request(String address, Object message, Handler<AsyncResult<Message<T>>> replyHandler) {
+    return request(address, message, new DeliveryOptions(), replyHandler);
+  }
 
   /**
    * Like {@link #request(String, Object, Handler)} but returns a {@code Future} of the asynchronous result
    */
   default <T> Future<Message<T>> request(String address, Object message) {
-    Promise<Message<T>> promise = Promise.promise();
-    request(address, message, promise);
-    return promise.future();
+    return request(address, message, new DeliveryOptions());
   }
 
   /**
@@ -91,16 +90,16 @@ public interface EventBus extends Measured {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  <T> EventBus request(String address, Object message, DeliveryOptions options, Handler<AsyncResult<Message<T>>> replyHandler);
+  default <T> EventBus request(String address, Object message, DeliveryOptions options, Handler<AsyncResult<Message<T>>> replyHandler) {
+    Future<Message<T>> reply = request(address, message, options);
+    reply.setHandler(replyHandler);
+    return this;
+  }
 
   /**
    * Like {@link #request(String, Object, DeliveryOptions, Handler)} but returns a {@code Future} of the asynchronous result
    */
-  default <T> Future<Message<T>> request(String address, Object message, DeliveryOptions options) {
-    Promise<Message<T>> promise = Promise.promise();
-    request(address, message, options, promise);
-    return promise.future();
-  }
+  <T> Future<Message<T>> request(String address, Object message, DeliveryOptions options);
 
   /**
    * Publish a message.<p>

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -310,8 +310,7 @@ public class EventBusImpl implements EventBus, MetricsProvider {
     return last;
   }
 
-  protected <T> void sendReply(MessageImpl replyMessage, MessageImpl replierMessage, DeliveryOptions options,
-                               ReplyHandler<T> replyHandler) {
+  protected <T> void sendReply(MessageImpl replyMessage, DeliveryOptions options, ReplyHandler<T> replyHandler) {
     if (replyMessage.address() == null) {
       throw new IllegalStateException("address not specified");
     } else {

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -320,12 +320,8 @@ public class EventBusImpl implements EventBus, MetricsProvider {
         // Guarantees the order when there is no current context in clustered mode
         ctx = sendNoContext;
       }
-      sendOrPubInternal(new OutboundDeliveryContext<>(ctx, replyMessage, options, replyHandler, replierMessage, null));
+      sendOrPubInternal(new OutboundDeliveryContext<>(ctx, replyMessage, options, replyHandler, null));
     }
-  }
-
-  protected <T> void sendReply(OutboundDeliveryContext<T> sendContext, MessageImpl replierMessage) {
-    sendOrPub(sendContext);
   }
 
   protected <T> void sendOrPub(OutboundDeliveryContext<T> sendContext) {

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -595,10 +595,6 @@ public class EventBusImpl implements EventBus, MetricsProvider {
     // Each handler gets a fresh copy
     MessageImpl copied = msg.copyBeforeReceive(holder.getHandler().src);
 
-    if (metrics != null) {
-      metrics.scheduleMessage(holder.getHandler().getMetric(), msg.isLocal());
-    }
-
     holder.getContext().runOnContext((v) -> {
       // Need to check handler is still there - the handler might have been removed after the message were sent but
       // before it was received

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -235,7 +235,7 @@ public class EventBusImpl implements EventBus, MetricsProvider {
     Objects.requireNonNull(address, "no null address accepted");
     MessageCodec codec = codecManager.lookupCodec(body, codecName);
     @SuppressWarnings("unchecked")
-    MessageImpl msg = new MessageImpl(address, null, headers, body, codec, send, src, this);
+    MessageImpl msg = new MessageImpl(address, headers, body, codec, send, src, this);
     return msg;
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerHolder.java
@@ -12,7 +12,6 @@
 package io.vertx.core.eventbus.impl;
 
 import io.vertx.core.Context;
-import io.vertx.core.spi.metrics.EventBusMetrics;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -20,15 +19,20 @@ import io.vertx.core.spi.metrics.EventBusMetrics;
 public class HandlerHolder<T> {
 
   private final Context context;
+  final String address;
   private final HandlerRegistration<T> handler;
   private final boolean replyHandler;
   private final boolean localOnly;
   private boolean removed;
 
-  public HandlerHolder(HandlerRegistration<T> handler, boolean replyHandler, boolean localOnly,
+  public HandlerHolder(HandlerRegistration<T> handler,
+                       String address,
+                       boolean replyHandler,
+                       boolean localOnly,
                        Context context) {
     this.context = context;
     this.handler = handler;
+    this.address = address;
     this.replyHandler = replyHandler;
     this.localOnly = localOnly;
   }

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerHolder.java
@@ -18,11 +18,11 @@ import io.vertx.core.Context;
  */
 public class HandlerHolder<T> {
 
-  private final Context context;
-  final String address;
-  private final HandlerRegistration<T> handler;
-  private final boolean replyHandler;
-  private final boolean localOnly;
+  public final Context context;
+  public final String address;
+  public final HandlerRegistration<T> handler;
+  public final boolean replyHandler;
+  public final boolean localOnly;
   private boolean removed;
 
   public HandlerHolder(HandlerRegistration<T> handler,

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -202,6 +202,9 @@ public class HandlerRegistration<T> implements MessageConsumer<T>, Handler<Messa
 
   @Override
   public void handle(Message<T> message) {
+    if (metrics != null) {
+      metrics.scheduleMessage(metric, ((MessageImpl)message).isLocal());
+    }
     Handler<Message<T>> theHandler;
     ContextInternal ctx;
     synchronized (this) {
@@ -350,10 +353,6 @@ public class HandlerRegistration<T> implements MessageConsumer<T>, Handler<Messa
 
   public Handler<Message<T>> getHandler() {
     return handler;
-  }
-
-  public Object getMetric() {
-    return metric;
   }
 
   protected class InboundDeliveryContext implements DeliveryContext<T> {

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -398,9 +398,11 @@ public class HandlerRegistration<T> implements MessageConsumer<T>, Handler<Messa
           }
           VertxTracer tracer = HandlerRegistration.this.context.tracer();
           if (tracer != null && !src) {
-            Object trace = tracer.receiveRequest(context, message, message.isSend() ? "send" : "publish", message.headers, MessageTagExtractor.INSTANCE);
+            message.trace = tracer.receiveRequest(context, message, message.isSend() ? "send" : "publish", message.headers, MessageTagExtractor.INSTANCE);
             handler.handle(message);
-            tracer.sendResponse(context, null, trace, null, TagExtractor.empty());
+            if (message.replyAddress == null) {
+              tracer.sendResponse(context, null, message.trace, null, TagExtractor.empty());
+            }
           } else {
             handler.handle(message);
           }

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -123,6 +123,7 @@ public class HandlerRegistration<T> implements MessageConsumer<T>, Handler<Messa
 
   @Override
   public Future<Void> unregister() {
+    // Todo when we support multiple listeners per future
     Promise<Void> promise = Promise.promise();
     doUnregister(promise);
     return promise.future();
@@ -359,7 +360,9 @@ public class HandlerRegistration<T> implements MessageConsumer<T>, Handler<Messa
       this.message = message;
       this.handler = handler;
       this.iter = eventBus.receiveInterceptors();
-      this.context = message.src ? context : context.duplicate();
+
+      // Temporary workaround
+      this.context = handler instanceof EventBusImpl.ReplyHandler ? ((EventBusImpl.ReplyHandler)handler).context : context.duplicate();
     }
 
     @Override

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.eventbus.impl;
+
+import io.vertx.core.*;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.impl.Arguments;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.streams.ReadStream;
+
+import java.util.*;
+
+/*
+ * This class is optimised for performance when used on the same event loop it was created on.
+ * However it can be used safely from other threads.
+ *
+ * The internal state is protected using the synchronized keyword. If always used on the same event loop, then
+ * we benefit from biased locking which makes the overhead of synchronized near zero.
+ */
+public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements MessageConsumer<T> {
+
+  private static final Logger log = LoggerFactory.getLogger(MessageConsumerImpl.class);
+
+  private static final int DEFAULT_MAX_BUFFERED_MESSAGES = 1000;
+
+  private final Vertx vertx;
+  private final ContextInternal context;
+  private final EventBusImpl eventBus;
+  private final String address;
+  private final boolean localOnly;
+  private Handler<Message<T>> handler;
+  private Handler<AsyncResult<Void>> completionHandler;
+  private Handler<Void> endHandler;
+  private Handler<Message<T>> discardHandler;
+  private int maxBufferedMessages = DEFAULT_MAX_BUFFERED_MESSAGES;
+  private Queue<Message<T>> pending = new ArrayDeque<>(8);
+  private long demand = Long.MAX_VALUE;
+  private Future<Void> result;
+
+  MessageConsumerImpl(Vertx vertx, ContextInternal context, EventBusImpl eventBus, String address, boolean localOnly) {
+    super(context, eventBus, address, false);
+    this.vertx = vertx;
+    this.context = context;
+    this.eventBus = eventBus;
+    this.address = address;
+    this.localOnly = localOnly;
+  }
+
+  @Override
+  public MessageConsumer<T> setMaxBufferedMessages(int maxBufferedMessages) {
+    Arguments.require(maxBufferedMessages >= 0, "Max buffered messages cannot be negative");
+    List<Message<T>> discarded;
+    Handler<Message<T>> discardHandler;
+    synchronized (this) {
+      this.maxBufferedMessages = maxBufferedMessages;
+      int overflow = pending.size() - maxBufferedMessages;
+      if (overflow <= 0) {
+        return this;
+      }
+      discardHandler = this.discardHandler;
+      if (discardHandler == null) {
+        while (pending.size() > maxBufferedMessages) {
+          pending.poll();
+        }
+        return this;
+      }
+      discarded = new ArrayList<>(overflow);
+      while (pending.size() > maxBufferedMessages) {
+        discarded.add(pending.poll());
+      }
+    }
+    for (Message<T> msg : discarded) {
+      discardHandler.handle(msg);
+    }
+    return this;
+  }
+
+  @Override
+  public synchronized int getMaxBufferedMessages() {
+    return maxBufferedMessages;
+  }
+
+  @Override
+  public String address() {
+    return address;
+  }
+
+  @Override
+  public synchronized void completionHandler(Handler<AsyncResult<Void>> handler) {
+    Objects.requireNonNull(handler);
+    completionHandler = handler;
+    checkCompletionHandler();
+  }
+
+  @Override
+  public Future<Void> unregister() {
+    // Todo when we support multiple listeners per future
+    Promise<Void> promise = Promise.promise();
+    unregister(promise);
+    return promise.future();
+  }
+
+  protected synchronized void doUnregister() {
+    handler = null;
+    if (endHandler != null) {
+      endHandler.handle(null);
+    }
+    if (pending.size() > 0 && discardHandler != null) {
+      Queue<Message<T>> discarded = pending;
+      Handler<Message<T>> handler = discardHandler;
+      pending = new ArrayDeque<>();
+      context.runOnContext(v -> {
+        Message<T> msg;
+        while ((msg = discarded.poll()) != null) {
+          handler.handle(msg);
+        }
+      });
+    }
+    result = Future.failedFuture("blah");
+    checkCompletionHandler();
+    discardHandler = null;
+    result = null;
+  }
+
+  protected void doReceive(Message<T> message) {
+    Handler<Message<T>> theHandler;
+    synchronized (this) {
+      if (!isRegistered()) {
+        return;
+      } else if (demand == 0L) {
+        if (pending.size() < maxBufferedMessages) {
+          pending.add(message);
+        } else {
+          if (discardHandler != null) {
+            discardHandler.handle(message);
+          } else {
+            log.warn("Discarding message as more than " + maxBufferedMessages + " buffered in paused consumer. address: " + address);
+          }
+        }
+        return;
+      } else {
+        if (pending.size() > 0) {
+          pending.add(message);
+          message = pending.poll();
+        }
+        if (demand != Long.MAX_VALUE) {
+          demand--;
+        }
+        theHandler = handler;
+      }
+    }
+    deliver(theHandler, message);
+  }
+
+  private void deliver(Handler<Message<T>> theHandler, Message<T> message) {
+    // Handle the message outside the sync block
+    // https://bugs.eclipse.org/bugs/show_bug.cgi?id=473714
+    String creditsAddress = message.headers().get(MessageProducerImpl.CREDIT_ADDRESS_HEADER_NAME);
+    if (creditsAddress != null) {
+      eventBus.send(creditsAddress, 1);
+    }
+    dispatch(theHandler, message, context.duplicate());
+    checkNextTick();
+  }
+
+  private synchronized void checkNextTick() {
+    // Check if there are more pending messages in the queue that can be processed next time around
+    if (!pending.isEmpty() && demand > 0L) {
+      context.runOnContext(v -> {
+        Message<T> message;
+        Handler<Message<T>> theHandler;
+        synchronized (MessageConsumerImpl.this) {
+          if (demand == 0L || (message = pending.poll()) == null) {
+            return;
+          }
+          if (demand != Long.MAX_VALUE) {
+            demand--;
+          }
+          theHandler = handler;
+        }
+        deliver(theHandler, message);
+      });
+    }
+  }
+
+  /*
+   * Internal API for testing purposes.
+   */
+  public synchronized void discardHandler(Handler<Message<T>> handler) {
+    this.discardHandler = handler;
+  }
+
+  @Override
+  public synchronized MessageConsumer<T> handler(Handler<Message<T>> h) {
+    if (h != null) {
+      synchronized (this) {
+        handler = h;
+        if (result == null) {
+          result = register(null, localOnly);
+          result.setHandler(ar -> checkCompletionHandler());
+        }
+      }
+    } else {
+      unregister();
+    }
+    return this;
+  }
+
+  private synchronized void checkCompletionHandler() {
+    Handler<AsyncResult<Void>> completionHandler = this.completionHandler;
+    Future<Void> result = this.result;
+    if (completionHandler != null && result != null && result.isComplete()) {
+      this.completionHandler = null;
+      this.result = null;
+      context.runOnContext(v -> {
+        completionHandler.handle(result);
+      });
+    }
+  }
+
+  @Override
+  public ReadStream<T> bodyStream() {
+    return new BodyReadStream<>(this);
+  }
+
+  @Override
+  public synchronized MessageConsumer<T> pause() {
+    demand = 0L;
+    return this;
+  }
+
+  @Override
+  public MessageConsumer<T> resume() {
+    return fetch(Long.MAX_VALUE);
+  }
+
+  @Override
+  public synchronized MessageConsumer<T> fetch(long amount) {
+    if (amount < 0) {
+      throw new IllegalArgumentException();
+    }
+    demand += amount;
+    if (demand < 0L) {
+      demand = Long.MAX_VALUE;
+    }
+    if (demand > 0L) {
+      checkNextTick();
+    }
+    return this;
+  }
+
+  @Override
+  public synchronized MessageConsumer<T> endHandler(Handler<Void> endHandler) {
+    if (endHandler != null) {
+      // We should use the HandlerHolder context to properly do this (needs small refactoring)
+      Context endCtx = vertx.getOrCreateContext();
+      this.endHandler = v1 -> endCtx.runOnContext(v2 -> endHandler.handle(null));
+    } else {
+      this.endHandler = null;
+    }
+    return this;
+  }
+
+  @Override
+  public synchronized MessageConsumer<T> exceptionHandler(Handler<Throwable> handler) {
+    return this;
+  }
+
+  public synchronized Handler<Message<T>> getHandler() {
+    return handler;
+  }
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -109,7 +109,7 @@ public class MessageImpl<U, V> implements Message<V> {
   @Override
   public void reply(Object message, DeliveryOptions options) {
     if (replyAddress != null) {
-      MessageImpl reply = bus.createMessage(true, src, replyAddress, options.getHeaders(), message, options.getCodecName());
+      MessageImpl reply = createReply(message, options);
       bus.sendReply(reply, this, options, null);
     }
   }
@@ -117,13 +117,17 @@ public class MessageImpl<U, V> implements Message<V> {
   @Override
   public <R> Future<Message<R>> replyAndRequest(Object message, DeliveryOptions options) {
     if (replyAddress != null) {
-      MessageImpl reply = bus.createMessage(true, src, replyAddress, options.getHeaders(), message, options.getCodecName());
+      MessageImpl reply = createReply(message, options);
       EventBusImpl.ReplyHandler<R> handler = bus.createReplyHandler(reply, reply.src, options);
       bus.sendReply(reply, this, options, handler);
       return handler.result.future();
     } else {
       throw new IllegalStateException();
     }
+  }
+
+  protected MessageImpl createReply(Object message, DeliveryOptions options) {
+    return bus.createMessage(true, src, replyAddress, options.getHeaders(), message, options.getCodecName());
   }
 
   @Override

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -115,9 +115,9 @@ public class MessageImpl<U, V> implements Message<V> {
   public <R> Future<Message<R>> replyAndRequest(Object message, DeliveryOptions options) {
     if (replyAddress != null) {
       MessageImpl reply = createReply(message, options);
-      EventBusImpl.ReplyHandler<R> handler = bus.createReplyHandler(reply, false, options);
+      ReplyHandler<R> handler = bus.createReplyHandler(reply, false, options);
       bus.sendReply(reply, options, handler);
-      return handler.result.future();
+      return handler.result();
     } else {
       throw new IllegalStateException();
     }

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -43,12 +43,11 @@ public class MessageImpl<U, V> implements Message<V> {
     this.src = src;
   }
 
-  public MessageImpl(String address, String replyAddress, MultiMap headers, U sentBody,
+  public MessageImpl(String address, MultiMap headers, U sentBody,
                      MessageCodec<U, V> messageCodec,
                      boolean send, boolean src, EventBusImpl bus) {
     this.messageCodec = messageCodec;
     this.address = address;
-    this.replyAddress = replyAddress;
     this.headers = headers;
     this.sentBody = sentBody;
     this.send = send;

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -37,6 +37,7 @@ public class MessageImpl<U, V> implements Message<V> {
   protected U sentBody;
   protected V receivedBody;
   protected boolean send;
+  protected Object trace;
 
   public MessageImpl(boolean src, EventBusImpl bus) {
     this.bus = bus;
@@ -127,7 +128,9 @@ public class MessageImpl<U, V> implements Message<V> {
   }
 
   protected MessageImpl createReply(Object message, DeliveryOptions options) {
-    return bus.createMessage(true, src, replyAddress, options.getHeaders(), message, options.getCodecName());
+    MessageImpl reply = bus.createMessage(true, src, replyAddress, options.getHeaders(), message, options.getCodecName());
+    reply.trace = trace;
+    return reply;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -110,7 +110,7 @@ public class MessageImpl<U, V> implements Message<V> {
   public void reply(Object message, DeliveryOptions options) {
     if (replyAddress != null) {
       MessageImpl reply = createReply(message, options);
-      bus.sendReply(reply, this, options, null);
+      bus.sendReply(reply, options, null);
     }
   }
 
@@ -119,7 +119,7 @@ public class MessageImpl<U, V> implements Message<V> {
     if (replyAddress != null) {
       MessageImpl reply = createReply(message, options);
       EventBusImpl.ReplyHandler<R> handler = bus.createReplyHandler(reply, reply.src, options);
-      bus.sendReply(reply, this, options, handler);
+      bus.sendReply(reply, options, handler);
       return handler.result.future();
     } else {
       throw new IllegalStateException();

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
@@ -98,7 +98,7 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
   }
 
   private void write(T data, Promise<Void> handler) {
-    MessageImpl msg = bus.createMessage(send, true, address, options.getHeaders(), data, options.getCodecName());
+    MessageImpl msg = bus.createMessage(send, address, options.getHeaders(), data, options.getCodecName());
     OutboundDeliveryContext<T> sendCtx = bus.newSendContext(msg, options, null, handler);
     if (send) {
       synchronized (this) {

--- a/src/main/java/io/vertx/core/eventbus/impl/OutboundDeliveryContext.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/OutboundDeliveryContext.java
@@ -32,7 +32,6 @@ public class OutboundDeliveryContext<T> implements DeliveryContext<T>, Handler<A
   public final MessageImpl message;
   public final DeliveryOptions options;
   public final EventBusImpl.ReplyHandler<T> replyHandler;
-  private final MessageImpl replierMessage;
   private final Promise<Void> writePromise;
 
   private Object trace;
@@ -42,14 +41,9 @@ public class OutboundDeliveryContext<T> implements DeliveryContext<T>, Handler<A
   EventBusMetrics metrics;
 
   OutboundDeliveryContext(ContextInternal ctx, MessageImpl message, DeliveryOptions options, EventBusImpl.ReplyHandler<T> replyHandler, Promise<Void> writePromise) {
-    this(ctx, message, options, replyHandler, null, writePromise);
-  }
-
-  OutboundDeliveryContext(ContextInternal ctx, MessageImpl message, DeliveryOptions options, EventBusImpl.ReplyHandler<T> replyHandler, MessageImpl replierMessage, Promise<Void> writePromise) {
     this.ctx = ctx;
     this.message = message;
     this.options = options;
-    this.replierMessage = replierMessage;
     this.replyHandler = replyHandler;
     this.writePromise = writePromise;
   }
@@ -120,11 +114,7 @@ public class OutboundDeliveryContext<T> implements DeliveryContext<T>, Handler<A
         BiConsumer<String, String> biConsumer = (String key, String val) -> message.headers().set(key, val);
         trace = tracer.sendRequest(ctx, message, message.send ? "send" : "publish", biConsumer, MessageTagExtractor.INSTANCE);
       }
-      if (replierMessage == null) {
-        bus.sendOrPub(this);
-      } else {
-        bus.sendReply(this, replierMessage);
-      }
+      bus.sendOrPub(this);
     }
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/OutboundDeliveryContext.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/OutboundDeliveryContext.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.eventbus.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.DeliveryContext;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.impl.ContextInternal;
+
+import java.util.Iterator;
+
+public class OutboundDeliveryContext<T> implements DeliveryContext<T> {
+
+  public final ContextInternal ctx;
+  public final MessageImpl message;
+  public final DeliveryOptions options;
+  public final EventBusImpl.ReplyHandler<T> replyHandler;
+  private final MessageImpl replierMessage;
+
+  Iterator<Handler<DeliveryContext>> iter;
+  EventBusImpl bus;
+
+  OutboundDeliveryContext(ContextInternal ctx, MessageImpl message, DeliveryOptions options, EventBusImpl.ReplyHandler<T> replyHandler) {
+    this(ctx, message, options, replyHandler, null);
+  }
+
+  OutboundDeliveryContext(ContextInternal ctx, MessageImpl message, DeliveryOptions options, EventBusImpl.ReplyHandler<T> replyHandler, MessageImpl replierMessage) {
+    this.ctx = ctx;
+    this.message = message;
+    this.options = options;
+    this.replierMessage = replierMessage;
+    this.replyHandler = replyHandler;
+  }
+
+  @Override
+  public Message<T> message() {
+    return message;
+  }
+
+  @Override
+  public void next() {
+    if (iter.hasNext()) {
+      Handler<DeliveryContext> handler = iter.next();
+      try {
+        if (handler != null) {
+          handler.handle(this);
+        } else {
+          next();
+        }
+      } catch (Throwable t) {
+        EventBusImpl.log.error("Failure in interceptor", t);
+      }
+    } else {
+      if (replierMessage == null) {
+        bus.sendOrPub(this);
+      } else {
+        bus.sendReply(this, replierMessage);
+      }
+    }
+  }
+
+  @Override
+  public boolean send() {
+    return message.isSend();
+  }
+
+  @Override
+  public Object body() {
+    return message.sentBody;
+  }
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/OutboundDeliveryContext.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/OutboundDeliveryContext.java
@@ -31,7 +31,7 @@ public class OutboundDeliveryContext<T> implements DeliveryContext<T>, Handler<A
   public final ContextInternal ctx;
   public final MessageImpl message;
   public final DeliveryOptions options;
-  public final EventBusImpl.ReplyHandler<T> replyHandler;
+  public final ReplyHandler<T> replyHandler;
   private final Promise<Void> writePromise;
   private boolean src;
 
@@ -39,7 +39,7 @@ public class OutboundDeliveryContext<T> implements DeliveryContext<T>, Handler<A
   EventBusImpl bus;
   EventBusMetrics metrics;
 
-  OutboundDeliveryContext(ContextInternal ctx, MessageImpl message, DeliveryOptions options, EventBusImpl.ReplyHandler<T> replyHandler, Promise<Void> writePromise) {
+  OutboundDeliveryContext(ContextInternal ctx, MessageImpl message, DeliveryOptions options, ReplyHandler<T> replyHandler, Promise<Void> writePromise) {
     this.ctx = ctx;
     this.message = message;
     this.options = options;

--- a/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
@@ -1,0 +1,80 @@
+package io.vertx.core.eventbus.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.spi.tracing.TagExtractor;
+import io.vertx.core.spi.tracing.VertxTracer;
+
+class ReplyHandler<T> extends HandlerRegistration<T> implements Handler<Message<T>> {
+
+  private final EventBusImpl eventBus;
+  private final ContextInternal context;
+  private final Promise<Message<T>> result;
+  private final long timeoutID;
+  private final boolean src;
+  private final String repliedAddress;
+  Object trace;
+
+  ReplyHandler(EventBusImpl eventBus, ContextInternal context, String address, String repliedAddress, boolean src, long timeout) {
+    super(context, eventBus, address, src);
+    this.eventBus = eventBus;
+    this.context = context;
+    this.result = Promise.promise();
+    this.src = src;
+    this.repliedAddress = repliedAddress;
+    this.timeoutID = eventBus.vertx.setTimer(timeout, id -> {
+      fail(new ReplyException(ReplyFailure.TIMEOUT, "Timed out after waiting " + timeout + "(ms) for a reply. address: " + address + ", repliedAddress: " + repliedAddress));
+    });
+  }
+
+  private void trace(Object reply, Throwable failure) {
+    VertxTracer tracer = context.tracer();
+    if (tracer != null && src) {
+      tracer.receiveResponse(context, reply, trace, failure, TagExtractor.empty());
+    }
+  }
+
+  Future<Message<T>> result() {
+    return result.future();
+  }
+
+  void fail(ReplyException failure) {
+    unregister(ar -> {});
+    if (eventBus.metrics != null) {
+      eventBus.metrics.replyFailure(repliedAddress, failure.failureType());
+    }
+    trace(null, failure);
+    result.tryFail(failure);
+  }
+
+
+  @Override
+  protected void doReceive(Message<T> reply) {
+    dispatch(this, reply, context);
+  }
+
+  @Override
+  protected void doUnregister() {
+  }
+
+  void register() {
+    register(repliedAddress, true);
+  }
+
+  @Override
+  public void handle(Message<T> reply) {
+    eventBus.vertx.cancelTimer(timeoutID);
+    if (reply.body() instanceof ReplyException) {
+      // This is kind of clunky - but hey-ho
+      fail((ReplyException) reply.body());
+    } else {
+      trace(reply, null);
+      result.complete(reply);
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -19,6 +19,7 @@ import io.vertx.core.eventbus.impl.CodecManager;
 import io.vertx.core.eventbus.impl.EventBusImpl;
 import io.vertx.core.eventbus.impl.HandlerHolder;
 import io.vertx.core.eventbus.impl.MessageImpl;
+import io.vertx.core.eventbus.impl.OutboundDeliveryContext;
 import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.impl.HAManager;
 import io.vertx.core.impl.VertxInternal;
@@ -35,7 +36,6 @@ import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -178,7 +178,7 @@ public class ClusteredEventBus extends EventBusImpl {
     Objects.requireNonNull(address, "no null address accepted");
     MessageCodec codec = codecManager.lookupCodec(body, codecName);
     @SuppressWarnings("unchecked")
-    ClusteredMessage msg = new ClusteredMessage(serverID, address, null, headers, body, codec, send, src, this);
+    ClusteredMessage msg = new ClusteredMessage(serverID, address, headers, body, codec, send, src, this);
     return msg;
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -174,11 +174,11 @@ public class ClusteredEventBus extends EventBusImpl {
   }
 
   @Override
-  public MessageImpl createMessage(boolean send, boolean src, String address, MultiMap headers, Object body, String codecName) {
+  public MessageImpl createMessage(boolean send, String address, MultiMap headers, Object body, String codecName) {
     Objects.requireNonNull(address, "no null address accepted");
     MessageCodec codec = codecManager.lookupCodec(body, codecName);
     @SuppressWarnings("unchecked")
-    ClusteredMessage msg = new ClusteredMessage(serverID, address, headers, body, codec, send, src, this);
+    ClusteredMessage msg = new ClusteredMessage(serverID, address, headers, body, codec, send, this);
     return msg;
   }
 
@@ -298,7 +298,7 @@ public class ClusteredEventBus extends EventBusImpl {
             size = buff.getInt(0);
             parser.fixedSizeMode(size);
           } else {
-            ClusteredMessage received = new ClusteredMessage(false, ClusteredEventBus.this);
+            ClusteredMessage received = new ClusteredMessage(ClusteredEventBus.this);
             received.readFromWire(buff, codecManager);
             if (metrics != null) {
               metrics.messageRead(received.address(), buff.length());

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -183,13 +183,11 @@ public class ClusteredEventBus extends EventBusImpl {
   }
 
   @Override
-  protected <T> void addRegistration(boolean newAddress, String address,
-                                     boolean replyHandler, boolean localOnly,
-                                     Handler<AsyncResult<Void>> completionHandler) {
-    if (newAddress && subs != null && !replyHandler && !localOnly) {
+  protected <T> void addRegistration(boolean newAddress, HandlerHolder<T> holder, Handler<AsyncResult<Void>> completionHandler) {
+    if (newAddress && subs != null && !holder.replyHandler && !holder.localOnly) {
       // Propagate the information
-      subs.add(address, nodeInfo, completionHandler);
-      ownSubs.add(address);
+      subs.add(holder.address, nodeInfo, completionHandler);
+      ownSubs.add(holder.address);
     } else {
       completionHandler.handle(Future.succeededFuture());
     }

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -176,7 +176,7 @@ public class ClusteredEventBus extends EventBusImpl {
   }
 
   @Override
-  public MessageImpl createMessage(boolean send, boolean src, String address, MultiMap headers, Object body, String codecName, Handler<AsyncResult<Void>> writeHandler) {
+  public MessageImpl createMessage(boolean send, boolean src, String address, MultiMap headers, Object body, String codecName, Promise<Void> writeHandler) {
     Objects.requireNonNull(address, "no null address accepted");
     MessageCodec codec = codecManager.lookupCodec(body, codecName);
     @SuppressWarnings("unchecked")
@@ -237,10 +237,7 @@ public class ClusteredEventBus extends EventBusImpl {
       }
     } else {
       log.error("Failed to send message", asyncResult.cause());
-      Handler<AsyncResult<Void>> handler = sendContext.message.writeHandler();
-      if (handler != null) {
-        handler.handle(asyncResult.mapEmpty());
-      }
+      sendContext.message.written(asyncResult.cause());
     }
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
@@ -44,18 +44,18 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
   private boolean fromWire;
   private boolean toWire;
 
-  public ClusteredMessage(boolean src, EventBusImpl bus) {
-    super(src, bus);
+  public ClusteredMessage(EventBusImpl bus) {
+    super(bus);
   }
 
   public ClusteredMessage(ServerID sender, String address, MultiMap headers, U sentBody,
-                          MessageCodec<U, V> messageCodec, boolean send, boolean src, EventBusImpl bus) {
-    super(address, headers, sentBody, messageCodec, send, src, bus);
+                          MessageCodec<U, V> messageCodec, boolean send, EventBusImpl bus) {
+    super(address, headers, sentBody, messageCodec, send, bus);
     this.sender = sender;
   }
 
-  protected ClusteredMessage(ClusteredMessage<U, V> other, boolean src) {
-    super(other, src);
+  protected ClusteredMessage(ClusteredMessage<U, V> other) {
+    super(other);
     this.sender = other.sender;
     if (other.sentBody == null) {
       this.wireBuffer = other.wireBuffer;
@@ -72,8 +72,8 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
     return reply;
   }
 
-  public ClusteredMessage<U, V> copyBeforeReceive(boolean src) {
-    return new ClusteredMessage<>(this, src);
+  public ClusteredMessage<U, V> copyBeforeReceive() {
+    return new ClusteredMessage<>(this);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
@@ -46,9 +46,9 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
     super(src, bus);
   }
 
-  public ClusteredMessage(ServerID sender, String address, String replyAddress, MultiMap headers, U sentBody,
+  public ClusteredMessage(ServerID sender, String address, MultiMap headers, U sentBody,
                           MessageCodec<U, V> messageCodec, boolean send, boolean src, EventBusImpl bus) {
-    super(address, replyAddress, headers, sentBody, messageCodec, send, src, bus);
+    super(address, headers, sentBody, messageCodec, send, src, bus);
     this.sender = sender;
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
@@ -15,6 +15,7 @@ import io.netty.util.CharsetUtil;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.MessageCodec;
 import io.vertx.core.eventbus.impl.CodecManager;
@@ -48,7 +49,7 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
   }
 
   public ClusteredMessage(ServerID sender, String address, String replyAddress, MultiMap headers, U sentBody,
-                          MessageCodec<U, V> messageCodec, boolean send, boolean src, EventBusImpl bus, Handler<AsyncResult<Void>> writeHandler) {
+                          MessageCodec<U, V> messageCodec, boolean send, boolean src, EventBusImpl bus, Promise<Void> writeHandler) {
     super(address, replyAddress, headers, sentBody, messageCodec, send, src, bus, writeHandler);
     this.sender = sender;
   }

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
@@ -14,6 +14,7 @@ package io.vertx.core.eventbus.impl.clustered;
 import io.netty.util.CharsetUtil;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.MessageCodec;
 import io.vertx.core.eventbus.impl.CodecManager;
 import io.vertx.core.eventbus.impl.EventBusImpl;
@@ -36,6 +37,7 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
   private static final byte WIRE_PROTOCOL_VERSION = 1;
 
   private ServerID sender;
+  private ServerID repliedTo;
   private Buffer wireBuffer;
   private int bodyPos;
   private int headersPos;
@@ -61,6 +63,13 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
       this.headersPos = other.headersPos;
     }
     this.fromWire = other.fromWire;
+  }
+
+  @Override
+  protected MessageImpl createReply(Object message, DeliveryOptions options) {
+    ClusteredMessage reply = (ClusteredMessage) super.createReply(message, options);
+    reply.repliedTo = sender;
+    return reply;
   }
 
   public ClusteredMessage<U, V> copyBeforeReceive(boolean src) {
@@ -238,6 +247,10 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
 
   ServerID getSender() {
     return sender;
+  }
+
+  ServerID getRepliedTo() {
+    return repliedTo;
   }
 
   public boolean isFromWire() {

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
@@ -12,10 +12,7 @@
 package io.vertx.core.eventbus.impl.clustered;
 
 import io.netty.util.CharsetUtil;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
-import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.MessageCodec;
 import io.vertx.core.eventbus.impl.CodecManager;
@@ -43,14 +40,15 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
   private int bodyPos;
   private int headersPos;
   private boolean fromWire;
+  private boolean toWire;
 
   public ClusteredMessage(boolean src, EventBusImpl bus) {
     super(src, bus);
   }
 
   public ClusteredMessage(ServerID sender, String address, String replyAddress, MultiMap headers, U sentBody,
-                          MessageCodec<U, V> messageCodec, boolean send, boolean src, EventBusImpl bus, Promise<Void> writeHandler) {
-    super(address, replyAddress, headers, sentBody, messageCodec, send, src, bus, writeHandler);
+                          MessageCodec<U, V> messageCodec, boolean send, boolean src, EventBusImpl bus) {
+    super(address, replyAddress, headers, sentBody, messageCodec, send, src, bus);
     this.sender = sender;
   }
 
@@ -100,6 +98,7 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
   }
 
   public Buffer encodeToWire() {
+    toWire = true;
     int length = 1024; // TODO make this configurable
     Buffer buffer = Buffer.buffer(length);
     buffer.appendInt(0);
@@ -243,6 +242,10 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
 
   public boolean isFromWire() {
     return fromWire;
+  }
+
+  public boolean isToWire() {
+    return toWire;
   }
 
   protected boolean isLocal() {

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
@@ -11,9 +11,6 @@
 
 package io.vertx.core.eventbus.impl.clustered;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBusOptions;
@@ -139,7 +136,7 @@ class ConnectionHolder {
         close();
       });
       ClusteredMessage pingMessage =
-        new ClusteredMessage<>(serverID, PING_ADDRESS, null, null, null, new PingMessageCodec(), true, true, eventBus);
+        new ClusteredMessage<>(serverID, PING_ADDRESS, null, null, new PingMessageCodec(), true, true, eventBus);
       Buffer data = pingMessage.encodeToWire();
       socket.write(data);
     });

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
@@ -84,7 +84,7 @@ class ConnectionHolder {
       if (metrics != null) {
         metrics.messageWritten(message.address(), data.length());
       }
-      socket.write(data, message.writeHandler());
+      socket.write(data, message.write());
     } else {
       if (pending == null) {
         if (log.isDebugEnabled()) {
@@ -110,12 +110,8 @@ class ConnectionHolder {
     synchronized (this) {
       ClusteredMessage<?, ?> msg;
       if (pending != null) {
-        Future<Void> failure = Future.failedFuture(cause);
         while ((msg = pending.poll()) != null) {
-          Handler<AsyncResult<Void>> handler = msg.writeHandler();
-          if (handler != null) {
-            handler.handle(failure);
-          }
+          msg.written(cause);
         }
       }
     }
@@ -171,7 +167,7 @@ class ConnectionHolder {
         if (metrics != null) {
           metrics.messageWritten(message.address(), data.length());
         }
-        socket.write(data, message.writeHandler());
+        socket.write(data, message.write());
       }
     }
     pending = null;

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
@@ -136,7 +136,7 @@ class ConnectionHolder {
         close();
       });
       ClusteredMessage pingMessage =
-        new ClusteredMessage<>(serverID, PING_ADDRESS, null, null, new PingMessageCodec(), true, true, eventBus);
+        new ClusteredMessage<>(serverID, PING_ADDRESS, null, null, new PingMessageCodec(), true, eventBus);
       Buffer data = pingMessage.encodeToWire();
       socket.write(data);
     });

--- a/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
@@ -12,7 +12,7 @@
 package io.vertx.core.eventbus;
 
 import io.vertx.core.*;
-import io.vertx.core.eventbus.impl.HandlerRegistration;
+import io.vertx.core.eventbus.impl.MessageConsumerImpl;
 import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.impl.ContextInternal;
@@ -1043,7 +1043,7 @@ public class LocalEventBusTest extends EventBusTestBase {
     };
     MessageConsumer<String> reg = eb.<String>consumer(ADDRESS1).setMaxBufferedMessages(10);
     ReadStream<?> controller = register.apply(reg, handler);
-    ((HandlerRegistration<String>) reg).discardHandler(msg -> {
+    ((MessageConsumerImpl<String>) reg).discardHandler(msg -> {
       assertEquals(data[10], msg.body());
       expected.addAll(Arrays.asList(data).subList(0, 10));
       controller.resume();
@@ -1072,7 +1072,7 @@ public class LocalEventBusTest extends EventBusTestBase {
     }
     List<String> received = Collections.synchronizedList(new ArrayList<>());
     CountDownLatch receiveLatch = new CountDownLatch(4);
-    HandlerRegistration<String> consumer = (HandlerRegistration<String>) eb.<String>consumer(ADDRESS1).setMaxBufferedMessages(5);
+    MessageConsumerImpl<String> consumer = (MessageConsumerImpl<String>) eb.<String>consumer(ADDRESS1).setMaxBufferedMessages(5);
     streamSupplier.apply(consumer, e -> {
       received.add(e);
       receiveLatch.countDown();
@@ -1105,7 +1105,7 @@ public class LocalEventBusTest extends EventBusTestBase {
       // Let enough time of the 20 messages to go in the consumer pending queue
       vertx.setTimer(20, v -> {
         AtomicInteger count = new AtomicInteger(1);
-        ((HandlerRegistration<Integer>)consumer).discardHandler(discarded -> {
+        ((MessageConsumerImpl<Integer>)consumer).discardHandler(discarded -> {
           int val = discarded.body();
           assertEquals(count.getAndIncrement(), val);
           if (val == 9) {
@@ -1149,7 +1149,7 @@ public class LocalEventBusTest extends EventBusTestBase {
     };
     MessageConsumer<String> reg = eb.<String>consumer(ADDRESS1).setMaxBufferedMessages(10);
     ReadStream<?> controller = register.apply(reg, handler);
-    ((HandlerRegistration<String>) reg).discardHandler(msg -> {
+    ((MessageConsumerImpl<String>) reg).discardHandler(msg -> {
       assertEquals(data[10], msg.body());
       expected.addAll(Arrays.asList(data).subList(0, 10));
       controller.resume();
@@ -1409,7 +1409,7 @@ public class LocalEventBusTest extends EventBusTestBase {
       Context ctx = Vertx.currentContext();
       ctx.runOnContext(v -> {
         consumer.resume();
-        ((HandlerRegistration<?>) consumer).discardHandler(discarded -> {
+        ((MessageConsumerImpl<?>) consumer).discardHandler(discarded -> {
           assertEquals("val1", discarded.body());
           testComplete();
         });

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -295,7 +295,6 @@ public class MetricsTest extends VertxTestBase {
   private void testHandlerProcessMessage(Vertx from, Vertx to, int expectedLocalCount) {
     FakeEventBusMetrics metrics = FakeMetricsBase.getMetrics(to.eventBus());
     CountDownLatch latch1 = new CountDownLatch(1);
-    CountDownLatch latch2 = new CountDownLatch(1);
     to.runOnContext(v -> {
       to.eventBus().consumer(ADDRESS1, msg -> {
         HandlerMetric registration = assertRegistration(metrics);
@@ -311,11 +310,6 @@ public class MetricsTest extends VertxTestBase {
       }).completionHandler(onSuccess(v2 -> {
         to.runOnContext(v3 -> {
           latch1.countDown();
-          try {
-            awaitLatch(latch2);
-          } catch (InterruptedException e) {
-            fail(e);
-          }
         });
       }));
     });
@@ -338,8 +332,6 @@ public class MetricsTest extends VertxTestBase {
       testComplete();
     });
     assertWaitUntil(() -> registration.scheduleCount.get() == 1);
-    assertEquals(0, registration.beginCount.get());
-    latch2.countDown();
     await();
   }
 

--- a/src/test/java/io/vertx/core/spi/tracing/EventBusTracerTestBase.java
+++ b/src/test/java/io/vertx/core/spi/tracing/EventBusTracerTestBase.java
@@ -19,6 +19,7 @@ import io.vertx.core.impl.ContextInternal;
 import io.vertx.test.core.Repeat;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.*;
@@ -244,9 +245,9 @@ public abstract class EventBusTracerTestBase extends VertxTestBase {
       vertx2.eventBus().request("the_address", "msg", new DeliveryOptions().setSendTimeout(100), onFailure(failure -> {
       }));
     });
-    waitUntil(() -> ebTracer.sendEvents.size() + ebTracer.receiveEvents.size() == 4);
+    waitUntil(() -> ebTracer.sendEvents.size() + ebTracer.receiveEvents.size() == 3);
     assertEquals(Arrays.asList("sendRequest[the_address]", "receiveResponse[TIMEOUT]"), ebTracer.sendEvents);
-    assertEquals(Arrays.asList("receiveRequest[the_address]", "sendResponse[]"), ebTracer.receiveEvents);
+    assertEquals(Arrays.asList("receiveRequest[the_address]"), ebTracer.receiveEvents);
   }
 
   @Test


### PR DESCRIPTION
A bunch of simplifications for the `EventBus` implementation. The addition of the tracing feature somehow complexified the implementation. The `HandlerRegistration` was also mixing concerns of `MessageConsumer` and `ReplyHandler`, the `HandlerRegistration` class has been made parent of a new `MessageConsumerImpl` and `ReplyHandler` each consuming messages in a different manner, consequently reply handlers shall be a tad more lightweight.


