### PR TITLE
Add Future#compose(Supplier<U> supplier) method

### DIFF
--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -20,6 +20,7 @@ import io.vertx.core.spi.FutureFactory;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Represents the result of an action that may, or may not, have occurred yet.
@@ -204,7 +205,24 @@ public interface Future<T> extends AsyncResult<T> {
   default <U> Future<U> compose(Function<T, Future<U>> mapper) {
     return compose(mapper, Future::failedFuture);
   }
-
+  
+  /**
+   * Compose this future with a {@code supplier} function.<p>
+   * 
+   * Similar to {@link #compose(Function)} except the {@code supplier} does not require
+   * the result value from the completed value of the previous operation.
+   *
+   * @param supplier the supplier function
+   * @return the composed future
+   */
+  @GenIgnore
+  default <U> Future<U> compose(Supplier<Future<U>> supplier) {
+    Function<T,Future<U>> f = junk -> {
+      return supplier.get();
+    };
+    return compose(f, Future::failedFuture);
+  }
+  
   /**
    * @return the context associated with this future or {@code null} when
    */

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -560,6 +560,41 @@ public class FutureTest extends VertxTestBase {
     p2.complete(4);
     assertEquals(2, count.get());
   }
+  
+  @Test
+  public void testComposeSupplier() {
+    Promise<Integer> p = Promise.promise();
+    Future<Integer> f = p.future();
+    Promise<String> p2 = Promise.promise();
+    Future<String> c = p2.future();
+    Future<String> composed = f.compose(() -> {
+      return c;
+    });
+    Checker<String> checker = new Checker<>(composed);
+    checker.assertNotCompleted();
+    p.complete(3);
+    checker.assertNotCompleted();
+    p2.complete("DONE");
+    checker.assertSucceeded("DONE");
+  }
+  
+  @Test
+  public void testComposeSupplierFailed() {
+    Throwable cause = new Throwable();
+    Promise<Integer> p = Promise.promise();
+    Future<Integer> f = p.future();
+    Promise<String> p2 = Promise.promise();
+    Future<String> c = p2.future();
+    Future<String> composed = f.compose(() -> {
+      return c;
+    });
+    Checker<String> checker = new Checker<>(composed);
+    checker.assertNotCompleted();
+    p.complete(3);
+    checker.assertNotCompleted();
+    p2.fail(cause);
+    checker.assertFailed(cause);
+  }
 
   @Test
   public void testComposeSuccessToSuccess() {


### PR DESCRIPTION
Motivation:

When chaining operations with a Future object, sometimes operations only depend on the completion of the previous operation, and don't care about the result value of the previous operation.

For example, with vertx-sql-client to perform a simple "insert then select" secenario, we have to do this:
```java
DB2Pool client = DB2Pool.pool(connectOptions, poolOptions);

// Note the "junk" variables
client.query("INSERT INTO Fortune (message) VALUES ('some data')").execute()
  .flatMap(junk -> client.query("SELECT * FROM Fortune WHERE id=23").execute())
  .onComplete(this::printResults)
  .flatMap(junk -> client.query("SELECT * FROM Fortune WHERE id=24").execute())
  .onComplete(this::printResults)
  .onComplete(junk -> {
    System.out.println("All done");
    client.close();
  });
```

After this new compose function is added, the above code reads a bit nicer:
```java
DB2Pool client = DB2Pool.pool(connectOptions, poolOptions);

client.query("INSERT INTO Fortune (message) VALUES ('some data')").execute()
  .flatMap(() -> client.query("SELECT * FROM Fortune WHERE id=23").execute())
  .onComplete(this::printResults)
  .flatMap(() -> client.query("SELECT * FROM Fortune WHERE id=24").execute())
  .onComplete(this::printResults)
  .onComplete(() -> {
    System.out.println("All done");
    client.close();
  });
```