### PR TITLE
CompositeFuture.allOf, anyOf, joinOf with generics

### DIFF
--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,8 +17,6 @@ import io.vertx.core.impl.future.CompositeFutureImpl;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  * The composite future wraps a list of {@link Future futures}, it is useful when several futures
@@ -72,11 +70,25 @@ public interface CompositeFuture extends Future<CompositeFuture> {
   }
 
   /**
-   * Like {@link #all(Future, Future)} but with a list of futures.<p>
-   *
-   * When the list is empty, the returned future will be already completed.
+   * Return a composite future, succeeded when all futures are succeeded,
+   * failed as soon as one of the futures is failed.
+   * <p/>
+   * When the list is empty, the returned future will be already succeeded.
    */
   static CompositeFuture all(List<Future> futures) {
+    return CompositeFutureImpl.all(futures.toArray(new Future[futures.size()]));
+  }
+
+  /**
+   * Return a composite future, succeeded when all futures are succeeded,
+   * failed as soon as one of the futures is failed.
+   * <p/>
+   * When the list is empty, the returned future will be already succeeded.
+   * <p/>
+   * This is the same as {@link #all(List)} but with generic type declaration.
+   */
+  @GenIgnore
+  static <T extends Future<?>> CompositeFuture allOf(List<T> futures) {
     return CompositeFutureImpl.all(futures.toArray(new Future[futures.size()]));
   }
 
@@ -122,11 +134,25 @@ public interface CompositeFuture extends Future<CompositeFuture> {
   }
 
   /**
-   * Like {@link #any(Future, Future)} but with a list of futures.<p>
-   *
-   * When the list is empty, the returned future will be already completed.
+   * Return a composite future, succeeded as soon as one future is succeeded,
+   * failed when all futures are failed.
+   * <p/>
+   * When the list is empty, the returned future will be already succeeded.
    */
   static CompositeFuture any(List<Future> futures) {
+    return CompositeFutureImpl.any(futures.toArray(new Future[futures.size()]));
+  }
+
+  /**
+   * Return a composite future, succeeded as soon as one future is succeeded,
+   * failed when all futures are failed.
+   * <p/>
+   * When the list is empty, the returned future will be already succeeded.
+   * <p/>
+   * This is the same as {@link #any(List)} but with generic type declaration.
+   */
+  @GenIgnore
+  static <T extends Future<?>> CompositeFuture anyOf(List<T> futures) {
     return CompositeFutureImpl.any(futures.toArray(new Future[futures.size()]));
   }
 
@@ -172,11 +198,31 @@ public interface CompositeFuture extends Future<CompositeFuture> {
   }
 
   /**
-   * Like {@link #join(Future, Future)} but with a list of futures.<p>
-   *
-   * When the list is empty, the returned future will be already completed.
+   * Return a composite future, succeeded when all {@code futures} are succeeded,
+   * failed when any of the {@code futures} is failed.
+   * <p/>
+   * It always waits until all its {@code futures} are completed and will not fail
+   * as soon as one of the {@code futures} fails.
+   * <p/>
+   * When the list is empty, the returned future will be already succeeded.
    */
   static CompositeFuture join(List<Future> futures) {
+    return CompositeFutureImpl.join(futures.toArray(new Future[futures.size()]));
+  }
+
+  /**
+   * Return a composite future, succeeded when all {@code futures} are succeeded,
+   * failed when any of the {@code futures} is failed.
+   * <p/>
+   * It always waits until all its {@code futures} are completed and will not fail
+   * as soon as one of the {@code futures} fails.
+   * <p/>
+   * When the list is empty, the returned future will be already succeeded.
+   * <p/>
+   * This is the same as {@link #join(List)} but with generic type declaration.
+   */
+  @GenIgnore
+  static <T extends Future<?>> CompositeFuture joinOf(List<T> futures) {
     return CompositeFutureImpl.join(futures.toArray(new Future[futures.size()]));
   }
 

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -526,6 +526,22 @@ public class FutureTest extends VertxTestBase {
   public void testJoinWithEmptyList() {
     CompositeFuture composite = CompositeFuture.join(Collections.emptyList());
     assertTrue(composite.isComplete());
+  }
+
+  @Test
+  public void testGenerics() {
+    List<Future<String>> successSuccess = Arrays.asList(Future.succeededFuture(), Future.succeededFuture());
+    List<Future<String>> successFailure = Arrays.asList(Future.succeededFuture(), Future.failedFuture(""));
+    assertTrue(CompositeFuture.allOf(successSuccess).succeeded());
+    assertTrue(CompositeFuture.allOf(successFailure).failed());
+    assertTrue(CompositeFuture.anyOf(successSuccess).succeeded());
+    assertTrue(CompositeFuture.anyOf(successFailure).succeeded());
+    assertTrue(CompositeFuture.joinOf(successSuccess).succeeded());
+    assertTrue(CompositeFuture.joinOf(successFailure).failed());
+
+    List<Future<String>> failureAndUnknown = Arrays.asList(Future.failedFuture(""), Promise.<String>promise().future());
+    assertTrue(CompositeFuture.allOf(failureAndUnknown).isComplete());
+    assertFalse(CompositeFuture.joinOf(failureAndUnknown).isComplete());
   }
 
   @Test


### PR DESCRIPTION
CompositeFuture.all(List<Future>), CompositeFuture.any(List<Future>) and
CompositeFuture.join(List<Future>) use the raw type of Future because
the code generator for other languages doesn't support wildcard extensions.
IDEs and other code checkers warn about the raw type because the compiler
cannot do type checks.

Jens Reimann (ctron) suggests to create allOf, anyOf and joinOf methods
in #2058. This avoids a breaking change with the existing methods and
allows not to generate the generic methods for other languages.

Resolves #1994, resolves #2058.