### PR TITLE
The shutdown hook wasn't starting the right thread and leaking the ca…

### DIFF
--- a/src/main/java/io/vertx/core/file/impl/FileResolver.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolver.java
@@ -26,8 +26,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Enumeration;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.function.IntPredicate;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -385,16 +383,16 @@ public class FileResolver {
     }
     // Add shutdown hook to delete on exit
     shutdownHook = new Thread(() -> {
-      CountDownLatch latch = new CountDownLatch(1);
-      new Thread(() -> {
+      final Thread deleteCacheDirThread = new Thread(() -> {
         try {
           deleteCacheDir();
         } catch (IOException ignore) {
         }
-        latch.countDown();
-      }).start();
+      });
+      // start the thread
+      deleteCacheDirThread.start();
       try {
-        latch.await(10, TimeUnit.SECONDS);
+        deleteCacheDirThread.join(10 * 1000);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }


### PR DESCRIPTION
…cheDir to null while still in use

Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

The delete cache dir shutdown hook isn't starting a thread properly, this means that the delete code set's the cache dir to null while still on the eventloop and may leak (like it happens on vertx-web unit tests). In this case cache files are written to the `CWD` when they shouldn't.