### PR TITLE
Reduced wrappers and copies on BufferImpl to reduce allocations and CPU usage

### DIFF
--- a/src/main/java/io/vertx/core/buffer/ByteBufUtils.java
+++ b/src/main/java/io/vertx/core/buffer/ByteBufUtils.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.buffer;
+
+import io.netty.buffer.*;
+import io.netty.util.CharsetUtil;
+import io.netty.util.internal.PlatformDependent;
+
+import java.nio.charset.Charset;
+import java.util.Objects;
+
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
+public final class ByteBufUtils {
+  private ByteBufUtils() {
+
+  }
+
+  // this wrapper is used to save copying byte[]
+  private static final class UnpooledWrappedByteBuf extends UnpooledHeapByteBuf {
+
+    protected UnpooledWrappedByteBuf(ByteBufAllocator alloc, byte[] initialArray, int maxCapacity) {
+      super(alloc, initialArray, maxCapacity);
+    }
+  }
+
+  public static UnpooledHeapByteBuf unpooledNotInstrumentedHeapByteBuf(int initialCapacity, int maxCapacity) {
+    checkPositiveOrZero(initialCapacity, "initialCapacity");
+    // this save instrumented heap ByteBuf allocation that would save statistics collection
+    return PlatformDependent.hasUnsafe() ?
+      new UnpooledUnsafeHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, initialCapacity, maxCapacity) :
+      new UnpooledHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, initialCapacity, maxCapacity);
+  }
+
+  public static ByteBuf unpooledBufferOf(String str, String enc) {
+    final Charset charset = Charset.forName(Objects.requireNonNull(enc));
+    return unpooledBufferOf(str, charset);
+  }
+
+  public static ByteBuf unpooledBufferOf(String str, Charset charset) {
+    if (charset.equals(CharsetUtil.UTF_8)) {
+      return utf8UnpooledBufferOf(str);
+    }
+    if (charset.equals(CharsetUtil.US_ASCII) || charset.equals(CharsetUtil.ISO_8859_1)) {
+      return usAsciiUnpooledBufferOf(str);
+    }
+    final byte[] bytes = str.getBytes(charset);
+    return new UnpooledWrappedByteBuf(UnpooledByteBufAllocator.DEFAULT, bytes, Integer.MAX_VALUE);
+  }
+
+  public static ByteBuf utf8UnpooledBufferOf(String str) {
+    final int utf8Bytes = ByteBufUtil.utf8Bytes(str);
+    final UnpooledHeapByteBuf buffer = unpooledNotInstrumentedHeapByteBuf(utf8Bytes, Integer.MAX_VALUE);
+    ByteBufUtil.reserveAndWriteUtf8(buffer, str, utf8Bytes);
+    return buffer;
+  }
+
+  public static ByteBuf usAsciiUnpooledBufferOf(String str) {
+    final int asciiBytes = str.length();
+    final UnpooledHeapByteBuf buffer = unpooledNotInstrumentedHeapByteBuf(asciiBytes, Integer.MAX_VALUE);
+    ByteBufUtil.writeAscii(buffer, str);
+    return buffer;
+  }
+
+}

