### PR TITLE
Allow to pass a delay of 0 to setTimer()

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -502,8 +502,8 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   public long scheduleTimeout(ContextInternal context, Handler<Long> handler, long delay, boolean periodic) {
-    if (delay < 1) {
-      throw new IllegalArgumentException("Cannot schedule a timer with delay < 1 ms");
+    if (delay < 0) {
+      throw new IllegalArgumentException("Cannot schedule a timer with delay < 0 ms");
     }
     long timerId = timeoutCounter.getAndIncrement();
     InternalTimerHandler task = new InternalTimerHandler(timerId, handler, periodic, delay, context);

--- a/src/test/java/io/vertx/core/TimerTest.java
+++ b/src/test/java/io/vertx/core/TimerTest.java
@@ -33,6 +33,11 @@ public class TimerTest extends VertxTestBase {
   }
 
   @Test
+  public void testTimer0() {
+    timer(0);
+  }
+
+  @Test
   public void testPeriodic() {
     periodic(10);
   }


### PR DESCRIPTION
Allow to pass a delay of 0 to setTimer() (handler is called back immediately).
First motivation : have the same code whether delay is zero or more
Second motivation : break callback chain by sometimes invoking `setTimer(0, l -> cb());` in order to have the cb invoked by the mainloop instead of by the current code.

Signed-off-by: Christophe Quintard <christophe.quintard@ouest-france.fr>
