### PR TITLE
Issues/3593

### DIFF
--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -201,7 +201,10 @@ The message send failed because no reply was received before the timeout time.
 The message send failed because no handlers were available to handle the message.
 +++
 |[[RECIPIENT_FAILURE]]`RECIPIENT_FAILURE`|+++
-The message send failed because the recipient actively sent back a failure (rejected the message)
+The message send failed because the recipient actively sent back a failure (rejected the message).
++++
+|[[ERROR]]`ERROR`|+++
+A fatal error occured while delivering the message. Do not retry to send.
 +++
 |===
 

--- a/src/test/java/io/vertx/core/file/FileResolverTestBase.java
+++ b/src/test/java/io/vertx/core/file/FileResolverTestBase.java
@@ -19,6 +19,7 @@ import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.file.impl.FileResolver;
+import io.vertx.core.impl.Utils;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Assert;
@@ -28,6 +29,7 @@ import java.io.File;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -127,6 +129,19 @@ public abstract class FileResolverTestBase extends VertxTestBase {
       assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>afile with spaces</body></html>", readFile(file));
+    }
+  }
+
+  @Test
+  public void testCacheDirIsPosix0700() throws Exception {
+    if (!Utils.isWindows()) {
+      File file = resolver.resolveFile("afile with spaces.html");
+      assertTrue(file.exists());
+      assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
+      File parent = file.getParentFile(); // this should be the cache directory
+      assertEquals(
+        "rwx------",
+        PosixFilePermissions.toString(Files.getPosixFilePermissions(parent.toPath())));
     }
   }
 

--- a/src/test/java/io/vertx/core/file/FileResolverTestBase.java
+++ b/src/test/java/io/vertx/core/file/FileResolverTestBase.java
@@ -23,6 +23,7 @@ import io.vertx.core.impl.Utils;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.File;
@@ -134,15 +135,15 @@ public abstract class FileResolverTestBase extends VertxTestBase {
 
   @Test
   public void testCacheDirIsPosix0700() throws Exception {
-    if (!Utils.isWindows()) {
-      File file = resolver.resolveFile("afile with spaces.html");
-      assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
-      File parent = file.getParentFile(); // this should be the cache directory
-      assertEquals(
-        "rwx------",
-        PosixFilePermissions.toString(Files.getPosixFilePermissions(parent.toPath())));
-    }
+    Assume.assumeFalse(Utils.isWindows());
+
+    File file = resolver.resolveFile("afile with spaces.html");
+    assertTrue(file.exists());
+    assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
+    File parent = file.getParentFile(); // this should be the cache directory
+    assertEquals(
+      "rwx------",
+      PosixFilePermissions.toString(Files.getPosixFilePermissions(parent.toPath())));
   }
 
   @Test


### PR DESCRIPTION
Motivation:

Fixes: #3593

Also addresses comments on: #3510

Cache directories are now guaranteed to be unique. While before the chance of collision was low due to the UUID suffix, this PR will throw ISE if a collision happens.

It also ensures that on posix systems (non windows) cache directories are created with 0700 permission just like the POSIX mkdtemp standard function does.