### PR TITLE
Deprecate the start/stop Future-based methods in AbstractVerticle

### DIFF
--- a/src/main/java/io/vertx/core/AbstractVerticle.java
+++ b/src/main/java/io/vertx/core/AbstractVerticle.java
@@ -100,7 +100,7 @@ public abstract class AbstractVerticle implements Verticle {
    * and call the startFuture some time later when start up is complete.
    * @param startFuture  a future which should be called when verticle start-up is complete.
    * @throws Exception
-   * @deprecated Use {@link #start(Promise)}
+   * @deprecated Override {@link AbstractVerticle#start(Promise)} instead.
    */
   @Override
   @Deprecated
@@ -116,7 +116,7 @@ public abstract class AbstractVerticle implements Verticle {
    * and call the stopFuture some time later when clean-up is complete.
    * @param stopFuture  a future which should be called when verticle clean-up is complete.
    * @throws Exception
-   * @deprecated Use {@link #stop(Promise)}
+   * @deprecated Override {@link AbstractVerticle#stop(Promise)} instead.
    */
   @Override
   @Deprecated

--- a/src/main/java/io/vertx/core/AbstractVerticle.java
+++ b/src/main/java/io/vertx/core/AbstractVerticle.java
@@ -100,7 +100,7 @@ public abstract class AbstractVerticle implements Verticle {
    * and call the startFuture some time later when start up is complete.
    * @param startFuture  a future which should be called when verticle start-up is complete.
    * @throws Exception
-   * @deprecated Use {@link Verticle#start(Promise)}
+   * @deprecated Use {@link #start(Promise)}
    */
   @Override
   @Deprecated
@@ -116,7 +116,7 @@ public abstract class AbstractVerticle implements Verticle {
    * and call the stopFuture some time later when clean-up is complete.
    * @param stopFuture  a future which should be called when verticle clean-up is complete.
    * @throws Exception
-   * @deprecated Use {@link Verticle#stop(Promise)}
+   * @deprecated Use {@link #stop(Promise)}
    */
   @Override
   @Deprecated

--- a/src/main/java/io/vertx/core/AbstractVerticle.java
+++ b/src/main/java/io/vertx/core/AbstractVerticle.java
@@ -100,8 +100,10 @@ public abstract class AbstractVerticle implements Verticle {
    * and call the startFuture some time later when start up is complete.
    * @param startFuture  a future which should be called when verticle start-up is complete.
    * @throws Exception
+   * @deprecated Use {@link Verticle#start(Promise)}
    */
   @Override
+  @Deprecated
   public void start(Future<Void> startFuture) throws Exception {
     start();
     startFuture.complete();
@@ -114,8 +116,10 @@ public abstract class AbstractVerticle implements Verticle {
    * and call the stopFuture some time later when clean-up is complete.
    * @param stopFuture  a future which should be called when verticle clean-up is complete.
    * @throws Exception
+   * @deprecated Use {@link Verticle#stop(Promise)}
    */
   @Override
+  @Deprecated
   public void stop(Future<Void> stopFuture) throws Exception {
     stop();
     stopFuture.complete();


### PR DESCRIPTION
Otherwise IDEs do not report these methods as deprecated, even if the Verticle interface has them deprecated.
