### PR TITLE
Websocket end handler should be called when idle timeout occurs

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -537,8 +537,10 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
 
   void handleClosed() {
     unregisterHandlers();
+    Handler<Void> endHandler;
     Handler<Void> closeHandler;
     synchronized (conn) {
+      endHandler = pending.isPaused() ? null : this.endHandler;
       closeHandler = this.closeHandler;
       closed = true;
       binaryHandlerRegistration = null;
@@ -546,6 +548,9 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
     }
     if (closeHandler != null) {
       closeHandler.handle(null);
+    }
+    if (endHandler != null) {
+      endHandler.handle(null);
     }
   }
 

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -1383,6 +1383,21 @@ public class WebSocketTest extends VertxTestBase {
   }
 
   @Test
+  public void testIdleTimeout() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(3);
+    server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT).setIdleTimeout(3).setIdleTimeoutUnit(TimeUnit.SECONDS)).webSocketHandler(serverWs -> {
+      serverWs.closeHandler(v -> latch.countDown());
+      serverWs.endHandler(v -> latch.countDown());
+    });
+    server.listen(onSuccess(s -> {
+      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/some/path", onSuccess(clientWs -> {
+        latch.countDown();
+      }));
+    }));
+    awaitLatch(latch);
+  }
+
+  @Test
   public void testRequestEntityTooLarge() {
     String path = "/some/path";
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).websocketHandler(ws -> fail());


### PR DESCRIPTION
Motivation:

Fixes https://github.com/eclipse-vertx/vert.x/issues/3527
