### PR TITLE
Change the implementation of HTTP read/write metrics event to report …

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -724,7 +724,6 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
 
   private void handleResponseChunk(Stream stream, ByteBuf chunk) {
     Buffer buff = Buffer.buffer(VertxHandler.safeBuffer(chunk, chctx.alloc()));
-    reportBytesRead(buff.length());
     stream.context.execute(buff, stream::handleChunk);
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -91,7 +91,6 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   private int keepAliveTimeout;
   private long expirationTimestamp;
   private int seq = 1;
-  private long bytesRead;
 
   Http1xClientConnection(ConnectionListener<HttpClientConnection> listener,
                          HttpVersion version,
@@ -208,8 +207,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
         metrics.requestEnd(s.metric);
       }
     }
-    reportBytesWritten(bytesWritten);
-    bytesWritten = 0L;
+    flushBytesWritten();
     if (next != null) {
       next.promise.complete((HttpClientStream) next);
     }
@@ -627,8 +625,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     } else if (obj instanceof HttpContent) {
       HttpContent chunk = (HttpContent) obj;
       if (chunk.content().isReadable()) {
-        Buffer buff = Buffer.buffer(VertxHandler.safeBuffer(chunk.content(), chctx.alloc()));
-        handleResponseChunk(stream, buff);
+        handleResponseChunk(stream, chunk.content());
       }
       if (!isConnect && chunk instanceof LastHttpContent) {
         handleResponseEnd(stream, (LastHttpContent) chunk);
@@ -645,8 +642,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
       }
     }
     if (chunk.isReadable()) {
-      Buffer buff = Buffer.buffer(VertxHandler.safeBuffer(chunk, chctx.alloc()));
-      handleResponseChunk(stream, buff);
+      handleResponseChunk(stream, chunk);
     }
   }
 
@@ -726,24 +722,20 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     return pending;
   }
 
