### PR TITLE
remove clustered flag in favor of createClusteredVertx

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -425,9 +425,6 @@ Set the public facing hostname to be used for clustering.
 |[[clusterPublicPort]]`@clusterPublicPort`|`Number (int)`|+++
 See link for an explanation.
 +++
-|[[clustered]]`@clustered`|`Boolean`|+++
-Sets whether or not the event bus is clustered.
-+++
 |[[connectTimeout]]`@connectTimeout`|`Number (int)`|+++
 Sets the connect timeout
 +++
@@ -1886,9 +1883,6 @@ Set the public facing hostname to be used for clustering.
 +++
 |[[clusterPublicPort]]`@clusterPublicPort`|`Number (int)`|+++
 See link for an explanation.
-+++
-|[[clustered]]`@clustered`|`Boolean`|+++
-Set whether or not the Vert.x instance will be clustered.
 +++
 |[[eventLoopPoolSize]]`@eventLoopPoolSize`|`Number (int)`|+++
 Set the number of event loop threads to be used by the Vert.x instance.

--- a/src/main/generated/io/vertx/core/VertxOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/VertxOptionsConverter.java
@@ -60,11 +60,6 @@ public class VertxOptionsConverter {
             obj.setClusterPublicPort(((Number)member.getValue()).intValue());
           }
           break;
