### PR TITLE
Add missing (but common Vary header name)

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -404,6 +404,12 @@ public interface HttpHeaders {
   CharSequence GET = createOptimized("GET");
 
   /**
+   * Vary header name
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence VARY = createOptimized("vary");
+
+  /**
    * Create an optimized {@link CharSequence} which can be used as header name or value.
    * This should be used if you expect to use it multiple times liked for example adding the same header name or value
    * for multiple responses or requests.


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

`Vary` is a common header that is missing from the vertx API and forces other modules (e.g.: vertx-web) to refer to netty internal classes or use strings for it. Adding it will not break any API and will allow a consistent experience.