### PR TITLE
Added Mime-Type for web assembly

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/MimeMapping.java
+++ b/src/main/java/io/vertx/core/http/impl/MimeMapping.java
@@ -576,6 +576,7 @@ public class MimeMapping {
     m.put("zirz", "application/vnd.zul");
     m.put("zaz", "application/vnd.zzazz.deck+xml");
     m.put("vxml", "application/voicexml+xml");
+    m.put("wasm", "application/wasm");
     m.put("wgt", "application/widget");
     m.put("hlp", "application/winhlp");
     m.put("wsdl", "application/wsdl+xml");


### PR DESCRIPTION
While experimenting with Rust/WASM I found out that the StaticHandler was using the wrong MIME-Type for WASM files which breaks them in the bbrowser. This is due to the MIME-Type missing in MimeMapping.
This PR adds the **applicsation/wasm**.