### PR TITLE
Fixes #3289 : Renames toJsonXXX() methods from Buffer to mapToJsonXXX()

### DIFF
--- a/src/main/java/io/vertx/core/buffer/Buffer.java
+++ b/src/main/java/io/vertx/core/buffer/Buffer.java
@@ -133,20 +133,47 @@ public interface Buffer extends ClusterSerializable, Shareable {
 
   /**
    * Returns a Json object representation of the Buffer.
+   *
+   * @deprecated use {@link #mapToJsonObject()} instead.
    */
+  @Deprecated
   JsonObject toJsonObject();
 
   /**
    * Returns a Json array representation of the Buffer.
+   *
+   * @deprecated use {@link #mapToJsonArray()} instead.
    */
+  @Deprecated
   JsonArray toJsonArray();
 
   /**
    * Returns a Json representation of the Buffer.
    *
    * @return a JSON element which can be a {@link JsonArray}, {@link JsonObject}, {@link String}, ...etc if the buffer contains an array, object, string, ...etc
+   *
+   * @deprecated use {@link #mapToJson()} instead
    */
   default Object toJson() {
+    return Json.CODEC.fromBuffer(this, Object.class);
+  }
+
+  /**
+   * Returns a Json object representation of the Buffer.
+   */
+  JsonObject mapToJsonObject();
+
+  /**
+   * Returns a Json array representation of the Buffer.
+   */
+  JsonArray mapToJsonArray();
+
+  /**
+   * Returns a Json representation of the Buffer.
+   *
+   * @return a JSON element which can be a {@link JsonArray}, {@link JsonObject}, {@link String}, ...etc if the buffer contains an array, object, string, ...etc
+   */
+  default Object mapToJson() {
     return Json.CODEC.fromBuffer(this, Object.class);
   }
 

--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -118,6 +118,16 @@ public class BufferImpl implements Buffer {
     return new JsonArray(this);
   }
 
+  @Override
+  public JsonObject mapToJsonObject() {
+    return new JsonObject(this);
+  }
+
+  @Override
+  public JsonArray mapToJsonArray() {
+    return new JsonArray(this);
+  }
+
   public byte getByte(int pos) {
     return buffer.getByte(pos);
   }

--- a/src/test/java/io/vertx/core/buffer/BufferTest.java
+++ b/src/test/java/io/vertx/core/buffer/BufferTest.java
@@ -1058,6 +1058,23 @@ public class BufferTest {
   }
 
   @Test
+  public void testMapToJsonObject() throws Exception {
+    JsonObject obj = new JsonObject();
+    obj.put("wibble", "wibble_value");
+    obj.put("foo", 5);
+    obj.put("bar", true);
+    Buffer buff = Buffer.buffer(obj.encode());
+    assertEquals(obj, buff.mapToJsonObject());
+
+    buff = Buffer.buffer(TestUtils.randomAlphaString(10));
+    try {
+      buff.mapToJsonObject();
+      fail();
+    } catch (DecodeException ignore) {
+    }
+  }
+
+  @Test
   public void testToJsonArray() throws Exception {
     JsonArray arr = new JsonArray();
     arr.add("wibble");
@@ -1069,6 +1086,23 @@ public class BufferTest {
     buff = Buffer.buffer(TestUtils.randomAlphaString(10));
     try {
       buff.toJsonObject();
+      fail();
+    } catch (DecodeException ignore) {
+    }
+  }
+
+  @Test
+  public void testMapToJsonArray() throws Exception {
+    JsonArray arr = new JsonArray();
+    arr.add("wibble");
+    arr.add(5);
+    arr.add(true);
+    Buffer buff = Buffer.buffer(arr.encode());
+    assertEquals(arr, buff.mapToJsonArray());
+
+    buff = Buffer.buffer(TestUtils.randomAlphaString(10));
+    try {
+      buff.mapToJsonObject();
       fail();
     } catch (DecodeException ignore) {
     }


### PR DESCRIPTION
* Renames toJsonObject to mapToJsonObject and deprecates the method
* Renames toJsonArray to mapToJsonArray and deprecates the method
* Renames toJson to mapToJson and deprecates the method

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
