### PR TITLE
Implementation of a generic message codec.

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/EventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBus.java
@@ -257,6 +257,26 @@ public interface EventBus extends Measured {
   EventBus unregisterDefaultCodec(Class clazz);
 
   /**
+   * Enables the generic serialization of any non standard message.
+   * <p>
+   * The generic codec is useful to send an exact copies of POJOS through the event bus.
+   * <p>
+   * For a specific serialization use your own message codec.
+   *
+   */
+  @GenIgnore
+  <T> EventBus enableGenericCodec();
+
+  /**
+   * Disable the generic serialization.
+   * <p>
+   * You need to specify your own non standard message codec through  `registerDefaultCodec`
+   *
+   */
+  @GenIgnore
+  <T> EventBus disableGenericCodec();
+
+  /**
    * Start the event bus. This would not normally be called in user code
    *
    * @param completionHandler  handler will be called when event bus is started

--- a/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
@@ -101,7 +101,7 @@ public class CodecManager {
     } else {
       codec = defaultCodecMap.get(body.getClass());
       if (codec == null && useGenericCodec.get()) {
-        codec = GENERIC_MESSAGE_CODEC;
+        codec = defaultCodecMap.getOrDefault(GenericMessageCodec.class, GENERIC_MESSAGE_CODEC);
       }
       if (codec == null) {
         throw new IllegalArgumentException("No message codec for type: " + body.getClass());

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -208,6 +208,18 @@ public class EventBusImpl implements EventBus, MetricsProvider {
   }
 
   @Override
+  public EventBus enableGenericCodec() {
+    codecManager.enableGenericCodec();
+    return this;
+  }
+
+  @Override
+  public EventBus disableGenericCodec() {
+    codecManager.disableGenericCodec();
+    return this;
+  }
+
+  @Override
   public void close(Handler<AsyncResult<Void>> completionHandler) {
     checkStarted();
     unregisterAll();

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
@@ -42,6 +42,7 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
   private int headersPos;
   private boolean fromWire;
   private boolean toWire;
+  public static int ENCODE_TOWIRE_LENGTH = 1024;
 
   public ClusteredMessage(EventBusImpl bus) {
     super(bus);
@@ -107,7 +108,7 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
 
   public Buffer encodeToWire() {
     toWire = true;
-    int length = 1024; // TODO make this configurable
+    int length = ENCODE_TOWIRE_LENGTH; // TODO make this configurable
     Buffer buffer = Buffer.buffer(length);
     buffer.appendInt(0);
     buffer.appendByte(WIRE_PROTOCOL_VERSION);

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/GenericMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/GenericMessageCodec.java
@@ -2,6 +2,7 @@ package io.vertx.core.eventbus.impl.codecs;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.core.eventbus.impl.clustered.ClusteredMessage;
 
 import java.io.*;
 
@@ -10,11 +11,11 @@ public class GenericMessageCodec<V, T> implements MessageCodec<V, T> {
 
   @Override
   public void encodeToWire(Buffer buffer, V v) {
-    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream(512);
+    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream(ClusteredMessage.ENCODE_TOWIRE_LENGTH);
     try (ObjectOutputStream object = new ObjectOutputStream(outputStream)) {
       object.writeObject(v);
     } catch (final IOException ex) {
-      throw new IllegalArgumentException("Error to encode message using a generic codec");
+      throw new IllegalArgumentException("Error to encode message using a generic codec. It must implement serializable interface.", ex);
     }
     byte[] bytes = outputStream.toByteArray();
     buffer.appendInt(bytes.length);

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/GenericMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/GenericMessageCodec.java
@@ -7,6 +7,7 @@ import java.io.*;
 
 
 public class GenericMessageCodec<V, T> implements MessageCodec<V, T> {
+
   @Override
   public void encodeToWire(Buffer buffer, V v) {
     final ByteArrayOutputStream outputStream = new ByteArrayOutputStream(512);
@@ -16,16 +17,19 @@ public class GenericMessageCodec<V, T> implements MessageCodec<V, T> {
       throw new IllegalArgumentException("Error to encode message using a generic codec");
     }
     byte[] bytes = outputStream.toByteArray();
+    buffer.appendInt(bytes.length);
     buffer.appendBytes(bytes);
   }
 
   @Override
   public T decodeFromWire(int pos, Buffer buffer) {
-    byte[] bytes = buffer.getBytes();
+    int length = buffer.getInt(pos);
+    pos += 4;
+    byte[] bytes = buffer.getBytes(pos, pos + length);
     T object = null;
     ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
     try (ObjectInputStream in = new ObjectInputStream(inputStream)) {
-      object = (T) in.readObject();
+      object = (T)in.readObject();
     } catch (final ClassNotFoundException | IOException ex) {
       throw new IllegalArgumentException("Error to decode message using a generic codec");
     }

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/GenericMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/GenericMessageCodec.java
@@ -1,0 +1,49 @@
+package io.vertx.core.eventbus.impl.codecs;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+
+import java.io.*;
+
+
+public class GenericMessageCodec<V, T> implements MessageCodec<V, T> {
+  @Override
+  public void encodeToWire(Buffer buffer, V v) {
+    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream(512);
+    try (ObjectOutputStream object = new ObjectOutputStream(outputStream)) {
+      object.writeObject(v);
+    } catch (final IOException ex) {
+      throw new IllegalArgumentException("Error to encode message using a generic codec");
+    }
+    byte[] bytes = outputStream.toByteArray();
+    buffer.appendBytes(bytes);
+  }
+
+  @Override
+  public T decodeFromWire(int pos, Buffer buffer) {
+    byte[] bytes = buffer.getBytes();
+    T object = null;
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
+    try (ObjectInputStream in = new ObjectInputStream(inputStream)) {
+      object = (T) in.readObject();
+    } catch (final ClassNotFoundException | IOException ex) {
+      throw new IllegalArgumentException("Error to decode message using a generic codec");
+    }
+    return object;
+  }
+
+  @Override
+  public T transform(V v) {
+    return (T)v;
+  }
+
+  @Override
+  public String name() {
+    return "generic";
+  }
+
+  @Override
+  public byte systemCodecID() {
+    return 16;
+  }
+}

--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
@@ -103,7 +103,7 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
   @Test
   public void testMyGenericDecoderReplyAsymmetric() throws Exception {
     startNodes(2);
-    MyGenericMessageCodec codec = new MyGenericMessageCodec<StringBuilder, String>();
+    MyGenericMessageCodec codec = new MyGenericMessageCodec();
     vertices[0].eventBus().enableGenericCodec().registerDefaultCodec(GenericMessageCodec.class, codec);
     vertices[1].eventBus().enableGenericCodec().registerDefaultCodec(GenericMessageCodec.class, codec);
     String str = TestUtils.randomAlphaString(100);

--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
@@ -13,6 +13,7 @@ package io.vertx.core.eventbus;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.eventbus.impl.codecs.GenericMessageCodec;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.tls.Cert;
@@ -25,7 +26,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -54,6 +54,31 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
   }
 
   @Test
+  public void testGenericDecoderSendAsymmetric() throws Exception {
+    startNodes(2);
+    vertices[0].eventBus().enableGenericCodec();
+    vertices[1].eventBus().enableGenericCodec();
+    String str = TestUtils.randomAlphaString(100);
+    MySerializablePOJO pojo = new MySerializablePOJO(str);
+    testSend(pojo, pojo, null, null);
+    vertices[0].eventBus().disableGenericCodec();
+    vertices[1].eventBus().disableGenericCodec();
+  }
+
+  @Test
+  public void testMyGenericDecoderSendAsymmetric() throws Exception {
+    startNodes(2);
+    MyGenericMessageCodec codec = new MyGenericMessageCodec();
+    vertices[0].eventBus().enableGenericCodec().registerDefaultCodec(GenericMessageCodec.class, codec);
+    vertices[1].eventBus().enableGenericCodec().registerDefaultCodec(GenericMessageCodec.class, codec);
+    String str = TestUtils.randomAlphaString(100);
+    MySerializablePOJO pojo = new MySerializablePOJO(str);
+    testSend(pojo, pojo, null, null);
+    vertices[0].eventBus().disableGenericCodec();
+    vertices[1].eventBus().disableGenericCodec();
+  }
+
+  @Test
   public void testDecoderReplyAsymmetric() throws Exception {
     startNodes(2);
     MessageCodec codec = new MyPOJOEncoder1();
@@ -61,6 +86,31 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
     vertices[1].eventBus().registerCodec(codec);
     String str = TestUtils.randomAlphaString(100);
     testReply(new MyPOJO(str), str, null, new DeliveryOptions().setCodecName(codec.name()));
+  }
+
+  @Test
+  public void testGenericDecoderReplyAsymmetric() throws Exception {
+    startNodes(2);
+    vertices[0].eventBus().enableGenericCodec();
+    vertices[1].eventBus().enableGenericCodec();
+    String str = TestUtils.randomAlphaString(100);
+    MySerializablePOJO pojo = new MySerializablePOJO(str);
+    testReply(pojo, pojo, null, null);
+    vertices[0].eventBus().disableGenericCodec();
+    vertices[1].eventBus().disableGenericCodec();
+  }
+
+  @Test
+  public void testMyGenericDecoderReplyAsymmetric() throws Exception {
+    startNodes(2);
+    MyGenericMessageCodec codec = new MyGenericMessageCodec<StringBuilder, String>();
+    vertices[0].eventBus().enableGenericCodec().registerDefaultCodec(GenericMessageCodec.class, codec);
+    vertices[1].eventBus().enableGenericCodec().registerDefaultCodec(GenericMessageCodec.class, codec);
+    String str = TestUtils.randomAlphaString(100);
+    MySerializablePOJO pojo = new MySerializablePOJO(str);
+    testReply(pojo, pojo, null, null);
+    vertices[0].eventBus().disableGenericCodec();
+    vertices[1].eventBus().disableGenericCodec();
   }
 
   @Test

--- a/src/test/java/io/vertx/core/eventbus/EventBusTestBase.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusTestBase.java
@@ -630,6 +630,32 @@ public abstract class EventBusTestBase extends VertxTestBase {
     }
   }
 
+  public static class MySerializablePOJO implements Serializable {
+    private String str;
+
+    public MySerializablePOJO(String str) {
+      this.str = str;
+    }
+
+    public String getStr() {
+      return str;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      MySerializablePOJO myPOJO = (MySerializablePOJO) o;
+      if (str != null ? !str.equals(myPOJO.str) : myPOJO.str != null) return false;
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return str != null ? str.hashCode() : 0;
+    }
+  }
+
   public static class MyReplyException extends ReplyException {
 
     public MyReplyException(int failureCode, String message) {
@@ -719,9 +745,6 @@ public abstract class EventBusTestBase extends VertxTestBase {
 
     @Override
     public T transform(V v) {
-      if(v instanceof StringBuilder) {
-        v = (V)((StringBuilder) v).append(":");
-      }
       return (T)v;
     }
 

--- a/src/test/java/io/vertx/core/eventbus/EventBusTestBase.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusTestBase.java
@@ -16,12 +16,14 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Context;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.impl.codecs.GenericMessageCodec;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
+import java.io.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
@@ -705,6 +707,27 @@ public abstract class EventBusTestBase extends VertxTestBase {
     @Override
     public String name() {
       return getClass().getName();
+    }
+
+    @Override
+    public byte systemCodecID() {
+      return -1;
+    }
+  }
+
+  public static class MyGenericMessageCodec<V,T> extends GenericMessageCodec<V, T> {
+
+    @Override
+    public T transform(V v) {
+      if(v instanceof StringBuilder) {
+        v = (V)((StringBuilder) v).append(":");
+      }
+      return (T)v;
+    }
+
+    @Override
+    public String name() {
+      return "my-generic";
     }
 
     @Override

--- a/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
@@ -13,6 +13,7 @@ package io.vertx.core.eventbus;
 
 import io.vertx.core.*;
 import io.vertx.core.eventbus.impl.MessageConsumerImpl;
+import io.vertx.core.eventbus.impl.codecs.GenericMessageCodec;
 import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.EventLoopContext;
@@ -867,6 +868,16 @@ public class LocalEventBusTest extends EventBusTestBase {
   }
 
   @Test
+  public void testMyGenericDecoderSendAsymmetric() throws Exception {
+    eb.enableGenericCodec();
+    eb.registerDefaultCodec(GenericMessageCodec.class, new MyGenericMessageCodec());
+    StringBuilder ping = new StringBuilder();
+    ping.append("ping");
+    testSend(ping, ping, null, null);
+    eb.disableGenericCodec();
+  }
+
+  @Test
   public void testDesabledGenericDecoderSend() throws Exception {
     assertIllegalArgumentException(() -> testSend(eb, eb, null, null));
   }
@@ -901,6 +912,16 @@ public class LocalEventBusTest extends EventBusTestBase {
   public void testGenericDecoderReplySymetric() throws Exception {
     eb.enableGenericCodec();
     testReply(eb, eb, null, null);
+    eb.disableGenericCodec();
+  }
+
+  @Test
+  public void testMyGenericDecoderReplySymetric() throws Exception {
+    eb.enableGenericCodec();
+    eb.registerDefaultCodec(GenericMessageCodec.class, new MyGenericMessageCodec());
+    StringBuilder ping = new StringBuilder();
+    ping.append("ping");
+    testReply(ping, ping, null, null);
     eb.disableGenericCodec();
   }
 

--- a/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
@@ -860,6 +860,18 @@ public class LocalEventBusTest extends EventBusTestBase {
   }
 
   @Test
+  public void testGenericDecoderSendAsymmetric() throws Exception {
+    eb.enableGenericCodec();
+    testSend(eb, eb, null, null);
+    eb.disableGenericCodec();
+  }
+
+  @Test
+  public void testDesabledGenericDecoderSend() throws Exception {
+    assertIllegalArgumentException(() -> testSend(eb, eb, null, null));
+  }
+
+  @Test
   public void testDefaultDecoderReplyAsymmetric() throws Exception {
     MessageCodec codec = new MyPOJOEncoder1();
     vertx.eventBus().registerDefaultCodec(MyPOJO.class, codec);
@@ -883,6 +895,13 @@ public class LocalEventBusTest extends EventBusTestBase {
     String str = TestUtils.randomAlphaString(100);
     MyPOJO pojo = new MyPOJO(str);
     testReply(pojo, pojo, null, null);
+  }
+
+  @Test
+  public void testGenericDecoderReplySymetric() throws Exception {
+    eb.enableGenericCodec();
+    testReply(eb, eb, null, null);
+    eb.disableGenericCodec();
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Rodrigo Salado Anaya <rodrigo.salado.anaya@gmail.com>

Motivation:

Provide a generic way to serialize POJOs without the need to implement your own.

Support must be enabled to use the generic codec.
E.g.
```java
EventBus eventBus = vertx.eventBus().enableGenericCodec();
POJO ping = new POJO("Ping...");

eventBus.<POJO>consumer(ADDRESS, message -> {
  POJO pong = new POJO("Pong...");
  message.reply(pong);
});

eventBus.<POJO>request(ADDRESS, ping, reply -> {
  POJO pong = reply.result().body();
});
```

See also #3279 
