### PR TITLE
#3482 Add getSameSite, isHttpOnly and isSecure to Cookie interface

### DIFF
--- a/src/main/java/io/vertx/core/http/Cookie.java
+++ b/src/main/java/io/vertx/core/http/Cookie.java
@@ -107,6 +107,11 @@ public interface Cookie {
   Cookie setSecure(boolean secure);
 
   /**
+   * @return the security status of this cookie
+   */
+  boolean isSecure();
+
+  /**
    * Determines if this cookie is HTTP only.
    * If set to true, this cookie cannot be accessed by a client
    * side script. However, this works only if the browser supports it.
@@ -119,6 +124,11 @@ public interface Cookie {
   Cookie setHttpOnly(boolean httpOnly);
 
   /**
+   * @return the http only status of this cookie
+   */
+  boolean isHttpOnly();
+
+  /**
    * Sets the same site of this cookie.
    *
    * @param policy The policy should be one of {@link CookieSameSite}.
@@ -126,6 +136,12 @@ public interface Cookie {
    */
   @Fluent
   Cookie setSameSite(CookieSameSite policy);
+
+  /**
+   * @return the SameSite policy of this cookie
+   */
+  @Nullable
+  CookieSameSite getSameSite();
 
   /**
    * Encode the cookie to a string. This is what is used in the Set-Cookie header

--- a/src/main/java/io/vertx/core/http/impl/CookieImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/CookieImpl.java
@@ -133,6 +133,11 @@ public class CookieImpl implements ServerCookie {
   }
 
   @Override
+  public boolean isSecure() {
+    return nettyCookie.isSecure();
+  }
+
+  @Override
   public Cookie setHttpOnly(final boolean httpOnly) {
     nettyCookie.setHttpOnly(httpOnly);
     this.changed = true;
@@ -140,10 +145,20 @@ public class CookieImpl implements ServerCookie {
   }
 
   @Override
+  public boolean isHttpOnly() {
+    return nettyCookie.isHttpOnly();
+  }
+
+  @Override
   public Cookie setSameSite(final CookieSameSite sameSite) {
     this.sameSite = sameSite;
     this.changed = true;
     return this;
+  }
+
+  @Override
+  public CookieSameSite getSameSite() {
+    return this.sameSite;
   }
 
   @Override

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -5858,16 +5858,19 @@ public abstract class HttpTest extends HttpTestBase {
 
     cookie.setMaxAge(Long.MIN_VALUE);
     cookie.setSecure(true);
+    assertTrue(cookie.isSecure());
     assertEquals("foo=bar; Path=/somepath; Domain=foo.com; Secure", cookie.encode());
     cookie.setHttpOnly(true);
+    assertTrue(cookie.isHttpOnly());
     assertEquals("foo=bar; Path=/somepath; Domain=foo.com; Secure; HTTPOnly", cookie.encode());
   }
 
   @Test
-  public void testCookieSameSiteFieldEncoding() throws Exception {
+  public void testCookieSameSiteFieldEncoding() {
     Cookie cookie = Cookie.cookie("foo", "bar").setSameSite(CookieSameSite.LAX);
     assertEquals("foo", cookie.getName());
     assertEquals("bar", cookie.getValue());
+    assertEquals(CookieSameSite.LAX, cookie.getSameSite());
     assertEquals("foo=bar; SameSite=Lax", cookie.encode());
 
     cookie.setSecure(true);


### PR DESCRIPTION
Motivation:

Issue: #3482

When using vertx Cookies it is frustrating to not be able to easily make assertions about the value of a cookies httpOnly status, security status and same site policy.