### PR TITLE
Bug when unregistering a message consumer and registering a handler again

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
@@ -126,11 +126,11 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
     }
     discardHandler = null;
     Future<Void> fut = super.unregister();
-    Promise<Void> res = result;
+
+    Promise<Void> res = result; // Alias reference because result can become null when the onComplete callback executes
     if (res != null) {
-      fut.onComplete(ar -> {
-        res.tryFail("blah");
-      });
+      fut.onComplete(ar -> res.tryFail("blah"));
+      result = null;
     }
     return fut;
   }

--- a/src/test/java/io/vertx/core/eventbus/EventBusFlowControlTest.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusFlowControlTest.java
@@ -13,6 +13,7 @@ package io.vertx.core.eventbus;
 
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
+import io.vertx.core.streams.ReadStream;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
@@ -196,10 +197,11 @@ public class EventBusFlowControlTest extends VertxTestBase {
   public void testMessageConsumerUnregisterThenRegisterAgain() {
     String address = "some-address";
     MessageConsumer<String> consumer = eb.consumer(address);
-    consumer.bodyStream().handler(m1 -> {
+    ReadStream<String> bodyStream = consumer.bodyStream();
+    bodyStream.handler(m1 -> {
       assertEquals("m1", m1);
       consumer.unregister();
-      consumer.handler(m2 -> {
+      bodyStream.handler(m2 -> {
         assertEquals("m2", m2);
         consumer.unregister();
         testComplete();

--- a/src/test/java/io/vertx/core/eventbus/EventBusFlowControlTest.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusFlowControlTest.java
@@ -201,13 +201,17 @@ public class EventBusFlowControlTest extends VertxTestBase {
     bodyStream.handler(m1 -> {
       assertEquals("m1", m1);
       consumer.unregister();
+      assertFalse("Consumer is not registered", consumer.isRegistered());
       bodyStream.handler(m2 -> {
         assertEquals("m2", m2);
         consumer.unregister();
+        assertFalse("Consumer is not registered", consumer.isRegistered());
         testComplete();
       });
+      assertTrue("Consumer is registered", consumer.isRegistered());
       eb.send(address, "m2");
     });
+    assertTrue("Consumer is registered", consumer.isRegistered());
     eb.send(address, "m1");
     await();
   }


### PR DESCRIPTION
Fixes a bug when unregistering a message consumer then registering it again where the new handler would not receive any message.

Spotted in https://github.com/vert-x3/vertx-rx/issues/221 and fixes the corresponding issue on my machine.