### PR TITLE
Implement file descriptor leak tests (#3408)

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
@@ -624,7 +624,13 @@ public class Http2ServerResponseImpl implements HttpServerResponse {
           checkSendHeaders(false);
           file.setReadPos(offset);
           file.setReadLength(contentLength);
-          file.pipeTo(this, h);
+          file.pipeTo(this, ar1 -> file.close(ar2 -> {
+            Throwable failure = ar1.failed() ? ar1.cause() : ar2.failed() ? ar2.cause() : null;
+            if(failure == null)
+              h.handle(ar1);
+            else
+              h.handle(Future.failedFuture(failure));
+          }));
         } else {
           h.handle(ar.mapEmpty());
         }

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -60,6 +60,7 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
+import io.vertx.test.core.DetectFileDescriptorLeaks;
 import io.vertx.test.core.Repeat;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.tls.Trust;
@@ -2353,6 +2354,7 @@ public class Http2ServerTest extends Http2TestBase {
   }
 
   @Test
+  @DetectFileDescriptorLeaks
   public void testNetSocketSendFile() throws Exception {
     Buffer expected = Buffer.buffer(TestUtils.randomAlphaString(1000 * 1000));
     File tmp = createTempFile(expected);
@@ -2367,6 +2369,7 @@ public class Http2ServerTest extends Http2TestBase {
     int to = 700 * 1000;
     testNetSocketSendFile(expected.slice(from, to), tmp.getAbsolutePath(), from, to - from);
   }
+
 
   private void testNetSocketSendFile(Buffer expected, String path, long offset, long length) throws Exception {
     server.requestHandler(req -> {

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -24,6 +24,7 @@ import io.vertx.core.file.AsyncFile;
 import io.vertx.core.http.impl.HeadersAdaptor;
 import io.vertx.core.net.*;
 import io.vertx.core.streams.Pump;
+import io.vertx.test.core.DetectFileDescriptorLeaks;
 import io.vertx.test.core.Repeat;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.netty.TestLoggerFactory;
@@ -1851,6 +1852,7 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
+  @DetectFileDescriptorLeaks
   public void testSendFile() throws Exception {
     String content = TestUtils.randomUnicodeString(10000);
     sendFile("test-send-file.html", content, false,

--- a/src/test/java/io/vertx/test/core/DetectFileDescriptorLeaks.java
+++ b/src/test/java/io/vertx/test/core/DetectFileDescriptorLeaks.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.test.core;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({java.lang.annotation.ElementType.METHOD})
+public @interface DetectFileDescriptorLeaks {
+  long baseline() default 20;
+  long iterations() default 20;
+}
+

--- a/src/test/java/io/vertx/test/core/FileDescriptorLeakDetectorRule.java
+++ b/src/test/java/io/vertx/test/core/FileDescriptorLeakDetectorRule.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.test.core;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import javax.management.JMException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FileDescriptorLeakDetectorRule implements TestRule {
+
+  private static final MBeanServer MBEAN_SERVER;
+  private static final ObjectName MBEAN_NAME;
+  private static final MBeanAttributeInfo OPEN_FD_INFO;
+
+  static {
+    MBeanServer server = null;
+    ObjectName name = null;
+    MBeanAttributeInfo openFdInfo = null;
+    try {
+      server = ManagementFactory.getPlatformMBeanServer();
+      name = ObjectName.getInstance(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME);
+      MBeanInfo info = server.getMBeanInfo(name);
+      openFdInfo = Stream
+        .of(info.getAttributes())
+        .filter(attrInfo ->attrInfo.getName().equals("OpenFileDescriptorCount") && attrInfo.getType().equals("long")
+          && attrInfo.isReadable()).findFirst()
+        .orElse(null);
+    } catch (JMException ignore) {
+
+    }
+    MBEAN_SERVER = server;
+    MBEAN_NAME = name;
+    OPEN_FD_INFO = openFdInfo;
+  }
+
+
+  @Override
+  public Statement apply(Statement statement, Description description) {
+    DetectFileDescriptorLeaks detectFileDescriptorsLeaks = description.getAnnotation(DetectFileDescriptorLeaks.class);
+    if (detectFileDescriptorsLeaks == null || OPEN_FD_INFO == null) {
+      return statement;
+    }
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+
+        //We do 40 runs. 20 to extract a baseline and 20 that will act as evaluation values
+        //From baseline values we get the max and from evaluation values we get the average
+        //If average is greater than max then we have a leak.
+        //The reason we do max and average is because getting file descriptors is not deterministic.
+        //i.e on first run we might get 80 on the second 81 and on the third 80 again.
+        //We dont care if baseline executions leak because in the end iterations will leak also
+        //resulting in a greater average than max
+        List<Long> baseLine = new ArrayList<>();
+        long baseline = detectFileDescriptorsLeaks.baseline();
+        System.out.println("*** Starting file leak descriptor test with " + baseline + " iterations");
+        for (int i = 0; i < baseline; i++) {
+          statement.evaluate();
+          long openFd = (Long) MBEAN_SERVER.getAttribute(MBEAN_NAME, OPEN_FD_INFO.getName());
+          baseLine.add(openFd);
+        }
+        long maxBaseLine = getMax(baseLine);
+        System.out.println("*** Open file descriptor max open file descriptors " + maxBaseLine);
+        List<Long> iterations = new ArrayList<>();
+        long a = detectFileDescriptorsLeaks.iterations();
+        for (int i = 0; i < a; i++) {
+          statement.evaluate();
+          long openFd = (Long) MBEAN_SERVER.getAttribute(MBEAN_NAME, OPEN_FD_INFO.getName());
+          System.out.println("*** Open file descriptor iteration " + (i + 1) + "/" + a + " " + openFd + " open file descriptors");
+          iterations.add(openFd);
+        }
+
+        long averageEvaluations = getAverage(iterations);
+        System.out.println("*** Open file descriptor open file descriptors average " + averageEvaluations);
+        assertThat(averageEvaluations).isLessThanOrEqualTo(maxBaseLine);
+      }
+    };
+  }
+
+  private static long getAverage(List<Long> values) {
+    return Double.valueOf(values.stream()
+      .mapToLong(v -> v)
+      .average()
+      .orElseThrow(IllegalStateException::new)).longValue();
+  }
+
+  private static long getMax(List<Long> values) {
+    return values.stream()
+      .mapToLong(v -> v)
+      .max()
+      .orElseThrow(IllegalStateException::new);
+  }
+}

--- a/src/test/java/io/vertx/test/core/VertxTestBase.java
+++ b/src/test/java/io/vertx/test/core/VertxTestBase.java
@@ -40,6 +40,9 @@ public class VertxTestBase extends AsyncTestBase {
   @Rule
   public RepeatRule repeatRule = new RepeatRule();
 
+  @Rule
+  public FileDescriptorLeakDetectorRule fileDescriptorLeakDetectorRule = new FileDescriptorLeakDetectorRule();
+
   protected Vertx vertx;
 
   protected Vertx[] vertices;


### PR DESCRIPTION
* Implement file descriptor leak tests

Signed-off-by: Dimitris Zenios <dimitris.zenios@gmail.com>

* Close the AsyncFile once we are finished with it

Closes #3396

Signed-off-by: Dimitris Zenios <dimitris.zenios@gmail.com>

* Comments and refactorings

Signed-off-by: Dimitris Zenios <dimitris.zenios@gmail.com>

* Make sure that FileDescriptorLeakDetectorRule will skip when run in os that does not support getting the open file descriptors

Signed-off-by: Dimitris Zenios <dimitris.zenios@gmail.com>

* Use JMX to collect the open file descriptor count instead of the com.sun API + minor improvements

Co-authored-by: Dimitris Zenios <dimitris.zenios@gmail.com>

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
