### PR TITLE
Allow to define a timer with no delay (handler is invoked immediately)

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -502,10 +502,11 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   public long scheduleTimeout(ContextInternal context, Handler<Long> handler, long delay, boolean periodic) {
-    if (delay < 1) {
-      throw new IllegalArgumentException("Cannot schedule a timer with delay < 1 ms");
-    }
     long timerId = timeoutCounter.getAndIncrement();
+    if (delay < 1) {
+      handler.handle(timerId);
+      return timerId;
+    }
     InternalTimerHandler task = new InternalTimerHandler(timerId, handler, periodic, delay, context);
     timeouts.put(timerId, task);
     if (context.isDeployment()) {


### PR DESCRIPTION
Sometimes I want to wait for an arbitrary delay before to perform an action. This delay can be zero, but the method setTimer() does not accept zero, which leads to the following tiedous code :

```
if(delay > 0) {
  cb();
} else {
  vertx.setTimer(delay, l -> cb());
}
```
With this change, I'll be able to invoke setTimer() even if the delay is zero.

Another reason why I need this change is that sometimes I want to break a callback chain. Invoking setTimer(0, l -> cb()) is a good way to have a function invoked from the mainloop instead of from the current code, without introducing any delay. For example, into Javax/Swing you invoke SwingUtilities.invokeLater(runnable).