### PR TITLE
Yet another issue related to #3487

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/headers/HeadersMultiMap.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/HeadersMultiMap.java
@@ -537,8 +537,9 @@ public final class HeadersMultiMap extends HttpHeaders implements MultiMap {
           prev.next = next;
         }
         e.remove();
+      } else {
+        prev = e;
       }
-      prev = e;
       e = next;
     }
   }

--- a/src/test/java/io/vertx/core/http/headers/VertxHttpHeadersTest.java
+++ b/src/test/java/io/vertx/core/http/headers/VertxHttpHeadersTest.java
@@ -214,7 +214,8 @@ public class VertxHttpHeadersTest extends HeadersTestBase {
     MultiMap mmap = newMultiMap();
     String name1 = this.sameHash1;
     String name2 = this.sameHash2;
-    mmap.set(name1, "v");
+    mmap.add(name1, "v");
+    mmap.add(name1, "v");
     mmap.add(name2, "q");
     mmap.remove(name1);
     mmap.set(name1, "w");


### PR DESCRIPTION
The prev(ous) pointer stays the same when removing.

Signed-off-by: Adam Dickmeiss <adam@indexdata.dk>