### PR TITLE
Update copyright notices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ It is important that all source code files have correct copyright notice headers
 You can opt for the general-purpose form:
 
     /*
-     * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+     * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
      *
      * This program and the accompanying materials are made available under the
      * terms of the Eclipse Public License 2.0 which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
   ~
   ~ This program and the accompanying materials are made available under the
   ~ terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/docoverride/buffer/Examples.java
+++ b/src/main/java/docoverride/buffer/Examples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/docoverride/dns/Examples.java
+++ b/src/main/java/docoverride/dns/Examples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/docoverride/eventbus/Examples.java
+++ b/src/main/java/docoverride/eventbus/Examples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/docoverride/json/Examples.java
+++ b/src/main/java/docoverride/json/Examples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/BufferExamples.java
+++ b/src/main/java/examples/BufferExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/ConfigurableVerticleExamples.java
+++ b/src/main/java/examples/ConfigurableVerticleExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/CoreExamples.java
+++ b/src/main/java/examples/CoreExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/DNSExamples.java
+++ b/src/main/java/examples/DNSExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/DatagramExamples.java
+++ b/src/main/java/examples/DatagramExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/EventBusExamples.java
+++ b/src/main/java/examples/EventBusExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/FileSystemExamples.java
+++ b/src/main/java/examples/FileSystemExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/HTTP2Examples.java
+++ b/src/main/java/examples/HTTP2Examples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/JsonPointerExamples.java
+++ b/src/main/java/examples/JsonPointerExamples.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package examples;
 
 import io.vertx.core.json.JsonArray;

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/ParseToolsExamples.java
+++ b/src/main/java/examples/ParseToolsExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/SharedDataExamples.java
+++ b/src/main/java/examples/SharedDataExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/StreamsExamples.java
+++ b/src/main/java/examples/StreamsExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/cli/AnnotatedCli.java
+++ b/src/main/java/examples/cli/AnnotatedCli.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/cli/CLIExamples.java
+++ b/src/main/java/examples/cli/CLIExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/cli/MyCommand.java
+++ b/src/main/java/examples/cli/MyCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/cli/TypedCLIExamples.java
+++ b/src/main/java/examples/cli/TypedCLIExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/cli/package-info.java
+++ b/src/main/java/examples/cli/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/examples/package-info.java
+++ b/src/main/java/examples/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/AbstractVerticle.java
+++ b/src/main/java/io/vertx/core/AbstractVerticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/AsyncResult.java
+++ b/src/main/java/io/vertx/core/AsyncResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/Closeable.java
+++ b/src/main/java/io/vertx/core/Closeable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/Context.java
+++ b/src/main/java/io/vertx/core/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/DeploymentOptions.java
+++ b/src/main/java/io/vertx/core/DeploymentOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/Handler.java
+++ b/src/main/java/io/vertx/core/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/Launcher.java
+++ b/src/main/java/io/vertx/core/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/MultiMap.java
+++ b/src/main/java/io/vertx/core/MultiMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/ServiceHelper.java
+++ b/src/main/java/io/vertx/core/ServiceHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/Starter.java
+++ b/src/main/java/io/vertx/core/Starter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/TimeoutStream.java
+++ b/src/main/java/io/vertx/core/TimeoutStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/Verticle.java
+++ b/src/main/java/io/vertx/core/Verticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/VertxException.java
+++ b/src/main/java/io/vertx/core/VertxException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/WorkerExecutor.java
+++ b/src/main/java/io/vertx/core/WorkerExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/buffer/Buffer.java
+++ b/src/main/java/io/vertx/core/buffer/Buffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/buffer/package-info.java
+++ b/src/main/java/io/vertx/core/buffer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/AmbiguousOptionException.java
+++ b/src/main/java/io/vertx/core/cli/AmbiguousOptionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/Argument.java
+++ b/src/main/java/io/vertx/core/cli/Argument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/CLI.java
+++ b/src/main/java/io/vertx/core/cli/CLI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/CLIException.java
+++ b/src/main/java/io/vertx/core/cli/CLIException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/CommandLine.java
+++ b/src/main/java/io/vertx/core/cli/CommandLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/InvalidValueException.java
+++ b/src/main/java/io/vertx/core/cli/InvalidValueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/MissingOptionException.java
+++ b/src/main/java/io/vertx/core/cli/MissingOptionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/MissingValueException.java
+++ b/src/main/java/io/vertx/core/cli/MissingValueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/Option.java
+++ b/src/main/java/io/vertx/core/cli/Option.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/TypedArgument.java
+++ b/src/main/java/io/vertx/core/cli/TypedArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/TypedOption.java
+++ b/src/main/java/io/vertx/core/cli/TypedOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/UsageMessageFormatter.java
+++ b/src/main/java/io/vertx/core/cli/UsageMessageFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/annotations/Argument.java
+++ b/src/main/java/io/vertx/core/cli/annotations/Argument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/annotations/CLIConfigurator.java
+++ b/src/main/java/io/vertx/core/cli/annotations/CLIConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/annotations/ConvertedBy.java
+++ b/src/main/java/io/vertx/core/cli/annotations/ConvertedBy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/annotations/DefaultValue.java
+++ b/src/main/java/io/vertx/core/cli/annotations/DefaultValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/annotations/Description.java
+++ b/src/main/java/io/vertx/core/cli/annotations/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/annotations/Hidden.java
+++ b/src/main/java/io/vertx/core/cli/annotations/Hidden.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/annotations/Name.java
+++ b/src/main/java/io/vertx/core/cli/annotations/Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/annotations/Option.java
+++ b/src/main/java/io/vertx/core/cli/annotations/Option.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/annotations/ParsedAsList.java
+++ b/src/main/java/io/vertx/core/cli/annotations/ParsedAsList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/annotations/Summary.java
+++ b/src/main/java/io/vertx/core/cli/annotations/Summary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/annotations/package-info.java
+++ b/src/main/java/io/vertx/core/cli/annotations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/converters/BooleanConverter.java
+++ b/src/main/java/io/vertx/core/cli/converters/BooleanConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/converters/CharacterConverter.java
+++ b/src/main/java/io/vertx/core/cli/converters/CharacterConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/converters/ConstructorBasedConverter.java
+++ b/src/main/java/io/vertx/core/cli/converters/ConstructorBasedConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/converters/Converter.java
+++ b/src/main/java/io/vertx/core/cli/converters/Converter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/converters/Converters.java
+++ b/src/main/java/io/vertx/core/cli/converters/Converters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/converters/FromBasedConverter.java
+++ b/src/main/java/io/vertx/core/cli/converters/FromBasedConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/converters/FromStringBasedConverter.java
+++ b/src/main/java/io/vertx/core/cli/converters/FromStringBasedConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/converters/ValueOfBasedConverter.java
+++ b/src/main/java/io/vertx/core/cli/converters/ValueOfBasedConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/impl/DefaultCLI.java
+++ b/src/main/java/io/vertx/core/cli/impl/DefaultCLI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/impl/DefaultCommandLine.java
+++ b/src/main/java/io/vertx/core/cli/impl/DefaultCommandLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/impl/DefaultParser.java
+++ b/src/main/java/io/vertx/core/cli/impl/DefaultParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/impl/ReflectionUtils.java
+++ b/src/main/java/io/vertx/core/cli/impl/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/cli/package-info.java
+++ b/src/main/java/io/vertx/core/cli/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/datagram/DatagramPacket.java
+++ b/src/main/java/io/vertx/core/datagram/DatagramPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/datagram/DatagramSocket.java
+++ b/src/main/java/io/vertx/core/datagram/DatagramSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/datagram/DatagramSocketOptions.java
+++ b/src/main/java/io/vertx/core/datagram/DatagramSocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramPacketImpl.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramPacketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/datagram/impl/InternetProtocolFamily.java
+++ b/src/main/java/io/vertx/core/datagram/impl/InternetProtocolFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/datagram/impl/PacketWriteStreamImpl.java
+++ b/src/main/java/io/vertx/core/datagram/impl/PacketWriteStreamImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/datagram/package-info.java
+++ b/src/main/java/io/vertx/core/datagram/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
+++ b/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/dns/DnsClient.java
+++ b/src/main/java/io/vertx/core/dns/DnsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/dns/DnsClientOptions.java
+++ b/src/main/java/io/vertx/core/dns/DnsClientOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -47,13 +47,13 @@ public class DnsClientOptions {
   * The default value for the recursion desired flag (RD) = {@code true}
   */
   public static final boolean DEFAULT_RECURSION_DESIRED = true;
