### PR TITLE
TCP socket options should not be applied when using domain socket wit…

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/transport/EpollTransport.java
+++ b/src/main/java/io/vertx/core/net/impl/transport/EpollTransport.java
@@ -139,22 +139,24 @@ class EpollTransport extends Transport {
   public void configure(NetServerOptions options, boolean domainSocket, ServerBootstrap bootstrap) {
     if (!domainSocket) {
       bootstrap.option(EpollChannelOption.SO_REUSEPORT, options.isReusePort());
+      if (options.isTcpFastOpen()) {
+        bootstrap.option(EpollChannelOption.TCP_FASTOPEN, options.isTcpFastOpen() ? pendingFastOpenRequestsThreshold : 0);
+      }
+      bootstrap.childOption(EpollChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
+      bootstrap.childOption(EpollChannelOption.TCP_CORK, options.isTcpCork());
     }
-    if (options.isTcpFastOpen()) {
-      bootstrap.option(EpollChannelOption.TCP_FASTOPEN, options.isTcpFastOpen() ? pendingFastOpenRequestsThreshold : 0);
-    }
-    bootstrap.childOption(EpollChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
-    bootstrap.childOption(EpollChannelOption.TCP_CORK, options.isTcpCork());
     super.configure(options, domainSocket, bootstrap);
   }
 
   @Override
   public void configure(ClientOptionsBase options, boolean domainSocket, Bootstrap bootstrap) {
-    if (options.isTcpFastOpen()) {
-      bootstrap.option(EpollChannelOption.TCP_FASTOPEN_CONNECT, options.isTcpFastOpen());
+    if (!domainSocket) {
+      if (options.isTcpFastOpen()) {
+        bootstrap.option(EpollChannelOption.TCP_FASTOPEN_CONNECT, options.isTcpFastOpen());
+      }
+      bootstrap.option(EpollChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
+      bootstrap.option(EpollChannelOption.TCP_CORK, options.isTcpCork());
     }
-    bootstrap.option(EpollChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
-    bootstrap.option(EpollChannelOption.TCP_CORK, options.isTcpCork());
     super.configure(options, domainSocket, bootstrap);
   }
 }


### PR DESCRIPTION
…h epoll - fixes #3125

Motivation:

Backport #3355 to `3.9` branch.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
