### PR TITLE
Fix duplicate line

### DIFF
--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -871,7 +871,6 @@ public class VertxOptions {
         ", metrics=" + metricsOptions +
         ", fileSystemOptions=" + fileSystemOptions +
         ", addressResolver=" + addressResolverOptions.toJson() +
-        ", addressResolver=" + addressResolverOptions.toJson() +
         ", eventbus=" + eventBusOptions.toJson() +
         ", warningExceptionTimeUnit=" + warningExceptionTimeUnit +
         ", warningExceptionTime=" + warningExceptionTime +


### PR DESCRIPTION
Motivation:

Function `VertxOptions::toString()` erroneously returns addressResolver field twice.