--- a/src/main/java/io/vertx/core/buffer/ByteBufUtils.java
+++ b/src/main/java/io/vertx/core/buffer/ByteBufUtils.java
@@ -45,7 +45,17 @@ public final class ByteBufUtils {
 
   public static ByteBuf unpooledBufferOf(String str, String enc) {
     final Charset charset = Charset.forName(Objects.requireNonNull(enc));
-    return unpooledBufferOf(str, charset);
+    final byte[] bytes;
+    if (charset.equals(CharsetUtil.UTF_8)) {
+      bytes = new byte[ByteBufUtil.utf8Bytes(str)];
+      writeUtf8(bytes, 0, str, 0, str.length());
+    } else if (charset.equals(CharsetUtil.US_ASCII) || charset.equals(CharsetUtil.ISO_8859_1)) {
+      bytes = new byte[str.length()];
+      writeAscii(bytes, 0, str, str.length());
+    } else {
+      bytes = str.getBytes(charset);
+    }
+    return new UnpooledWrappedByteBuf(UnpooledByteBufAllocator.DEFAULT, bytes, Integer.MAX_VALUE);
   }
 
   public static ByteBuf unpooledBufferOf(String str, Charset charset) {

--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -13,8 +13,14 @@ package io.vertx.core.buffer.impl;
 
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.buffer.UnpooledHeapByteBuf;
+import io.netty.buffer.UnpooledUnsafeHeapByteBuf;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.PlatformDependent;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.Arguments;
 import io.vertx.core.json.JsonArray;
@@ -22,38 +28,85 @@ import io.vertx.core.json.JsonObject;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class BufferImpl implements Buffer {
 
+  // this wrapper is used to save copying byte[]
+  public static final class UnpooledWrappedByteBuf extends UnpooledHeapByteBuf {
+
+    protected UnpooledWrappedByteBuf(ByteBufAllocator alloc, byte[] initialArray, int maxCapacity) {
+      super(alloc, initialArray, maxCapacity);
+    }
+  }
+
   private ByteBuf buffer;
+
+  private static UnpooledHeapByteBuf unpooledNotInstrumentedHeapByteBuf(int initialCapacity, int maxCapacity) {
+    // this save instrumented heap ByteBuf allocation that would save statistics collection
+    return PlatformDependent.hasUnsafe() ?
+      new UnpooledUnsafeHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, initialCapacity, maxCapacity) :
+      new UnpooledHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, initialCapacity, maxCapacity);
+  }
 
   public BufferImpl() {
     this(0);
   }
 
   BufferImpl(int initialSizeHint) {
-    buffer = Unpooled.unreleasableBuffer(Unpooled.buffer(initialSizeHint, Integer.MAX_VALUE));
+    checkPositiveOrZero(initialSizeHint, "initialCapacity");
+    buffer = unpooledNotInstrumentedHeapByteBuf(initialSizeHint, Integer.MAX_VALUE);
   }
 
   BufferImpl(byte[] bytes) {
-    buffer = Unpooled.unreleasableBuffer(Unpooled.buffer(bytes.length, Integer.MAX_VALUE)).writeBytes(bytes);
+    buffer = unpooledNotInstrumentedHeapByteBuf(bytes.length, Integer.MAX_VALUE).writeBytes(bytes);
   }
 
   BufferImpl(String str, String enc) {
-    this(str.getBytes(Charset.forName(Objects.requireNonNull(enc))));
+    buffer = buffer(str, enc);
+  }
+
+  private static ByteBuf buffer(String str, String enc) {
+    final Charset charset = Charset.forName(Objects.requireNonNull(enc));
+    return buffer(str, charset);
+  }
+
+  private static ByteBuf buffer(String str, Charset charset) {
+    if (charset.equals(CharsetUtil.UTF_8)) {
+      return utf8Buffer(str);
+    }
+    if (charset.equals(CharsetUtil.US_ASCII) || charset.equals(CharsetUtil.ISO_8859_1)) {
+      return usAsciiBuffer(str);
+    }
+    final byte[] bytes = str.getBytes(charset);
+    return new UnpooledWrappedByteBuf(UnpooledByteBufAllocator.DEFAULT, bytes, Integer.MAX_VALUE);
+  }
+
+  private static ByteBuf utf8Buffer(String str) {
+    final int utf8Bytes = ByteBufUtil.utf8Bytes(str);
+    final UnpooledHeapByteBuf buffer = unpooledNotInstrumentedHeapByteBuf(utf8Bytes, Integer.MAX_VALUE);
+    ByteBufUtil.reserveAndWriteUtf8(buffer, str, utf8Bytes);
+    return buffer;
+  }
+
+  private static ByteBuf usAsciiBuffer(String str) {
+    final int asciiBytes = str.length();
+    final UnpooledHeapByteBuf buffer = unpooledNotInstrumentedHeapByteBuf(asciiBytes, Integer.MAX_VALUE);
+    ByteBufUtil.writeAscii(buffer, str);
+    return buffer;
   }
 
   BufferImpl(String str, Charset cs) {
-    this(str.getBytes(cs));
+    buffer = buffer(str, cs);
   }
 
   BufferImpl(String str) {
-    this(str, StandardCharsets.UTF_8);
+    this.buffer = utf8Buffer(str);
   }
 
   BufferImpl(ByteBuf buffer) {
@@ -61,7 +114,7 @@ public class BufferImpl implements Buffer {
   }
 
   public String toString() {
-    return buffer.toString(StandardCharsets.UTF_8);
+    return buffer.toString(CharsetUtil.UTF_8);
   }
 
   public String toString(String enc) {
@@ -201,8 +254,8 @@ public class BufferImpl implements Buffer {
   }
 
   public String getString(int start, int end) {
-    byte[] bytes = getBytes(start, end);
-    return new String(bytes, StandardCharsets.UTF_8);
+    Arguments.require(end >= start, "end must be greater or equal than start");
+    return buffer.toString(start, end - start, CharsetUtil.UTF_8);
   }
 
   public Buffer appendBuffer(Buffer buff) {
@@ -469,7 +522,7 @@ public class BufferImpl implements Buffer {
   public ByteBuf getByteBuf() {
     // Return a duplicate so the Buffer can be written multiple times.
     // See #648
-    return buffer.duplicate();
+    return Unpooled.unreleasableBuffer(buffer.duplicate());
   }
 
   private Buffer append(String str, Charset charset) {

--- a/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -28,6 +28,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.buffer.ByteBufUtils;
 import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -312,22 +313,22 @@ public class HttpServerResponseImpl implements HttpServerResponse {
 
   @Override
   public HttpServerResponseImpl write(String chunk, String enc) {
-    return write(Buffer.buffer(chunk, enc).getByteBuf(), conn.voidPromise);
+    return write(Unpooled.unreleasableBuffer(ByteBufUtils.unpooledBufferOf(chunk, enc)), conn.voidPromise);
   }
 
   @Override
   public HttpServerResponse write(String chunk, String enc, Handler<AsyncResult<Void>> handler) {
-    return write(Buffer.buffer(chunk, enc).getByteBuf(), conn.toPromise(handler));
+    return write(Unpooled.unreleasableBuffer(ByteBufUtils.unpooledBufferOf(chunk, enc)), conn.toPromise(handler));
   }
 
   @Override
   public HttpServerResponseImpl write(String chunk) {
-    return write(Buffer.buffer(chunk).getByteBuf(), conn.voidPromise);
+    return write(Unpooled.unreleasableBuffer(ByteBufUtils.utf8UnpooledBufferOf(chunk)), conn.voidPromise);
   }
 
   @Override
   public HttpServerResponse write(String chunk, Handler<AsyncResult<Void>> handler) {
-    return write(Buffer.buffer(chunk).getByteBuf(), conn.toPromise(handler));
+    return write(Unpooled.unreleasableBuffer(ByteBufUtils.utf8UnpooledBufferOf(chunk)), conn.toPromise(handler));
   }
 
   @Override
@@ -338,22 +339,22 @@ public class HttpServerResponseImpl implements HttpServerResponse {
 
   @Override
   public void end(String chunk) {
-    end(Buffer.buffer(chunk));
+    end(Unpooled.unreleasableBuffer(ByteBufUtils.utf8UnpooledBufferOf(chunk)), conn.voidPromise);
   }
 
   @Override
   public void end(String chunk, Handler<AsyncResult<Void>> handler) {
-    end(Buffer.buffer(chunk), handler);
+    end(Unpooled.unreleasableBuffer(ByteBufUtils.utf8UnpooledBufferOf(chunk)), conn.toPromise(handler));
   }
 
   @Override
   public void end(String chunk, String enc) {
-    end(Buffer.buffer(chunk, enc));
+    end(Unpooled.unreleasableBuffer(ByteBufUtils.unpooledBufferOf(chunk, enc)), conn.voidPromise);
   }
 
   @Override
   public void end(String chunk, String enc, Handler<AsyncResult<Void>> handler) {
-    end(Buffer.buffer(chunk, enc), handler);
+    end(Unpooled.unreleasableBuffer(ByteBufUtils.unpooledBufferOf(chunk, enc)), conn.toPromise(handler));
   }
 
   @Override
@@ -367,20 +368,23 @@ public class HttpServerResponseImpl implements HttpServerResponse {
   }
 
   private void end(Buffer chunk, ChannelPromise promise) {
+    end(chunk.getByteBuf(), promise);
+  }
+
+  private void end(ByteBuf chunk, ChannelPromise promise) {
     synchronized (conn) {
       if (written) {
         throw new IllegalStateException(RESPONSE_WRITTEN);
       }
-      ByteBuf data = chunk.getByteBuf();
-      bytesWritten += data.readableBytes();
+      bytesWritten += chunk.readableBytes();
       HttpObject msg;
       if (!headWritten) {
         // if the head was not written yet we can write out everything in one go
         // which is cheaper.
         prepareHeaders(bytesWritten);
-        msg = new AssembledFullHttpResponse(head, version, status, headers, data, trailingHeaders);
+        msg = new AssembledFullHttpResponse(head, version, status, headers, chunk, trailingHeaders);
       } else {
-        msg = new AssembledLastHttpContent(data, trailingHeaders);
+        msg = new AssembledLastHttpContent(chunk, trailingHeaders);
       }
       conn.writeToChannel(msg, promise);
       written = true;

--- a/src/test/benchmarks/io/vertx/benchmarks/BufferCreationBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/BufferCreationBenchmark.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.benchmarks;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.CharsetUtil;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.buffer.ByteBufUtils;
+import org.openjdk.jmh.annotations.*;
+
+@State(Scope.Benchmark)
+public class BufferCreationBenchmark extends BenchmarkBase {
+
+  @Param({"1", "4", "8", "16", "64"})
+  private int length;
+  private String endString;
+
+  @Setup
+  public void setup() {
+    final StringBuilder builder = new StringBuilder(length);
+    for (int i = 0; i < length; i++) {
+      // single ASCII char
+      builder.append('a');
+    }
+    endString = builder.toString();
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public Buffer utf8Buffer() {
+    return Buffer.buffer(endString);
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public Buffer utf8CharsetLookupBuffer() {
+    return Buffer.buffer(endString, CharsetUtil.UTF_8.name());
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public ByteBuf utf8ByteBuffer() {
+    return ByteBufUtils.utf8UnpooledBufferOf(endString);
+  }
+}


### PR DESCRIPTION
Buffer creation is creating unecessary Netty ByteBuf wrappers and performing avoidable copies while encoding into US_ASCII/UTF 8 and other charsets.