### PR TITLE
Use super classes to search MessageCodecs.

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
@@ -92,6 +92,9 @@ public class CodecManager {
       codec = BYTE_MESSAGE_CODEC;
     } else if (body instanceof ReplyException) {
       codec = defaultCodecMap.get(body.getClass());
+      if(codec == null) {
+        codec = defaultCodecMap.get(body.getClass().getSuperclass());
+      }
       if (codec == null) {
         codec = REPLY_EXCEPTION_MESSAGE_CODEC;
       }

--- a/src/test/java/io/vertx/core/eventbus/EventBusTestBase.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusTestBase.java
@@ -628,6 +628,12 @@ public abstract class EventBusTestBase extends VertxTestBase {
     }
   }
 
+  public static class MyExtendedPOJO extends MyPOJO {
+    public MyExtendedPOJO(String str) {
+      super(str);
+    }
+  }
+
   public static class MyReplyException extends ReplyException {
 
     public MyReplyException(int failureCode, String message) {

--- a/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
@@ -778,6 +778,16 @@ public class LocalEventBusTest extends EventBusTestBase {
   }
 
   @Test
+  public void testExtendedDecoderSendAsymmetric() throws Exception {
+    MessageCodec codec = new MyPOJOEncoder2();
+    vertx.eventBus().registerCodec(codec);
+    String str = TestUtils.randomAlphaString(100);
+    MyExtendedPOJO pojo = new MyExtendedPOJO(str);
+    MyPOJO recived = new MyPOJO(str);
+    testSend(pojo, recived, null, new DeliveryOptions().setCodecName(codec.name()));
+  }
+
+  @Test
   public void testDecoderReplyAsymmetric() throws Exception {
     MessageCodec codec = new MyPOJOEncoder1();
     vertx.eventBus().registerCodec(codec);
@@ -890,6 +900,17 @@ public class LocalEventBusTest extends EventBusTestBase {
     String str = TestUtils.randomAlphaString(100);
     MyPOJO pojo = new MyPOJO(str);
     testReply(pojo, pojo, null, null);
+  }
+
+
+  @Test
+  public void testDefaultExtendedDecoderReplySymetric() throws Exception {
+    MessageCodec codec = new MyPOJOEncoder2();
+    vertx.eventBus().registerDefaultCodec(MyPOJO.class, codec);
+    String str = TestUtils.randomAlphaString(100);
+    MyExtendedPOJO pojo = new MyExtendedPOJO(str);
+    MyPOJO recived = new MyPOJO(str);
+    testReply(pojo, recived, null, null);
   }
 
   @Test
@@ -1560,4 +1581,3 @@ public class LocalEventBusTest extends EventBusTestBase {
     await();
   }
 }
-


### PR DESCRIPTION
Motivation:

Use a super class to implement a MessageCodec, it allow to send/receive; if you need, a generic type of class.

In my work we have a monolith and I want to break it into modular services and I will use the eventBus to send the updates of those modules, but since at this moment all the services extend from a base class, I need to implement a MessageCodec from that class base.
