### PR TITLE
Make testHttpServerWithIdleTimeoutSendChunkedFile reliably in CI

### DIFF
--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -4773,7 +4773,6 @@ public class Http1xTest extends HttpTest {
 
   @Test
   public void testHttpServerWithIdleTimeoutSendChunkedFile() throws Exception {
-    // Does not pass reliably in CI (timeout)
     final int timeToWait = 120;
     Assume.assumeFalse(vertx.isNativeTransportEnabled());
     int expected = getFileSizeExtected(timeToWait);
@@ -4782,9 +4781,7 @@ public class Http1xTest extends HttpTest {
     server = vertx
       .createHttpServer(createBaseServerOptions().setIdleTimeout(400).setIdleTimeoutUnit(TimeUnit.MILLISECONDS))
       .requestHandler(
-        req -> {
-          req.response().sendFile(sent.getAbsolutePath());
-        });
+        req -> req.response().sendFile(sent.getAbsolutePath()));
     startServer(testAddress);
     client.request(HttpMethod.GET, testAddress, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/")
       .setHandler(onSuccess(resp -> {

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -4774,8 +4774,9 @@ public class Http1xTest extends HttpTest {
   @Test
   public void testHttpServerWithIdleTimeoutSendChunkedFile() throws Exception {
     // Does not pass reliably in CI (timeout)
+    final int timeToWait = 120;
     Assume.assumeFalse(vertx.isNativeTransportEnabled());
-    int expected = 16 * 1024 * 1024; // We estimate this will take more than 200ms to transfer with a 1ms pause in chunks
+    int expected = getFileSizeExtected(timeToWait);
     File sent = TestUtils.tmpFile(".dat", expected);
     server.close();
     server = vertx
@@ -4804,7 +4805,7 @@ public class Http1xTest extends HttpTest {
         });
       }))
       .end();
-    await();
+    await(timeToWait, TimeUnit.SECONDS);
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/HttpTestBase.java
+++ b/src/test/java/io/vertx/core/http/HttpTestBase.java
@@ -158,7 +158,6 @@ public class HttpTestBase extends VertxTestBase {
       .setHandler(onSuccess(resp -> {
         long now = System.currentTimeMillis();
         resp.handler(ignore -> {
-          log.info("[testHttpServerWithIdleTimeoutSendChunkedFile] -> testLength: " + ignore.length());
           resp.pause();
           vertx.setTimer(1, id -> {
             resp.resume();


### PR DESCRIPTION
Signed-off-by: Rodrigo Salado Anaya <rodrigo.salado.anaya@gmail.com>

Motivation:

Make an effort to testHttpServerWithIdleTimeoutSendChunkedFile always pass in CI.
