### PR TITLE
Proposal for same site cookie value

### DIFF
--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -26,6 +26,32 @@ Require client to present authentication, if not presented then negotiations wil
 +++
 |===
 
+[[CookieSameSite]]
+== CookieSameSite
+
+++++
+ Represents the Cookie SameSite policy to be used. For more info <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies">https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies</a>.
+++++
+'''
+
+[cols=">25%,75%"]
+[frame="topbot"]
+|===
+^|Name | Description
+|[[NONE]]`NONE`|+++
+The browser will send cookies with both cross-site requests and same-site requests.
++++
+|[[STRICT]]`STRICT`|+++
+The browser will only send cookies for same-site requests (requests originating from the site that set the cookie).
+ If the request originated from a different URL than the URL of the current location, none of the cookies tagged
+ with the Strict attribute will be included.
++++
+|[[LAX]]`LAX`|+++
+Same-site cookies are withheld on cross-site subrequests, such as calls to load images or frames, but will be sent
+ when a user navigates to the URL from an external site; for example, by following a link.
++++
+|===
+
 [[DnsResponseCode]]
 == DnsResponseCode
 

--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -351,6 +351,19 @@ browser can store them.
 Cookies are described by instances of {@link io.vertx.core.http.Cookie}. This allows you to retrieve the name,
 value, domain, path and other normal cookie properties.
 
+Same Site Cookies let servers require that a cookie shouldn't be sent with cross-site (where Site is defined by the
+registrable domain) requests, which provides some protection against cross-site request forgery attacks. This kind
+of cookies are enabled using the setter: {@link io.vertx.core.http.Cookie#setSameSite(CookieSameSite)}.
+
+Same site cookies can have one of 3 values:
+
+* None - The browser will send cookies with both cross-site requests and same-site requests.
+* Strict - he browser will only send cookies for same-site requests (requests originating from the site that set the
+  cookie). If the request originated from a different URL than the URL of the current location, none of the cookies
+  tagged with the Strict attribute will be included.
+* Lax - Same-site cookies are withheld on cross-site subrequests, such as calls to load images or frames, but will be
+  sent when a user navigates to the URL from an external site; for example, by following a link.
+
 Here's an example of querying and adding cookies:
 
 [source,$lang]

--- a/src/main/java/io/vertx/core/http/Cookie.java
+++ b/src/main/java/io/vertx/core/http/Cookie.java
@@ -121,12 +121,11 @@ public interface Cookie {
   /**
    * Sets the same site of this cookie.
    *
-   * @param policy The policy should be one of {@code Lax}, {@code Strict} or {@code None}
+   * @param policy The policy should be one of {@link CookieSameSite}.
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  Cookie setSameSite(String policy);
-
+  Cookie setSameSite(CookieSameSite policy);
 
   /**
    * Encode the cookie to a string. This is what is used in the Set-Cookie header

--- a/src/main/java/io/vertx/core/http/Cookie.java
+++ b/src/main/java/io/vertx/core/http/Cookie.java
@@ -119,6 +119,16 @@ public interface Cookie {
   Cookie setHttpOnly(boolean httpOnly);
 
   /**
+   * Sets the same site of this cookie.
+   *
+   * @param policy The policy should be one of {@code Lax}, {@code Strict} or {@code None}
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  Cookie setSameSite(String policy);
+
+
+  /**
    * Encode the cookie to a string. This is what is used in the Set-Cookie header
    *
    * @return  the encoded cookie

--- a/src/main/java/io/vertx/core/http/CookieSameSite.java
+++ b/src/main/java/io/vertx/core/http/CookieSameSite.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * Represents the Cookie SameSite policy to be used. For more info <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies">https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies</a>.
+ *
+ * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
+ */
+@VertxGen
+public enum CookieSameSite {
+
+  /**
+   * The browser will send cookies with both cross-site requests and same-site requests.
+   */
+  NONE("None"),
+
+  /**
+   * The browser will only send cookies for same-site requests (requests originating from the site that set the cookie).
+   * If the request originated from a different URL than the URL of the current location, none of the cookies tagged
+   * with the Strict attribute will be included.
+   */
+  STRICT("Strict"),
+
+  /**
+   * Same-site cookies are withheld on cross-site subrequests, such as calls to load images or frames, but will be sent
+   * when a user navigates to the URL from an external site; for example, by following a link.
+   */
+  LAX("Lax");
+
+  /**
+   * Just use a human friendly label instead of the capitalized name.
+   */
+  private final String label;
+
+  CookieSameSite(String label) {
+    this.label = label;
+  }
+
+  @Override
+  public String toString() {
+    return label;
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/CookieImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/CookieImpl.java
@@ -15,6 +15,7 @@ import io.netty.handler.codec.http.cookie.DefaultCookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 import io.vertx.core.http.Cookie;
+import io.vertx.core.http.CookieSameSite;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -64,7 +65,7 @@ public class CookieImpl implements ServerCookie {
   private boolean changed;
   private boolean fromUserAgent;
   // extension features
-  private String sameSite;
+  private CookieSameSite sameSite;
 
   public CookieImpl(String name, String value) {
     this.nettyCookie = new DefaultCookie(name, value);
@@ -139,30 +140,7 @@ public class CookieImpl implements ServerCookie {
   }
 
   @Override
-  public Cookie setSameSite(final String sameSite) {
-    if (sameSite != null) {
-      // validate
-      int length = sameSite.length();
-      switch (length) {
-        case 3:
-          if (!sameSite.equalsIgnoreCase("LAX")) {
-            throw new IllegalArgumentException("sameSite contains an invalid value: " + sameSite);
-          }
-          break;
-        case 4:
-          if (!sameSite.equalsIgnoreCase("NONE")) {
-            throw new IllegalArgumentException("sameSite contains an invalid value: " + sameSite);
-          }
-          break;
-        case 6:
-          if (!sameSite.equalsIgnoreCase("STRICT")) {
-            throw new IllegalArgumentException("sameSite contains an invalid value: " + sameSite);
-          }
-          break;
-        default:
-          throw new IllegalArgumentException("sameSite contains an invalid value: " + sameSite);
-      }
-    }
+  public Cookie setSameSite(final CookieSameSite sameSite) {
     this.sameSite = sameSite;
     this.changed = true;
     return this;
@@ -171,7 +149,7 @@ public class CookieImpl implements ServerCookie {
   @Override
   public String encode() {
     if (sameSite != null) {
-      return ServerCookieEncoder.STRICT.encode(nettyCookie) + "; SameSite=" + sameSite;
+      return ServerCookieEncoder.STRICT.encode(nettyCookie) + "; SameSite=" + sameSite.toString();
     } else {
       return ServerCookieEncoder.STRICT.encode(nettyCookie);
     }

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -5405,15 +5405,15 @@ public abstract class HttpTest extends HttpTestBase {
 
   @Test
   public void testCookieSameSiteFieldEncoding() throws Exception {
-    Cookie cookie = Cookie.cookie("foo", "bar").setSameSite("lax");
+    Cookie cookie = Cookie.cookie("foo", "bar").setSameSite(CookieSameSite.LAX);
     assertEquals("foo", cookie.getName());
     assertEquals("bar", cookie.getValue());
-    assertEquals("foo=bar; SameSite=lax", cookie.encode());
+    assertEquals("foo=bar; SameSite=Lax", cookie.encode());
 
     cookie.setSecure(true);
-    assertEquals("foo=bar; Secure; SameSite=lax", cookie.encode());
+    assertEquals("foo=bar; Secure; SameSite=Lax", cookie.encode());
     cookie.setHttpOnly(true);
-    assertEquals("foo=bar; Secure; HTTPOnly; SameSite=lax", cookie.encode());
+    assertEquals("foo=bar; Secure; HTTPOnly; SameSite=Lax", cookie.encode());
   }
 
   @Test
@@ -5421,35 +5421,16 @@ public abstract class HttpTest extends HttpTestBase {
     Cookie cookie = Cookie.cookie("foo", "bar");
 
     try {
-      cookie.setSameSite("Lax");
+      cookie.setSameSite(CookieSameSite.LAX);
       // OK
-      cookie.setSameSite("Strict");
+      cookie.setSameSite(CookieSameSite.STRICT);
       // OK
-      cookie.setSameSite("NoNe");
+      cookie.setSameSite(CookieSameSite.NONE);
       // OK
       cookie.setSameSite(null);
       // OK
     } catch (RuntimeException e) {
       fail();
-    }
-
-    try {
-      cookie.setSameSite("XYZ");
-      fail();
-    } catch (RuntimeException e) {
-      // OK
-    }
-    try {
-      cookie.setSameSite("DURP");
-      fail();
-    } catch (RuntimeException e) {
-      // OK
-    }
-    try {
-      cookie.setSameSite("some random stuff");
-      fail();
-    } catch (RuntimeException e) {
-      // OK
     }
   }
 

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -5404,6 +5404,56 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
+  public void testCookieSameSiteFieldEncoding() throws Exception {
+    Cookie cookie = Cookie.cookie("foo", "bar").setSameSite("lax");
+    assertEquals("foo", cookie.getName());
+    assertEquals("bar", cookie.getValue());
+    assertEquals("foo=bar; SameSite=lax", cookie.encode());
+
+    cookie.setSecure(true);
+    assertEquals("foo=bar; Secure; SameSite=lax", cookie.encode());
+    cookie.setHttpOnly(true);
+    assertEquals("foo=bar; Secure; HTTPOnly; SameSite=lax", cookie.encode());
+  }
+
+  @Test
+  public void testCookieSameSiteFieldValidation() throws Exception {
+    Cookie cookie = Cookie.cookie("foo", "bar");
+
+    try {
+      cookie.setSameSite("Lax");
+      // OK
+      cookie.setSameSite("Strict");
+      // OK
+      cookie.setSameSite("NoNe");
+      // OK
+      cookie.setSameSite(null);
+      // OK
+    } catch (RuntimeException e) {
+      fail();
+    }
+
+    try {
+      cookie.setSameSite("XYZ");
+      fail();
+    } catch (RuntimeException e) {
+      // OK
+    }
+    try {
+      cookie.setSameSite("DURP");
+      fail();
+    } catch (RuntimeException e) {
+      // OK
+    }
+    try {
+      cookie.setSameSite("some random stuff");
+      fail();
+    } catch (RuntimeException e) {
+      // OK
+    }
+  }
+
+  @Test
   public void testRemoveCookies() throws Exception {
     testCookies("foo=bar", req -> {
       Cookie removed = req.response().removeCookie("foo");


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

This PR is a proposal to support same site policy for cookies (server side only). There is no parsing involved (as that is a feature only applicable to browsers).

The Same Site policy is supported by all major browsers and a security feature to prevent cross site request forgery.

Although this isn't present in netty (yet) discussions seem to show that this will only land on the 5.x branch which means vertx can't offer the current owasp recommendation on cookies https://www.owasp.org/index.php/SameSite 

As a workaround this PR allows users to build secure cookie based applications and once support lands upstream we can easily drop this and fully support it.

Also note that the chrome team will be "strict" with this flag:

https://www.chromium.org/updates/same-site
