### PR TITLE
Issues/cookie expires improvement

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/CookieImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/CookieImpl.java
@@ -53,6 +53,8 @@ public class CookieImpl implements ServerCookie {
         // we need to expire it and sent it back to it can be
         // invalidated
         cookie.setMaxAge(0L);
+        // void the value for user-agents that still read the cookie
+        cookie.setValue("");
       } else {
         // this was a temporary cookie so we can safely remove it
         cookieMap.remove(name);

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -5965,7 +5965,7 @@ public abstract class HttpTest extends HttpTestBase {
       Cookie removed = req.response().removeCookie("foo");
       assertNotNull(removed);
       assertEquals("foo", removed.getName());
-      assertEquals("bar", removed.getValue());
+      assertEquals("", removed.getValue());
       req.response().end();
     }, resp -> {
       List<String> cookies = resp.headers().getAll("set-cookie");

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -5971,7 +5971,7 @@ public abstract class HttpTest extends HttpTestBase {
       List<String> cookies = resp.headers().getAll("set-cookie");
       // the expired cookie must be sent back
       assertEquals(1, cookies.size());
-      assertTrue(cookies.get(0).contains("foo=bar"));
+      assertTrue(cookies.get(0).contains("foo="));
       assertTrue(cookies.get(0).contains("Max-Age=0"));
       assertTrue(cookies.get(0).contains("Expires="));
     });


### PR DESCRIPTION
Motivation:

Cookie expiration is not required to be executed immediately. Chrome for example will not remove the cookie after parsing the header, so it is recommended to clear the value as well as setting the max age to 0.