-  private void handleResponseChunk(Stream stream, Buffer buff) {
-    synchronized (this) {
-      bytesRead += buff.length();
-    }
+  private void handleResponseChunk(Stream stream, ByteBuf chunk) {
+    Buffer buff = Buffer.buffer(VertxHandler.safeBuffer(chunk, chctx.alloc()));
+    reportBytesRead(buff.length());
     stream.context.execute(buff, stream::handleChunk);
   }
 
   private void handleResponseEnd(Stream stream, LastHttpContent trailer) {
     boolean check;
-    long bytesRead;
     synchronized (this) {
       if (stream.response == null) {
         // 100-continue
         return;
       }
       responses.pop();
-      bytesRead = this.bytesRead;
-      this.bytesRead = 0L;
       close |= !options.isKeepAlive();
       stream.responseEnded = true;
       check = requests.peek() != stream;
@@ -757,7 +749,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     }
     stream.context.execute(trailer, stream::handleEnd);
     this.doResume();
-    reportBytesRead(bytesRead);
+    flushBytesRead();
     if (check) {
       checkLifecycle();
     }

--- a/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
@@ -15,7 +15,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.FileRegion;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.handler.stream.ChunkedFile;
 import io.vertx.codegen.annotations.Nullable;
@@ -41,7 +40,6 @@ abstract class Http1xConnectionBase<S extends WebSocketImplBase<S>> extends Conn
   }
 
   void handleWsFrame(WebSocketFrame msg) {
-    reportBytesRead(sizeOf(msg));
     WebSocketImplBase<?> w;
     synchronized (this) {
       w = webSocket;
@@ -130,6 +128,12 @@ abstract class Http1xConnectionBase<S extends WebSocketImplBase<S>> extends Conn
   protected void reportsBytesWritten(Object msg) {
     long size = sizeOf(msg);
     reportBytesWritten(size);
+  }
+
+  @Override
+  protected void reportBytesRead(Object msg) {
+    long size = sizeOf(msg);
+    reportBytesRead(size);
   }
 
   static long sizeOf(WebSocketFrame obj) {

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -74,7 +74,6 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
   private final String serverOrigin;
   private final SSLHelper sslHelper;
   private boolean requestFailed;
-  private long bytesRead;
 
   private Http1xServerRequest requestInProgress;
   private Http1xServerRequest responseInProgress;
@@ -239,22 +238,18 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
   }
 
   private void reportBytesRead(Buffer buffer) {
-    if (metrics != null) {
-      bytesRead += buffer.length();
-    }
+    reportBytesRead(buffer.length());
   }
 
   private void reportRequestComplete() {
     if (metrics != null) {
-      reportBytesRead(bytesRead);
-      bytesRead = 0;
+      flushBytesRead();
     }
   }
 
   private void reportResponseComplete() {
     if (metrics != null) {
-      reportBytesWritten(bytesWritten);
-      bytesWritten = 0L;
+      flushBytesWritten();
       if (requestFailed) {
         metrics.requestReset(responseInProgress.metric());
         requestFailed = false;

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -26,7 +26,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.ServerWebSocket;
-import io.vertx.core.http.WebsocketVersion;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.logging.Logger;
@@ -170,9 +169,6 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
     Buffer buffer = Buffer.buffer(VertxHandler.safeBuffer(content.content(), chctx.alloc()));
     Http1xServerRequest request;
     synchronized (this) {
-      if (METRICS_ENABLED) {
-        reportBytesRead(buffer);
-      }
       request = requestInProgress;
     }
     request.context.execute(buffer, request::handleContent);
@@ -235,10 +231,6 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
       channelPaused = false;
       super.doResume();
     }
-  }
-
-  private void reportBytesRead(Buffer buffer) {
-    reportBytesRead(buffer.length());
   }
 
   private void reportRequestComplete() {

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -419,11 +419,6 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
     }
 
     @Override
-    void handleClose() {
-      super.handleClose();
-    }
-
-    @Override
     void handleWritabilityChanged(boolean writable) {
       if (writable && drainHandler != null) {
         drainHandler.handle(null);

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -192,18 +192,6 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
     }
 
     @Override
-    void handleEnd(MultiMap trailers) {
-    }
-
-    @Override
-    void handleData(Buffer buf) {
-    }
-
-    @Override
-    void handlePriorityChange(StreamPriority newPriority) {
-    }
-
-    @Override
     void handleWritabilityChanged(boolean writable) {
       response.handlerWritabilityChanged(writable);
     }

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -49,6 +49,9 @@ import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
  */
 public abstract class ConnectionBase {
 
+  private static final long METRICS_REPORTED_BYTES_LOW_MASK = 0xFFF; // 4K
+  private static final long METRICS_REPORTED_BYTES_HIGH_MASK = ~METRICS_REPORTED_BYTES_LOW_MASK; // 4K
+
   /**
    * An exception used to signal a closed connection to an exception handler. Exception are
    * expensive to create, this instance can be used for this purpose. It does not capture a stack
@@ -71,6 +74,8 @@ public abstract class ConnectionBase {
   private SocketAddress remoteAddress;
   private SocketAddress localAddress;
   private Promise<Void> closePromise;
+  private long remainingBytesRead;
+  private long remainingBytesWritten;
 
   // State accessed exclusively from the event loop thread
   private boolean read;
@@ -343,8 +348,12 @@ public abstract class ConnectionBase {
   protected void handleClosed() {
     closed = true;
     NetworkMetrics metrics = metrics();
-    if (metrics instanceof TCPMetrics) {
-      ((TCPMetrics) metrics).disconnected(metric(), remoteAddress());
+    if (metrics != null) {
+      flushBytesRead();
+      flushBytesWritten();
+      if (metrics instanceof TCPMetrics) {
+        ((TCPMetrics) metrics).disconnected(metric(), remoteAddress());
+      }
     }
     closePromise.complete();
   }
@@ -377,16 +386,52 @@ public abstract class ConnectionBase {
   }
 
   public void reportBytesRead(long numberOfBytes) {
-    NetworkMetrics metrics = metrics();
-    if (metrics != null) {
-      metrics.bytesRead(metric(), remoteAddress(), numberOfBytes);
+    if (numberOfBytes < 0L) {
+      throw new IllegalArgumentException();
     }
+    long bytes = remainingBytesRead;
+    bytes += numberOfBytes;
+    NetworkMetrics metrics = metrics();
+    long val = bytes & METRICS_REPORTED_BYTES_HIGH_MASK;
+    if (metrics != null && val > 0) {
+      bytes &= METRICS_REPORTED_BYTES_LOW_MASK;
+      metrics.bytesRead(metric(), remoteAddress(), val);
+    }
+    remainingBytesRead = bytes;
   }
 
   public void reportBytesWritten(long numberOfBytes) {
+    if (numberOfBytes < 0L) {
+      throw new IllegalArgumentException();
+    }
+    long bytes = remainingBytesWritten;
+    bytes += numberOfBytes;
     NetworkMetrics metrics = metrics();
-    if (metrics != null && numberOfBytes > 0) {
-      metrics.bytesWritten(metric, remoteAddress(), numberOfBytes);
+    long val = bytes & METRICS_REPORTED_BYTES_HIGH_MASK;
+    if (metrics != null && val > 0) {
+      bytes &= METRICS_REPORTED_BYTES_LOW_MASK;
+      metrics.bytesWritten(metric, remoteAddress(), val);
+    }
+    remainingBytesWritten = bytes;
+  }
+
+  public void flushBytesRead() {
+    long val = remainingBytesRead;
+    if (val > 0L) {
+      NetworkMetrics metrics = metrics();
+      remainingBytesRead = 0L;
+      if (metrics != null)
+        metrics.bytesRead(metric(), remoteAddress(), val);
+    }
+  }
+
+  public void flushBytesWritten() {
+    long val = remainingBytesWritten;
+    if (val > 0L) {
+      NetworkMetrics metrics = metrics();
+      remainingBytesWritten = 0L;
+      if (metrics != null)
+        metrics.bytesWritten(metric(), remoteAddress(), val);
     }
   }
 

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -129,6 +129,9 @@ public abstract class ConnectionBase {
   final void read(Object msg) {
     read = true;
     if (!closed) {
+      if (METRICS_ENABLED) {
+        reportBytesRead(msg);
+      }
       handleMessage(msg);
     }
   }
@@ -176,9 +179,6 @@ public abstract class ConnectionBase {
         chctx.channel().close().addListener(promise);
       });
     writeToChannel(Unpooled.EMPTY_BUFFER, true, channelPromise);
-  }
-
-  protected void reportsBytesWritten(Object msg) {
   }
 
   private ChannelPromise wrap(FutureListener<Void> handler) {
@@ -385,6 +385,9 @@ public abstract class ConnectionBase {
     return !isSsl();
   }
 
+  protected void reportBytesRead(Object msg) {
+  }
+
   public void reportBytesRead(long numberOfBytes) {
     if (numberOfBytes < 0L) {
       throw new IllegalArgumentException();
@@ -398,6 +401,9 @@ public abstract class ConnectionBase {
       metrics.bytesRead(metric(), remoteAddress(), val);
     }
     remainingBytesRead = bytes;
+  }
+
+  protected void reportsBytesWritten(Object msg) {
   }
 
   public void reportBytesWritten(long numberOfBytes) {

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -136,6 +136,13 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
   }
 
   @Override
+  protected void reportBytesRead(Object msg) {
+    if (msg instanceof ByteBuf) {
+      reportBytesRead(((ByteBuf)msg).readableBytes());
+    }
+  }
+
+  @Override
   public Future<Void> write(Buffer data) {
     return writeMessage(data.getByteBuf());
   }
@@ -371,9 +378,6 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
   }
 
   public void handleMessage(Object msg) {
-    if (msg instanceof ByteBuf) {
-      reportBytesRead(((ByteBuf)msg).readableBytes());
-    }
     context.emit(msg, o -> {
       if (!pending.write(msg)) {
         doPause();

--- a/src/test/java/io/vertx/test/fakemetrics/FakeHttpClientMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeHttpClientMetrics.java
@@ -137,11 +137,13 @@ public class FakeHttpClientMetrics extends FakeMetricsBase implements HttpClient
   @Override
   public void bytesRead(SocketMetric socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
     socketMetric.bytesRead.addAndGet(numberOfBytes);
+    socketMetric.bytesReadEvents.add(numberOfBytes);
   }
 
   @Override
   public void bytesWritten(SocketMetric socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
     socketMetric.bytesWritten.addAndGet(numberOfBytes);
+    socketMetric.bytesWrittenEvents.add(numberOfBytes);
   }
 
   @Override

--- a/src/test/java/io/vertx/test/fakemetrics/FakeHttpServerMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeHttpServerMetrics.java
@@ -104,11 +104,13 @@ public class FakeHttpServerMetrics extends FakeMetricsBase implements HttpServer
   @Override
   public void bytesRead(SocketMetric socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
     socketMetric.bytesRead.addAndGet(numberOfBytes);
+    socketMetric.bytesReadEvents.add(numberOfBytes);
   }
 
   @Override
   public void bytesWritten(SocketMetric socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
     socketMetric.bytesWritten.addAndGet(numberOfBytes);
+    socketMetric.bytesWrittenEvents.add(numberOfBytes);
   }
 
   @Override

--- a/src/test/java/io/vertx/test/fakemetrics/SocketMetric.java
+++ b/src/test/java/io/vertx/test/fakemetrics/SocketMetric.java
@@ -13,6 +13,9 @@ package io.vertx.test.fakemetrics;
 
 import io.vertx.core.net.SocketAddress;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -25,7 +28,9 @@ public class SocketMetric {
   public final String remoteName;
   public final AtomicBoolean connected = new AtomicBoolean(true);
   public final AtomicLong bytesRead = new AtomicLong();
+  public final List<Long> bytesReadEvents = Collections.synchronizedList(new ArrayList<>());
   public final AtomicLong bytesWritten = new AtomicLong();
+  public final List<Long> bytesWrittenEvents = Collections.synchronizedList(new ArrayList<>());
 
   public SocketMetric(SocketAddress remoteAddress, String remoteName) {
     this.remoteAddress = remoteAddress;


### PR DESCRIPTION
…when the accumulated size gets above 4K. When the request/response ends the remaining bytes value is reported. Metrics implementation should not be affected by this change. - fixes #3585

Fixes also https://github.com/eclipse-vertx/vert.x/issues/2747