### PR TITLE
Use try -with-resources statement ensures that resource is close

### DIFF
--- a/src/main/java/io/vertx/core/Starter.java
+++ b/src/main/java/io/vertx/core/Starter.java
@@ -474,9 +474,7 @@ public class Starter {
     try {
       Enumeration<URL> resources = getClass().getClassLoader().getResources("META-INF/MANIFEST.MF");
       while (resources.hasMoreElements()) {
-        InputStream stream = null;
-        try {
-          stream = resources.nextElement().openStream();
+        try (InputStream stream = resources.nextElement().openStream()) {
           Manifest manifest = new Manifest(stream);
           Attributes attributes = manifest.getMainAttributes();
           String mainClass = attributes.getValue("Main-Class");
@@ -486,24 +484,12 @@ public class Starter {
               return theMainVerticle;
             }
           }
-        } finally {
-          closeQuietly(stream);
         }
       }
     } catch (IOException e) {
       throw new IllegalStateException(e.getMessage());
     }
     return null;
-  }
-
-  private void closeQuietly(InputStream stream) {
-    if (stream != null) {
-      try {
-        stream.close();
-      } catch (IOException e) {
-        // Ignore it.
-      }
-    }
   }
 
   private void displaySyntax() {

--- a/src/main/java/io/vertx/core/cli/UsageMessageFormatter.java
+++ b/src/main/java/io/vertx/core/cli/UsageMessageFormatter.java
@@ -602,8 +602,7 @@ public class UsageMessageFormatter {
    * @param text            The text to be rendered.
    */
   public Appendable renderWrappedTextBlock(StringBuilder sb, int width, int nextLineTabStop, String text) {
-    try {
-      BufferedReader in = new BufferedReader(new StringReader(text));
+    try (BufferedReader in = new BufferedReader(new StringReader(text))) {
       String line;
       boolean firstLine = true;
       while ((line = in.readLine()) != null) {

--- a/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
@@ -508,7 +508,6 @@ public class FileSystemImpl implements FileSystem {
     Objects.requireNonNull(p);
     return new BlockingAction<Void>(handler) {
       public Void perform() {
-        RandomAccessFile raf = null;
         try {
           String path = vertx.resolveFile(p).getAbsolutePath();
           if (len < 0) {
@@ -517,11 +516,8 @@ public class FileSystemImpl implements FileSystem {
           if (!Files.exists(Paths.get(path))) {
             throw new FileSystemException("Cannot truncate file " + path + ". Does not exist");
           }
-          try {
-            raf = new RandomAccessFile(path, "rw");
+          try (RandomAccessFile raf = new RandomAccessFile(path, "rw")) {
             raf.setLength(len);
-          } finally {
-            if (raf != null) raf.close();
           }
         } catch (IOException e) {
           throw new FileSystemException(e);
@@ -961,7 +957,7 @@ public class FileSystemImpl implements FileSystem {
       this.handler = handler;
       this.context = vertx.getOrCreateContext();
     }
-    
+
     /**
      * Run the blocking action using a thread from the worker pool.
      */

--- a/src/main/java/io/vertx/core/impl/launcher/commands/ListCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/ListCommand.java
@@ -91,20 +91,19 @@ public class ListCommand extends DefaultCommand {
   private void dumpFoundVertxApplications(List<String> cmd) throws IOException, InterruptedException {
     boolean none = true;
     final Process process = new ProcessBuilder(cmd).start();
-    BufferedReader reader =
-        new BufferedReader(new InputStreamReader(process.getInputStream()));
-    String line;
-    while ((line = reader.readLine()) != null) {
-      final Matcher matcher = PS.matcher(line);
-      if (matcher.find()) {
-        String id = matcher.group(1);
-        String details = extractApplicationDetails(line);
-        out.println(id + "\t" + details);
-        none = false;
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        final Matcher matcher = PS.matcher(line);
+        if (matcher.find()) {
+          String id = matcher.group(1);
+          String details = extractApplicationDetails(line);
+          out.println(id + "\t" + details);
+          none = false;
+        }
       }
+      process.waitFor();
     }
-    process.waitFor();
-    reader.close();
     if (none) {
       out.println("No vert.x application found.");
     }

--- a/src/main/java/io/vertx/core/impl/launcher/commands/StopCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/StopCommand.java
@@ -140,17 +140,16 @@ public class StopCommand extends DefaultCommand {
   private String pid() {
     try {
       final Process process = new ProcessBuilder(Arrays.asList("sh", "-c", "ps ax | grep \"" + id + "\"")).start();
-      BufferedReader reader =
-          new BufferedReader(new InputStreamReader(process.getInputStream()));
-      String line;
-      while ((line = reader.readLine()) != null) {
-        final Matcher matcher = PS.matcher(line);
-        if (matcher.find()) {
-          return matcher.group(1);
+      try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          final Matcher matcher = PS.matcher(line);
+          if (matcher.find()) {
+            return matcher.group(1);
+          }
         }
+        process.waitFor();
       }
-      process.waitFor();
-      reader.close();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       e.printStackTrace(out);

--- a/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
@@ -280,17 +280,8 @@ public class KeyStoreHelper {
 
   private static KeyStore loadJKSOrPKCS12(String type, String password, Supplier<Buffer> value) throws Exception {
     KeyStore ks = KeyStore.getInstance(type);
-    InputStream in = null;
-    try {
-      in = new ByteArrayInputStream(value.get().getBytes());
-      ks.load(in, password != null ? password.toCharArray(): null);
-    } finally {
-      if (in != null) {
-        try {
-          in.close();
-        } catch (IOException ignore) {
-        }
-      }
+    try (InputStream in = new ByteArrayInputStream(value.get().getBytes())) {
+      ks.load(in, password != null ? password.toCharArray() : null);
     }
     return ks;
   }

--- a/src/test/java/io/vertx/core/LauncherTest.java
+++ b/src/test/java/io/vertx/core/LauncherTest.java
@@ -53,10 +53,9 @@ public class LauncherTest extends VertxTestBase {
     if (resource == null) {
       throw new IllegalStateException("Cannot find the vertx-version.txt");
     } else {
-      BufferedReader in = new BufferedReader(
-        new InputStreamReader(resource.openStream()));
-      expectedVersion = in.readLine();
-      in.close();
+      try (BufferedReader in = new BufferedReader(new InputStreamReader(resource.openStream()))) {
+        expectedVersion = in.readLine();
+      }
     }
 
     Launcher.resetProcessArguments();


### PR DESCRIPTION
Signed-off-by: Michael Panchenko <panchmp@gmail.com>

Motivation:
"try-with-resources" statement should be used  to ensure that resources are closed
