### PR TITLE
add vert.x options to specify thread prefix

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -2088,6 +2088,9 @@ Set whether Netty pooled buffers are enabled
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
+|[[acceptorThreadPrefix]]`@acceptorThreadPrefix`|`String`|+++
+Set acceptor thread prefix.
++++
 |[[addressResolverOptions]]`@addressResolverOptions`|`link:dataobjects.html#AddressResolverOptions[AddressResolverOptions]`|+++
 Sets the address resolver configuration to configure resolving DNS servers, cache TTL, etc...
 +++
@@ -2130,6 +2133,9 @@ Sets the event bus configuration to configure the host, port, ssl...
 |[[eventLoopPoolSize]]`@eventLoopPoolSize`|`Number (int)`|+++
 Set the number of event loop threads to be used by the Vert.x instance.
 +++
+|[[eventLoopThreadPrefix]]`@eventLoopThreadPrefix`|`String`|+++
+Set the event loop thread prefix.
++++
 |[[fileResolverCachingEnabled]]`@fileResolverCachingEnabled`|`Boolean`|+++
 Set whether the Vert.x file resolver uses caching for classpath resources.
 +++
@@ -2144,6 +2150,9 @@ Set the HA group to be used when HA is enabled.
 +++
 |[[internalBlockingPoolSize]]`@internalBlockingPoolSize`|`Number (int)`|+++
 Set the value of internal blocking pool size
++++
+|[[internalBlockingThreadPrefix]]`@internalBlockingThreadPrefix`|`String`|+++
+Set internal blocking thread prefix.
 +++
 |[[maxEventLoopExecuteTime]]`@maxEventLoopExecuteTime`|`Number (long)`|+++
 Sets the value of max event loop execute time, in link.
@@ -2176,6 +2185,9 @@ Set the threshold value above this, the blocked warning contains a stack trace. 
 +++
 |[[warningExceptionTimeUnit]]`@warningExceptionTimeUnit`|`link:enums.html#TimeUnit[TimeUnit]`|+++
 Set the time unit of <code>warningExceptionTime</code>.
++++
+|[[workThreadPrefix]]`@workThreadPrefix`|`String`|+++
+Set worker thread prefix.
 +++
 |[[workerPoolSize]]`@workerPoolSize`|`Number (int)`|+++
 Set the maximum number of worker threads to be used by the Vert.x instance.

--- a/src/main/generated/io/vertx/core/VertxOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/VertxOptionsConverter.java
@@ -14,6 +14,11 @@ import java.time.format.DateTimeFormatter;
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, VertxOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "acceptorThreadPrefix":
+          if (member.getValue() instanceof String) {
+            obj.setAcceptorThreadPrefix((String)member.getValue());
+          }
+          break;
         case "addressResolverOptions":
           if (member.getValue() instanceof JsonObject) {
             obj.setAddressResolverOptions(new io.vertx.core.dns.AddressResolverOptions((JsonObject)member.getValue()));
@@ -74,6 +79,11 @@ import java.time.format.DateTimeFormatter;
             obj.setEventLoopPoolSize(((Number)member.getValue()).intValue());
           }
           break;