-        case "clustered":
-          if (member.getValue() instanceof Boolean) {
-            obj.setClustered((Boolean)member.getValue());
-          }
-          break;
         case "eventBusOptions":
           if (member.getValue() instanceof JsonObject) {
             obj.setEventBusOptions(new io.vertx.core.eventbus.EventBusOptions((JsonObject)member.getValue()));
@@ -176,7 +171,6 @@ public class VertxOptionsConverter {
       json.put("clusterPublicHost", obj.getClusterPublicHost());
     }
     json.put("clusterPublicPort", obj.getClusterPublicPort());
-    json.put("clustered", obj.isClustered());
     if (obj.getEventBusOptions() != null) {
       json.put("eventBusOptions", obj.getEventBusOptions().toJson());
     }

--- a/src/main/generated/io/vertx/core/eventbus/EventBusOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/eventbus/EventBusOptionsConverter.java
@@ -45,11 +45,6 @@ public class EventBusOptionsConverter {
             obj.setClusterPublicPort(((Number)member.getValue()).intValue());
           }
           break;
-        case "clustered":
-          if (member.getValue() instanceof Boolean) {
-            obj.setClustered((Boolean)member.getValue());
-          }
-          break;
         case "connectTimeout":
           if (member.getValue() instanceof Number) {
             obj.setConnectTimeout(((Number)member.getValue()).intValue());
@@ -263,7 +258,6 @@ public class EventBusOptionsConverter {
       json.put("clusterPublicHost", obj.getClusterPublicHost());
     }
     json.put("clusterPublicPort", obj.getClusterPublicPort());
-    json.put("clustered", obj.isClustered());
     json.put("connectTimeout", obj.getConnectTimeout());
     if (obj.getCrlPaths() != null) {
       JsonArray array = new JsonArray();

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -50,14 +50,6 @@ public class VertxOptions {
   public static final int DEFAULT_INTERNAL_BLOCKING_POOL_SIZE = 20;
 
   /**
-   * The default value of whether Vert.x is clustered = false.
-   *
-   * @deprecated as of 3.7, use {@link EventBusOptions#DEFAULT_CLUSTERED} instead
-   */
-  @Deprecated
-  public static final boolean DEFAULT_CLUSTERED = false;
-
-  /**
    * The default hostname to use when clustering = "localhost"
    *
    * @deprecated as of 3.7, use {@link EventBusOptions#DEFAULT_CLUSTER_HOST} instead
@@ -278,32 +270,6 @@ public class VertxOptions {
       throw new IllegalArgumentException("workerPoolSize must be > 0");
     }
     this.workerPoolSize = workerPoolSize;
-    return this;
-  }
-
-  /**
-   * Is the Vert.x instance clustered?
-   *
-   * @return true if clustered, false if not
-   *
-   * @deprecated as of 3.7, use {@link #getEventBusOptions()} and then {@link EventBusOptions#isClustered()} instead
-   */
-  @Deprecated
-  public boolean isClustered() {
-    return eventBusOptions.isClustered();
-  }
-
-  /**
-   * Set whether or not the Vert.x instance will be clustered.
-   *
-   * @param clustered if true, the Vert.x instance will be clustered, otherwise not
-   * @return a reference to this, so the API can be used fluently
-   *
-   * @deprecated as of 3.7, use {@link #getEventBusOptions()} and then {@link EventBusOptions#setClustered(boolean)} instead
-   */
-  @Deprecated
-  public VertxOptions setClustered(boolean clustered) {
-    eventBusOptions.setClustered(clustered);
     return this;
   }
 

--- a/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
@@ -31,11 +31,6 @@ import java.util.concurrent.TimeUnit;
 public class EventBusOptions extends TCPSSLOptions {
 
   /**
-   * The default value of whether Vert.x is clustered = false.
-   */
-  public static final boolean DEFAULT_CLUSTERED = VertxOptions.DEFAULT_CLUSTERED;
-
-  /**
    * The default hostname to use when clustering = "localhost"
    */
   public static final String DEFAULT_CLUSTER_HOST = VertxOptions.DEFAULT_CLUSTER_HOST;
@@ -65,7 +60,6 @@ public class EventBusOptions extends TCPSSLOptions {
    */
   public static final long DEFAULT_CLUSTER_PING_REPLY_INTERVAL = VertxOptions.DEFAULT_CLUSTER_PING_REPLY_INTERVAL;
 
-  private boolean clustered = DEFAULT_CLUSTERED;
   private String clusterPublicHost = DEFAULT_CLUSTER_PUBLIC_HOST;
   private int clusterPublicPort = DEFAULT_CLUSTER_PUBLIC_PORT;
   private long clusterPingInterval = DEFAULT_CLUSTER_PING_INTERVAL;
@@ -132,8 +126,6 @@ public class EventBusOptions extends TCPSSLOptions {
   public EventBusOptions() {
     super();
 
-    clustered = DEFAULT_CLUSTERED;
-
     port = DEFAULT_PORT;
     host = DEFAULT_HOST;
     acceptBacklog = DEFAULT_ACCEPT_BACKLOG;
@@ -154,7 +146,6 @@ public class EventBusOptions extends TCPSSLOptions {
   public EventBusOptions(EventBusOptions other) {
     super(other);
 
-    this.clustered = other.clustered;
     this.clusterPublicHost = other.clusterPublicHost;
     this.clusterPublicPort = other.clusterPublicPort;
     this.clusterPingInterval = other.clusterPingInterval;
@@ -511,24 +502,6 @@ public class EventBusOptions extends TCPSSLOptions {
   @Override
   public EventBusOptions setSslHandshakeTimeoutUnit(TimeUnit sslHandshakeTimeoutUnit) {
     return (EventBusOptions) super.setSslHandshakeTimeoutUnit(sslHandshakeTimeoutUnit);
-  }
-
-  /**
-   * @return whether or not the event bus is clustered
-   */
-  public boolean isClustered() {
-    return clustered;
-  }
-
-  /**
-   * Sets whether or not the event bus is clustered.
-   *
-   * @param clustered {@code true} to start the event bus as a clustered event bus.
-   * @return a reference to this, so the API can be used fluently
-   */
-  public EventBusOptions setClustered(boolean clustered) {
-    this.clustered = clustered;
-    return this;
   }
 
   /**

--- a/src/main/java/io/vertx/core/impl/VertxFactory.java
+++ b/src/main/java/io/vertx/core/impl/VertxFactory.java
@@ -70,17 +70,12 @@ public class VertxFactory {
   }
 
   public Vertx vertx() {
-    if (options.getEventBusOptions().isClustered()) {
-      throw new IllegalArgumentException("Please use Vertx.clusteredVertx() to create a clustered Vert.x instance");
-    }
     VertxImpl vertx = new VertxImpl(options, null, createMetrics(), createTracer(), createTransport(), createFileResolver());
     vertx.init();
     return vertx;
   }
 
   public void clusteredVertx(Handler<AsyncResult<Vertx>> handler) {
-    // We don't require the user to set clustered to true if they use this method
-    options.getEventBusOptions().setClustered(true);
     VertxImpl vertx = new VertxImpl(options, createClusterManager(), createMetrics(), createTracer(), createTransport(), createFileResolver());
     vertx.joinCluster(options, handler);
   }

--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
@@ -238,8 +238,8 @@ public class BareCommand extends ClasspathHandler {
       CountDownLatch latch = new CountDownLatch(1);
       AtomicReference<AsyncResult<Vertx>> result = new AtomicReference<>();
 
-      eventBusOptions.setClustered(true)
-        .setHost(clusterHost).setPort(clusterPort)
+      eventBusOptions.setHost(clusterHost)
+        .setPort(clusterPort)
         .setClusterPublicHost(clusterPublicHost);
       if (clusterPublicPort != -1) {
         eventBusOptions.setClusterPublicPort(clusterPublicPort);

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -226,7 +226,7 @@ public class RunCommand extends BareCommand {
    */
   @Override
   public boolean isClustered() {
-    return cluster || ha || (options != null && options.getEventBusOptions().isClustered());
+    return cluster || ha;
   }
 
   @Override

--- a/src/test/java/io/vertx/core/CreateVertxTest.java
+++ b/src/test/java/io/vertx/core/CreateVertxTest.java
@@ -35,21 +35,8 @@ public class CreateVertxTest extends VertxTestBase {
   }
 
   @Test
-  public void testFailCreateClusteredVertxSynchronously() {
-    VertxOptions options = new VertxOptions();
-    options.getEventBusOptions().setClustered(true);
-    try {
-      Vertx.vertx(options);
-      fail("Should throw exception");
-    } catch (IllegalArgumentException e) {
-      // OK
-    }
-  }
-
-  @Test
   public void testCreateClusteredVertxAsync() {
     VertxOptions options = new VertxOptions();
-    options.getEventBusOptions().setClustered(true);
     clusteredVertx(options, ar -> {
       assertTrue(ar.succeeded());
       assertNotNull(ar.result());
@@ -62,27 +49,6 @@ public class CreateVertxTest extends VertxTestBase {
     });
     await();
   }
-
-  /*
-  If the user doesn't explicitly set clustered to true, it should still create a clustered Vert.x
-   */
-  @Test
-  public void testCreateClusteredVertxAsyncDontSetClustered() {
-    VertxOptions options = new VertxOptions();
-    clusteredVertx(options, ar -> {
-      assertTrue(ar.succeeded());
-      assertNotNull(ar.result());
-      assertTrue(options.getEventBusOptions().isClustered());
-      assertTrue(ar.result().isClustered());
-      Vertx v = ar.result();
-      v.close(ar2 -> {
-        assertTrue(ar2.succeeded());
-        testComplete();
-      });
-    });
-    await();
-  }
-
 
   @Test
   public void testCreateClusteredVertxAsyncDetectJoinFailure() {

--- a/src/test/java/io/vertx/core/HATest.java
+++ b/src/test/java/io/vertx/core/HATest.java
@@ -384,7 +384,7 @@ public class HATest extends VertxTestBase {
       .setHAEnabled(ha)
       .setClusterManager(getClusterManager());
     options.getEventBusOptions()
-      .setClustered(true).setHost("localhost");
+      .setHost("localhost");
     if (ha) {
       options.setQuorumSize(quorumSize);
       if (haGroup != null) {

--- a/src/test/java/io/vertx/core/LauncherTest.java
+++ b/src/test/java/io/vertx/core/LauncherTest.java
@@ -469,7 +469,7 @@ public class LauncherTest extends VertxTestBase {
       .put("eventLoopPoolSize", 123)
       .put("maxEventLoopExecuteTime", 123767667)
       .put("metricsOptions", new JsonObject().put("enabled", true))
-      .put("eventBusOptions", new JsonObject().put("clustered", true).put("clusterPublicHost", "mars"))
+      .put("eventBusOptions", new JsonObject().put("clusterPublicHost", "mars"))
       .put("haGroup", "somegroup")
       .put("maxEventLoopExecuteTimeUnit", "SECONDS");
 
@@ -492,7 +492,6 @@ public class LauncherTest extends VertxTestBase {
     assertEquals(123, opts.getEventLoopPoolSize(), 0);
     assertEquals(123767667L, opts.getMaxEventLoopExecuteTime());
     assertEquals(true, opts.getMetricsOptions().isEnabled());
-    assertEquals(true, opts.getEventBusOptions().isClustered());
     assertEquals("mars", opts.getEventBusOptions().getClusterPublicHost());
     assertEquals("somegroup", opts.getHAGroup());
     assertEquals(TimeUnit.SECONDS, opts.getMaxEventLoopExecuteTimeUnit());

--- a/src/test/java/io/vertx/core/VertxOptionsTest.java
+++ b/src/test/java/io/vertx/core/VertxOptionsTest.java
@@ -61,9 +61,6 @@ public class VertxOptionsTest extends VertxTestBase {
     } catch (IllegalArgumentException e) {
       // OK
     }
-    assertFalse(options.getEventBusOptions().isClustered());
-    options.getEventBusOptions().setClustered(true);
-    assertTrue(options.getEventBusOptions().isClustered());
     assertEquals(0, options.getEventBusOptions().getPort());
     options.getEventBusOptions().setPort(1234);
     assertEquals(1234, options.getEventBusOptions().getPort());
@@ -290,7 +287,6 @@ public class VertxOptionsTest extends VertxTestBase {
     VertxOptions json = new VertxOptions(new JsonObject());
     assertEquals(def.getEventLoopPoolSize(), json.getEventLoopPoolSize());
     assertEquals(def.getWorkerPoolSize(), json.getWorkerPoolSize());
-    assertEquals(def.getEventBusOptions().isClustered(), json.getEventBusOptions().isClustered());
     assertEquals(def.getEventBusOptions().getHost(), json.getEventBusOptions().getHost());
     assertEquals(def.getEventBusOptions().getClusterPublicHost(), json.getEventBusOptions().getClusterPublicHost());
     assertEquals(def.getEventBusOptions().getClusterPublicPort(), json.getEventBusOptions().getClusterPublicPort());

--- a/src/test/java/io/vertx/core/eventbus/WriteHandlerLookupFailureTest.java
+++ b/src/test/java/io/vertx/core/eventbus/WriteHandlerLookupFailureTest.java
@@ -69,7 +69,7 @@ public final class WriteHandlerLookupFailureTest extends VertxTestBase {
       }
     };
     VertxOptions options = new VertxOptions().setClusterManager(cm);
-    options.getEventBusOptions().setHost("localhost").setPort(0).setClustered(true);
+    options.getEventBusOptions().setHost("localhost").setPort(0);
     vertices = new Vertx[1];
     clusteredVertx(options, onSuccess(node -> {
       vertices[0] = node;

--- a/src/test/java/io/vertx/core/impl/VertxFactoryTest.java
+++ b/src/test/java/io/vertx/core/impl/VertxFactoryTest.java
@@ -36,7 +36,6 @@ import java.nio.file.Files;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -67,17 +66,6 @@ public class VertxFactoryTest {
     Vertx vertx = fut.get(10, TimeUnit.SECONDS);
     assertNotNull(vertx);
     assertNotNull(((VertxInternal)vertx).getClusterManager());
-  }
-
-  @Test
-  public void testCreateClusteredSync() {
-    VertxFactory factory = new VertxFactory(new VertxOptions().setClustered(true));
-    try {
-      factory.vertx();
-      fail();
-    } catch (IllegalArgumentException ignore) {
-      // Expected
-    }
   }
 
   @Test
@@ -136,7 +124,7 @@ public class VertxFactoryTest {
     FakeClusterManager clusterManager = new FakeClusterManager();
     CompletableFuture<Vertx> res = new CompletableFuture<>();
     runWithServiceFromMetaInf(ClusterManager.class, FakeClusterManager.class.getName(), () -> {
-      VertxFactory factory = new VertxFactory(new VertxOptions().setClustered(true));
+      VertxFactory factory = new VertxFactory(new VertxOptions());
       factory.clusterManager(clusterManager);
       factory.clusteredVertx(ar -> {
         if (ar.succeeded()) {

--- a/src/test/java/io/vertx/core/impl/launcher/LauncherExtensibilityTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/LauncherExtensibilityTest.java
@@ -107,57 +107,6 @@ public class LauncherExtensibilityTest extends CommandTestBase {
   }
 
   @Test
-  public void testThatCustomLauncherCanCustomizeTheClusteredOption() throws InterruptedException {
-
-    AtomicBoolean asv = new AtomicBoolean();
-    AtomicBoolean bsv = new AtomicBoolean();
-
-    Launcher myLauncher = new Launcher() {
-      @Override
-      protected String getMainVerticle() {
-        return HttpTestVerticle.class.getName();
-      }
-
-      @Override
-      public void afterStartingVertx(Vertx vertx) {
-        LauncherExtensibilityTest.this.vertx = vertx;
-      }
-
-      @Override
-      public void beforeStartingVertx(VertxOptions options) {
-        options.getEventBusOptions().setClustered(true);
-      }
-
-      @Override
-      public void afterStoppingVertx() {
-        asv.set(true);
-      }
-
-      @Override
-      public void beforeStoppingVertx(Vertx vertx) {
-        bsv.set(vertx != null);
-      }
-    };
-
-    myLauncher.dispatch(new String[0]);
-    assertWaitUntil(() -> {
-      try {
-        return RunCommandTest.getHttpCode() == 200;
-      } catch (IOException e) {
-        return false;
-      }
-    });
-
-    assertThat(this.vertx.isClustered()).isTrue();
-
-    BareCommand.getTerminationRunnable(vertx, LoggerFactory.getLogger("foo"), () -> asv.set(true)).run();
-
-    assertThat(bsv.get()).isTrue();
-    assertThat(asv.get()).isTrue();
-    vertx = null;
-  }
-
-  @Test
   public void testThatCustomLauncherCanUpdateConfigurationWhenNoneArePassed() throws IOException {
     long time = System.nanoTime();
     Launcher myLauncher = new Launcher() {

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
@@ -62,7 +62,7 @@ public class MetricsContextTest extends VertxTestBase {
     };
     VertxOptions options = new VertxOptions()
       .setMetricsOptions(new MetricsOptions().setEnabled(true).setFactory(factory))
-      .setEventBusOptions(new EventBusOptions().setClustered(true));
+      .setEventBusOptions(new EventBusOptions());
     clusteredVertx(options, onSuccess(vertx -> {
       assertSame(testThread, metricsThread.get());
       assertNull(metricsContext.get());

--- a/src/test/java/io/vertx/test/core/VertxTestBase.java
+++ b/src/test/java/io/vertx/test/core/VertxTestBase.java
@@ -160,7 +160,7 @@ public class VertxTestBase extends AsyncTestBase {
     for (int i = 0; i < numNodes; i++) {
       int index = i;
       options[i].setClusterManager(getClusterManager())
-        .getEventBusOptions().setHost("localhost").setPort(0).setClustered(true);
+        .getEventBusOptions().setHost("localhost").setPort(0);
       clusteredVertx(options[i], ar -> {
           try {
             if (ar.failed()) {


### PR DESCRIPTION
Signed-off-by: Selim Dincer <wowselim@live.de>

Motivation: This PR implements the change discussed in #3230. I have removed the clustered flag entirely and adjusted the tests accordingly.
 
There is one test where I don't know whether it should still exist or not:
`LauncherExtensibilityTest#testThatCustomLauncherCanCustomizeTheClusteredOption`