-  
+
   private int port = DEFAULT_PORT;
   private String host = DEFAULT_HOST;
   private long queryTimeout = DEFAULT_QUERY_TIMEOUT;
   private boolean logActivity = DEFAULT_LOG_ENABLED;
   private boolean recursionDesired = DEFAULT_RECURSION_DESIRED;
-  
+
   public DnsClientOptions() {
   }
 
@@ -157,7 +157,7 @@ public class DnsClientOptions {
   public boolean isRecursionDesired() {
     return recursionDesired;
   }
-  
+
   /**
    * Set whether or not recursion is desired
    *
@@ -168,7 +168,7 @@ public class DnsClientOptions {
     this.recursionDesired = recursionDesired;
     return this;
   }
-  
+
   public JsonObject toJson() {
     JsonObject json = new JsonObject();
     DnsClientOptionsConverter.toJson(this, json);

--- a/src/main/java/io/vertx/core/dns/DnsException.java
+++ b/src/main/java/io/vertx/core/dns/DnsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/dns/DnsResponseCode.java
+++ b/src/main/java/io/vertx/core/dns/DnsResponseCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/dns/MxRecord.java
+++ b/src/main/java/io/vertx/core/dns/MxRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/dns/SrvRecord.java
+++ b/src/main/java/io/vertx/core/dns/SrvRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
+++ b/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/dns/impl/MxRecordImpl.java
+++ b/src/main/java/io/vertx/core/dns/impl/MxRecordImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/dns/impl/SrvRecordImpl.java
+++ b/src/main/java/io/vertx/core/dns/impl/SrvRecordImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/dns/impl/decoder/RecordDecoder.java
+++ b/src/main/java/io/vertx/core/dns/impl/decoder/RecordDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 The Netty Project
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/dns/impl/decoder/StartOfAuthorityRecord.java
+++ b/src/main/java/io/vertx/core/dns/impl/decoder/StartOfAuthorityRecord.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2013 The Netty Project
-
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0

--- a/src/main/java/io/vertx/core/dns/impl/decoder/package-info.java
+++ b/src/main/java/io/vertx/core/dns/impl/decoder/package-info.java
@@ -1,17 +1,12 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
- * The Netty Project licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
 /**

--- a/src/main/java/io/vertx/core/dns/package-info.java
+++ b/src/main/java/io/vertx/core/dns/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/DeliveryContext.java
+++ b/src/main/java/io/vertx/core/eventbus/DeliveryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/DeliveryOptions.java
+++ b/src/main/java/io/vertx/core/eventbus/DeliveryOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/EventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/Message.java
+++ b/src/main/java/io/vertx/core/eventbus/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/MessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/MessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/MessageConsumer.java
+++ b/src/main/java/io/vertx/core/eventbus/MessageConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/MessageProducer.java
+++ b/src/main/java/io/vertx/core/eventbus/MessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/ReplyException.java
+++ b/src/main/java/io/vertx/core/eventbus/ReplyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/ReplyFailure.java
+++ b/src/main/java/io/vertx/core/eventbus/ReplyFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/BodyReadStream.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/BodyReadStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageTagExtractor.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageTagExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/OutboundDeliveryContext.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/OutboundDeliveryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.core.eventbus.impl;
 
 import io.vertx.core.Future;

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusterNodeInfo.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusterNodeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/BooleanMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/BooleanMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/BufferMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/BufferMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/ByteArrayMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/ByteArrayMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/ByteMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/ByteMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/CharMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/CharMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/DoubleMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/DoubleMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/FloatMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/FloatMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/IntMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/IntMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/JsonArrayMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/JsonArrayMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/JsonObjectMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/JsonObjectMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/LongMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/LongMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/NullMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/NullMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/PingMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/PingMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/ReplyExceptionMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/ReplyExceptionMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/ShortMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/ShortMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/StringMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/StringMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/eventbus/package-info.java
+++ b/src/main/java/io/vertx/core/eventbus/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/AsyncFile.java
+++ b/src/main/java/io/vertx/core/file/AsyncFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/CopyOptions.java
+++ b/src/main/java/io/vertx/core/file/CopyOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/FileProps.java
+++ b/src/main/java/io/vertx/core/file/FileProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/FileSystem.java
+++ b/src/main/java/io/vertx/core/file/FileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/FileSystemException.java
+++ b/src/main/java/io/vertx/core/file/FileSystemException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/FileSystemOptions.java
+++ b/src/main/java/io/vertx/core/file/FileSystemOptions.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/FileSystemProps.java
+++ b/src/main/java/io/vertx/core/file/FileSystemProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/OpenOptions.java
+++ b/src/main/java/io/vertx/core/file/OpenOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/impl/FilePropsImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FilePropsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/impl/FileResolver.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/impl/FileSystemPropsImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileSystemPropsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/impl/WindowsFileSystem.java
+++ b/src/main/java/io/vertx/core/file/impl/WindowsFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/file/package-info.java
+++ b/src/main/java/io/vertx/core/file/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/CaseInsensitiveHeaders.java
+++ b/src/main/java/io/vertx/core/http/CaseInsensitiveHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/ClientAuth.java
+++ b/src/main/java/io/vertx/core/http/ClientAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/ConnectionPoolTooBusyException.java
+++ b/src/main/java/io/vertx/core/http/ConnectionPoolTooBusyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/Cookie.java
+++ b/src/main/java/io/vertx/core/http/Cookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/GoAway.java
+++ b/src/main/java/io/vertx/core/http/GoAway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/Http2Settings.java
+++ b/src/main/java/io/vertx/core/http/Http2Settings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -1208,7 +1208,7 @@ public class HttpClientOptions extends ClientOptionsBase {
 
   /**
    * set to {@code initialBufferSizeHttpDecoder} the initial buffer of the HttpDecoder.
-   * 
+   *
    * @param decoderInitialBufferSize the initial buffer size
    * @return a reference to this, so the API can be used fluently
    */

--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -422,7 +422,7 @@ public interface HttpClientRequest extends WriteStream<Buffer>, Future<HttpClien
   default HttpClientRequest writeCustomFrame(HttpFrame frame) {
     return writeCustomFrame(frame.type(), frame.flags(), frame.payload());
   }
-  
+
   /**
    * Sets the priority of the associated stream.
    * <p/>

--- a/src/main/java/io/vertx/core/http/HttpClientResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpClientResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/HttpFrame.java
+++ b/src/main/java/io/vertx/core/http/HttpFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/HttpMethod.java
+++ b/src/main/java/io/vertx/core/http/HttpMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/HttpServerFileUpload.java
+++ b/src/main/java/io/vertx/core/http/HttpServerFileUpload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -104,17 +104,17 @@ public class HttpServerOptions extends NetServerOptions {
    * Default initial buffer size for HttpObjectDecoder = 128 bytes
    */
   public static final int DEFAULT_DECODER_INITIAL_BUFFER_SIZE = 128;
-  
+
   /**
    * Default support for WebSockets per-frame deflate compression extension = {@code true}
    */
   public static final boolean DEFAULT_PER_FRAME_WEBSOCKET_COMPRESSION_SUPPORTED = true;
-  
+
   /**
    * Default support for WebSockets per-message deflate compression extension = {@code true}
    */
   public static final boolean DEFAULT_PER_MESSAGE_WEBSOCKET_COMPRESSION_SUPPORTED = true;
-  
+
   /**
    * Default WebSocket deflate compression level = 6
    */
@@ -759,8 +759,8 @@ public class HttpServerOptions extends NetServerOptions {
 	  this.perFrameWebsocketCompressionSupported = supported;
 	  return this;
   }
-  
-  /** 
+
+  /**
    * Get whether WebSocket the per-frame deflate compression extension is supported.
    *
    * @return {@code true} if the http server will accept the per-frame deflate compression extension
@@ -768,7 +768,7 @@ public class HttpServerOptions extends NetServerOptions {
   public boolean getPerFrameWebsocketCompressionSupported() {
 	  return this.perFrameWebsocketCompressionSupported;
   }
-  
+
   /**
    * Enable or disable support for WebSocket per-message deflate compression extension.
    *
@@ -779,7 +779,7 @@ public class HttpServerOptions extends NetServerOptions {
 	  this.perMessageWebsocketCompressionSupported = supported;
 	  return this;
   }
-  
+
   /**
    * Get whether WebSocket per-message deflate compression extension is supported.
    *
@@ -788,7 +788,7 @@ public class HttpServerOptions extends NetServerOptions {
   public boolean getPerMessageWebsocketCompressionSupported() {
 	  return this.perMessageWebsocketCompressionSupported;
   }
-  
+
   /**
    * Set the WebSocket compression level.
    *
@@ -799,14 +799,14 @@ public class HttpServerOptions extends NetServerOptions {
 	  this.websocketCompressionLevel = compressionLevel;
 	  return this;
   }
-  
+
   /**
    * @return the current WebSocket deflate compression level
    */
   public int getWebsocketCompressionLevel() {
 	  return this.websocketCompressionLevel;
   }
-  
+
   /**
    * Set whether the WebSocket server will accept the {@code server_no_context_takeover} parameter of the per-message
    * deflate compression extension offered by the client.
@@ -818,7 +818,7 @@ public class HttpServerOptions extends NetServerOptions {
 	  this.websocketAllowServerNoContext = accept;
 	  return this;
   }
-  
+
   /**
    * @return {@code true} when the WebSocket server will accept the {@code server_no_context_takeover} parameter for the per-message
    * deflate compression extension offered by the client
@@ -826,7 +826,7 @@ public class HttpServerOptions extends NetServerOptions {
   public boolean getWebsocketAllowServerNoContext () {
 	  return this.websocketAllowServerNoContext;
   }
-  
+
   /**
    * Set whether the WebSocket server will accept the {@code client_no_context_takeover} parameter of the per-message
    * deflate compression extension offered by the client.

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -364,7 +364,7 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
    * Set an handler for stream priority changes
    * <p>
    * This is not implemented for HTTP/1.x.
-   * 
+   *
    * @param handler the handler to be called when stream priority changes
    */
   @Fluent

--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/HttpVersion.java
+++ b/src/main/java/io/vertx/core/http/HttpVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/RequestOptions.java
+++ b/src/main/java/io/vertx/core/http/RequestOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/ServerWebSocket.java
+++ b/src/main/java/io/vertx/core/http/ServerWebSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/StreamPriority.java
+++ b/src/main/java/io/vertx/core/http/StreamPriority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -117,12 +117,12 @@ public class StreamPriority {
     if (this == obj) return true;
     if (obj == null) return false;
     if (getClass() != obj.getClass()) return false;
-    
+
     StreamPriority other = (StreamPriority) obj;
     if (exclusive != other.exclusive) return false;
     if (dependency != other.dependency) return false;
     if (weight != other.weight) return false;
-    
+
     return true;
   }
 

--- a/src/main/java/io/vertx/core/http/StreamResetException.java
+++ b/src/main/java/io/vertx/core/http/StreamResetException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/WebSocket.java
+++ b/src/main/java/io/vertx/core/http/WebSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/WebSocketBase.java
+++ b/src/main/java/io/vertx/core/http/WebSocketBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/WebSocketFrame.java
+++ b/src/main/java/io/vertx/core/http/WebSocketFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010 The Netty Project
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/WebsocketRejectedException.java
+++ b/src/main/java/io/vertx/core/http/WebsocketRejectedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/WebsocketVersion.java
+++ b/src/main/java/io/vertx/core/http/WebsocketVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/AssembledFullHttpRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/AssembledFullHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/AssembledFullHttpResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/AssembledFullHttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/AssembledHttpRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/AssembledHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/AssembledHttpResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/AssembledHttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/AssembledLastHttpContent.java
+++ b/src/main/java/io/vertx/core/http/impl/AssembledLastHttpContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/CookieImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/CookieImpl.java
@@ -1,17 +1,12 @@
 /*
- * Copyright 2014 Red Hat, Inc.
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Apache License v2.0 which accompanies this distribution.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  The Eclipse Public License is available at
- *  http://www.eclipse.org/legal/epl-v10.html
- *
- *  The Apache License v2.0 is available at
- *  http://www.opensource.org/licenses/apache2.0.php
- *
- *  You may elect to redistribute this code under either of these licenses.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
 package io.vertx.core.http.impl;

--- a/src/main/java/io/vertx/core/http/impl/FileStreamChannel.java
+++ b/src/main/java/io/vertx/core/http/impl/FileStreamChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/FrameType.java
+++ b/src/main/java/io/vertx/core/http/impl/FrameType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HeadersAdaptor.java
+++ b/src/main/java/io/vertx/core/http/impl/HeadersAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/Http1xOrH2CHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xOrH2CHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/Http1xUpgradeToH2CHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xUpgradeToH2CHandler.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.core.http.impl;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -319,7 +319,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
       response.handleUnknownFrame(new HttpFrameImpl(type, flags, buff));
     }
 
-    
+
     @Override
     void handlePriorityChange(StreamPriority streamPriority) {
       if(streamPriority != null && !streamPriority.equals(priority())) {
@@ -439,7 +439,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
         handlerContext.flush();
       }
     }
-    
+
     @Override
     public void writeFrame(int type, int flags, ByteBuf payload) {
       super.writeFrame(type, flags, payload);
@@ -543,7 +543,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
         if (m == null)  {
           m = metrics.connected(conn.remoteAddress(), conn.remoteName());
           metrics.endpointConnected(queueMetric, m);
-        } 
+        }
         conn.metric(m);
       }
       long concurrency = conn.remoteSettings().getMaxConcurrentStreams();

--- a/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/Http2HeadersAdaptor.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2HeadersAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradedClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradedClientConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpChunkContentCompressor.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpChunkContentCompressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -57,7 +57,7 @@ public interface HttpClientStream {
   void endRequest();
 
   NetSocket createNetSocket();
-  
+
   StreamPriority priority();
   void updatePriority(StreamPriority streamPriority);
 }

--- a/src/main/java/io/vertx/core/http/impl/HttpFrameImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpFrameImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpHandlers.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpServerChannelInitializer.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerChannelInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpServerFileUploadImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerFileUploadImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/MimeMapping.java
+++ b/src/main/java/io/vertx/core/http/impl/MimeMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/NettyFileUpload.java
+++ b/src/main/java/io/vertx/core/http/impl/NettyFileUpload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/NettyFileUploadDataFactory.java
+++ b/src/main/java/io/vertx/core/http/impl/NettyFileUploadDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/ServerCookie.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2ClientUpgradeCodec.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2ClientUpgradeCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -455,7 +455,7 @@ class VertxHttp2ConnectionHandler<C extends Http2ConnectionBase> extends Http2Co
   public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags, ByteBuf payload) throws Http2Exception {
     throw new UnsupportedOperationException();
   }
-  
+
   private void _writePriority(Http2Stream stream, int streamDependency, short weight, boolean exclusive) {
       encoder().writePriority(chctx, stream.id(), streamDependency, weight, exclusive, chctx.newPromise());
   }

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandlerBuilder.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandlerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2NetSocket.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2NetSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -179,7 +179,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
   void handleClose() {
     conn.reportBytesWritten(bytesWritten);
   }
-  
+
   synchronized void priority(StreamPriority streamPriority) {
     this.priority = streamPriority;
   }

--- a/src/main/java/io/vertx/core/http/impl/VertxHttpRequestDecoder.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttpRequestDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/VertxHttpResponseEncoder.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttpResponseEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/WebSocketRequestHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/cgbystrom/FlashPolicyHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/cgbystrom/FlashPolicyHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/pool/ConnectResult.java
+++ b/src/main/java/io/vertx/core/http/impl/pool/ConnectResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/pool/ConnectionListener.java
+++ b/src/main/java/io/vertx/core/http/impl/pool/ConnectionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/pool/ConnectionProvider.java
+++ b/src/main/java/io/vertx/core/http/impl/pool/ConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/pool/Pool.java
+++ b/src/main/java/io/vertx/core/http/impl/pool/Pool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/pool/Waiter.java
+++ b/src/main/java/io/vertx/core/http/impl/pool/Waiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/ws/WebSocketFrameImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ws/WebSocketFrameImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010 The Netty Project
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/impl/ws/WebSocketFrameInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/ws/WebSocketFrameInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010 The Netty Project
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/http/package-info.java
+++ b/src/main/java/io/vertx/core/http/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/AbstractContext.java
+++ b/src/main/java/io/vertx/core/impl/AbstractContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/AddressResolver.java
+++ b/src/main/java/io/vertx/core/impl/AddressResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/Args.java
+++ b/src/main/java/io/vertx/core/impl/Args.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/Arguments.java
+++ b/src/main/java/io/vertx/core/impl/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
+++ b/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/CloseHooks.java
+++ b/src/main/java/io/vertx/core/impl/CloseHooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/CompositeFutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/CompositeFutureImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/ConcurrentHashSet.java
+++ b/src/main/java/io/vertx/core/impl/ConcurrentHashSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/ContextInternal.java
+++ b/src/main/java/io/vertx/core/impl/ContextInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/ConversionHelper.java
+++ b/src/main/java/io/vertx/core/impl/ConversionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/Deployment.java
+++ b/src/main/java/io/vertx/core/impl/Deployment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/EventLoopContext.java
+++ b/src/main/java/io/vertx/core/impl/EventLoopContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/FailedFuture.java
+++ b/src/main/java/io/vertx/core/impl/FailedFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/FailoverCompleteHandler.java
+++ b/src/main/java/io/vertx/core/impl/FailoverCompleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/FutureFactoryImpl.java
+++ b/src/main/java/io/vertx/core/impl/FutureFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/FutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/FutureImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/HAManager.java
+++ b/src/main/java/io/vertx/core/impl/HAManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/IsolatingClassLoader.java
+++ b/src/main/java/io/vertx/core/impl/IsolatingClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/JavaVerticleFactory.java
+++ b/src/main/java/io/vertx/core/impl/JavaVerticleFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/NoStackTraceThrowable.java
+++ b/src/main/java/io/vertx/core/impl/NoStackTraceThrowable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/StringEscapeUtils.java
+++ b/src/main/java/io/vertx/core/impl/StringEscapeUtils.java
@@ -1,20 +1,12 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * Modified from original form by Tim Fox
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 package io.vertx.core.impl;
 

--- a/src/main/java/io/vertx/core/impl/SucceededFuture.java
+++ b/src/main/java/io/vertx/core/impl/SucceededFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/TaskQueue.java
+++ b/src/main/java/io/vertx/core/impl/TaskQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/Utils.java
+++ b/src/main/java/io/vertx/core/impl/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/VertxFactoryImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/VertxInternal.java
+++ b/src/main/java/io/vertx/core/impl/VertxInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/VertxThread.java
+++ b/src/main/java/io/vertx/core/impl/VertxThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/VertxThreadFactory.java
+++ b/src/main/java/io/vertx/core/impl/VertxThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/WorkerContext.java
+++ b/src/main/java/io/vertx/core/impl/WorkerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
+++ b/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/WorkerExecutorInternal.java
+++ b/src/main/java/io/vertx/core/impl/WorkerExecutorInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/WorkerPool.java
+++ b/src/main/java/io/vertx/core/impl/WorkerPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/cpu/CpuCoreSensor.java
+++ b/src/main/java/io/vertx/core/impl/cpu/CpuCoreSensor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/CommandLineUtils.java
+++ b/src/main/java/io/vertx/core/impl/launcher/CommandLineUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/ServiceCommandFactoryLoader.java
+++ b/src/main/java/io/vertx/core/impl/launcher/ServiceCommandFactoryLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/VertxCommandLauncher.java
+++ b/src/main/java/io/vertx/core/impl/launcher/VertxCommandLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/VertxLifecycleHooks.java
+++ b/src/main/java/io/vertx/core/impl/launcher/VertxLifecycleHooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommandFactory.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/ClasspathHandler.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/ClasspathHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/ExecUtils.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/ExecUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/FileSelector.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/FileSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/ListCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/ListCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/ListCommandFactory.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/ListCommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommandFactory.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/StartCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/StartCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/StartCommandFactory.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/StartCommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/StopCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/StopCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/StopCommandFactory.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/StopCommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/VersionCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/VersionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/VersionCommandFactory.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/VersionCommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/VertxIsolatedDeployer.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/VertxIsolatedDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/launcher/commands/Watcher.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/Watcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/resolver/DefaultResolverProvider.java
+++ b/src/main/java/io/vertx/core/impl/resolver/DefaultResolverProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/resolver/DnsResolverProvider.java
+++ b/src/main/java/io/vertx/core/impl/resolver/DnsResolverProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/utils/ConcurrentCyclicSequence.java
+++ b/src/main/java/io/vertx/core/impl/utils/ConcurrentCyclicSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/verticle/CompilingClassLoader.java
+++ b/src/main/java/io/vertx/core/impl/verticle/CompilingClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/verticle/CustomJavaFileObject.java
+++ b/src/main/java/io/vertx/core/impl/verticle/CustomJavaFileObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/verticle/JavaSourceContext.java
+++ b/src/main/java/io/vertx/core/impl/verticle/JavaSourceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/verticle/MemoryFileManager.java
+++ b/src/main/java/io/vertx/core/impl/verticle/MemoryFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/impl/verticle/PackageHelper.java
+++ b/src/main/java/io/vertx/core/impl/verticle/PackageHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/DecodeException.java
+++ b/src/main/java/io/vertx/core/json/DecodeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/EncodeException.java
+++ b/src/main/java/io/vertx/core/json/EncodeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/jackson/ByteArrayDeserializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/ByteArrayDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/jackson/ByteArraySerializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/ByteArraySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/jackson/InstantDeserializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/InstantDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/jackson/InstantSerializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/InstantSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/jackson/JacksonFactory.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/jackson/JsonArraySerializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/JsonArraySerializer.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.core.json.jackson;
 
 import com.fasterxml.jackson.core.JsonGenerator;

--- a/src/main/java/io/vertx/core/json/jackson/JsonObjectSerializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/JsonObjectSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/pointer/JsonPointer.java
+++ b/src/main/java/io/vertx/core/json/pointer/JsonPointer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/pointer/JsonPointerIterator.java
+++ b/src/main/java/io/vertx/core/json/pointer/JsonPointerIterator.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.core.json.pointer;
 
 import io.vertx.codegen.annotations.Nullable;

--- a/src/main/java/io/vertx/core/json/pointer/impl/JsonPointerImpl.java
+++ b/src/main/java/io/vertx/core/json/pointer/impl/JsonPointerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/json/pointer/impl/JsonPointerIteratorImpl.java
+++ b/src/main/java/io/vertx/core/json/pointer/impl/JsonPointerIteratorImpl.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.core.json.pointer.impl;
 
 import io.vertx.core.json.JsonArray;

--- a/src/main/java/io/vertx/core/logging/JULLogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/JULLogDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/logging/JULLogDelegateFactory.java
+++ b/src/main/java/io/vertx/core/logging/JULLogDelegateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/logging/Log4j2LogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/Log4j2LogDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/logging/Log4j2LogDelegateFactory.java
+++ b/src/main/java/io/vertx/core/logging/Log4j2LogDelegateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/logging/Log4jLogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/Log4jLogDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/logging/Log4jLogDelegateFactory.java
+++ b/src/main/java/io/vertx/core/logging/Log4jLogDelegateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/logging/Logger.java
+++ b/src/main/java/io/vertx/core/logging/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/logging/LoggerFactory.java
+++ b/src/main/java/io/vertx/core/logging/LoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/logging/SLF4JLogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/SLF4JLogDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/logging/SLF4JLogDelegateFactory.java
+++ b/src/main/java/io/vertx/core/logging/SLF4JLogDelegateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/logging/VertxLoggerFormatter.java
+++ b/src/main/java/io/vertx/core/logging/VertxLoggerFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/metrics/Measured.java
+++ b/src/main/java/io/vertx/core/metrics/Measured.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/metrics/MetricsOptions.java
+++ b/src/main/java/io/vertx/core/metrics/MetricsOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/metrics/impl/DummyVertxMetrics.java
+++ b/src/main/java/io/vertx/core/metrics/impl/DummyVertxMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/metrics/package-info.java
+++ b/src/main/java/io/vertx/core/metrics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/ClientOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/ClientOptionsBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/JksOptions.java
+++ b/src/main/java/io/vertx/core/net/JksOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/KeyCertOptions.java
+++ b/src/main/java/io/vertx/core/net/KeyCertOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/NetClient.java
+++ b/src/main/java/io/vertx/core/net/NetClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/NetServer.java
+++ b/src/main/java/io/vertx/core/net/NetServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/src/main/java/io/vertx/core/net/NetSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/NetworkOptions.java
+++ b/src/main/java/io/vertx/core/net/NetworkOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/OpenSSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/OpenSSLEngineOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/PemKeyCertOptions.java
+++ b/src/main/java/io/vertx/core/net/PemKeyCertOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/PemTrustOptions.java
+++ b/src/main/java/io/vertx/core/net/PemTrustOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/PfxOptions.java
+++ b/src/main/java/io/vertx/core/net/PfxOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/ProxyOptions.java
+++ b/src/main/java/io/vertx/core/net/ProxyOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/ProxyType.java
+++ b/src/main/java/io/vertx/core/net/ProxyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/SSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/SSLEngineOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/SelfSignedCertificate.java
+++ b/src/main/java/io/vertx/core/net/SelfSignedCertificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/ServerOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/ServerOptionsBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/SocketAddress.java
+++ b/src/main/java/io/vertx/core/net/SocketAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/TrustOptions.java
+++ b/src/main/java/io/vertx/core/net/TrustOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/AsyncResolveConnectHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/AsyncResolveConnectHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/ChannelFutureListenerAdapter.java
+++ b/src/main/java/io/vertx/core/net/impl/ChannelFutureListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/HandlerHolder.java
+++ b/src/main/java/io/vertx/core/net/impl/HandlerHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/HandlerManager.java
+++ b/src/main/java/io/vertx/core/net/impl/HandlerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/NetSocketInternal.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/PartialPooledByteBufAllocator.java
+++ b/src/main/java/io/vertx/core/net/impl/PartialPooledByteBufAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/SelfSignedCertificateImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/SelfSignedCertificateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/ServerID.java
+++ b/src/main/java/io/vertx/core/net/impl/ServerID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/SocketAddressImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/SocketAddressImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/SslHandshakeCompletionHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/SslHandshakeCompletionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/TrustAllTrustManager.java
+++ b/src/main/java/io/vertx/core/net/impl/TrustAllTrustManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/URIDecoder.java
+++ b/src/main/java/io/vertx/core/net/impl/URIDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/VertxEventLoopGroup.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxEventLoopGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/VertxHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/VertxTrustManagerFactory.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxTrustManagerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/transport/EpollTransport.java
+++ b/src/main/java/io/vertx/core/net/impl/transport/EpollTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/transport/KQueueTransport.java
+++ b/src/main/java/io/vertx/core/net/impl/transport/KQueueTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/impl/transport/Transport.java
+++ b/src/main/java/io/vertx/core/net/impl/transport/Transport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/net/package-info.java
+++ b/src/main/java/io/vertx/core/net/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/parsetools/JsonEvent.java
+++ b/src/main/java/io/vertx/core/parsetools/JsonEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/parsetools/JsonEventType.java
+++ b/src/main/java/io/vertx/core/parsetools/JsonEventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/parsetools/JsonParser.java
+++ b/src/main/java/io/vertx/core/parsetools/JsonParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/parsetools/RecordParser.java
+++ b/src/main/java/io/vertx/core/parsetools/RecordParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/parsetools/impl/JsonEventImpl.java
+++ b/src/main/java/io/vertx/core/parsetools/impl/JsonEventImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/parsetools/impl/JsonParserImpl.java
+++ b/src/main/java/io/vertx/core/parsetools/impl/JsonParserImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/parsetools/impl/RecordParserImpl.java
+++ b/src/main/java/io/vertx/core/parsetools/impl/RecordParserImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/parsetools/package-info.java
+++ b/src/main/java/io/vertx/core/parsetools/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/AsyncMap.java
+++ b/src/main/java/io/vertx/core/shareddata/AsyncMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/Counter.java
+++ b/src/main/java/io/vertx/core/shareddata/Counter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/LocalMap.java
+++ b/src/main/java/io/vertx/core/shareddata/LocalMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/Lock.java
+++ b/src/main/java/io/vertx/core/shareddata/Lock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/Shareable.java
+++ b/src/main/java/io/vertx/core/shareddata/Shareable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/SharedData.java
+++ b/src/main/java/io/vertx/core/shareddata/SharedData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/impl/AsynchronousCounter.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/AsynchronousCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/impl/Checker.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/Checker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/impl/ClusterSerializable.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/ClusterSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/impl/LocalAsyncLocks.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/LocalAsyncLocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/impl/LocalAsyncMapImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/LocalAsyncMapImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/impl/LocalMapImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/LocalMapImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/shareddata/package-info.java
+++ b/src/main/java/io/vertx/core/shareddata/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/FutureFactory.java
+++ b/src/main/java/io/vertx/core/spi/FutureFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/JsonFactory.java
+++ b/src/main/java/io/vertx/core/spi/JsonFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/VerticleFactory.java
+++ b/src/main/java/io/vertx/core/spi/VerticleFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/VertxFactory.java
+++ b/src/main/java/io/vertx/core/spi/VertxFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/VertxMetricsFactory.java
+++ b/src/main/java/io/vertx/core/spi/VertxMetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/VertxTracerFactory.java
+++ b/src/main/java/io/vertx/core/spi/VertxTracerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/cluster/AsyncMultiMap.java
+++ b/src/main/java/io/vertx/core/spi/cluster/AsyncMultiMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/cluster/ChoosableIterable.java
+++ b/src/main/java/io/vertx/core/spi/cluster/ChoosableIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
+++ b/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/cluster/NodeListener.java
+++ b/src/main/java/io/vertx/core/spi/cluster/NodeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/json/JsonCodec.java
+++ b/src/main/java/io/vertx/core/spi/json/JsonCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/launcher/Command.java
+++ b/src/main/java/io/vertx/core/spi/launcher/Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/launcher/CommandFactory.java
+++ b/src/main/java/io/vertx/core/spi/launcher/CommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/launcher/CommandFactoryLookup.java
+++ b/src/main/java/io/vertx/core/spi/launcher/CommandFactoryLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/launcher/DefaultCommand.java
+++ b/src/main/java/io/vertx/core/spi/launcher/DefaultCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/launcher/DefaultCommandFactory.java
+++ b/src/main/java/io/vertx/core/spi/launcher/DefaultCommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/launcher/ExecutionContext.java
+++ b/src/main/java/io/vertx/core/spi/launcher/ExecutionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/logging/LogDelegate.java
+++ b/src/main/java/io/vertx/core/spi/logging/LogDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/logging/LogDelegateFactory.java
+++ b/src/main/java/io/vertx/core/spi/logging/LogDelegateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/metrics/DatagramSocketMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/DatagramSocketMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/metrics/EventBusMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/EventBusMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/metrics/HttpServerMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/HttpServerMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/metrics/Metrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/Metrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/metrics/MetricsProvider.java
+++ b/src/main/java/io/vertx/core/spi/metrics/MetricsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/metrics/NetworkMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/NetworkMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/metrics/PoolMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/PoolMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/metrics/TCPMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/TCPMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/resolver/ResolverProvider.java
+++ b/src/main/java/io/vertx/core/spi/resolver/ResolverProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/tracing/Extractors.java
+++ b/src/main/java/io/vertx/core/spi/tracing/Extractors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/tracing/TagExtractor.java
+++ b/src/main/java/io/vertx/core/spi/tracing/TagExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/spi/tracing/VertxTracer.java
+++ b/src/main/java/io/vertx/core/spi/tracing/VertxTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/streams/Pipe.java
+++ b/src/main/java/io/vertx/core/streams/Pipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/streams/Pump.java
+++ b/src/main/java/io/vertx/core/streams/Pump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/streams/ReadStream.java
+++ b/src/main/java/io/vertx/core/streams/ReadStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/streams/StreamBase.java
+++ b/src/main/java/io/vertx/core/streams/StreamBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/streams/WriteStream.java
+++ b/src/main/java/io/vertx/core/streams/WriteStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/streams/impl/InboundBuffer.java
+++ b/src/main/java/io/vertx/core/streams/impl/InboundBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/streams/impl/PipeImpl.java
+++ b/src/main/java/io/vertx/core/streams/impl/PipeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/streams/impl/PumpImpl.java
+++ b/src/main/java/io/vertx/core/streams/impl/PumpImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/streams/package-info.java
+++ b/src/main/java/io/vertx/core/streams/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main/java/io/vertx/core/tracing/TracingOptions.java
+++ b/src/main/java/io/vertx/core/tracing/TracingOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/benchmarks/io/vertx/benchmarks/ConcurrentCyclicSequenceBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/ConcurrentCyclicSequenceBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/benchmarks/io/vertx/benchmarks/ContextBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/ContextBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersContainsBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersContainsBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersEncodeBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersEncodeBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersSetBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersSetBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersUtils.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/benchmarks/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/benchmarks/io/vertx/benchmarks/JsonDecodeBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/JsonDecodeBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/benchmarks/io/vertx/benchmarks/JsonEncodeBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/JsonEncodeBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/benchmarks/io/vertx/core/impl/BenchmarkContext.java
+++ b/src/test/benchmarks/io/vertx/core/impl/BenchmarkContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/benchmarks/io/vertx/core/impl/VertxExecutorService.java
+++ b/src/test/benchmarks/io/vertx/core/impl/VertxExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/externals/MyVerticle.java
+++ b/src/test/externals/MyVerticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/externals/SomeFactoryImplA.java
+++ b/src/test/externals/SomeFactoryImplA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/AbstractVerticleTest.java
+++ b/src/test/java/io/vertx/core/AbstractVerticleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/BlockedThreadCheckerTest.java
+++ b/src/test/java/io/vertx/core/BlockedThreadCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/ClasspathVerticleFactory.java
+++ b/src/test/java/io/vertx/core/ClasspathVerticleFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/ClasspathVerticleFactoryTest.java
+++ b/src/test/java/io/vertx/core/ClasspathVerticleFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/ComplexHATest.java
+++ b/src/test/java/io/vertx/core/ComplexHATest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/ConversionHelperTest.java
+++ b/src/test/java/io/vertx/core/ConversionHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/CreateVertxTest.java
+++ b/src/test/java/io/vertx/core/CreateVertxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/CustomMetricsFactory.java
+++ b/src/test/java/io/vertx/core/CustomMetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/CustomMetricsOptions.java
+++ b/src/test/java/io/vertx/core/CustomMetricsOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/DeploymentTest.java
+++ b/src/test/java/io/vertx/core/DeploymentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/EventLoopGroupTest.java
+++ b/src/test/java/io/vertx/core/EventLoopGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/ExecuteBlockingTest.java
+++ b/src/test/java/io/vertx/core/ExecuteBlockingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/FakeFactoryImplA.java
+++ b/src/test/java/io/vertx/core/FakeFactoryImplA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/FakeFactoryImplB.java
+++ b/src/test/java/io/vertx/core/FakeFactoryImplB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/HATest.java
+++ b/src/test/java/io/vertx/core/HATest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/IsolatingClassLoaderTest.java
+++ b/src/test/java/io/vertx/core/IsolatingClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/LauncherTest.java
+++ b/src/test/java/io/vertx/core/LauncherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/NamedWorkerPoolTest.java
+++ b/src/test/java/io/vertx/core/NamedWorkerPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/NestedMetricsOptions.java
+++ b/src/test/java/io/vertx/core/NestedMetricsOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/ServiceHelperTest.java
+++ b/src/test/java/io/vertx/core/ServiceHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/StarterTest.java
+++ b/src/test/java/io/vertx/core/StarterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/TimerTest.java
+++ b/src/test/java/io/vertx/core/TimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/VerticleFactoryTest.java
+++ b/src/test/java/io/vertx/core/VerticleFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/VertxOptionsTest.java
+++ b/src/test/java/io/vertx/core/VertxOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/VertxTest.java
+++ b/src/test/java/io/vertx/core/VertxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/buffer/BufferTest.java
+++ b/src/test/java/io/vertx/core/buffer/BufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/AmbiguousOptionExceptionTest.java
+++ b/src/test/java/io/vertx/core/cli/AmbiguousOptionExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/OptionTest.java
+++ b/src/test/java/io/vertx/core/cli/OptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/converters/BooleanConverterTest.java
+++ b/src/test/java/io/vertx/core/cli/converters/BooleanConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/converters/CharacterConverterTest.java
+++ b/src/test/java/io/vertx/core/cli/converters/CharacterConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/converters/ConstructorBasedConverterTest.java
+++ b/src/test/java/io/vertx/core/cli/converters/ConstructorBasedConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/converters/ConvertersTest.java
+++ b/src/test/java/io/vertx/core/cli/converters/ConvertersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/converters/CustomConverterTest.java
+++ b/src/test/java/io/vertx/core/cli/converters/CustomConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/converters/Person.java
+++ b/src/test/java/io/vertx/core/cli/converters/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/converters/Person2.java
+++ b/src/test/java/io/vertx/core/cli/converters/Person2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/converters/Person3.java
+++ b/src/test/java/io/vertx/core/cli/converters/Person3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/converters/Person4.java
+++ b/src/test/java/io/vertx/core/cli/converters/Person4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/converters/Person4Converter.java
+++ b/src/test/java/io/vertx/core/cli/converters/Person4Converter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/impl/CLIConfiguratorTest.java
+++ b/src/test/java/io/vertx/core/cli/impl/CLIConfiguratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/impl/DefaultCLITest.java
+++ b/src/test/java/io/vertx/core/cli/impl/DefaultCLITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/impl/DefaultParserTest.java
+++ b/src/test/java/io/vertx/core/cli/impl/DefaultParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/impl/HelloClI.java
+++ b/src/test/java/io/vertx/core/cli/impl/HelloClI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/impl/IntensiveDefaultParserTest.java
+++ b/src/test/java/io/vertx/core/cli/impl/IntensiveDefaultParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/cli/impl/TypedArgumentTest.java
+++ b/src/test/java/io/vertx/core/cli/impl/TypedArgumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/datagram/DatagramTest.java
+++ b/src/test/java/io/vertx/core/datagram/DatagramTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/dns/DNSTest.java
+++ b/src/test/java/io/vertx/core/dns/DNSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/dns/HostnameResolutionTest.java
+++ b/src/test/java/io/vertx/core/dns/HostnameResolutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusStartFailureTest.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusStartFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTestBase.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusWithSSLTest.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusWithSSLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/eventbus/DeliveryOptionsTest.java
+++ b/src/test/java/io/vertx/core/eventbus/DeliveryOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/eventbus/EventBusFlowControlTest.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusFlowControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/eventbus/EventBusInterceptorTest.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/eventbus/EventBusRegistrationRaceTest.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusRegistrationRaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/eventbus/EventBusTestBase.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/eventbus/FaultToleranceTest.java
+++ b/src/test/java/io/vertx/core/eventbus/FaultToleranceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/eventbus/JsonEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/JsonEventBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/file/FileResolverTestBase.java
+++ b/src/test/java/io/vertx/core/file/FileResolverTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/file/FileSystemFileResolverTest.java
+++ b/src/test/java/io/vertx/core/file/FileSystemFileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/file/FileSystemOptionsTest.java
+++ b/src/test/java/io/vertx/core/file/FileSystemOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/file/FileSystemTest.java
+++ b/src/test/java/io/vertx/core/file/FileSystemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -1538,8 +1538,8 @@ public class FileSystemTest extends VertxTestBase {
         rs.setReadBufferSize(readBufferSize);
         final Buffer buff = Buffer.buffer();
         final int[] appendCount = new int[] {0};
-        rs.handler((rsBuff) -> { 
-          buff.appendBuffer(rsBuff); 
+        rs.handler((rsBuff) -> {
+          buff.appendBuffer(rsBuff);
           appendCount[0]++;
           });
         rs.exceptionHandler(t -> fail(t.getMessage()));

--- a/src/test/java/io/vertx/core/file/JarFileResolverTest.java
+++ b/src/test/java/io/vertx/core/file/JarFileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/file/JarFileResolverWithSpacesTest.java
+++ b/src/test/java/io/vertx/core/file/JarFileResolverWithSpacesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/file/NestedJarFileResolverTest.java
+++ b/src/test/java/io/vertx/core/file/NestedJarFileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/file/NestedRootJarResolverTest.java
+++ b/src/test/java/io/vertx/core/file/NestedRootJarResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/file/NestedZipFileResolverTest.java
+++ b/src/test/java/io/vertx/core/file/NestedZipFileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/file/ZipFileResolverTest.java
+++ b/src/test/java/io/vertx/core/file/ZipFileResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/file/impl/FileSystemImplTest.java
+++ b/src/test/java/io/vertx/core/file/impl/FileSystemImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/CaseInsensitiveHeadersTest.java
+++ b/src/test/java/io/vertx/core/http/CaseInsensitiveHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/Http1xMetricsTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/Http1xProxyTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/Http1xTLSTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTLSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/Http2ClientTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -1887,8 +1887,8 @@ public class Http2ClientTest extends Http2TestBase {
 
     await();
   }
-  
-  
+
+
   @Test
   public void testStreamPriority() throws Exception {
     StreamPriority requestStreamPriority = new StreamPriority().setDependency(123).setWeight((short)45).setExclusive(true);
@@ -1968,7 +1968,7 @@ public class Http2ClientTest extends Http2TestBase {
           }
           return super.onDataRead(ctx, streamId, data, padding, endOfStream);
       }
-      
+
     });
     ChannelFuture s = bootstrap.bind(DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT).sync();
     try {
@@ -2035,7 +2035,7 @@ public class Http2ClientTest extends Http2TestBase {
           }
           return super.onDataRead(ctx, streamId, data, padding, endOfStream);
       }
-      
+
     });
     ChannelFuture s = bootstrap.bind(DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT).sync();
     try {
@@ -2063,5 +2063,5 @@ public class Http2ClientTest extends Http2TestBase {
     }
   }
 
-  
+
 }

--- a/src/test/java/io/vertx/core/http/Http2CompressionTest.java
+++ b/src/test/java/io/vertx/core/http/Http2CompressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/Http2HeadersTest.java
+++ b/src/test/java/io/vertx/core/http/Http2HeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/Http2MetricsTest.java
+++ b/src/test/java/io/vertx/core/http/Http2MetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -3059,8 +3059,8 @@ public class Http2ServerTest extends Http2TestBase {
     assertEquals(Http1xOrH2CHandler.HTTP_2_PREFACE, res.toString(StandardCharsets.UTF_8));
     assertNull(ch.pipeline().get(TestHttp1xOrH2CHandler.class));
   }
-  
-  
+
+
   @Test
   public void testStreamPriority() throws Exception {
     StreamPriority requestStreamPriority = new StreamPriority().setDependency(123).setWeight((short)45).setExclusive(true);
@@ -3183,7 +3183,7 @@ public class Http2ServerTest extends Http2TestBase {
             }
             return super.onDataRead(ctx, streamId, data, padding, endOfStream);
         }
-        
+
       });
     });
     fut.sync();
@@ -3251,8 +3251,8 @@ public class Http2ServerTest extends Http2TestBase {
             }
             return super.onDataRead(ctx, streamId, data, padding, endOfStream);
         }
-        
-        
+
+
       });
     });
     fut.sync();

--- a/src/test/java/io/vertx/core/http/Http2SettingsTest.java
+++ b/src/test/java/io/vertx/core/http/Http2SettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/Http2TLSTest.java
+++ b/src/test/java/io/vertx/core/http/Http2TLSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/Http2Test.java
+++ b/src/test/java/io/vertx/core/http/Http2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -432,7 +432,7 @@ public class Http2Test extends HttpTest {
     })).end();
     await();
   }
-  
+
   @Test
   public void testStreamWeightAndDependency() throws Exception {
     int requestStreamDependency = 56;

--- a/src/test/java/io/vertx/core/http/Http2TestBase.java
+++ b/src/test/java/io/vertx/core/http/Http2TestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/HttpCompressionTest.java
+++ b/src/test/java/io/vertx/core/http/HttpCompressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/HttpConnectionEarlyResetTest.java
+++ b/src/test/java/io/vertx/core/http/HttpConnectionEarlyResetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
+++ b/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/HttpRequestStreamTest.java
+++ b/src/test/java/io/vertx/core/http/HttpRequestStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/HttpTestBase.java
+++ b/src/test/java/io/vertx/core/http/HttpTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/HttpUtilsTest.java
+++ b/src/test/java/io/vertx/core/http/HttpUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/VertxHttpHeadersTest.java
+++ b/src/test/java/io/vertx/core/http/VertxHttpHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/GlobalEventExecutorNotificationTest.java
+++ b/src/test/java/io/vertx/core/impl/GlobalEventExecutorNotificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/cpu/CpuCoreSensorTest.java
+++ b/src/test/java/io/vertx/core/impl/cpu/CpuCoreSensorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/DefaultCommandTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/DefaultCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/LauncherExtensibilityTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/LauncherExtensibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/ServiceCommandLoaderTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/ServiceCommandLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/VertxCommandLineInterfaceTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/VertxCommandLineInterfaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/BareCommandTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/BareCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/ClasspathHandlerTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/ClasspathHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/CommandTestBase.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/CommandTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/ComplexCommand.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/ComplexCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/ComplexCommandFactory.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/ComplexCommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/ExecUtilsTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/ExecUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/FileSelectorTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/FileSelectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/GoodByeCommand.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/GoodByeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/GoodByeCommandFactory.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/GoodByeCommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/Hello2Command.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/Hello2Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/Hello2CommandFactory.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/Hello2CommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/HelloCommand.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/HelloCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/HelloCommandFactory.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/HelloCommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/HiddenCommand.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/HiddenCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/HiddenCommandFactory.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/HiddenCommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/HttpTestVerticle.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/HttpTestVerticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/PriorityCommandTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/PriorityCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/RedeployTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/RedeployTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/RunCommandTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/RunCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/ServiceCommandLookupTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/ServiceCommandLookupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/StartStopListCommandsTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/StartStopListCommandsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/WatcherAbsolutePathTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/WatcherAbsolutePathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/launcher/commands/WatcherTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/WatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/transport/TransportTest.java
+++ b/src/test/java/io/vertx/core/impl/transport/TransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/impl/utils/ConcurrentCyclicSequenceTest.java
+++ b/src/test/java/io/vertx/core/impl/utils/ConcurrentCyclicSequenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/json/JsonArrayTest.java
+++ b/src/test/java/io/vertx/core/json/JsonArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/json/JsonObjectTest.java
+++ b/src/test/java/io/vertx/core/json/JsonObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/json/JsonPOJOMapperTest.java
+++ b/src/test/java/io/vertx/core/json/JsonPOJOMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/json/pointer/impl/JsonPointerTest.java
+++ b/src/test/java/io/vertx/core/json/pointer/impl/JsonPointerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/logging/LoggerFactoryTest.java
+++ b/src/test/java/io/vertx/core/logging/LoggerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/net/ConnectionPoolTest.java
+++ b/src/test/java/io/vertx/core/net/ConnectionPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/net/KeyStoreTest.java
+++ b/src/test/java/io/vertx/core/net/KeyStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/net/ProxyErrorTest.java
+++ b/src/test/java/io/vertx/core/net/ProxyErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/net/ProxyOptionsTest.java
+++ b/src/test/java/io/vertx/core/net/ProxyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/net/SSLEngineTest.java
+++ b/src/test/java/io/vertx/core/net/SSLEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/net/SSLHelperTest.java
+++ b/src/test/java/io/vertx/core/net/SSLHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/net/impl/KeyStoreHelperTest.java
+++ b/src/test/java/io/vertx/core/net/impl/KeyStoreHelperTest.java
@@ -1,14 +1,12 @@
-/**
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
 
@@ -45,7 +43,7 @@ public class KeyStoreHelperTest {
   /**
    * Verifies that the key store helper can read a PKCS#8 encoded RSA private key
    * from a PEM file.
-   * 
+   *
    * @throws Exception if the key cannot be read.
    */
   @Test
@@ -62,7 +60,7 @@ public class KeyStoreHelperTest {
   /**
    * Verifies that the key store helper can read a PKCS#8 encoded EC private key
    * from a PEM file.
-   * 
+   *
    * @throws Exception if the key cannot be read.
    */
   @Test

--- a/src/test/java/io/vertx/core/net/impl/URIDecoderTest.java
+++ b/src/test/java/io/vertx/core/net/impl/URIDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/net/impl/pkcs1/PrivateKeyParserTest.java
+++ b/src/test/java/io/vertx/core/net/impl/pkcs1/PrivateKeyParserTest.java
@@ -1,14 +1,12 @@
-/**
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- * SPDX-License-Identifier: EPL-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
 

--- a/src/test/java/io/vertx/core/parsetools/FakeStream.java
+++ b/src/test/java/io/vertx/core/parsetools/FakeStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/parsetools/JsonParserTest.java
+++ b/src/test/java/io/vertx/core/parsetools/JsonParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/parsetools/RecordParserTest.java
+++ b/src/test/java/io/vertx/core/parsetools/RecordParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/shareddata/AsyncMapTest.java
+++ b/src/test/java/io/vertx/core/shareddata/AsyncMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/shareddata/AsyncMultiMapTest.java
+++ b/src/test/java/io/vertx/core/shareddata/AsyncMultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/shareddata/AsynchronousLockTest.java
+++ b/src/test/java/io/vertx/core/shareddata/AsynchronousLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/shareddata/ClusteredAsyncMapTest.java
+++ b/src/test/java/io/vertx/core/shareddata/ClusteredAsyncMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/shareddata/ClusteredAsynchronousLockTest.java
+++ b/src/test/java/io/vertx/core/shareddata/ClusteredAsynchronousLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/shareddata/ClusteredSharedCounterTest.java
+++ b/src/test/java/io/vertx/core/shareddata/ClusteredSharedCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/shareddata/LocalAsyncMapTest.java
+++ b/src/test/java/io/vertx/core/shareddata/LocalAsyncMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/shareddata/LocalSharedDataTest.java
+++ b/src/test/java/io/vertx/core/shareddata/LocalSharedDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/shareddata/SharedCounterTest.java
+++ b/src/test/java/io/vertx/core/shareddata/SharedCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsOptionsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/metrics/SimpleVertxMetricsFactory.java
+++ b/src/test/java/io/vertx/core/spi/metrics/SimpleVertxMetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/ClusteredEventBusTracerTest.java
+++ b/src/test/java/io/vertx/core/spi/tracing/ClusteredEventBusTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/ClusteredEventBusTracingTest.java
+++ b/src/test/java/io/vertx/core/spi/tracing/ClusteredEventBusTracingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/EventBusTracerTestBase.java
+++ b/src/test/java/io/vertx/core/spi/tracing/EventBusTracerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/EventBusTracingTestBase.java
+++ b/src/test/java/io/vertx/core/spi/tracing/EventBusTracingTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/Http1xTracerTest.java
+++ b/src/test/java/io/vertx/core/spi/tracing/Http1xTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/Http1xTracingTest.java
+++ b/src/test/java/io/vertx/core/spi/tracing/Http1xTracingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/Http2TracerTest.java
+++ b/src/test/java/io/vertx/core/spi/tracing/Http2TracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/Http2TracingTest.java
+++ b/src/test/java/io/vertx/core/spi/tracing/Http2TracingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/HttpTracerTestBase.java
+++ b/src/test/java/io/vertx/core/spi/tracing/HttpTracerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/HttpTracingTestBase.java
+++ b/src/test/java/io/vertx/core/spi/tracing/HttpTracingTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/LocalEventBusTracerTest.java
+++ b/src/test/java/io/vertx/core/spi/tracing/LocalEventBusTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/LocalEventBusTracingTest.java
+++ b/src/test/java/io/vertx/core/spi/tracing/LocalEventBusTracingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/spi/tracing/TracerTest.java
+++ b/src/test/java/io/vertx/core/spi/tracing/TracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/streams/InboundBufferTest.java
+++ b/src/test/java/io/vertx/core/streams/InboundBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/streams/PipeTest.java
+++ b/src/test/java/io/vertx/core/streams/PipeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/streams/PumpTest.java
+++ b/src/test/java/io/vertx/core/streams/PumpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/core/streams/WriteStreamTest.java
+++ b/src/test/java/io/vertx/core/streams/WriteStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/it/CustomJsonCodecTest.java
+++ b/src/test/java/io/vertx/it/CustomJsonCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/it/CustomJsonFactory.java
+++ b/src/test/java/io/vertx/it/CustomJsonFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/it/JULLogDelegateTest.java
+++ b/src/test/java/io/vertx/it/JULLogDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/it/JsonCodecTest.java
+++ b/src/test/java/io/vertx/it/JsonCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/it/JsonTest.java
+++ b/src/test/java/io/vertx/it/JsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/it/Log4J2LogDelegateTest.java
+++ b/src/test/java/io/vertx/it/Log4J2LogDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/it/NettyCompatTest.java
+++ b/src/test/java/io/vertx/it/NettyCompatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/it/Recording.java
+++ b/src/test/java/io/vertx/it/Recording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/it/SLF4JLogDelegateTest.java
+++ b/src/test/java/io/vertx/it/SLF4JLogDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/it/SSLEngineTest.java
+++ b/src/test/java/io/vertx/it/SSLEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/it/StreamRecording.java
+++ b/src/test/java/io/vertx/it/StreamRecording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/it/TransportTest.java
+++ b/src/test/java/io/vertx/it/TransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/core/AsyncTestBase.java
+++ b/src/test/java/io/vertx/test/core/AsyncTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/core/AsyncTestBaseTest.java
+++ b/src/test/java/io/vertx/test/core/AsyncTestBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/core/BlockedThreadWarning.java
+++ b/src/test/java/io/vertx/test/core/BlockedThreadWarning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/core/CheckingSender.java
+++ b/src/test/java/io/vertx/test/core/CheckingSender.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.test.core;
 
 import io.vertx.core.Context;

--- a/src/test/java/io/vertx/test/core/Repeat.java
+++ b/src/test/java/io/vertx/test/core/Repeat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/core/RepeatRule.java
+++ b/src/test/java/io/vertx/test/core/RepeatRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/core/TestUtils.java
+++ b/src/test/java/io/vertx/test/core/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/core/VertxTestBase.java
+++ b/src/test/java/io/vertx/test/core/VertxTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakecluster/ChoosableSet.java
+++ b/src/test/java/io/vertx/test/fakecluster/ChoosableSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
+++ b/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakedns/FakeDNSServer.java
+++ b/src/test/java/io/vertx/test/fakedns/FakeDNSServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat, Inc. and others
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/EndpointMetric.java
+++ b/src/test/java/io/vertx/test/fakemetrics/EndpointMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/FakeDatagramSocketMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeDatagramSocketMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/FakeEventBusMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeEventBusMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/FakeHttpClientMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeHttpClientMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/FakeHttpServerMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeHttpServerMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/FakeMetricsBase.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeMetricsBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/FakeMetricsFactory.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeMetricsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/FakePoolMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakePoolMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/HandlerMetric.java
+++ b/src/test/java/io/vertx/test/fakemetrics/HandlerMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/HttpClientMetric.java
+++ b/src/test/java/io/vertx/test/fakemetrics/HttpClientMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/HttpServerMetric.java
+++ b/src/test/java/io/vertx/test/fakemetrics/HttpServerMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/PacketMetric.java
+++ b/src/test/java/io/vertx/test/fakemetrics/PacketMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/ReceivedMessage.java
+++ b/src/test/java/io/vertx/test/fakemetrics/ReceivedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/SentMessage.java
+++ b/src/test/java/io/vertx/test/fakemetrics/SentMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/SocketMetric.java
+++ b/src/test/java/io/vertx/test/fakemetrics/SocketMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakemetrics/WebSocketMetric.java
+++ b/src/test/java/io/vertx/test/fakemetrics/WebSocketMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakestream/FakeStream.java
+++ b/src/test/java/io/vertx/test/fakestream/FakeStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/fakestream/FakeStreamTest.java
+++ b/src/test/java/io/vertx/test/fakestream/FakeStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/faketracer/FakeTracer.java
+++ b/src/test/java/io/vertx/test/faketracer/FakeTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/faketracer/Scope.java
+++ b/src/test/java/io/vertx/test/faketracer/Scope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/faketracer/Span.java
+++ b/src/test/java/io/vertx/test/faketracer/Span.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/netty/TestLoggerFactory.java
+++ b/src/test/java/io/vertx/test/netty/TestLoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/proxy/HttpProxy.java
+++ b/src/test/java/io/vertx/test/proxy/HttpProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/proxy/Socks4Proxy.java
+++ b/src/test/java/io/vertx/test/proxy/Socks4Proxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/proxy/SocksProxy.java
+++ b/src/test/java/io/vertx/test/proxy/SocksProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/proxy/TestProxyBase.java
+++ b/src/test/java/io/vertx/test/proxy/TestProxyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/spi/FakeFactory.java
+++ b/src/test/java/io/vertx/test/spi/FakeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/spi/NotImplementedSPI.java
+++ b/src/test/java/io/vertx/test/spi/NotImplementedSPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/spi/SomeFactory.java
+++ b/src/test/java/io/vertx/test/spi/SomeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/tls/Cert.java
+++ b/src/test/java/io/vertx/test/tls/Cert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/tls/Trust.java
+++ b/src/test/java/io/vertx/test/tls/Trust.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/verticles/ExtraCPVerticleAlreadyInParentLoader.java
+++ b/src/test/java/io/vertx/test/verticles/ExtraCPVerticleAlreadyInParentLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/verticles/ExtraCPVerticleNotInParentLoader.java
+++ b/src/test/java/io/vertx/test/verticles/ExtraCPVerticleNotInParentLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/verticles/FaultToleranceVerticle.java
+++ b/src/test/java/io/vertx/test/verticles/FaultToleranceVerticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/verticles/HAVerticle1.java
+++ b/src/test/java/io/vertx/test/verticles/HAVerticle1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/verticles/HAVerticle2.java
+++ b/src/test/java/io/vertx/test/verticles/HAVerticle2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/verticles/HAVerticle3.java
+++ b/src/test/java/io/vertx/test/verticles/HAVerticle3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/verticles/SimpleServer.java
+++ b/src/test/java/io/vertx/test/verticles/SimpleServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/verticles/TestVerticle.java
+++ b/src/test/java/io/vertx/test/verticles/TestVerticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/verticles/TestVerticle2.java
+++ b/src/test/java/io/vertx/test/verticles/TestVerticle2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/verticles/TestVerticle3.java
+++ b/src/test/java/io/vertx/test/verticles/TestVerticle3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/verticles/sourceverticle/SourceVerticle.java
+++ b/src/test/java/io/vertx/test/verticles/sourceverticle/SourceVerticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/test/java/io/vertx/test/verticles/sourceverticle/somepackage/OtherSourceVerticle.java
+++ b/src/test/java/io/vertx/test/verticles/sourceverticle/somepackage/OtherSourceVerticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at


### PR DESCRIPTION
This also:

1. updates copyright to 2011-2019,
2. adds missing headers,
3. harmonizes to "Contributors to the Eclipse Foundation"
   (replacing a "Copyright Red Hat, Inc." by that is correct).
