### PR TITLE
Support header size limit exceeded with http status 431

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -469,7 +469,14 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
       } else {
         version = HttpVersion.HTTP_1_1;
       }
-      HttpResponseStatus status = causeMsg.startsWith("An HTTP line is larger than") ? HttpResponseStatus.REQUEST_URI_TOO_LONG : HttpResponseStatus.BAD_REQUEST;
+      HttpResponseStatus status;
+      if (causeMsg.startsWith("An HTTP line is larger than")) {
+        status = HttpResponseStatus.REQUEST_URI_TOO_LONG;
+      } else if (causeMsg.startsWith("HTTP header is larger than")) {
+        status = HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE;
+      } else {
+        status = HttpResponseStatus.BAD_REQUEST;
+      }
       DefaultFullHttpResponse resp = new DefaultFullHttpResponse(version, status);
       ChannelPromise fut = chctx.newPromise();
       writeToChannel(resp, fut);

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -2674,7 +2674,7 @@ public class Http1xTest extends HttpTest {
                 assertEquals(200, resp.statusCode());
                 testComplete();
               } else {
-                assertEquals(400, resp.statusCode());
+                assertEquals(431, resp.statusCode());
                 resp.request().connection().closeHandler(v -> {
                   testComplete();
                 });


### PR DESCRIPTION
Vertx does not return 431 Request Header Fields Too Large status for HTTP/1.1 (could not confirm how it works on HTTP/2.0), instead it falls back to the generic 400 Bad Message (only handling explicitly 414 URI Too Long).

Back porting from https://github.com/eclipse-vertx/vert.x/pull/3458

Conformance:
Signed Eclipse Contributor Agreement