### PR TITLE
Prevent extra buffer copies when parsing did not extract anything

### DIFF
--- a/src/main/java/io/vertx/core/parsetools/impl/RecordParserImpl.java
+++ b/src/main/java/io/vertx/core/parsetools/impl/RecordParserImpl.java
@@ -228,7 +228,7 @@ public class RecordParserImpl implements RecordParser {
       int len = buff.length();
       if (start == len) {
         buff = EMPTY_BUFFER;
-      } else {
+      } else if (start > 0) {
         buff = buff.getBuffer(start, len);
       }
       pos -= start;


### PR DESCRIPTION
Signed-off-by: Thomas Cataldo <thomas.cataldo@blue-mind.net>


Motivation:

My workload needs to parse a stream containing 10 chunks with 100MB of fixed sized items inside a bigger string. Performance is abysmal and yourkit pointed to this line.
