### PR TITLE
Added a method to CompositeFuture to retrieve all failure causes

### DIFF
--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -17,6 +17,8 @@ import io.vertx.core.impl.future.CompositeFutureImpl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * The composite future wraps a list of {@link Future futures}, it is useful when several futures
@@ -245,5 +247,15 @@ public interface CompositeFuture extends Future<CompositeFuture> {
       list.add(resultAt(index));
     }
     return list;
+  }
+
+  /**
+   * @return a list of all the eventual failure causes. If no future failed, returns a list of null values.
+   */
+  @GenIgnore
+  default List<Throwable> causes() {
+    return IntStream.range(0, size())
+      .mapToObj(this::cause)
+      .collect(Collectors.toList());
   }
 }

--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -254,8 +254,11 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    */
   @GenIgnore
   default List<Throwable> causes() {
-    return IntStream.range(0, size())
-      .mapToObj(this::cause)
-      .collect(Collectors.toList());
+    int size = size();
+    ArrayList<Throwable> list = new ArrayList<>(size);
+    for (int index = 0; index < size; index++) {
+      list.add(cause(index));
+    }
+    return list;
   }
 }

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -543,6 +543,17 @@ public class FutureTest extends VertxTestBase {
   }
 
   @Test
+  public void testCompositeFutureCauses() {
+    CompositeFuture composite = CompositeFuture.all(Future.failedFuture("blabla"), Future.succeededFuture());
+
+    assertEquals(2, composite.causes().size());
+    assertNotNull(composite.causes().get(0));
+    assertEquals("blabla", composite.causes().get(0).getMessage());
+
+    assertNull(composite.causes().get(1));
+  }
+
+  @Test
   public void testCompositeFutureMulti() {
     Promise<String> p1 = Promise.promise();
     Future<String> f1 = p1.future();


### PR DESCRIPTION
Motivation:

Retrieving failures from a composite future requires some boilerplate, which can be avoided with this `causes` method.
