### PR TITLE
HAProxy protocol support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,11 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-codec-haproxy</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <optional>true</optional>
     </dependency>
@@ -537,6 +542,25 @@
               <classpathDependencyExcludes>
                 <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-core</classpathDependencyExclude>
                 <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-databind</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>no-haproxy-codec</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>io/vertx/it/HAProxyTest.java</include>
+              </includes>
+              <systemProperties>
+                <vertx-test-alpn-jdk>false</vertx-test-alpn-jdk>
+                <vertx-test-alpn-openssl>false</vertx-test-alpn-openssl>
+              </systemProperties>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>io.netty:netty-codec-haproxy</classpathDependencyExclude>
               </classpathDependencyExcludes>
             </configuration>
           </execution>

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -967,6 +967,12 @@ Enable or disable support for WebSocket per-message deflate compression extensio
 |[[port]]`@port`|`Number (int)`|+++
 Set the port
 +++
+|[[proxyProtocolTimeout]]`@proxyProtocolTimeout`|`Number (long)`|+++
+Set the Proxy protocol timeout, default time unit is seconds.
++++
+|[[proxyProtocolTimeoutUnit]]`@proxyProtocolTimeoutUnit`|`link:enums.html#TimeUnit[TimeUnit]`|+++
+Set the Proxy protocol timeout unit. If not specified, default is seconds.
++++
 |[[receiveBufferSize]]`@receiveBufferSize`|`Number (int)`|+++
 Set the TCP receive buffer size
 +++
@@ -1265,6 +1271,12 @@ Set to true to enabled network activity logging: Netty's pipeline is configured 
 +++
 |[[port]]`@port`|`Number (int)`|+++
 Set the port
++++
+|[[proxyProtocolTimeout]]`@proxyProtocolTimeout`|`Number (long)`|+++
+Set the Proxy protocol timeout, default time unit is seconds.
++++
+|[[proxyProtocolTimeoutUnit]]`@proxyProtocolTimeoutUnit`|`link:enums.html#TimeUnit[TimeUnit]`|+++
+Set the Proxy protocol timeout unit. If not specified, default is seconds.
 +++
 |[[receiveBufferSize]]`@receiveBufferSize`|`Number (int)`|+++
 Set the TCP receive buffer size

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -1017,6 +1017,9 @@ Set the value of traffic class
 |[[useAlpn]]`@useAlpn`|`Boolean`|+++
 Set the ALPN usage.
 +++
+|[[useProxyProtocol]]`@useProxyProtocol`|`Boolean`|+++
+Set whether the server uses the HA Proxy protocol
++++
 |[[webSocketAllowServerNoContext]]`@webSocketAllowServerNoContext`|`Boolean`|+++
 Set whether the WebSocket server will accept the <code>server_no_context_takeover</code> parameter of the per-message
  deflate compression extension offered by the client.
@@ -1312,6 +1315,9 @@ Set the value of traffic class
 +++
 |[[useAlpn]]`@useAlpn`|`Boolean`|+++
 Set the ALPN usage.
++++
+|[[useProxyProtocol]]`@useProxyProtocol`|`Boolean`|+++
+Set whether the server uses the HA Proxy protocol
 +++
 |===
 

--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -1803,6 +1803,29 @@ use the full URL specified in the request URI:
 {@link examples.HTTPExamples#example60}
 ----
 
+=== Using HA PROXY protocol
+
+https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt[HA PROXY protocol] provides a convenient way to safely transport connection
+information such as a client's address across multiple layers of NAT or TCP
+proxies.
+
+HA PROXY protocol can be enabled by setting the option {@link io.vertx.core.http.HttpServerOptions#setUseProxyProtocol(boolean)}
+and adding the following dependency in your classpath:
+
+[source,xml]
+----
+<dependency>
+  <groupId>io.netty</groupId>
+  <artifactId>netty-codec-haproxy</artifactId>
+  <!--<version>Should align with netty version that Vert.x uses</version>-->
+</dependency>
+----
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#example61}
+----
+
 === Automatic clean-up in verticles
 
 If you're creating http servers and clients from inside verticles, those servers and clients will be automatically closed

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1396,8 +1396,8 @@ You need to add the following dependency in your classpath:
 <dependency>
   <groupId>io.netty</groupId>
   <artifactId>netty-transport-native-epoll</artifactId>
-  <version>4.1.15.Final</version>
   <classifier>linux-x86_64</classifier>
+  <!--<version>Should align with netty version that Vert.x uses</version>-->
 </dependency>
 ----
 
@@ -1422,8 +1422,8 @@ You need to add the following dependency in your classpath:
 <dependency>
   <groupId>io.netty</groupId>
   <artifactId>netty-transport-native-kqueue</artifactId>
-  <version>4.1.15.Final</version>
   <classifier>osx-x86_64</classifier>
+  <!--<version>Should align with netty version that Vert.x uses</version>-->
 </dependency>
 ----
 

--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -770,3 +770,27 @@ Here's an example:
 
 The DNS resolution is always done on the proxy server, to achieve the functionality of a SOCKS4 client, it is necessary
 to resolve the DNS address locally.
+
+
+=== Using HA PROXY protocol
+
+https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt[HA PROXY protocol] provides a convenient way to safely transport connection
+information such as a client's address across multiple layers of NAT or TCP
+proxies.
+
+HA PROXY protocol can be enabled by setting the option {@link io.vertx.core.net.NetServerOptions#setUseProxyProtocol(boolean)}
+and adding the following dependency in your classpath:
+
+[source,xml]
+----
+<dependency>
+  <groupId>io.netty</groupId>
+  <artifactId>netty-codec-haproxy</artifactId>
+  <!--<version>Should align with netty version that Vert.x uses</version>-->
+</dependency>
+----
+
+[source,$lang]
+----
+{@link examples.NetExamples#example51}
+----

--- a/src/main/generated/io/vertx/core/net/NetServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/net/NetServerOptionsConverter.java
@@ -40,6 +40,11 @@ public class NetServerOptionsConverter {
             obj.setSni((Boolean)member.getValue());
           }
           break;
+        case "useProxyProtocol":
+          if (member.getValue() instanceof Boolean) {
+            obj.setUseProxyProtocol((Boolean)member.getValue());
+          }
+          break;
       }
     }
   }
@@ -58,5 +63,6 @@ public class NetServerOptionsConverter {
     }
     json.put("port", obj.getPort());
     json.put("sni", obj.isSni());
+    json.put("useProxyProtocol", obj.isUseProxyProtocol());
   }
 }

