### PR TITLE
Fixes #3227

### DIFF
--- a/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -35,6 +35,8 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -270,7 +272,7 @@ public class JacksonCodec implements JsonCodec {
         generator.writeEndObject();
       } else if (json instanceof List) {
         generator.writeStartArray();
-        for (Object item : (List)json) {
+        for (Object item : (List<?>) json) {
           encodeJson(item, generator);
         }
         generator.writeEndArray();
@@ -287,15 +289,24 @@ public class JacksonCodec implements JsonCodec {
           generator.writeNumber((Float) json);
         } else if (json instanceof Double) {
           generator.writeNumber((Double) json);
+        } else if (json instanceof BigInteger) {
+          generator.writeNumber((BigInteger) json);
+        } else if (json instanceof BigDecimal) {
+          generator.writeNumber((BigDecimal) json);
         } else {
           throw new UnsupportedOperationException();
         }
       } else if (json instanceof Boolean) {
         generator.writeBoolean((Boolean)json);
       } else if (json instanceof Instant) {
+        // RFC-7493
         generator.writeString((ISO_INSTANT.format((Instant)json)));
       } else if (json instanceof byte[]) {
+        // RFC-7493
         generator.writeString(BASE64_ENCODER.encodeToString((byte[]) json));
+      } else if (json instanceof Enum) {
+        // vert.x extra (non standard but allowed conversion)
+        generator.writeString(((Enum<?>) json).name());
       } else if (json == null) {
         generator.writeNull();
       } else {

--- a/src/test/java/io/vertx/core/json/JsonCodecTest.java
+++ b/src/test/java/io/vertx/core/json/JsonCodecTest.java
@@ -12,6 +12,7 @@ package io.vertx.core.json;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.impl.Utils;
 import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.core.json.jackson.JacksonCodec;
@@ -22,6 +23,8 @@ import org.junit.runners.Parameterized;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
@@ -393,6 +396,24 @@ public class JsonCodecTest {
     assertDecodeValue(Buffer.buffer("[0,1,2]"), Arrays.asList(0, 1, 2), LIST_TYPE_REF);
     assertDecodeValue(Buffer.buffer("true"), true, BOOLEAN_TYPE_REF);
     assertDecodeValue(Buffer.buffer("false"), false, BOOLEAN_TYPE_REF);
+  }
+
+  @Test
+  public void testEnumValue() {
+    // just a random enum
+    Buffer json = mapper.toBuffer(HttpMethod.CONNECT);
+    assertNotNull(json);
+    assertEquals("\"CONNECT\"", json.toString());
+  }
+
+  @Test
+  public void testBigNumberValues() {
+    Buffer json = mapper.toBuffer(new BigDecimal("124567890124567890.09876543210987654321"));
+    assertNotNull(json);
+    assertEquals("124567890124567890.09876543210987654321", json.toString());
+    Buffer json2 = mapper.toBuffer(new BigInteger("12456789009876543211245678900987654321"));
+    assertNotNull(json2);
+    assertEquals("12456789009876543211245678900987654321", json2.toString());
   }
 
   private <T> void assertDecodeValue(Buffer buffer, T expected, TypeReference<T> ref) {


### PR DESCRIPTION
Brings JacksonCore codec on par with Databind for enum and big numbers.