### PR TITLE
Fix a typo in the javadoc for HttpConnection.localAddress

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -246,7 +246,7 @@ public interface HttpConnection {
   SocketAddress remoteAddress();
 
   /**
-   * @return the remote address for this connection
+   * @return the local address for this connection
    */
   @CacheReturn
   SocketAddress localAddress();


### PR DESCRIPTION
This is my first time to make use of vertx to implement a web server and this comment was confusing me a bit...