### PR TITLE
Context.put and .putLocal should remove if value is null

### DIFF
--- a/src/main/java/io/vertx/core/Context.java
+++ b/src/main/java/io/vertx/core/Context.java
@@ -195,6 +195,7 @@ public interface Context {
    * @param key  the key of the data
    * @param <T>  the type of the data
    * @return the data
+   * @throws NullPointerException  if the specified key is null
    */
   <T> T get(String key);
 
@@ -204,7 +205,8 @@ public interface Context {
    * This can be used to share data between different handlers that share a context
    *
    * @param key  the key of the data
-   * @param value  the data
+   * @param value  the data, or null to remove the key
+   * @throws NullPointerException  if the specified key is null
    */
   void put(String key, Object value);
 
@@ -213,6 +215,7 @@ public interface Context {
    *
    * @param key  the key to remove
    * @return true if removed successfully, false otherwise
+   * @throws NullPointerException  if the specified key is null
    */
   boolean remove(String key);
 
@@ -222,6 +225,7 @@ public interface Context {
    * @param key  the key of the data
    * @param <T>  the type of the data
    * @return the data
+   * @throws NullPointerException  if the specified key is null
    */
   <T> T getLocal(String key);
 
@@ -231,7 +235,8 @@ public interface Context {
    * This can be used to share data between different handlers that share a context
    *
    * @param key  the key of the data
-   * @param value  the data
+   * @param value  the data, or null to remove the key
+   * @throws NullPointerException  if the specified key is null
    */
   void putLocal(String key, Object value);
 
@@ -240,6 +245,7 @@ public interface Context {
    *
    * @param key  the key to remove
    * @return true if removed successfully, false otherwise
+   * @throws NullPointerException  if the specified key is null
    */
   boolean removeLocal(String key);
 

--- a/src/main/java/io/vertx/core/impl/AbstractContext.java
+++ b/src/main/java/io/vertx/core/impl/AbstractContext.java
@@ -298,7 +298,11 @@ abstract class AbstractContext implements ContextInternal {
 
   @Override
   public final void put(String key, Object value) {
-    contextData().put(key, value);
+    if (value == null) {
+      contextData().remove(key);
+    } else {
+      contextData().put(key, value);
+    }
   }
 
   @Override
@@ -314,7 +318,11 @@ abstract class AbstractContext implements ContextInternal {
 
   @Override
   public final void putLocal(String key, Object value) {
-    localContextData().put(key, value);
+    if (value == null) {
+      localContextData().remove(key);
+    } else {
+      localContextData().put(key, value);
+    }
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/ContextInternal.java
+++ b/src/main/java/io/vertx/core/impl/ContextInternal.java
@@ -13,7 +13,6 @@ package io.vertx.core.impl;
 
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.FastThreadLocalThread;
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.*;
 import io.vertx.core.spi.tracing.VertxTracer;
 
@@ -220,11 +219,15 @@ public interface ContextInternal extends Context, Executor {
    * @return the {@link ConcurrentMap} used to store context data
    * @see Context#get(String)
    * @see Context#put(String, Object)
+   * @see Context#remove(String)
    */
   ConcurrentMap<Object, Object> contextData();
 
   /**
    * @return the {@link ConcurrentMap} used to store local context data
+   * @see Context#getLocal(String)
+   * @see Context#putLocal(String, Object)
+   * @see Context#removeLocal(String)
    */
   ConcurrentMap<Object, Object> localContextData();
 

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -84,20 +84,49 @@ public class ContextTest extends VertxTestBase {
   class SomeObject {
   }
 
+  class LocalObject {
+  }
+
   @Test
   public void testPutGetRemoveData() throws Exception {
     SomeObject obj = new SomeObject();
+    LocalObject loc = new LocalObject();
     vertx.runOnContext(v -> {
       Context ctx = Vertx.currentContext();
+      // check that put and putLocal use different hashes
       ctx.put("foo", obj);
+      ctx.putLocal("foo", loc);
       ctx.runOnContext(v2 -> {
         assertEquals(obj, ctx.get("foo"));
+        assertEquals(loc, ctx.getLocal("foo"));
         assertTrue(ctx.remove("foo"));
+        assertTrue(ctx.removeLocal("foo"));
         ctx.runOnContext(v3 -> {
           assertNull(ctx.get("foo"));
+          assertNull(ctx.getLocal("foo"));
           testComplete();
         });
       });
+    });
+    await();
+  }
+
+  @Test
+  public void testNullData() throws Exception {
+    LocalObject obj = new LocalObject();
+    LocalObject loc = new LocalObject();
+    vertx.runOnContext(v -> {
+      Context ctx = Vertx.currentContext();
+      ctx.put("foo", obj);
+      ctx.putLocal("foo", loc);
+      ctx.put("foo", null);  // null should remove
+      assertNull(ctx.get("foo"));
+      assertFalse(ctx.remove("foo"));  // should already have been removed
+      assertEquals(loc, ctx.getLocal("foo"));
+      ctx.putLocal("foo", null);  // null should remove
+      assertNull(ctx.getLocal("foo"));
+      assertFalse(ctx.removeLocal("foo"));  // should already have been removed
+      testComplete();
     });
     await();
   }


### PR DESCRIPTION
Context.put(key, value) and Context.putLocal(key, value) are implemented
with a ConcurrentHashMap that throws NullPointerException if key or value
is null.

For usability remove the key when putting a null value. This is almost
always what the caller wants.

Add javadoc when put, get, remove, putLocal, getLocal, removeLocal
throw NullPointerException.

Signed-off-by: Julian Ladisch <eclipse.org-rtn@ladisch.de>