### PR TITLE
Fix cache dir path, atomically create dirs and set ownership

### DIFF
--- a/src/main/asciidoc/filesystem.adoc
+++ b/src/main/asciidoc/filesystem.adoc
@@ -130,9 +130,10 @@ You can also use the _pipe_ to write file content into HTTP responses, or more g
 [[classpath]]
 ==== Accessing files from the classpath
 
-When vert.x cannot find the file on the filesystem it tries to resolve the
-file from the class path. Note that classpath resource paths never start with
-a `/`.
+When Vert.x needs to read a file from the classpath (embedded in a fat jar, in a jar form the classpath or a file
+that is on the classpath), it copies it to a cache directory. This behavior can be configured.
+
+Note that classpath resource paths never start with a `/`.
 
 Due to the fact that Java does not offer async access to classpath
 resources, the file is copied to the filesystem in a worker thread when the
@@ -142,21 +143,31 @@ the filesystem is served directly from the filesystem. The original content
 is served even if the classpath resource changes (e.g. in a development
 system).
 
+==== Configuring Vert.x cache
+
 This caching behaviour can be set on the {@link io.vertx.core.file.FileSystemOptions#setFileCachingEnabled(boolean)}
 option. The default value of this option is `true` unless the system property `vertx.disableFileCaching` is
 defined.
 
-The path where the files are cached is `.vertx` by default and can be customized by setting the system
-property `vertx.cacheDirBase`.
+When you are editing resources such as HTML, CSS or JavaScript, this cache mechanism can be annoying as it serves
+only the first version of the file (and so you won't see your edits if you reload your page). To avoid this
+behavior, launch your application with `-Dvertx.disableFileCaching=true`. With this setting, Vert.x still uses
+the cache, but always refresh the version stored in the cache with the original source. So if you edit a file
+served from the classpath and refresh your browser, Vert.x reads it from the classpath, copies it to the cache
+directory and serves it from there. Do not use this setting in production, it can kill your performances.
 
-The whole classpath resolving feature can be disabled system-wide by setting the system
-property `vertx.disableFileCPResolving` to `true`.
+The path where the files are cached is the default temporary directory as denoted by the `java.io.tmpdir`
+system property or the current directory as fall-back. The cache directory can be customized by setting the system
+property `vertx.cacheDirBase`. Vert.x creates a unique directory inside this one to avoid conflicts.
+If multiple users use the same `vertx.cacheDirBase` it must be created beforehand with write permissions
+for all of them.
+
+Finally, you can disable completely the cache by using `-Dvertx.disableFileCPResolving=true`. This setting is not
+without consequences. Vert.x would be unable to read any files from the classpath (only from the file system). Be
+very careful when using this settings.
 
 NOTE: these system properties are evaluated once when the the `io.vertx.core.file.FileSystemOptions` class is loaded, so
 these properties should be set before loading this class or as a JVM system property when launching it.
-
-If you want to disable classpath resolving for a particular application but keep it enabled by default system-wide,
-you can do so via the {@link io.vertx.core.file.FileSystemOptions#setClassPathResolvingEnabled(boolean)} option.
 
 ==== Closing an AsyncFile
 

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1561,35 +1561,3 @@ When you use the {@link io.vertx.core.Launcher} class as main class, it uses the
 `stop` command
 * `14` if the system configuration is not meeting the system requirement (shc as java not found)
 * `15` if the main verticle cannot be deployed
-
-== Configuring Vert.x cache
-
-When Vert.x needs to read a file from the classpath (embedded in a fat jar, in a jar form the classpath or a file
-that is on the classpath), it copies it to a cache directory. The reason behind this is simple: reading a file
-from a jar or from an input stream is blocking. So to avoid to pay the price every time, Vert.x copies the file to
-its cache directory and reads it from there every subsequent read. This behavior can be configured.
-
-First, by default, Vert.x uses `$CWD/.vertx` as cache directory. It creates a unique directory inside this one to
-avoid conflicts. This location can be configured by using the `vertx.cacheDirBase` system property. For instance
-if the current working directory is not writable (such as in an immutable container context), launch your
-application with:
-
-[source]
-----
-vertx run my.Verticle -Dvertx.cacheDirBase=/tmp/vertx-cache
-# or
-java -jar my-fat.jar vertx.cacheDirBase=/tmp/vertx-cache
-----
-
-IMPORTANT: the directory must be **writable**.
-
-When you are editing resources such as HTML, CSS or JavaScript, this cache mechanism can be annoying as it serves
-only the first version of the file (and so you won't see your edits if you reload your page). To avoid this
-behavior, launch your application with `-Dvertx.disableFileCaching=true`. With this setting, Vert.x still uses
-the cache, but always refresh the version stored in the cache with the original source. So if you edit a file
-served from the classpath and refresh your browser, Vert.x reads it from the classpath, copies it to the cache
-directory and serves it from there. Do not use this setting in production, it can kill your performances.
-
-Finally, you can disable completely the cache by using `-Dvertx.disableFileCPResolving=true`. This setting is not
-without consequences. Vert.x would be unable to read any files from the classpath (only from the file system). Be
-very careful when using this settings.

--- a/src/main/java/io/vertx/core/file/FileSystemOptions.java
+++ b/src/main/java/io/vertx/core/file/FileSystemOptions.java
@@ -15,8 +15,6 @@ package io.vertx.core.file;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
-import java.io.File;
-
 import static io.vertx.core.file.impl.FileResolver.*;
 
 /**
@@ -40,13 +38,12 @@ public class FileSystemOptions {
   // get the system default temp dir location (can be overriden by using the standard java system property)
   // if not present default to the process start CWD
   private static final String TMPDIR = System.getProperty("java.io.tmpdir", ".");
-  private static final String DEFAULT_CACHE_DIR_BASE = "vertx-cache";
 
   /**
    * The default file caching dir. If the system property {@code "vertx.cacheDirBase"} is set, then this is the value
-   * If not, then the system property {@code java.io.tmpdir} is taken or {code .} if not set. suffixed with {@code vertx-cache}.
+   * If not, then the system property {@code java.io.tmpdir} is taken or {code .} if not set.
    */
-  public static final String DEFAULT_FILE_CACHING_DIR = System.getProperty(CACHE_DIR_BASE_PROP_NAME, TMPDIR + File.separator + DEFAULT_CACHE_DIR_BASE);
+  public static final String DEFAULT_FILE_CACHING_DIR = System.getProperty(CACHE_DIR_BASE_PROP_NAME, TMPDIR);
 
   private boolean classPathResolvingEnabled = DEFAULT_CLASS_PATH_RESOLVING_ENABLED;
   private boolean fileCachingEnabled = DEFAULT_FILE_CACHING_ENABLED;

--- a/src/main/java/io/vertx/core/file/impl/FileResolver.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolver.java
@@ -19,13 +19,17 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Enumeration;
-import java.util.UUID;
+import java.util.Set;
 import java.util.function.IntPredicate;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -92,7 +96,7 @@ public class FileResolver {
   private Thread shutdownHook;
   private final boolean enableCaching;
   private final boolean enableCpResolving;
-  private final String fileCacheDir;
+  private final String cacheDirBaseName;
 
   public FileResolver() {
     this(new FileSystemOptions());
@@ -101,7 +105,7 @@ public class FileResolver {
   public FileResolver(FileSystemOptions fileSystemOptions) {
     this.enableCaching = fileSystemOptions.isFileCachingEnabled();
     this.enableCpResolving = fileSystemOptions.isClassPathResolvingEnabled();
-    this.fileCacheDir = fileSystemOptions.getFileCacheDir();
+    this.cacheDirBaseName = fileSystemOptions.getFileCacheDir();
 
     String cwdOverride = System.getProperty("vertx.cwd");
     if (cwdOverride != null) {
@@ -110,7 +114,7 @@ public class FileResolver {
       cwd = null;
     }
     if (this.enableCpResolving) {
-      setupCacheDir(UUID.randomUUID().toString());
+      setupCacheDir();
     }
   }
 
@@ -375,11 +379,16 @@ public class FileResolver {
     return cl;
   }
 
-  private synchronized void setupCacheDir(String id) {
-    String cacheDirName = fileCacheDir + "/file-cache-" + id;
-    cacheDir = new File(cacheDirName);
-    if (!cacheDir.mkdirs()) {
-      throw new IllegalStateException("Failed to create cache dir: " + cacheDirName);
+  private synchronized void setupCacheDir() {
+    FileAttribute<Set<PosixFilePermission>> ownerPermissions =
+        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
+
+    try {
+      Path cacheDirBase = new File(cacheDirBaseName).toPath();
+      Files.createDirectories(cacheDirBase, ownerPermissions);
+      cacheDir = Files.createTempDirectory(cacheDirBase, "vertx-cache-", ownerPermissions).toFile();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e.getMessage() + ": " + cacheDirBaseName, e);
     }
     // Add shutdown hook to delete on exit
     shutdownHook = new Thread(() -> {

--- a/src/test/java/io/vertx/core/file/FileResolverTestBase.java
+++ b/src/test/java/io/vertx/core/file/FileResolverTestBase.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  */
 public abstract class FileResolverTestBase extends VertxTestBase {
 
-  private final String cacheBaseDir = new File(System.getProperty("java.io.tmpdir", ".") + File.separator + "vertx-cache").getAbsolutePath();
+  private final String cacheBaseDir = new File(System.getProperty("java.io.tmpdir", ".")).getAbsolutePath();
 
   protected FileResolver resolver;
 
@@ -96,7 +96,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile("afile.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>afile</body></html>", readFile(file));
     }
@@ -109,7 +109,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
       for (int i = 0; i < 2; i++) {
         File file = vertx.resolveFile("afile.html");
         assertTrue(file.exists());
-        assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+        assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
         assertFalse(file.isDirectory());
         assertEquals("<html><body>afile</body></html>", readFile(file));
       }
@@ -123,7 +123,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile("afile with spaces.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>afile with spaces</body></html>", readFile(file));
     }
@@ -134,7 +134,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot);
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
       assertTrue(file.isDirectory());
     }
   }
@@ -144,7 +144,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot + "/somefile.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>blah</body></html>", readFile(file));
     }
@@ -155,7 +155,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot + "/subdir");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
       assertTrue(file.isDirectory());
     }
   }
@@ -165,7 +165,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot + "/subdir/subfile.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>subfile</body></html>", readFile(file));
     }


### PR DESCRIPTION
On a multi-user system the first user that runs Vert.x
creates /tmp/vertx-cache/ and owns this directory and
prevents all other users from using it.

Solution:

Replace
/tmp/vertx-cache/file-cache-xxxxx/
by
/tmp/vertx-cache-xxxxx/

To prevent any race conditions use Files.createTempDirectory.

The "vertx.cacheDirBase" configuration option works as before: If
the directory doesn't exist it is created. Files.createDirectories
is used to prevent race conditions.

For security the directory permissions are restricted to the user
atomically when they are created.

Resolves #3510