### PR TITLE
1.Fix HA PROXY tests that were failing when run with -PtestDomainSockets

### DIFF
--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -2823,9 +2823,6 @@ public class Http1xTest extends HttpTest {
       Handler<HttpClientRequest> clientRequest,
       Handler<NetSocket> connectHandler
   ) throws Exception {
-    // Cannot reliably pass due to https://github.com/netty/netty/issues/9113
-    Assume.assumeTrue(testAddress.isInetSocket());
-
     client.close();
     server.close();
 

--- a/src/test/java/io/vertx/test/proxy/HAProxy.java
+++ b/src/test/java/io/vertx/test/proxy/HAProxy.java
@@ -17,8 +17,7 @@ public class HAProxy {
   private static final Logger log = LoggerFactory.getLogger(HAProxy.class);
   private static final String HOST = "localhost";
   private static final int PORT = 11080;
-  private final String remoteHost;
-  private final int remotePort;
+  private final SocketAddress remoteAddress;
   private final Buffer header;
   private NetServer server;
 
@@ -26,10 +25,13 @@ public class HAProxy {
   private SocketAddress connectionRemoteAddress;
   private SocketAddress connectionLocalAddress;
 
-  public HAProxy(String remoteHost, int remotePort, Buffer header) {
-    this.remoteHost = remoteHost;
-    this.remotePort = remotePort;
+  public HAProxy(SocketAddress remoteAddress, Buffer header) {
+    this.remoteAddress = remoteAddress;
     this.header = header;
+  }
+
+  public HAProxy(String host, int port, Buffer header) {
+    this(SocketAddress.inetSocketAddress(port, host), header);
   }
 
   public HAProxy start(Vertx vertx) throws Exception {
@@ -39,7 +41,7 @@ public class HAProxy {
     server.connectHandler(socket -> {
       socket.pause();
       NetClient netClient = vertx.createNetClient(new NetClientOptions());
-      netClient.connect(remotePort, remoteHost, result -> {
+      netClient.connect(remoteAddress, result -> {
         if (result.succeeded()) {
           log.debug("connected, writing header");
           NetSocket clientSocket = result.result();


### PR DESCRIPTION
2.Restore tests that were disabled due to https://github.com/netty/netty/issues/9113

Signed-off-by: Dimitris Zenios <dimitris.zenios@gmail.com>
