### PR TITLE
InternalError eventbus failure type

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/ReplyFailure.java
+++ b/src/main/java/io/vertx/core/eventbus/ReplyFailure.java
@@ -39,7 +39,7 @@ public enum ReplyFailure {
   /**
    * A fatal error occured while delivering the message. Do not retry to send.
    */
-  INTERNAL_ERROR;
+  ERROR;
 
   public static ReplyFailure fromInt(int i) {
     switch (i) {
@@ -50,7 +50,7 @@ public enum ReplyFailure {
       case 2:
         return RECIPIENT_FAILURE;
       case 3:
-        return INTERNAL_ERROR;
+        return ERROR;
       default:
         throw new IllegalStateException("Invalid index " + i);
     }
@@ -64,7 +64,7 @@ public enum ReplyFailure {
         return 1;
       case RECIPIENT_FAILURE:
         return 2;
-      case INTERNAL_ERROR:
+      case ERROR:
         return 3;
       default:
         throw new IllegalStateException("How did we get here?");

--- a/src/main/java/io/vertx/core/eventbus/ReplyFailure.java
+++ b/src/main/java/io/vertx/core/eventbus/ReplyFailure.java
@@ -32,25 +32,42 @@ public enum ReplyFailure {
   NO_HANDLERS,
 
   /**
-   * The message send failed because the recipient actively sent back a failure (rejected the message)
+   * The message send failed because the recipient actively sent back a failure (rejected the message).
    */
-  RECIPIENT_FAILURE;
+  RECIPIENT_FAILURE,
+
+  /**
+   * A fatal error occured while delivering the message. Do not retry to send.
+   */
+  INTERNAL_ERROR;
 
   public static ReplyFailure fromInt(int i) {
     switch (i) {
-      case 0: return TIMEOUT;
-      case 1: return NO_HANDLERS;
-      case 2: return RECIPIENT_FAILURE;
-      default: throw new IllegalStateException("Invalid index " + i);
+      case 0:
+        return TIMEOUT;
+      case 1:
+        return NO_HANDLERS;
+      case 2:
+        return RECIPIENT_FAILURE;
+      case 3:
+        return INTERNAL_ERROR;
+      default:
+        throw new IllegalStateException("Invalid index " + i);
     }
   }
 
   public int toInt() {
     switch (this) {
-      case TIMEOUT: return 0;
-      case NO_HANDLERS: return 1;
-      case RECIPIENT_FAILURE: return 2;
-      default: throw new IllegalStateException("How did we get here?");
+      case TIMEOUT:
+        return 0;
+      case NO_HANDLERS:
+        return 1;
+      case RECIPIENT_FAILURE:
+        return 2;
+      case INTERNAL_ERROR:
+        return 3;
+      default:
+        throw new IllegalStateException("How did we get here?");
     }
   }
 }

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -250,7 +250,9 @@ public class ClusteredEventBus extends EventBusImpl {
             }
             parser.fixedSizeMode(4);
             size = -1;
-            if (received.codec() == CodecManager.PING_MESSAGE_CODEC) {
+            if (received.hasFailure()) {
+              received.internalError();
+            } else if (received.codec() == CodecManager.PING_MESSAGE_CODEC) {
               // Just send back pong directly on connection
               socket.write(PONG);
             } else {

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
@@ -16,6 +16,8 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
 import io.vertx.core.eventbus.impl.CodecManager;
 import io.vertx.core.eventbus.impl.EventBusImpl;
 import io.vertx.core.eventbus.impl.MessageImpl;
@@ -41,6 +43,7 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
   private int headersPos;
   private boolean fromWire;
   private boolean toWire;
+  private String failure;
 
   public ClusteredMessage(EventBusImpl bus) {
     super(bus);
@@ -135,8 +138,7 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
     // Overall Length already read when passed in here
     byte protocolVersion = buffer.getByte(pos);
     if (protocolVersion > WIRE_PROTOCOL_VERSION) {
-      throw new IllegalStateException("Invalid wire protocol version " + protocolVersion +
-                                      " should be <= " + WIRE_PROTOCOL_VERSION);
+      setFailure("Invalid wire protocol version " + protocolVersion + " should be <= " + WIRE_PROTOCOL_VERSION);
     }
     pos++;
     byte systemCodecCode = buffer.getByte(pos);
@@ -149,7 +151,7 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
       String codecName = new String(bytes, CharsetUtil.UTF_8);
       messageCodec = codecManager.getCodec(codecName);
       if (messageCodec == null) {
-        throw new IllegalStateException("No message codec registered with name " + codecName);
+        setFailure("No message codec registered with name " + codecName);
       }
       pos += length;
     } else {
@@ -181,6 +183,12 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
     bodyPos = pos;
     wireBuffer = buffer;
     fromWire = true;
+  }
+
+  private void setFailure(String s) {
+    if (failure == null) {
+      failure = s;
+    }
   }
 
   private void decodeBody() {
@@ -257,5 +265,17 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
 
   protected boolean isLocal() {
     return !isFromWire();
+  }
+
+  boolean hasFailure() {
+    return failure != null;
+  }
+
+  void internalError() {
+    if (replyAddress != null) {
+      reply(new ReplyException(ReplyFailure.INTERNAL_ERROR, failure));
+    } else {
+      log.trace(failure);
+    }
   }
 }

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
@@ -273,7 +273,7 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
 
   void internalError() {
     if (replyAddress != null) {
-      reply(new ReplyException(ReplyFailure.INTERNAL_ERROR, failure));
+      reply(new ReplyException(ReplyFailure.ERROR, failure));
     } else {
       log.trace(failure);
     }

--- a/src/test/java/io/vertx/core/eventbus/InternalErrorTest.java
+++ b/src/test/java/io/vertx/core/eventbus/InternalErrorTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.eventbus;
+
+import io.vertx.core.eventbus.EventBusTestBase.MyPOJO;
+import io.vertx.core.eventbus.EventBusTestBase.MyPOJOEncoder2;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+public class InternalErrorTest extends VertxTestBase {
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    startNodes(2);
+  }
+
+  @Test
+  public void testUnknownCodec() {
+    MyPOJOEncoder2 codec = new MyPOJOEncoder2();
+    vertices[0].eventBus().registerCodec(codec);
+    vertices[1].eventBus().consumer("foo", msg -> {
+      fail("Should not receive message");
+    }).completionHandler(onSuccess(v -> {
+      DeliveryOptions options = new DeliveryOptions().setCodecName(codec.name());
+      vertices[0].eventBus().request("foo", new MyPOJO("bar"), options, onFailure(t -> {
+        assertThat(t, instanceOf(ReplyException.class));
+        ReplyException e = (ReplyException) t;
+        assertSame(ReplyFailure.INTERNAL_ERROR, e.failureType());
+        testComplete();
+      }));
+    }));
+    await();
+  }
+}

--- a/src/test/java/io/vertx/core/eventbus/ReplyFailureErrorTest.java
+++ b/src/test/java/io/vertx/core/eventbus/ReplyFailureErrorTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-public class InternalErrorTest extends VertxTestBase {
+public class ReplyFailureErrorTest extends VertxTestBase {
 
   @Override
   public void setUp() throws Exception {
@@ -37,7 +37,7 @@ public class InternalErrorTest extends VertxTestBase {
       vertices[0].eventBus().request("foo", new MyPOJO("bar"), options, onFailure(t -> {
         assertThat(t, instanceOf(ReplyException.class));
         ReplyException e = (ReplyException) t;
-        assertSame(ReplyFailure.INTERNAL_ERROR, e.failureType());
+        assertSame(ReplyFailure.ERROR, e.failureType());
         testComplete();
       }));
     }));


### PR DESCRIPTION
This is the first part of the solution for #3406.

It allows to communicate an internal error from the receiver side (e.g. protocol mismatch, unknown codec) instead of failing silently.