### PR TITLE
Add route support to http server metrics.

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -412,4 +412,15 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
    */
   Map<String, Cookie> cookieMap();
 
+	/**
+	 * Marks this request as being routed to the given route. This is purely informational and is
+	 * being provided to metrics.
+	 *
+	 * @param route The route this request has been routed to.
+	 */
+	@Fluent
+	default HttpServerRequest routed(String route) {
+	  return this;
+  }
+
 }

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -581,7 +581,7 @@ public class Http1xServerRequest implements HttpServerRequest {
 
   @Override
   public HttpServerRequest routed(String route) {
-    if (METRICS_ENABLED && conn.metrics != null) {
+    if (METRICS_ENABLED && !response.ended() && conn.metrics != null) {
       conn.metrics.requestRouted(metric, route);
     }
     return this;

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -578,4 +578,12 @@ public class Http1xServerRequest implements HttpServerRequest {
   public Map<String, Cookie> cookieMap() {
     return (Map)response.cookies();
   }
+
+  @Override
+  public HttpServerRequest routed(String route) {
+    if (METRICS_ENABLED && conn.metrics != null) {
+      conn.metrics.requestRouted(metric, route);
+    }
+    return this;
+  }
 }

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
@@ -531,4 +531,10 @@ public class Http2ServerRequestImpl extends Http2ServerStream implements HttpSer
   public Map<String, Cookie> cookieMap() {
     return (Map) response.cookies();
   }
+
+  @Override
+  public HttpServerRequest routed(String route) {
+    super.routed(route);
+    return this;
+  }
 }

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
@@ -130,7 +130,7 @@ abstract class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection>
   }
 
   HttpServerRequest routed(String route) {
-    if (METRICS_ENABLED) {
+    if (METRICS_ENABLED && !response.ended()) {
       HttpServerMetrics metrics = conn.metrics();
       if (metrics != null) {
         metrics.requestRouted(metric, route);

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
@@ -128,4 +128,14 @@ abstract class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection>
       }
     }
   }
+
+  HttpServerRequest routed(String route) {
+    if (METRICS_ENABLED) {
+      HttpServerMetrics metrics = conn.metrics();
+      if (metrics != null) {
+        metrics.requestRouted(metric, route);
+      }
+    }
+    return null;
+  }
 }

--- a/src/main/java/io/vertx/core/spi/metrics/HttpServerMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/HttpServerMetrics.java
@@ -108,4 +108,12 @@ public interface HttpServerMetrics<R, W, S> extends TCPMetrics<S> {
    */
   default void disconnected(W serverWebSocketMetric) {
   }
+
+  /**
+   * Called when a routing layer indicates a request has been routed.
+   * @param requestMetric the request metric
+   * @param route the route the request has been routed to
+   */
+  default void requestRouted(R requestMetric, String route) {
+  }
 }

--- a/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
+++ b/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
@@ -67,6 +67,9 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
       assertNotNull(serverMetric.get().socket);
       assertNull(serverMetric.get().response.get());
       assertTrue(serverMetric.get().socket.connected.get());
+      assertNull(serverMetric.get().route.get());
+      req.routed("/route/:param");
+      assertEquals("/route/:param", serverMetric.get().route.get());
       req.bodyHandler(buff -> {
         assertEquals(contentLength, buff.length());
         HttpServerResponse resp = req.response().setChunked(true);
@@ -257,6 +260,24 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
         assertTrue(metric.failed.get());
         testComplete();
       });
+    });
+    startServer();
+    client.request(requestOptions).onComplete(onSuccess(HttpClientRequest::end));
+    await();
+  }
+
+  @Test
+  public void testRouteMetrics() throws Exception {
+    server.requestHandler(req -> {
+      FakeHttpServerMetrics metrics = FakeMetricsBase.getMetrics(server);
+      HttpServerMetric metric = metrics.getMetric(req);
+      assertNull(metric.route.get());
+      req.routed("MyRoute");
+      assertEquals("MyRoute", metric.route.get());
+      req.routed("MyRoute - rerouted");
+      assertEquals("MyRoute - rerouted", metric.route.get());
+      req.response().end();
+      testComplete();
     });
     startServer();
     client.request(requestOptions).onComplete(onSuccess(HttpClientRequest::end));

--- a/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
+++ b/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
@@ -283,4 +283,20 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
     client.request(requestOptions).onComplete(onSuccess(HttpClientRequest::end));
     await();
   }
+
+  @Test
+  public void testRouteMetricsIgnoredAfterResponseEnd() throws Exception {
+    server.requestHandler(req -> {
+      FakeHttpServerMetrics metrics = FakeMetricsBase.getMetrics(server);
+      HttpServerMetric metric = metrics.getMetric(req);
+      assertNull(metric.route.get());
+      req.response().end();
+      req.routed("Routed after ending");
+      assertNull(metric.route.get());
+      testComplete();
+    });
+    startServer();
+    client.request(requestOptions).onComplete(onSuccess(HttpClientRequest::end));
+    await();
+  }
 }

--- a/src/test/java/io/vertx/test/fakemetrics/FakeHttpServerMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeHttpServerMetrics.java
@@ -115,4 +115,8 @@ public class FakeHttpServerMetrics extends FakeMetricsBase implements HttpServer
   public void exceptionOccurred(SocketMetric socketMetric, SocketAddress remoteAddress, Throwable t) {
   }
 
+  @Override
+  public void requestRouted(HttpServerMetric requestMetric, String route) {
+    requestMetric.route.set(route);
+  }
 }

--- a/src/test/java/io/vertx/test/fakemetrics/HttpServerMetric.java
+++ b/src/test/java/io/vertx/test/fakemetrics/HttpServerMetric.java
@@ -26,6 +26,7 @@ public class HttpServerMetric {
   public final SocketMetric socket;
   public final AtomicBoolean failed = new AtomicBoolean();
   public final AtomicReference<HttpServerResponse> response = new AtomicReference<>();
+  public final AtomicReference<String> route = new AtomicReference<>();
 
   public HttpServerMetric(HttpServerRequest request, SocketMetric socket) {
     this.request = request;


### PR DESCRIPTION
Motivation:

In preparation for https://github.com/vert-x3/vertx-web/issues/1431 and https://github.com/vert-x3/vertx-micrometer-metrics/issues/34

* adds `requestRouted(R requestMetric, String route)` to the http server metric SPI as proposed by @vietj [here](https://github.com/vert-x3/vertx-micrometer-metrics/issues/34#issuecomment-462356893)
* adds a `routed(String route)` to `HttpServerRequest` delegating to metrics to avoid exposing `requestMetric`

Companion PRs:
* https://github.com/vert-x3/vertx-web/pull/1682
* https://github.com/vert-x3/vertx-micrometer-metrics/pull/111
* https://github.com/vert-x3/vertx-dropwizard-metrics/pull/101