### PR TITLE
Avoid eventbus npe on verticle factories

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -171,8 +171,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     this.fileResolver = new FileResolver(options.getFileSystemOptions());
     this.addressResolverOptions = options.getAddressResolverOptions();
     this.addressResolver = new AddressResolver(this, options.getAddressResolverOptions());
-    this.deploymentManager = new DeploymentManager(this);
-    this.verticleManager = new VerticleManager(this, deploymentManager);
     this.tracer = initializeTracer(options);
     if (options.getEventBusOptions().isClustered()) {
       this.clusterManager = getClusterManager(options);
@@ -182,6 +180,8 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       this.eventBus = new EventBusImpl(this);
     }
     this.sharedData = new SharedDataImpl(this, clusterManager);
+    this.deploymentManager = new DeploymentManager(this);
+    this.verticleManager = new VerticleManager(this, deploymentManager);
   }
 
   private void init() {

--- a/src/test/java/io/vertx/core/AccessEventBusFromInitVerticleFactory.java
+++ b/src/test/java/io/vertx/core/AccessEventBusFromInitVerticleFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core;
+
+import io.vertx.core.spi.VerticleFactory;
+
+import java.util.concurrent.Callable;
+
+public class AccessEventBusFromInitVerticleFactory implements VerticleFactory {
+
+  @Override
+  public void init(Vertx vertx) {
+    // should not be null
+    if (vertx.eventBus() == null) {
+      throw new IllegalStateException("eventBus was null, while it shouldn't");
+    }
+    if (vertx.sharedData() == null) {
+      throw new IllegalStateException("sharedData was null, while it shouldn't");
+    }
+  }
+
+  @Override
+  public String prefix() {
+    return "invalid";
+  }
+
+  @Override
+  public void createVerticle(String verticleName, ClassLoader classLoader, Promise<Callable<Verticle>> promise) {
+    promise.complete();
+  }
+
+  @Override
+  public void close() {
+
+  }
+}

--- a/src/test/java/io/vertx/core/AccessEventBusFromInitVerticleFactoryTest.java
+++ b/src/test/java/io/vertx/core/AccessEventBusFromInitVerticleFactoryTest.java
@@ -1,0 +1,20 @@
+package io.vertx.core;
+
+import io.vertx.core.spi.VerticleFactory;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+public class AccessEventBusFromInitVerticleFactoryTest extends VertxTestBase {
+
+  @Test
+  public void testLoadFactoryThatCheckEventBusAndSharedDataForNull() {
+    assertEquals(2, vertx.verticleFactories().size());
+    boolean found = false;
+    for (VerticleFactory fact : vertx.verticleFactories()) {
+      if (fact instanceof AccessEventBusFromInitVerticleFactory) {
+        found = true;
+      }
+    }
+    assertTrue(found);
+  }
+}

--- a/src/test/java/io/vertx/core/ClasspathVerticleFactoryTest.java
+++ b/src/test/java/io/vertx/core/ClasspathVerticleFactoryTest.java
@@ -22,8 +22,13 @@ public class ClasspathVerticleFactoryTest extends VertxTestBase {
 
   @Test
   public void testLoadedFromClasspath() {
-    assertEquals(1, vertx.verticleFactories().size());
-    VerticleFactory fact = vertx.verticleFactories().iterator().next();
-    assertTrue(fact instanceof ClasspathVerticleFactory);
+    assertEquals(2, vertx.verticleFactories().size());
+    boolean found = false;
+    for (VerticleFactory fact : vertx.verticleFactories()) {
+      if (fact instanceof ClasspathVerticleFactory) {
+        found = true;
+      }
+    }
+    assertTrue(found);
   }
 }

--- a/src/test/java/io/vertx/core/VerticleFactoryTest.java
+++ b/src/test/java/io/vertx/core/VerticleFactoryTest.java
@@ -29,9 +29,10 @@ public class VerticleFactoryTest extends VertxTestBase {
 
   public void setUp() throws Exception {
     super.setUp();
-    // Unregister the factory that's loaded from the classpath
-    VerticleFactory factory = vertx.verticleFactories().iterator().next();
-    vertx.unregisterVerticleFactory(factory);
+    // Unregister the factories that are loaded from the classpath
+    for (VerticleFactory factory : vertx.verticleFactories()) {
+      vertx.unregisterVerticleFactory(factory);
+    }
   }
 
   @Test

--- a/src/test/resources/META-INF/services/io.vertx.core.spi.VerticleFactory
+++ b/src/test/resources/META-INF/services/io.vertx.core.spi.VerticleFactory
@@ -1,1 +1,2 @@
 io.vertx.core.ClasspathVerticleFactory
+io.vertx.core.AccessEventBusFromInitVerticleFactory


### PR DESCRIPTION
Verticle factories will see an NPE on `vertx.eventBus().xxx()` because the object is only initialized later. Changing the order will avoid it, and allow factories to access the eventbus for doing stuff like registering custom codecs, etc... 