### PR TITLE
Completed futures should operate on provided context

### DIFF
--- a/src/main/java/io/vertx/core/impl/FailedFuture.java
+++ b/src/main/java/io/vertx/core/impl/FailedFuture.java
@@ -52,7 +52,11 @@ public class FailedFuture<T> implements Future<T> {
 
   @Override
   public Future<T> onComplete(Handler<AsyncResult<T>> handler) {
-    handler.handle(this);
+    if (context != null) {
+      context.dispatch(this, handler);
+    } else {
+      handler.handle(this);
+    }
     return this;
   }
 

--- a/src/main/java/io/vertx/core/impl/SucceededFuture.java
+++ b/src/main/java/io/vertx/core/impl/SucceededFuture.java
@@ -45,7 +45,11 @@ class SucceededFuture<T> implements Future<T> {
 
   @Override
   public Future<T> onComplete(Handler<AsyncResult<T>> handler) {
-    handler.handle(this);
+    if (context != null) {
+      context.dispatch(this, handler);
+    } else {
+      handler.handle(this);
+    }
     return this;
   }
 

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -1575,11 +1575,16 @@ public class FutureTest extends VertxTestBase {
   }
 
   @Test
-  public void testCompletedFuturesContext() {
+  public void testCompletedFuturesContext() throws Exception {
     waitFor(4);
 
     Thread testThread = Thread.currentThread();
     ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
+
+
+    CompletableFuture<Thread> cf = new CompletableFuture<>();
+    context.runOnContext(v -> cf.complete(Thread.currentThread()));
+    Thread contextThread = cf.get();
 
     Future.succeededFuture().onSuccess(v -> {
       assertSame(testThread, Thread.currentThread());
@@ -1590,6 +1595,7 @@ public class FutureTest extends VertxTestBase {
     context.succeededFuture().onSuccess(v -> {
       assertNotSame(testThread, Thread.currentThread());
       assertSame(context, Vertx.currentContext());
+      assertSame(contextThread, Thread.currentThread());
       complete();
     });
 
@@ -1602,6 +1608,7 @@ public class FutureTest extends VertxTestBase {
     context.failedFuture(new Exception()).onFailure(v -> {
       assertNotSame(testThread, Thread.currentThread());
       assertSame(context, Vertx.currentContext());
+      assertSame(contextThread, Thread.currentThread());
       complete();
     });
 


### PR DESCRIPTION
SucceededFuture and FailedFuture, like other futures, take a context as constructor param.
If not null, this context should be used to dispatch the execution of future handlers.