--- a/src/main/generated/io/vertx/core/net/NetServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/net/NetServerOptionsConverter.java
@@ -35,6 +35,16 @@ public class NetServerOptionsConverter {
             obj.setPort(((Number)member.getValue()).intValue());
           }
           break;
+        case "proxyProtocolTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setProxyProtocolTimeout(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "proxyProtocolTimeoutUnit":
+          if (member.getValue() instanceof String) {
+            obj.setProxyProtocolTimeoutUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
+          }
+          break;
         case "sni":
           if (member.getValue() instanceof Boolean) {
             obj.setSni((Boolean)member.getValue());
@@ -62,6 +72,10 @@ public class NetServerOptionsConverter {
       json.put("host", obj.getHost());
     }
     json.put("port", obj.getPort());
+    json.put("proxyProtocolTimeout", obj.getProxyProtocolTimeout());
+    if (obj.getProxyProtocolTimeoutUnit() != null) {
+      json.put("proxyProtocolTimeoutUnit", obj.getProxyProtocolTimeoutUnit().name());
+    }
     json.put("sni", obj.isSni());
     json.put("useProxyProtocol", obj.isUseProxyProtocol());
   }

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -918,6 +918,21 @@ public class HTTPExamples {
 
   }
 
+  public void example61(Vertx vertx) {
+
+    HttpServerOptions options = new HttpServerOptions()
+      .setUseProxyProtocol(true);
+
+    HttpServer server = vertx.createHttpServer(options);
+    server.requestHandler(request -> {
+      // Print the actual client address provided by the HA proxy protocol instead of the proxy address
+      System.out.println(request.remoteAddress());
+
+      // Print the address of the proxy
+      System.out.println(request.localAddress());
+    });
+  }
+
   public void serversharing(Vertx vertx) {
     vertx.createHttpServer().requestHandler(request -> {
       request.response().end("Hello from server " + this);

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -598,6 +598,18 @@ public class NetExamples {
       .listen(8080);
   }
 
+  public void example51(Vertx vertx) {
+    NetServerOptions options = new NetServerOptions().setUseProxyProtocol(true);
+    NetServer server = vertx.createNetServer(options);
+    server.connectHandler(so -> {
+      // Print the actual client address provided by the HA proxy protocol instead of the proxy address
+      System.out.println(so.remoteAddress());
+
+      // Print the address of the proxy
+      System.out.println(so.localAddress());
+    });
+  }
+
   public void configureSNIServer(Vertx vertx) {
     JksOptions keyCertOptions = new JksOptions().setPath("keystore.jks").setPassword("wibble");
 

--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -240,13 +240,15 @@ public interface HttpConnection {
   HttpConnection exceptionHandler(Handler<Throwable> handler);
 
   /**
-   * @return the remote address for this connection, possibly {@code null} (e.g a server bound on a domain socket)
+   * @return the remote address for this connection, possibly {@code null} (e.g a server bound on a domain socket).
+   * If {@code useProxyProtocol} is set to {@code true}, the address returned will be of the actual connecting client.
    */
   @CacheReturn
   SocketAddress remoteAddress();
 
   /**
    * @return the local address for this connection, possibly {@code null} (e.g a server bound on a domain socket)
+   * If {@code useProxyProtocol} is set to {@code true}, the address returned will be of the proxy.
    */
   @CacheReturn
   SocketAddress localAddress();

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -729,6 +729,10 @@ public class HttpServerOptions extends NetServerOptions {
     return (HttpServerOptions) super.setSni(sni);
   }
 
+  public HttpServerOptions setUseProxyProtocol(boolean useProxyProtocol) {
+    return (HttpServerOptions) super.setUseProxyProtocol(useProxyProtocol);
+  }
+
   /**
    * @return {@code true} if the server supports decompression
    */

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -725,12 +725,24 @@ public class HttpServerOptions extends NetServerOptions {
     return (HttpServerOptions) super.setLogActivity(logEnabled);
   }
 
+  @Override
   public HttpServerOptions setSni(boolean sni) {
     return (HttpServerOptions) super.setSni(sni);
   }
 
+  @Override
   public HttpServerOptions setUseProxyProtocol(boolean useProxyProtocol) {
     return (HttpServerOptions) super.setUseProxyProtocol(useProxyProtocol);
+  }
+
+  @Override
+  public HttpServerOptions setProxyProtocolTimeout(long proxyProtocolTimeout) {
+    return (HttpServerOptions) super.setProxyProtocolTimeout(proxyProtocolTimeout);
+  }
+
+  @Override
+  public HttpServerOptions setProxyProtocolTimeoutUnit(TimeUnit proxyProtocolTimeoutUnit) {
+    return (HttpServerOptions) super.setProxyProtocolTimeoutUnit(proxyProtocolTimeoutUnit);
   }
 
   /**

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -166,7 +166,8 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   }
 
   /**
-   * @return the remote address for this connection, possibly {@code null} (e.g a server bound on a domain socket)
+   * @return the remote address for this connection, possibly {@code null} (e.g a server bound on a domain socket).
+   * If {@code useProxyProtocol} is set to {@code true}, the address returned will be of the actual connecting client.
    */
   @CacheReturn
   default SocketAddress remoteAddress() {
@@ -175,6 +176,7 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
 
   /**
    * @return the local address for this connection, possibly {@code null} (e.g a server bound on a domain socket)
+   * If {@code useProxyProtocol} is set to {@code true}, the address returned will be of the proxy.
    */
   @CacheReturn
   default SocketAddress localAddress() {

--- a/src/main/java/io/vertx/core/http/WebSocketBase.java
+++ b/src/main/java/io/vertx/core/http/WebSocketBase.java
@@ -349,13 +349,15 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
   void close(short statusCode, @Nullable String reason, Handler<AsyncResult<Void>> handler);
 
   /**
-   * @return the remote address for this connection, possibly {@code null} (e.g a server bound on a domain socket)
+   * @return the remote address for this connection, possibly {@code null} (e.g a server bound on a domain socket).
+   * If {@code useProxyProtocol} is set to {@code true}, the address returned will be of the actual connecting client.
    */
   @CacheReturn
   SocketAddress remoteAddress();
 
   /**
    * @return the local address for this connection, possibly {@code null} (e.g a server bound on a domain socket)
+   * If {@code useProxyProtocol} is set to {@code true}, the address returned will be of the proxy.
    */
   @CacheReturn
   SocketAddress localAddress();

--- a/src/main/java/io/vertx/core/http/impl/HttpServerChannelInitializer.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerChannelInitializer.java
@@ -85,8 +85,8 @@ import java.util.function.Function;
       IdleStateHandler idle;
       io.netty.util.concurrent.Promise<Channel> p = ch.eventLoop().newPromise();
       ch.pipeline().addLast(new HAProxyMessageDecoder());
-      if (options.getIdleTimeout() > 0) {
-        ch.pipeline().addLast("idle", idle = new IdleStateHandler(0, 0, options.getIdleTimeout(), options.getIdleTimeoutUnit()));
+      if (options.getProxyProtocolTimeout() > 0) {
+        ch.pipeline().addLast("idle", idle = new IdleStateHandler(0, 0, options.getProxyProtocolTimeout(), options.getProxyProtocolTimeoutUnit()));
       } else {
         idle = null;
       }

--- a/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -55,9 +55,19 @@ public class NetServerOptions extends TCPSSLOptions {
   public static final boolean DEFAULT_SNI = false;
 
   /**
-   * Default value of whether the server supports HA Proxy protocol = false
+   * Default value of whether the server supports HA PROXY protocol = false
    */
   public static final boolean DEFAULT_USE_PROXY_PROTOCOL = false;
+
+  /**
+   * The default value of HA PROXY protocol timeout = 10
+   */
+  public static final long DEFAULT_PROXY_PROTOCOL_TIMEOUT = 10L;
+
+  /**
+   * Default HA PROXY protocol time unit = SECONDS
+   */
+  public static final TimeUnit DEFAULT_PROXY_PROTOCOL_TIMEOUT_TIME_UNIT = TimeUnit.SECONDS;
 
   private int port;
   private String host;
@@ -65,6 +75,8 @@ public class NetServerOptions extends TCPSSLOptions {
   private ClientAuth clientAuth;
   private boolean sni;
   private boolean useProxyProtocol;
+  private long proxyProtocolTimeout;
+  private TimeUnit proxyProtocolTimeoutUnit;
 
   /**
    * Default constructor
@@ -87,6 +99,10 @@ public class NetServerOptions extends TCPSSLOptions {
     this.clientAuth = other.getClientAuth();
     this.sni = other.isSni();
     this.useProxyProtocol = other.isUseProxyProtocol();
+    this.proxyProtocolTimeout = other.proxyProtocolTimeout;
+    this.proxyProtocolTimeoutUnit = other.getProxyProtocolTimeoutUnit() != null ?
+      other.getProxyProtocolTimeoutUnit() :
+      DEFAULT_PROXY_PROTOCOL_TIMEOUT_TIME_UNIT;
   }
 
   /**
@@ -402,7 +418,6 @@ public class NetServerOptions extends TCPSSLOptions {
    */
   public boolean isUseProxyProtocol() { return useProxyProtocol; }
 
-
   /**
    * Set whether the server uses the HA Proxy protocol
    *
@@ -413,6 +428,45 @@ public class NetServerOptions extends TCPSSLOptions {
     return this;
   }
 
+  /**
+   * @return the Proxy protocol timeout, in time unit specified by {@link #getProxyProtocolTimeoutUnit()}.
+   */
+  public long getProxyProtocolTimeout() {
+    return proxyProtocolTimeout;
+  }
+
+  /**
+   * Set the Proxy protocol timeout, default time unit is seconds.
+   *
+   * @param proxyProtocolTimeout the Proxy protocol timeout to set
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetServerOptions setProxyProtocolTimeout(long proxyProtocolTimeout) {
+    if (proxyProtocolTimeout < 0) {
+      throw new IllegalArgumentException("proxyProtocolTimeout must be >= 0");
+    }
+    this.proxyProtocolTimeout = proxyProtocolTimeout;
+    return this;
+  }
+
+  /**
+   * Set the Proxy protocol timeout unit. If not specified, default is seconds.
+   *
+   * @param proxyProtocolTimeoutUnit specify time unit.
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetServerOptions setProxyProtocolTimeoutUnit(TimeUnit proxyProtocolTimeoutUnit) {
+    this.proxyProtocolTimeoutUnit = proxyProtocolTimeoutUnit;
+    return this;
+  }
+
+  /**
+   * @return the Proxy protocol timeout unit.
+   */
+  public TimeUnit getProxyProtocolTimeoutUnit() {
+    return proxyProtocolTimeoutUnit;
+  }
+
   private void init() {
     this.port = DEFAULT_PORT;
     this.host = DEFAULT_HOST;
@@ -420,5 +474,7 @@ public class NetServerOptions extends TCPSSLOptions {
     this.clientAuth = DEFAULT_CLIENT_AUTH;
     this.sni = DEFAULT_SNI;
     this.useProxyProtocol = DEFAULT_USE_PROXY_PROTOCOL;
+    this.proxyProtocolTimeout = DEFAULT_PROXY_PROTOCOL_TIMEOUT;
+    this.proxyProtocolTimeoutUnit = DEFAULT_PROXY_PROTOCOL_TIMEOUT_TIME_UNIT;
   }
 }

--- a/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -54,11 +54,17 @@ public class NetServerOptions extends TCPSSLOptions {
    */
   public static final boolean DEFAULT_SNI = false;
 
+  /**
+   * Default value of whether the server supports HA Proxy protocol = false
+   */
+  public static final boolean DEFAULT_USE_PROXY_PROTOCOL = false;
+
   private int port;
   private String host;
   private int acceptBacklog;
   private ClientAuth clientAuth;
   private boolean sni;
+  private boolean useProxyProtocol;
 
   /**
    * Default constructor
@@ -80,6 +86,7 @@ public class NetServerOptions extends TCPSSLOptions {
     this.acceptBacklog = other.getAcceptBacklog();
     this.clientAuth = other.getClientAuth();
     this.sni = other.isSni();
+    this.useProxyProtocol = other.isUseProxyProtocol();
   }
 
   /**
@@ -390,11 +397,28 @@ public class NetServerOptions extends TCPSSLOptions {
     return this;
   }
 
+  /**
+   * @return whether the server uses the HA Proxy protocol
+   */
+  public boolean isUseProxyProtocol() { return useProxyProtocol; }
+
+
+  /**
+   * Set whether the server uses the HA Proxy protocol
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetServerOptions setUseProxyProtocol(boolean useProxyProtocol) {
+    this.useProxyProtocol = useProxyProtocol;
+    return this;
+  }
+
   private void init() {
     this.port = DEFAULT_PORT;
     this.host = DEFAULT_HOST;
     this.acceptBacklog = DEFAULT_ACCEPT_BACKLOG;
     this.clientAuth = DEFAULT_CLIENT_AUTH;
     this.sni = DEFAULT_SNI;
+    this.useProxyProtocol = DEFAULT_USE_PROXY_PROTOCOL;
   }
 }

--- a/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/src/main/java/io/vertx/core/net/NetSocket.java
@@ -189,13 +189,15 @@ public interface NetSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
   NetSocket sendFile(String filename, long offset, long length, Handler<AsyncResult<Void>> resultHandler);
 
   /**
-   * @return the remote address for this connection, possibly {@code null} (e.g a server bound on a domain socket)
+   * @return the remote address for this connection, possibly {@code null} (e.g a server bound on a domain socket).
+   * If {@code useProxyProtocol} is set to {@code true}, the address returned will be of the actual connecting client.
    */
   @CacheReturn
   SocketAddress remoteAddress();
 
   /**
    * @return the local address for this connection, possibly {@code null} (e.g a server bound on a domain socket)
+   * If {@code useProxyProtocol} is set to {@code true}, the address returned will be of the proxy.
    */
   @CacheReturn
   SocketAddress localAddress();

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -55,8 +55,8 @@ public abstract class ConnectionBase {
    * trace to not be misleading.
    */
   public static final VertxException CLOSED_EXCEPTION = new VertxException("Connection was closed", true);
-  public static final AttributeKey<java.net.SocketAddress> REMOTE_ADDRESS_OVERRIDE = AttributeKey.valueOf("RemoteAddressOverride");
-  public static final AttributeKey<java.net.SocketAddress> LOCAL_ADDRESS_OVERRIDE = AttributeKey.valueOf("LocalAddressOverride");
+  public static final AttributeKey<SocketAddress> REMOTE_ADDRESS_OVERRIDE = AttributeKey.valueOf("RemoteAddressOverride");
+  public static final AttributeKey<SocketAddress> LOCAL_ADDRESS_OVERRIDE = AttributeKey.valueOf("LocalAddressOverride");
   private static final Logger log = LoggerFactory.getLogger(ConnectionBase.class);
   private static final int MAX_REGION_SIZE = 1024 * 1024;
 
@@ -482,14 +482,17 @@ public abstract class ConnectionBase {
   public SocketAddress remoteAddress() {
     SocketAddress address = remoteAddress;
     if (address == null) {
-      java.net.SocketAddress addr = chctx.channel().hasAttr(REMOTE_ADDRESS_OVERRIDE) ?
-        chctx.channel().attr(REMOTE_ADDRESS_OVERRIDE).getAndSet(null) :
-        chctx.channel().remoteAddress();
-
-      if (addr != null) {
-        address = vertx.transport().convert(addr);
-        remoteAddress = address;
+      if (chctx.channel().hasAttr(REMOTE_ADDRESS_OVERRIDE)) {
+        address = chctx.channel().attr(REMOTE_ADDRESS_OVERRIDE).getAndSet(null);
+      } else {
+        java.net.SocketAddress addr = chctx.channel().remoteAddress();
+        if (addr != null) {
+          address = vertx.transport().convert(addr);
+        }
       }
+
+      if (address != null)
+        remoteAddress = address;
     }
     return address;
   }
@@ -497,14 +500,17 @@ public abstract class ConnectionBase {
   public SocketAddress localAddress() {
     SocketAddress address = localAddress;
     if (address == null) {
-      java.net.SocketAddress addr = chctx.channel().hasAttr(LOCAL_ADDRESS_OVERRIDE) ?
-        chctx.channel().attr(LOCAL_ADDRESS_OVERRIDE).getAndSet(null) :
-        chctx.channel().localAddress();
-
-      if (addr != null) {
-        address = vertx.transport().convert(addr);
-        localAddress = address;
+      if (chctx.channel().hasAttr(LOCAL_ADDRESS_OVERRIDE)) {
+        address = chctx.channel().attr(LOCAL_ADDRESS_OVERRIDE).getAndSet(null);
+      } else {
+        java.net.SocketAddress addr = chctx.channel().localAddress();
+        if (addr != null) {
+          address = vertx.transport().convert(addr);
+        }
       }
+
+      if (address != null)
+        localAddress = address;
     }
     return address;
   }

--- a/src/main/java/io/vertx/core/net/impl/HAProxyMessageCompletionHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/HAProxyMessageCompletionHandler.java
@@ -1,0 +1,78 @@
+package io.vertx.core.net.impl;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.timeout.IdleState;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.util.NetUtil;
+import io.netty.util.concurrent.Promise;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+public class HAProxyMessageCompletionHandler extends MessageToMessageDecoder<HAProxyMessage> {
+  private static final Logger log = LoggerFactory.getLogger(HAProxyMessageCompletionHandler.class);
+  private static final boolean proxyProtocolCodecFound;
+
+  static {
+    boolean proxyProtocolCodecCheck = true;
+    try {
+      Class.forName("io.netty.handler.codec.haproxy.HAProxyMessageDecoder");
+    } catch (Throwable ex) {
+      proxyProtocolCodecCheck = false;
+    }
+    proxyProtocolCodecFound = proxyProtocolCodecCheck;
+  }
+
+  public static boolean canUseProxyProtocol(boolean requested) {
+    if (requested && !proxyProtocolCodecFound)
+      log.warn("Proxy protocol support could not be enabled. Make sure that netty-codec-haproxy is included in your classpath");
+    return proxyProtocolCodecFound && requested;
+  }
+
+  private final Promise<Channel> promise;
+
+  public HAProxyMessageCompletionHandler(Promise<Channel> promise) {
+    this.promise = promise;
+  }
+
+
+  @Override
+  protected void decode(ChannelHandlerContext ctx, HAProxyMessage msg, List<Object> out) throws Exception {
+    if (msg.sourceAddress() != null && msg.sourcePort() != 0) {
+      InetAddress src = InetAddress.getByAddress(
+        NetUtil.createByteArrayFromIpAddressString(msg.sourceAddress()));
+      ctx.channel().attr(ConnectionBase.REMOTE_ADDRESS_OVERRIDE)
+        .set(new InetSocketAddress(src, msg.sourcePort()));
+    }
+
+    if (msg.destinationAddress() != null && msg.destinationPort() != 0) {
+      InetAddress dst = InetAddress.getByAddress(
+        NetUtil.createByteArrayFromIpAddressString(msg.destinationAddress()));
+      ctx.channel().attr(ConnectionBase.LOCAL_ADDRESS_OVERRIDE)
+        .set(new InetSocketAddress(dst, msg.destinationPort()));
+    }
+    ctx.pipeline().remove(this);
+    promise.setSuccess(ctx.channel());
+  }
+
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    promise.tryFailure(cause);
+  }
+
+  @Override
+  public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+    if (evt instanceof IdleStateEvent && ((IdleStateEvent) evt).state() == IdleState.ALL_IDLE) {
+      ctx.close();
+    } else {
+      ctx.fireUserEventTriggered(evt);
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
@@ -452,8 +452,8 @@ public class NetServerImpl implements Closeable, MetricsProvider, NetServer {
           IdleStateHandler idle;
           io.netty.util.concurrent.Promise<Channel> p = ch.eventLoop().newPromise();
           ch.pipeline().addLast(new HAProxyMessageDecoder());
-          if (options.getIdleTimeout() > 0) {
-            ch.pipeline().addLast("idle", idle = new IdleStateHandler(0, 0, options.getIdleTimeout(), options.getIdleTimeoutUnit()));
+          if (options.getProxyProtocolTimeout() > 0) {
+            ch.pipeline().addLast("idle", idle = new IdleStateHandler(0, 0, options.getProxyProtocolTimeout(), options.getProxyProtocolTimeoutUnit()));
           } else {
             idle = null;
           }

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -26,6 +26,7 @@ import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.test.core.Repeat;
 import io.vertx.test.core.CheckingSender;
+import io.vertx.test.proxy.HAProxy;
 import io.vertx.test.verticles.SimpleServer;
 import io.vertx.test.core.TestUtils;
 import org.junit.Assume;

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -1547,8 +1547,10 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testHAProxy() throws Exception {
-    Buffer version1ProtocolHeader = HAProxy.createVersion1ProtocolHeader("192.168.0.1", 56324, "192.168.0.11", 443);
-    HAProxy proxy = new HAProxy("localhost", 4043, version1ProtocolHeader);
+    SocketAddress remote = SocketAddress.inetSocketAddress(56324, "192.168.0.1");
+    SocketAddress local = SocketAddress.inetSocketAddress(443, "192.168.0.11");
+    Buffer header = HAProxy.createVersion1TCP4ProtocolHeader(remote, local);
+    HAProxy proxy = new HAProxy("localhost", 4043, header);
     proxy.start(vertx);
     try {
       testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE)

--- a/src/test/java/io/vertx/it/HAProxyTest.java
+++ b/src/test/java/io/vertx/it/HAProxyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.it;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import static io.vertx.core.http.HttpTestBase.DEFAULT_HTTP_HOST;
+import static io.vertx.core.http.HttpTestBase.DEFAULT_HTTP_PORT;
+
+/**
+ * @author <a href="mailto:dimitris.zenios@gmail.com">Dimitris Zenios</a>
+ */
+public class HAProxyTest extends VertxTestBase {
+  @Test
+  public void testHttpWithoutHAProxySupport() {
+    Vertx vertx = Vertx.vertx();
+    try {
+      vertx.createHttpServer(new HttpServerOptions().setUseProxyProtocol(true))
+        .requestHandler(req -> {
+          req.response().end("hello");
+        })
+        .listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, onSuccess(s -> {
+          HttpClient client = vertx.createHttpClient();
+          client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/", onSuccess(resp -> {
+            resp.body().onComplete(onSuccess(body -> {
+              assertEquals("hello", body.toString());
+              testComplete();
+            }));
+          }));
+        }));
+      await();
+    } finally {
+      vertx.close();
+    }
+  }
+}

--- a/src/test/java/io/vertx/test/proxy/HAProxy.java
+++ b/src/test/java/io/vertx/test/proxy/HAProxy.java
@@ -1,0 +1,124 @@
+package io.vertx.test.proxy;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.net.*;
+import io.vertx.core.streams.Pump;
+
+import java.net.InetAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+public class HAProxy {
+  private static final Logger log = LoggerFactory.getLogger(HAProxy.class);
+  private static final String HOST = "localhost";
+  private static final int PORT = 11080;
+  private final String remoteHost;
+  private final int remotePort;
+  private final Buffer header;
+  private NetServer server;
+
+  public HAProxy(String remoteHost, int remotePort, Buffer header) {
+    this.remoteHost = remoteHost;
+    this.remotePort = remotePort;
+    this.header = header;
+  }
+
+  public HAProxy start(Vertx vertx) throws Exception {
+    NetServerOptions options = new NetServerOptions();
+    options.setHost(HOST).setPort(PORT);
+    server = vertx.createNetServer(options);
+    server.connectHandler(socket -> {
+      socket.pause();
+      NetClient netClient = vertx.createNetClient(new NetClientOptions());
+      netClient.connect(remotePort, remoteHost, result -> {
+        if (result.succeeded()) {
+          log.debug("connected, writing header");
+          NetSocket clientSocket = result.result();
+          clientSocket.write(header).onSuccess(u -> {
+            log.debug("starting pump");
+            socket.closeHandler(v -> clientSocket.close());
+            clientSocket.closeHandler(v -> socket.close());
+            Pump.pump(socket, clientSocket).start();
+            Pump.pump(clientSocket, socket).start();
+            socket.resume();
+          }).onFailure(u -> {
+            log.error("exception writing header", result.cause());
+            socket.close();
+          });
+        } else {
+          log.error("exception", result.cause());
+          socket.close();
+        }
+      });
+    });
+
+    CompletableFuture<Void> fut = new CompletableFuture<>();
+    server.listen(ar -> {
+      if (ar.succeeded()) {
+        fut.complete(null);
+      } else {
+        fut.completeExceptionally(ar.cause());
+      }
+    });
+    fut.get(10, TimeUnit.SECONDS);
+    log.debug("HAProxy server started");
+    return this;
+  }
+
+  public void stop() {
+    if (server != null) {
+      server.close();
+      server = null;
+    }
+  }
+
+  public String getHost() {
+    return HOST;
+  }
+
+  public int getPort() {
+    return PORT;
+  }
+
+  public static Buffer createVersion1ProtocolHeader(String remoteAddress, int remotePort, String localAddress, int localPort) {
+    return Buffer.buffer(String.format("PROXY TCP4 %s %s %d %d\r\n", remoteAddress, localAddress, remotePort, localPort));
+  }
+
+  public static Buffer createVersion2ProtocolHeader(String remoteAddress, int remotePort, String localAddress, int localPort) {
+    try {
+      InetAddress remoteInetAddress = InetAddress.getByName(remoteAddress);
+      InetAddress localInetAddress = InetAddress.getByName(localAddress);
+
+      byte[] header = new byte[16];
+      header[0] = 0x0D;        // Binary Prefix
+      header[1] = 0x0A;        // -----
+      header[2] = 0x0D;        // -----
+      header[3] = 0x0A;        // -----
+      header[4] = 0x00;        // -----
+      header[5] = 0x0D;        // -----
+      header[6] = 0x0A;        // -----
+      header[7] = 0x51;        // -----
+      header[8] = 0x55;        // -----
+      header[9] = 0x49;        // -----
+      header[10] = 0x54;        // -----
+      header[11] = 0x0A;        // -----
+
+      header[12] = 0x21;        // v2, cmd=PROXY
+      header[13] = 0x11;        // TCP over IPv4
+
+      header[14] = 0x00;        // Remaining Bytes
+      header[15] = 0x0c;        // -----
+
+      return Buffer.buffer(header)
+        .appendBytes(remoteInetAddress.getAddress())
+        .appendBytes(localInetAddress.getAddress())
+        .appendUnsignedShort(remotePort)
+        .appendUnsignedShort(localPort);
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/io/vertx/test/proxy/HAProxy.java
+++ b/src/test/java/io/vertx/test/proxy/HAProxy.java
@@ -8,8 +8,10 @@ import io.vertx.core.net.*;
 import io.vertx.core.streams.Pump;
 
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 public class HAProxy {
   private static final Logger log = LoggerFactory.getLogger(HAProxy.class);
@@ -19,6 +21,10 @@ public class HAProxy {
   private final int remotePort;
   private final Buffer header;
   private NetServer server;
+
+  //Used to test unknown protocol
+  private SocketAddress connectionRemoteAddress;
+  private SocketAddress connectionLocalAddress;
 
   public HAProxy(String remoteHost, int remotePort, Buffer header) {
     this.remoteHost = remoteHost;
@@ -37,6 +43,8 @@ public class HAProxy {
         if (result.succeeded()) {
           log.debug("connected, writing header");
           NetSocket clientSocket = result.result();
+          connectionRemoteAddress = clientSocket.remoteAddress();
+          connectionLocalAddress = clientSocket.localAddress();
           clientSocket.write(header).onSuccess(u -> {
             log.debug("starting pump");
             socket.closeHandler(v -> clientSocket.close());
@@ -83,42 +91,106 @@ public class HAProxy {
     return PORT;
   }
 
-  public static Buffer createVersion1ProtocolHeader(String remoteAddress, int remotePort, String localAddress, int localPort) {
-    return Buffer.buffer(String.format("PROXY TCP4 %s %s %d %d\r\n", remoteAddress, localAddress, remotePort, localPort));
+  public SocketAddress getConnectionRemoteAddress() {
+    return connectionRemoteAddress;
   }
 
-  public static Buffer createVersion2ProtocolHeader(String remoteAddress, int remotePort, String localAddress, int localPort) {
+  public SocketAddress getConnectionLocalAddress() {
+    return connectionLocalAddress;
+  }
+
+  public static Buffer createVersion1TCP4ProtocolHeader(SocketAddress remote, SocketAddress local) {
+    return Buffer.buffer(String.format("PROXY TCP4 %s %s %d %d\r\n", remote.hostAddress(), local.hostAddress(), remote.port(), local.port()));
+  }
+
+  public static Buffer createVersion1TCP6ProtocolHeader(SocketAddress remote, SocketAddress local) {
+    return Buffer.buffer(String.format("PROXY TCP6 %s %s %d %d\r\n", remote.hostAddress(), local.hostAddress(), remote.port(), local.port()));
+  }
+
+  public static Buffer createVersion1UnknownProtocolHeader() {
+    return Buffer.buffer("PROXY UNKNOWN\r\n");
+  }
+
+  public static Buffer createVersion2TCP4ProtocolHeader(SocketAddress remote, SocketAddress local) {
+    return createIPv4IPv6ProtocolHeader((byte) 0x11, remote, local);
+  }
+
+  public static Buffer createVersion2TCP6ProtocolHeader(SocketAddress remote, SocketAddress local) {
+    return createIPv4IPv6ProtocolHeader((byte) 0x21, remote, local);
+  }
+
+  public static Buffer createVersion2UDP4ProtocolHeader(SocketAddress remote, SocketAddress local) {
+    return createIPv4IPv6ProtocolHeader((byte) 0x12, remote, local);
+  }
+
+  public static Buffer createVersion2UDP6ProtocolHeader(SocketAddress remote, SocketAddress local) {
+    return createIPv4IPv6ProtocolHeader((byte) 0x22, remote, local);
+  }
+
+  public static Buffer createVersion2UnixStreamProtocolHeader(SocketAddress remote, SocketAddress local) {
+    return createUnixStreamDatagramProtocolHeader((byte) 0x31, remote, local);
+  }
+
+  public static Buffer createVersion2UnixDatagramProtocolHeader(SocketAddress remote, SocketAddress local) {
+    return createUnixStreamDatagramProtocolHeader((byte) 0x32, remote, local);
+  }
+
+  public static Buffer createVersion2UnknownProtocolHeader() {
+    return createVersion2ProtocolHeader((byte) 0x00, Buffer.buffer());
+  }
+
+  private static Buffer createUnixStreamDatagramProtocolHeader(byte protocolByte, SocketAddress remote, SocketAddress local) {
+    Buffer addresses = Stream.of(remote.path(), local.path())
+      .map(s -> {
+        byte[] result = new byte[108];
+        byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+        System.arraycopy(bytes, 0, result, 0, Math.min(bytes.length, result.length));
+        return result;
+      })
+      .reduce(Buffer.buffer(), Buffer::appendBytes, (b0, b1) -> b1);
+    return createVersion2ProtocolHeader(protocolByte, addresses);
+  }
+
+  private static Buffer createIPv4IPv6ProtocolHeader(byte protocolByte, SocketAddress remote, SocketAddress local) {
     try {
-      InetAddress remoteInetAddress = InetAddress.getByName(remoteAddress);
-      InetAddress localInetAddress = InetAddress.getByName(localAddress);
-
-      byte[] header = new byte[16];
-      header[0] = 0x0D;        // Binary Prefix
-      header[1] = 0x0A;        // -----
-      header[2] = 0x0D;        // -----
-      header[3] = 0x0A;        // -----
-      header[4] = 0x00;        // -----
-      header[5] = 0x0D;        // -----
-      header[6] = 0x0A;        // -----
-      header[7] = 0x51;        // -----
-      header[8] = 0x55;        // -----
-      header[9] = 0x49;        // -----
-      header[10] = 0x54;        // -----
-      header[11] = 0x0A;        // -----
-
-      header[12] = 0x21;        // v2, cmd=PROXY
-      header[13] = 0x11;        // TCP over IPv4
-
-      header[14] = 0x00;        // Remaining Bytes
-      header[15] = 0x0c;        // -----
-
-      return Buffer.buffer(header)
-        .appendBytes(remoteInetAddress.getAddress())
-        .appendBytes(localInetAddress.getAddress())
-        .appendUnsignedShort(remotePort)
-        .appendUnsignedShort(localPort);
+      InetAddress remoteInetAddress = InetAddress.getByName(remote.hostAddress());
+      InetAddress localInetAddress = InetAddress.getByName(local.hostAddress());
+      return createVersion2ProtocolHeader(
+        protocolByte,
+        Buffer.buffer()
+          .appendBytes(remoteInetAddress.getAddress())
+          .appendBytes(localInetAddress.getAddress())
+          .appendUnsignedShort(remote.port())
+          .appendUnsignedShort(local.port())
+      );
     } catch (Throwable e) {
       throw new RuntimeException(e);
     }
+  }
+
+
+  private static Buffer createVersion2ProtocolHeader(byte protocolByte, Buffer address) {
+    byte[] header = new byte[15];
+    header[0] = 0x0D;        // Binary Prefix
+    header[1] = 0x0A;        // -----
+    header[2] = 0x0D;        // -----
+    header[3] = 0x0A;        // -----
+    header[4] = 0x00;        // -----
+    header[5] = 0x0D;        // -----
+    header[6] = 0x0A;        // -----
+    header[7] = 0x51;        // -----
+    header[8] = 0x55;        // -----
+    header[9] = 0x49;        // -----
+    header[10] = 0x54;        // -----
+    header[11] = 0x0A;        // -----
+
+    header[12] = 0x21;        // v2, cmd=PROXY
+    header[13] = protocolByte;
+
+    header[14] = 0x00;        // Remaining Bytes
+
+    return Buffer.buffer(header)
+      .appendByte((byte) address.length())
+      .appendBuffer(address);
   }
 }


### PR DESCRIPTION
Signed-off-by: zenios dimitris.zenios@gmail.com

**Notes:**
1. Hardcoded netty version (4.1.48.Final) for netty-codec-haproxy in order to avoid creating a pull request for vertx-dependencies

2. Tests were copied from #1271. That PR can be closed if this one gets merged
