### PR TITLE
Replace LinkedBlockingQueue with LinkedTransferQueue in worker-pool

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -148,8 +148,10 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
     metrics = initialiseMetrics(options);
 
-    ExecutorService workerExec = Executors.newFixedThreadPool(options.getWorkerPoolSize(),
-        new VertxThreadFactory("vert.x-worker-thread-", checker, true, options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit()));
+    int workerPoolSize = options.getWorkerPoolSize();
+    ExecutorService workerExec = new ThreadPoolExecutor(workerPoolSize, workerPoolSize,
+      0L, TimeUnit.MILLISECONDS, new LinkedTransferQueue<>(),
+      new VertxThreadFactory("vert.x-worker-thread-", checker, true, options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit()));
     PoolMetrics workerPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-worker-thread", options.getWorkerPoolSize()) : null;
     ExecutorService internalBlockingExec = Executors.newFixedThreadPool(options.getInternalBlockingPoolSize(),
         new VertxThreadFactory("vert.x-internal-blocking-", checker, true, options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit()));


### PR DESCRIPTION
This is an alternative to #3182 that performs equally well to JCTools' queues in tested quarkus scenario. (Despite LTQ had lower performance in the synthetic benchmark).

I believe that this change can't have any negative impact on Vert.x, uses a well-established queue and solves the scaling problem for Quarkus.