### PR TITLE
testListenInvalidPort now valid for Windows and OSX

### DIFF
--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -2706,11 +2706,18 @@ public abstract class HttpTest extends HttpTestBase {
   @Test
   public void testListenInvalidPort() throws Exception {
     server.close();
-    try(ServerSocket occupied = new ServerSocket(0)){
+    ServerSocket occupied = null;
+    try{
+      /* Ask to be given a usable port, then use it exclusively so Vert.x can't use the port number */
+      occupied = new ServerSocket(0);
       occupied.setReuseAddress(false);
       server = vertx.createHttpServer(new HttpServerOptions().setPort(occupied.getLocalPort()));
       server.requestHandler(noOpHandler()).listen(onFailure(server -> testComplete()));
       await();
+    }finally {
+      if( occupied != null ) {
+        occupied.close();
+      }
     }
   }
 


### PR DESCRIPTION
Motivation:

The test 'testListenInvalidPort' fails on OSX as it is possible to use port 7 in that env,
from reading the test it also looks like this is true in Windows too.
 
Its test's failure trips up 'mvn clean install' on OSX.

This PR changes the test to first occupy a valid port (by asking for port 0)
exclusively (need to set this on OSX) and then using that occupied port
for the collision. The socket is Closable so the try with resources should
close the port (after the await) meaning the test should not leak socket
resources.

This test is also mentioned as failing in another env in #3051 

Signed-off-by: Gordon Hutchison <Gordon.Hutchison@gmail.com>