+        case "eventLoopThreadPrefix":
+          if (member.getValue() instanceof String) {
+            obj.setEventLoopThreadPrefix((String)member.getValue());
+          }
+          break;
         case "fileResolverCachingEnabled":
           if (member.getValue() instanceof Boolean) {
             obj.setFileResolverCachingEnabled((Boolean)member.getValue());
@@ -97,6 +107,11 @@ import java.time.format.DateTimeFormatter;
         case "internalBlockingPoolSize":
           if (member.getValue() instanceof Number) {
             obj.setInternalBlockingPoolSize(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "internalBlockingThreadPrefix":
+          if (member.getValue() instanceof String) {
+            obj.setInternalBlockingThreadPrefix((String)member.getValue());
           }
           break;
         case "maxEventLoopExecuteTime":
@@ -144,6 +159,11 @@ import java.time.format.DateTimeFormatter;
             obj.setWarningExceptionTimeUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
           }
           break;
+        case "workThreadPrefix":
+          if (member.getValue() instanceof String) {
+            obj.setWorkThreadPrefix((String)member.getValue());
+          }
+          break;
         case "workerPoolSize":
           if (member.getValue() instanceof Number) {
             obj.setWorkerPoolSize(((Number)member.getValue()).intValue());
@@ -158,6 +178,9 @@ import java.time.format.DateTimeFormatter;
   }
 
    static void toJson(VertxOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getAcceptorThreadPrefix() != null) {
+      json.put("acceptorThreadPrefix", obj.getAcceptorThreadPrefix());
+    }
     if (obj.getAddressResolverOptions() != null) {
       json.put("addressResolverOptions", obj.getAddressResolverOptions().toJson());
     }
@@ -180,6 +203,9 @@ import java.time.format.DateTimeFormatter;
       json.put("eventBusOptions", obj.getEventBusOptions().toJson());
     }
     json.put("eventLoopPoolSize", obj.getEventLoopPoolSize());
+    if (obj.getEventLoopThreadPrefix() != null) {
+      json.put("eventLoopThreadPrefix", obj.getEventLoopThreadPrefix());
+    }
     json.put("fileResolverCachingEnabled", obj.isFileResolverCachingEnabled());
     if (obj.getFileSystemOptions() != null) {
       json.put("fileSystemOptions", obj.getFileSystemOptions().toJson());
@@ -189,6 +215,9 @@ import java.time.format.DateTimeFormatter;
       json.put("haGroup", obj.getHAGroup());
     }
     json.put("internalBlockingPoolSize", obj.getInternalBlockingPoolSize());
+    if (obj.getInternalBlockingThreadPrefix() != null) {
+      json.put("internalBlockingThreadPrefix", obj.getInternalBlockingThreadPrefix());
+    }
     json.put("maxEventLoopExecuteTime", obj.getMaxEventLoopExecuteTime());
     if (obj.getMaxEventLoopExecuteTimeUnit() != null) {
       json.put("maxEventLoopExecuteTimeUnit", obj.getMaxEventLoopExecuteTimeUnit().name());
@@ -205,6 +234,9 @@ import java.time.format.DateTimeFormatter;
     json.put("warningExceptionTime", obj.getWarningExceptionTime());
     if (obj.getWarningExceptionTimeUnit() != null) {
       json.put("warningExceptionTimeUnit", obj.getWarningExceptionTimeUnit().name());
+    }
+    if (obj.getWorkThreadPrefix() != null) {
+      json.put("workThreadPrefix", obj.getWorkThreadPrefix());
     }
     json.put("workerPoolSize", obj.getWorkerPoolSize());
   }

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -44,6 +44,26 @@ public class VertxOptions {
   public static final int DEFAULT_WORKER_POOL_SIZE = 20;
 
   /**
+   * The default event loop thread prefix
+   */
+  public static final String DEFAULT_EVENT_LOOP_THREAD_PREFIX = "vert.x-eventloop-thread-";
+
+  /**
+   * The default acceptor thread prefix
+   */
+  public static final String DEFAULT_ACCEPTOR_THREAD_PREFIX = "vert.x-acceptor-thread-";
+
+  /**
+   * The default worker thread prefix
+   */
+  public static final String DEFAULT_WORKER_THREAD_PREFIX = "vert.x-worker-thread-";
+
+  /**
+   * The default internal blocking thread prefix
+   */
+  public static final String DEFAULT_INTERNAL_BLOCKING_THREAD_PREFIX = "vert.x-internal-blocking-";
+
+  /**
    * The default number of threads in the internal blocking  pool (used by some internal operations) = 20
    */
   public static final int DEFAULT_INTERNAL_BLOCKING_POOL_SIZE = 20;
@@ -168,6 +188,10 @@ public class VertxOptions {
 
   private int eventLoopPoolSize = DEFAULT_EVENT_LOOP_POOL_SIZE;
   private int workerPoolSize = DEFAULT_WORKER_POOL_SIZE;
+  private String eventLoopThreadPrefix = DEFAULT_EVENT_LOOP_THREAD_PREFIX;
+  private String acceptorThreadPrefix = DEFAULT_ACCEPTOR_THREAD_PREFIX;
+  private String workThreadPrefix = DEFAULT_WORKER_THREAD_PREFIX;
+  private String internalBlockingThreadPrefix = DEFAULT_INTERNAL_BLOCKING_THREAD_PREFIX;
   private int internalBlockingPoolSize = DEFAULT_INTERNAL_BLOCKING_POOL_SIZE;
   private long blockedThreadCheckInterval = DEFAULT_BLOCKED_THREAD_CHECK_INTERVAL;
   private long maxEventLoopExecuteTime = DEFAULT_MAX_EVENT_LOOP_EXECUTE_TIME;
@@ -201,6 +225,10 @@ public class VertxOptions {
   public VertxOptions(VertxOptions other) {
     this.eventLoopPoolSize = other.getEventLoopPoolSize();
     this.workerPoolSize = other.getWorkerPoolSize();
+    this.eventLoopThreadPrefix = other.getEventLoopThreadPrefix();
+    this.acceptorThreadPrefix = other.getAcceptorThreadPrefix();
+    this.workThreadPrefix = other.getWorkThreadPrefix();
+    this.internalBlockingThreadPrefix = other.getInternalBlockingThreadPrefix();
     this.blockedThreadCheckInterval = other.getBlockedThreadCheckInterval();
     this.maxEventLoopExecuteTime = other.getMaxEventLoopExecuteTime();
     this.maxWorkerExecuteTime = other.getMaxWorkerExecuteTime();
@@ -275,6 +303,90 @@ public class VertxOptions {
       throw new IllegalArgumentException("workerPoolSize must be > 0");
     }
     this.workerPoolSize = workerPoolSize;
+    return this;
+  }
+
+  /**
+   * Get the event loop thread prefix.
+   *
+   * @return the event loop thread prefix
+   */
+  public String getEventLoopThreadPrefix() {
+    return eventLoopThreadPrefix;
+  }
+
+  /**
+   * Set the event loop thread prefix.
+   *
+   * @param eventLoopThreadPrefix the event loop thread prefix
+   * @return a reference to this, so the API can be used fluently
+   */
+  public VertxOptions setEventLoopThreadPrefix(String eventLoopThreadPrefix) {
+    Objects.requireNonNull(eventLoopThreadPrefix, "event loop thread prefix cannot be null");
+    this.eventLoopThreadPrefix = eventLoopThreadPrefix;
+    return this;
+  }
+
+  /**
+   * Get the acceptor thread prefix.
+   *
+   * @return the acceptor thread prefix
+   */
+  public String getAcceptorThreadPrefix() {
+    return acceptorThreadPrefix;
+  }
+
+  /**
+   * Set acceptor thread prefix.
+   *
+   * @param acceptorThreadPrefix the acceptor thread prefix
+   * @return a reference to this, so the API can be used fluently
+   */
+  public VertxOptions setAcceptorThreadPrefix(String acceptorThreadPrefix) {
+    Objects.requireNonNull(acceptorThreadPrefix, "acceptor thread prefix cannot be null");
+    this.acceptorThreadPrefix = acceptorThreadPrefix;
+    return this;
+  }
+
+  /**
+   * Get the worker thread prefix.
+   *
+   * @return the worker thread prefix
+   */
+  public String getWorkThreadPrefix() {
+    return workThreadPrefix;
+  }
+
+  /**
+   * Set worker thread prefix.
+   *
+   * @param workThreadPrefix the worker thread prefix
+   * @return a reference to this, so the API can be used fluently
+   */
+  public VertxOptions setWorkThreadPrefix(String workThreadPrefix) {
+    Objects.requireNonNull(workThreadPrefix, "worker thread prefix cannot be null");
+    this.workThreadPrefix = workThreadPrefix;
+    return this;
+  }
+
+  /**
+   * Get the internal blocking thread prefix.
+   *
+   * @return the internal blocking thread prefix
+   */
+  public String getInternalBlockingThreadPrefix() {
+    return internalBlockingThreadPrefix;
+  }
+
+  /**
+   * Set internal blocking thread prefix.
+   *
+   * @param internalBlockingThreadPrefix the internal blocking thread prefix
+   * @return a reference to this, so the API can be used fluently
+   */
+  public VertxOptions setInternalBlockingThreadPrefix(String internalBlockingThreadPrefix) {
+    Objects.requireNonNull(internalBlockingThreadPrefix, "internal blocking thread prefix cannot be null");
+    this.internalBlockingThreadPrefix = internalBlockingThreadPrefix;
     return this;
   }
 
@@ -904,6 +1016,10 @@ public class VertxOptions {
 
     if (eventLoopPoolSize != that.eventLoopPoolSize) return false;
     if (workerPoolSize != that.workerPoolSize) return false;
+    if (!eventLoopThreadPrefix.equals(that.eventLoopThreadPrefix)) return false;
+    if (!acceptorThreadPrefix.equals(that.acceptorThreadPrefix)) return false;
+    if (!workThreadPrefix.equals(that.workThreadPrefix)) return false;
+    if (!internalBlockingThreadPrefix.equals(that.internalBlockingThreadPrefix)) return false;
     if (internalBlockingPoolSize != that.internalBlockingPoolSize) return false;
     if (blockedThreadCheckInterval != that.blockedThreadCheckInterval) return false;
     if (blockedThreadCheckIntervalUnit != that.blockedThreadCheckIntervalUnit) return false;
@@ -934,6 +1050,10 @@ public class VertxOptions {
     int result = eventLoopPoolSize;
     result = 31 * result + workerPoolSize;
     result = 31 * result + internalBlockingPoolSize;
+    result = 31 * result + eventLoopThreadPrefix.hashCode();
+    result = 31 * result + acceptorThreadPrefix.hashCode();
+    result = 31 * result + workThreadPrefix.hashCode();
+    result = 31 * result + internalBlockingThreadPrefix.hashCode();
     result = 31 * result + (int) (blockedThreadCheckInterval ^ (blockedThreadCheckInterval >>> 32));
     result = 31 * result + (int) (maxEventLoopExecuteTime ^ (maxEventLoopExecuteTime >>> 32));
     result = 31 * result + (int) (maxWorkerExecuteTime ^ (maxWorkerExecuteTime >>> 32));
@@ -959,6 +1079,10 @@ public class VertxOptions {
     return "VertxOptions{" +
         "eventLoopPoolSize=" + eventLoopPoolSize +
         ", workerPoolSize=" + workerPoolSize +
+        ", eventLoopThreadPrefix=" + eventLoopThreadPrefix +
+        ", acceptorThreadPrefix=" + acceptorThreadPrefix +
+        ", workThreadPrefix=" + workThreadPrefix +
+        ", internalBlockingThreadPrefix=" + internalBlockingThreadPrefix +
         ", internalBlockingPoolSize=" + internalBlockingPoolSize +
         ", blockedThreadCheckIntervalUnit=" + blockedThreadCheckIntervalUnit +
         ", blockedThreadCheckInterval=" + blockedThreadCheckInterval +

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -139,9 +139,9 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     checker = new BlockedThreadChecker(options.getBlockedThreadCheckInterval(), options.getBlockedThreadCheckIntervalUnit(), options.getWarningExceptionTime(), options.getWarningExceptionTimeUnit());
     maxEventLoopExTime = options.getMaxEventLoopExecuteTime();
     maxEventLoopExecTimeUnit = options.getMaxEventLoopExecuteTimeUnit();
-    eventLoopThreadFactory = new VertxThreadFactory("vert.x-eventloop-thread-", checker, false, maxEventLoopExTime, maxEventLoopExecTimeUnit);
+    eventLoopThreadFactory = new VertxThreadFactory(options.getEventLoopThreadPrefix(), checker, false, maxEventLoopExTime, maxEventLoopExecTimeUnit);
     eventLoopGroup = transport.eventLoopGroup(Transport.IO_EVENT_LOOP_GROUP, options.getEventLoopPoolSize(), eventLoopThreadFactory, NETTY_IO_RATIO);
-    ThreadFactory acceptorEventLoopThreadFactory = new VertxThreadFactory("vert.x-acceptor-thread-", checker, false, options.getMaxEventLoopExecuteTime(), options.getMaxEventLoopExecuteTimeUnit());
+    ThreadFactory acceptorEventLoopThreadFactory = new VertxThreadFactory(options.getAcceptorThreadPrefix(), checker, false, options.getMaxEventLoopExecuteTime(), options.getMaxEventLoopExecuteTimeUnit());
     // The acceptor event loop thread needs to be from a different pool otherwise can get lags in accepted connections
     // under a lot of load
     acceptorEventLoopGroup = transport.eventLoopGroup(Transport.ACCEPTOR_EVENT_LOOP_GROUP, 1, acceptorEventLoopThreadFactory, 100);
@@ -151,10 +151,10 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     int workerPoolSize = options.getWorkerPoolSize();
     ExecutorService workerExec = new ThreadPoolExecutor(workerPoolSize, workerPoolSize,
       0L, TimeUnit.MILLISECONDS, new LinkedTransferQueue<>(),
-      new VertxThreadFactory("vert.x-worker-thread-", checker, true, options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit()));
+      new VertxThreadFactory(options.getWorkThreadPrefix(), checker, true, options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit()));
     PoolMetrics workerPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-worker-thread", options.getWorkerPoolSize()) : null;
     ExecutorService internalBlockingExec = Executors.newFixedThreadPool(options.getInternalBlockingPoolSize(),
-        new VertxThreadFactory("vert.x-internal-blocking-", checker, true, options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit()));
+        new VertxThreadFactory(options.getInternalBlockingThreadPrefix(), checker, true, options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit()));
     PoolMetrics internalBlockingPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-internal-blocking", options.getInternalBlockingPoolSize()) : null;
     internalBlockingPool = new WorkerPool(internalBlockingExec, internalBlockingPoolMetrics);
     namedWorkerPools = new HashMap<>();


### PR DESCRIPTION
Signed-off-by: liubao <bismy@qq.com>

Motivation:

In our application, we connect to many different systems using vert.x clients, and also listen to different transports(http, tcp,etc) using vert.x server. And many of them deploy different vert.x instances. We need to add different thread prefix to distinguish the logs printed by different clients and transports. 

Now we change thread name by hacking the code using reflection. After upgrading to JDK 14, the hacking is not allowed any more. 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
