### PR TITLE
Make NodeInfo and RegistrationInfo implement ClusterSerializable

### DIFF
--- a/src/main/java/io/vertx/core/spi/cluster/NodeInfo.java
+++ b/src/main/java/io/vertx/core/spi/cluster/NodeInfo.java
@@ -11,8 +11,10 @@
 
 package io.vertx.core.spi.cluster;
 
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.Arguments;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.shareddata.impl.ClusterSerializable;
 
 import java.util.Objects;
 
@@ -21,11 +23,14 @@ import java.util.Objects;
  *
  * @author Thomas Segismont
  */
-public final class NodeInfo {
+public class NodeInfo implements ClusterSerializable {
 
-  private final String host;
-  private final int port;
-  private final JsonObject metadata;
+  private String host;
+  private int port;
+  private JsonObject metadata;
+
+  public NodeInfo() {
+  }
 
   public NodeInfo(String host, int port, JsonObject metadata) {
     this.host = Objects.requireNonNull(host, "host is null");
@@ -33,7 +38,6 @@ public final class NodeInfo {
     this.port = port;
     this.metadata = metadata;
   }
-
 
   public String host() {
     return host;
@@ -48,11 +52,63 @@ public final class NodeInfo {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    NodeInfo nodeInfo = (NodeInfo) o;
+
+    if (port != nodeInfo.port) return false;
+    if (!host.equals(nodeInfo.host)) return false;
+    return Objects.equals(metadata, nodeInfo.metadata);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = host.hashCode();
+    result = 31 * result + port;
+    result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
+    return result;
+  }
+
+  @Override
   public String toString() {
     return "NodeInfo{" +
       "host='" + host + '\'' +
       ", port=" + port +
       ", metadata=" + metadata +
       '}';
+  }
+
+  @Override
+  public void writeToBuffer(Buffer buffer) {
+    buffer.appendInt(host.length()).appendString(host);
+    buffer.appendInt(port);
+    if (metadata == null) {
+      buffer.appendInt(-1);
+    } else {
+      Buffer buf = metadata.toBuffer();
+      buffer.appendInt(buf.length()).appendBuffer(buf);
+    }
+  }
+
+  @Override
+  public int readFromBuffer(int start, Buffer buffer) {
+    int pos = start;
+    int len = buffer.getInt(pos);
+    pos += 4;
+    host = buffer.getString(pos, pos + len);
+    pos += len;
+    port = buffer.getInt(pos);
+    pos += 4;
+    len = buffer.getInt(pos);
+    pos += 4;
+    if (len == 0) {
+      metadata = new JsonObject();
+    } else if (len > 0) {
+      metadata = new JsonObject(buffer.getBuffer(pos, pos + len));
+      pos += len;
+    }
+    return pos;
   }
 }

--- a/src/test/java/io/vertx/core/spi/cluster/NodeInfoSerializationTest.java
+++ b/src/test/java/io/vertx/core/spi/cluster/NodeInfoSerializationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.spi.cluster;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.test.core.TestUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Thomas Segismont
+ */
+@RunWith(Parameterized.class)
+public class NodeInfoSerializationTest {
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+      {new NodeInfo("foo", 13004, null)},
+      {new NodeInfo("bar", 59500, new JsonObject())},
+      {new NodeInfo("baz", 30120, new JsonObject().put("foo", "bar"))}
+    });
+  }
+
+  private final NodeInfo expected;
+
+  public NodeInfoSerializationTest(NodeInfo expected) {
+    this.expected = expected;
+  }
+
+  @Test
+  public void testSerialization() {
+    Buffer padding = TestUtils.randomBuffer(TestUtils.randomShort());
+    Buffer buffer = Buffer.buffer();
+    buffer.appendBuffer(padding);
+    expected.writeToBuffer(buffer);
+    NodeInfo registrationInfo = new NodeInfo();
+    int pos = registrationInfo.readFromBuffer(padding.length(), buffer);
+    assertEquals(expected, registrationInfo);
+    assertEquals(buffer.length(), pos);
+  }
+}

--- a/src/test/java/io/vertx/core/spi/cluster/RegistrationInfoSerializationTest.java
+++ b/src/test/java/io/vertx/core/spi/cluster/RegistrationInfoSerializationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.spi.cluster;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.test.core.TestUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Thomas Segismont
+ */
+@RunWith(Parameterized.class)
+public class RegistrationInfoSerializationTest {
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+      {new RegistrationInfo("foo", -13004, true)},
+      {new RegistrationInfo("bar", +13004, false)}
+    });
+  }
+
+  private final RegistrationInfo expected;
+
+  public RegistrationInfoSerializationTest(RegistrationInfo expected) {
+    this.expected = expected;
+  }
+
+  @Test
+  public void testSerialization() {
+    Buffer padding = TestUtils.randomBuffer(TestUtils.randomShort());
+    Buffer buffer = Buffer.buffer();
+    buffer.appendBuffer(padding);
+    expected.writeToBuffer(buffer);
+    RegistrationInfo registrationInfo = new RegistrationInfo();
+    int pos = registrationInfo.readFromBuffer(padding.length(), buffer);
+    assertEquals(expected, registrationInfo);
+    assertEquals(buffer.length(), pos);
+  }
+}


### PR DESCRIPTION
This will ease CM implementations:

- no need to creating wrappers
- share the serialization implementation in Vert.x core