### PR TITLE
Use a http server to hold the port busy before the real test.

### DIFF
--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -904,21 +904,22 @@ public class NetTest extends VertxTestBase {
   @Test
   public void testListenInvalidPort() {
     final int port = 9090;
-    final HttpServer httpServer = vertx.createHttpServer();
-    httpServer.requestHandler(r -> {}).listen(port, httpResult -> {
-      server.close();
+    HttpServer httpServer = vertx.createHttpServer();
+    server.close();
+    final Runnable netServerTest = () -> {
       server = vertx.createNetServer(new NetServerOptions().setPort(port));
       server.connectHandler((netSocket) -> {
       }).listen(ar -> {
-        if(httpResult.succeeded()) {
-          httpServer.close();
-        }
         assertTrue(ar.failed());
         assertFalse(ar.succeeded());
         assertNotNull(ar.cause());
+        httpServer.close();
         testComplete();
       });
-    });
+    };
+    httpServer.requestHandler(ignore -> {}).listen(port)
+      .onSuccess(s -> netServerTest.run())
+      .onFailure(e -> netServerTest.run());
     await();
   }
 

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -904,17 +904,20 @@ public class NetTest extends VertxTestBase {
   @Test
   public void testListenInvalidPort() {
     final int port = 9090;
-    final HttpServer httpServer = vertx.createHttpServer()
-      .requestHandler(ignore -> {})
-      .listen(port, onSuccess(s ->
-        vertx.createNetServer()
-          .connectHandler(ignore -> {})
-          .listen(port, onFailure(error -> {
-            assertNotNull(error);
-            testComplete();
-          }))));
-    await();
-    httpServer.close();
+    final HttpServer httpServer = vertx.createHttpServer();
+    try {
+      httpServer.requestHandler(ignore -> {})
+        .listen(port, onSuccess(s ->
+          vertx.createNetServer()
+            .connectHandler(ignore -> {})
+            .listen(port, onFailure(error -> {
+              assertNotNull(error);
+              testComplete();
+            }))));
+      await();
+    } finally {
+      httpServer.close();
+    }
   }
 
   @Test

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -906,13 +906,13 @@ public class NetTest extends VertxTestBase {
     final int port = 9090;
     final HttpServer httpServer = vertx.createHttpServer()
       .requestHandler(ignore -> {})
-      .listen(port, httpResult ->
+      .listen(port, onSuccess(s ->
         vertx.createNetServer()
           .connectHandler(ignore -> {})
           .listen(port, onFailure(error -> {
             assertNotNull(error);
             testComplete();
-          })));
+          }))));
     await();
     httpServer.close();
   }

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -903,16 +903,21 @@ public class NetTest extends VertxTestBase {
 
   @Test
   public void testListenInvalidPort() {
-    /* Port 80 is free to use by any application on Windows, so this test fails. */
-    Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
-    server.close();
-    server = vertx.createNetServer(new NetServerOptions().setPort(80));
-    server.connectHandler((netSocket) -> {
-    }).listen(ar -> {
-      assertTrue(ar.failed());
-      assertFalse(ar.succeeded());
-      assertNotNull(ar.cause());
-      testComplete();
+    final int port = 9090;
+    final HttpServer httpServer = vertx.createHttpServer();
+    httpServer.requestHandler(r -> {}).listen(port, httpResult -> {
+      server.close();
+      server = vertx.createNetServer(new NetServerOptions().setPort(port));
+      server.connectHandler((netSocket) -> {
+      }).listen(ar -> {
+        if(httpResult.succeeded()) {
+          httpServer.close();
+        }
+        assertTrue(ar.failed());
+        assertFalse(ar.succeeded());
+        assertNotNull(ar.cause());
+        testComplete();
+      });
     });
     await();
   }


### PR DESCRIPTION
Signed-off-by: Rodrigo Salado Anaya <rodrigo.salado.anaya@gmail.com>

Motivation:
Improvement to the test `testListenInvalidPort`, currently when port 80 is available the test fails.

```java
mvn -Dtest=NetTest#testListenInvalidPort test
```