### PR TITLE
Added default value for query parameters.

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -29,6 +29,7 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a server-side HTTP request.
@@ -203,6 +204,19 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   @Nullable
   default String getParam(String paramName) {
     return params().get(paramName);
+  }
+
+  /**
+   * Return the first param value with the specified name or {@code defaultValue} when the query param is not present
+   *
+   * @param paramName    the param name
+   * @param defaultValue the default value, must be non-null
+   * @return the param value or {@code defaultValue} when not present
+   */
+  default String getParam(String paramName, String defaultValue) {
+    Objects.requireNonNull(defaultValue, "defaultValue");
+    final String paramValue = params().get(paramName);
+    return paramValue != null ? paramValue : defaultValue;
   }
 
   /**

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -857,6 +857,32 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
+  public void testGetParamDefaultValue() {
+    String paramName1 = "foo";
+    String paramName1Value = "bar";
+    String paramName2 = "notPresentParam";
+    String paramName2DefaultValue = "defaultValue";
+    String reqUri = DEFAULT_TEST_URI + "/?" + paramName1 + "=" + paramName1Value;
+
+    server.requestHandler(req -> {
+      assertTrue(req.params().contains(paramName1));
+      assertEquals(paramName1Value, req.getParam(paramName1, paramName2DefaultValue));
+      assertFalse(req.params().contains(paramName2));
+      assertEquals(paramName2DefaultValue, req.getParam(paramName2, paramName2DefaultValue));
+      req.response().end();
+    });
+
+    server.listen(testAddress, onSuccess(server -> {
+      client.request(new RequestOptions(requestOptions).setURI(reqUri))
+        .onComplete(onSuccess(req -> {
+          req.send(onSuccess(resp -> testComplete()));
+        }));
+    }));
+
+    await();
+  }
+
+  @Test
   public void testMissingContentTypeMultipartRequest() throws Exception {
     testInvalidMultipartRequest(null, HttpMethod.POST);
   }


### PR DESCRIPTION
Return default value instead of null if query param is not present. 
 - removed unused imports

Improvement based on: [vertx-web#1473](https://github.com/vert-x3/vertx-web/issues/1473)

