### PR TITLE
Revert "Deprecate Message replyAddress method"

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/Message.java
+++ b/src/main/java/io/vertx/core/eventbus/Message.java
@@ -59,10 +59,8 @@ public interface Message<T> {
    * The reply address. Can be null.
    *
    * @return the reply address, or null, if message was sent without a reply handler.
-   * @deprecated deprecated as of Vert.x 4.0, exposes internal details
    */
   @Nullable
-  @Deprecated
   String replyAddress();
 
   /**

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -539,8 +539,10 @@ public class MetricsTest extends VertxTestBase {
     CountDownLatch latch = new CountDownLatch(1);
     EventBus eb = vertx.eventBus();
     FakeEventBusMetrics metrics = FakeMetricsBase.getMetrics(eb);
+    AtomicReference<String> replyAddress = new AtomicReference<>();
     CountDownLatch regLatch = new CountDownLatch(1);
     eb.consumer("foo", msg -> {
+      replyAddress.set(msg.replyAddress());
       msg.fail(0, "whatever");
     }).completionHandler(onSuccess(v -> {
       regLatch.countDown();


### PR DESCRIPTION
Reverts eclipse-vertx/vert.x#3509

`replyAddress` is used by eventbus bridges.