### PR TITLE
use rawPath for HttpUtils resolveURIReference(vertx-web#1637)

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -379,12 +379,12 @@ public final class HttpUtils {
     if (_ref.getScheme() != null) {
       scheme = _ref.getScheme();
       authority = _ref.getAuthority();
-      path = removeDots(_ref.getPath());
+      path = removeDots(_ref.getRawPath());
       query = _ref.getRawQuery();
     } else {
       if (_ref.getAuthority() != null) {
         authority = _ref.getAuthority();
-        path = _ref.getPath();
+        path = _ref.getRawPath();
         query = _ref.getRawQuery();
       } else {
         if (_ref.getPath().length() == 0) {
@@ -396,19 +396,19 @@ public final class HttpUtils {
           }
         } else {
           if (_ref.getPath().startsWith("/")) {
-            path = removeDots(_ref.getPath());
+            path = removeDots(_ref.getRawPath());
           } else {
             // Merge paths
             String mergedPath;
             String basePath = base.getPath();
             if (base.getAuthority() != null && basePath.length() == 0) {
-              mergedPath = "/" + _ref.getPath();
+              mergedPath = "/" + _ref.getRawPath();
             } else {
               int index = basePath.lastIndexOf('/');
               if (index > -1) {
                 mergedPath = basePath.substring(0, index + 1) + _ref.getPath();
               } else {
-                mergedPath = _ref.getPath();
+                mergedPath = _ref.getRawPath();
               }
             }
             path = removeDots(mergedPath);

--- a/src/test/java/io/vertx/core/http/HttpUtilsTest.java
+++ b/src/test/java/io/vertx/core/http/HttpUtilsTest.java
@@ -192,6 +192,14 @@ public class HttpUtilsTest {
     assertEquals("/b/", HttpUtils.normalizePath("/b/c/.."));
   }
 
+  @Test
+  public void testResolveURIEncode() throws Exception {
+    String url = "https://example.com";
+    String ref = "/%7Eusername/";
+    URI uri = HttpUtils.resolveURIReference(url, ref);
+    assertEquals(ref,uri.getPath());
+  }
+
   private void assertResolveUri(String expected, String base, String rel) throws Exception {
     URI resolved = HttpUtils.resolveURIReference(base, rel);
     assertEquals(URI.create(expected), resolved);


### PR DESCRIPTION
Fix [Repeat redirects 301 same location](https://github.com/vert-x3/vertx-web/issues/1637)