### PR TITLE
Fixes incomplete promise when a child verticle could not be deployed …

### DIFF
--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -463,8 +463,7 @@ public class DeploymentManager {
                   deployment.child = true;
                 } else {
                   // Orphan
-                  deployment.undeploy(event -> {});
-                  promise.fail("Verticle deployment failed.Could not be added as child of parent verticle");
+                  deployment.undeploy(event -> promise.fail("Verticle deployment failed.Could not be added as child of parent verticle"));
                   return;
                 }
               }

--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -463,7 +463,8 @@ public class DeploymentManager {
                   deployment.child = true;
                 } else {
                   // Orphan
-                  deployment.undeploy(null);
+                  deployment.undeploy(event -> {});
+                  promise.fail("Verticle deployment failed.Could not be added as child of parent verticle");
                   return;
                 }
               }

--- a/src/test/java/io/vertx/core/DeploymentTest.java
+++ b/src/test/java/io/vertx/core/DeploymentTest.java
@@ -1235,6 +1235,28 @@ public class DeploymentTest extends VertxTestBase {
   }
 
   @Test
+  public void testDeployChildOnParentUndeploy() throws Exception {
+    class ParentVerticle extends AbstractVerticle {
+      @Override
+      public void stop(Promise<Void> stopPromise) {
+        vertx.deployVerticle(ChildVerticle.class.getName())
+          .<Void>mapEmpty()
+          .setHandler(stopPromise);
+      }
+    }
+
+    CountDownLatch latch = new CountDownLatch(1);
+    vertx.deployVerticle(new ParentVerticle(), ar1 -> {
+      assertTrue(ar1.succeeded());
+      vertx.undeploy(ar1.result(), ar2 -> {
+        assertFalse(ar2.succeeded());
+        latch.countDown();
+      });
+    });
+    awaitLatch(latch);
+  }
+
+  @Test
   public void testUndeployAllFailureInUndeploy() throws Exception {
     int numVerticles = 10;
     List<MyVerticle> verticles = new ArrayList<>();

--- a/src/test/java/io/vertx/core/DeploymentTest.java
+++ b/src/test/java/io/vertx/core/DeploymentTest.java
@@ -1246,13 +1246,8 @@ public class DeploymentTest extends VertxTestBase {
     }
 
     CountDownLatch latch = new CountDownLatch(1);
-    vertx.deployVerticle(new ParentVerticle(), ar1 -> {
-      assertTrue(ar1.succeeded());
-      vertx.undeploy(ar1.result(), ar2 -> {
-        assertFalse(ar2.succeeded());
-        latch.countDown();
-      });
-    });
+    vertx.deployVerticle(new ParentVerticle(), onSuccess(id ->
+      vertx.undeploy(id, onFailure(u -> latch.countDown()))));
     awaitLatch(latch);
   }
 

--- a/src/test/java/io/vertx/core/DeploymentTest.java
+++ b/src/test/java/io/vertx/core/DeploymentTest.java
@@ -1235,7 +1235,7 @@ public class DeploymentTest extends VertxTestBase {
   }
 
   @Test
-  public void testDeployChildOnParentUndeploy() throws Exception {
+  public void testDeployChildOnParentUndeploy() {
     class ParentVerticle extends AbstractVerticle {
       @Override
       public void stop(Promise<Void> stopPromise) {
@@ -1245,10 +1245,9 @@ public class DeploymentTest extends VertxTestBase {
       }
     }
 
-    CountDownLatch latch = new CountDownLatch(1);
     vertx.deployVerticle(new ParentVerticle(), onSuccess(id ->
-      vertx.undeploy(id, onFailure(u -> latch.countDown()))));
-    awaitLatch(latch);
+      vertx.undeploy(id, onFailure(u -> testComplete()))));
+    await();
   }
 
   @Test


### PR DESCRIPTION
…because its parent has been undeployed

Signed-off-by: zenios <dimitris.zenios@gmail.com>

Not sure if its better to wait for underemployment to complete and then fail the promise.