### PR TITLE
Fixes Resolver delete race against file resolve

### DIFF
--- a/src/main/java/io/vertx/core/file/impl/FileResolver.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolver.java
@@ -114,19 +114,18 @@ public class FileResolver {
    * Close this file resolver, this is a blocking operation.
    */
   public void close() throws IOException {
-    // avoid monitor, if already disabled
-    if (shutdownHook != null) {
-      synchronized (this) {
-        if (shutdownHook != null) {
-          // May throw IllegalStateException if called from other shutdown hook so ignore that
-          try {
-            Runtime.getRuntime().removeShutdownHook(shutdownHook);
-          } catch (IllegalStateException ignore) {
-            // ignore
-          } finally {
-            shutdownHook = null;
-          }
-        }
+    final Thread hook;
+    synchronized (this) {
+      hook = shutdownHook;
+      // disable the shutdown hook thread
+      shutdownHook = null;
+    }
+    if (hook != null) {
+      // May throw IllegalStateException if called from other shutdown hook so ignore that
+      try {
+        Runtime.getRuntime().removeShutdownHook(hook);
+      } catch (IllegalStateException ignore) {
+        // ignore
       }
     }
     deleteCacheDir();

--- a/src/main/java/io/vertx/core/file/impl/FileResolver.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolver.java
@@ -384,6 +384,7 @@ public class FileResolver {
     }
 
     // the cachedir will be prefixed a unique id to avoid eavesdroping from other processes
+    // also this ensures that if process A deletes cacheDir, it won't affect process B
     String cacheDirName = fileCacheDir + "-" + UUID.randomUUID().toString();
     File cacheDir = new File(cacheDirName);
 

--- a/src/test/java/io/vertx/core/file/FileResolverTestBase.java
+++ b/src/test/java/io/vertx/core/file/FileResolverTestBase.java
@@ -97,7 +97,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile("afile.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>afile</body></html>", readFile(file));
     }
@@ -110,7 +110,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
       for (int i = 0; i < 2; i++) {
         File file = vertx.resolveFile("afile.html");
         assertTrue(file.exists());
-        assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+        assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
         assertFalse(file.isDirectory());
         assertEquals("<html><body>afile</body></html>", readFile(file));
       }
@@ -124,7 +124,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile("afile with spaces.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>afile with spaces</body></html>", readFile(file));
     }
@@ -135,7 +135,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot);
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertTrue(file.isDirectory());
     }
   }
@@ -145,7 +145,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot + "/somefile.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>blah</body></html>", readFile(file));
     }
@@ -156,7 +156,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot + "/subdir");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertTrue(file.isDirectory());
     }
   }
@@ -166,7 +166,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot + "/subdir/subfile.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>subfile</body></html>", readFile(file));
     }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Cleaning the FileSystem cache happens usually on a shutdown thread, outside the resolver monitor. It also changes the resolver state to set the cache dir object to null.

This has a couple of side effects:

1. A call to resolve while the delete is happening will use the "to be deleted directory" as root.
2. A resolve call during clear cache will see that the `cacheDir` object is `null` which will lead to resolved file to be written to the `${user.dir}`.
3. As `cacheDir` shared the same directory for all instances (by default) a clear for instance A will wipe the cache for instance B

The last item was also reported by https://github.com/eclipse-vertx/vert.x/issues/3510

This PR addresses the issue in the following way:

1. `cacheDir` is `final` and computed at `<ctor>` time.
2. `clearCache` will be synchronized on the `resolver` iif the is `cacheDir`
3. caches are suffixed with an UUID instead of sharing a common directory.

The last item only addresses the uniqueness and independence of caches not the full discussion on https://github.com/eclipse-vertx/vert.x/issues/3510 . As a note the mentioned issue warns about potential collisions, however wikipedia tells us that the change of a collision is 1 in a billion: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random) . Given that most `unices` can handle a few million processes:

```
cat /proc/sys/kernel/pid_max
4194304
```

I'm not attempting to change the current use of UUIDs + on regular operations caches are deleted on VM shutdown, which means the probability will be even smaller.
