### PR TITLE
Explain WriteStream.write internal queue and Handler/Future

### DIFF
--- a/src/main/java/io/vertx/core/streams/WriteStream.java
+++ b/src/main/java/io/vertx/core/streams/WriteStream.java
@@ -46,12 +46,17 @@ public interface WriteStream<T> extends StreamBase {
    * check the {@link #writeQueueFull} method before writing. This is done automatically if using a {@link Pump}.
    *
    * @param data  the data to write
-   * @return a future completed with the result
+   * @return a future completed when the internal queue got the data
    */
   Future<Void> write(T data);
 
   /**
-   * Same as {@link #write(T)} but with an {@code handler} called when the operation completes
+   * Write some data to the stream. The data is put on an internal write queue, and the write actually happens
+   * asynchronously. To avoid running out of memory by putting too much on the write queue,
+   * check the {@link #writeQueueFull} method before writing. This is done automatically if using a {@link Pump}.
+   *
+   * @param data  the data to write
+   * @param handler  called after the internal queue got the data
    */
   void write(T data, Handler<AsyncResult<Void>> handler);
 


### PR DESCRIPTION
The javadoc of write(T, Handler) is unclear whether the Handler
is called after putting T into the internal queue or after
the actual write of T.

Solution:

Copy the javadoc of write(T) to write(T, Handler) to make it clear.

Also mention it in the Future `@return` and Handler `@param` javadoc.