### PR TITLE
Fix incorrect behavior for `SucceededFuture#otherwise(Object)` since 4224779

### DIFF
--- a/src/main/java/io/vertx/core/impl/future/SucceededFuture.java
+++ b/src/main/java/io/vertx/core/impl/future/SucceededFuture.java
@@ -115,7 +115,7 @@ public final class SucceededFuture<T> extends FutureBase<T> {
 
   @Override
   public Future<T> otherwise(T value) {
-    return new SucceededFuture<>(context, value);
+    return this;
   }
 
   @Override

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -655,6 +655,25 @@ public class FutureTest extends VertxTestBase {
   }
 
   @Test
+  public void testMapValueSuccess() {
+    Promise<Integer> p = Promise.promise();
+    Future<Integer> f = p.future();
+    Future<String> mapped = f.map("5");
+    Checker<String> checker = new Checker<>(mapped);
+    checker.assertNotCompleted();
+    p.complete(3);
+    checker.assertSucceeded("5");
+  }
+
+  @Test
+  public void testMapValueAlreadySuccess() {
+    Future<Integer> f = Future.succeededFuture(3);
+    Future<String> mapped = f.map("5");
+    Checker<String> checker = new Checker<>(mapped);
+    checker.assertSucceeded("5");
+  }
+
+  @Test
   public void testMapFailure() {
     Throwable cause = new Throwable();
     Promise<String> p = Promise.promise();
@@ -663,6 +682,36 @@ public class FutureTest extends VertxTestBase {
     Checker<String> checker = new Checker<>(mapped);
     checker.assertNotCompleted();
     p.fail(cause);
+    checker.assertFailed(cause);
+  }
+
+  @Test
+  public void testMapAlreadyFailure() {
+    Throwable cause = new Throwable();
+    Future<String> f = Future.failedFuture(cause);
+    Future<String> mapped = f.map(Object::toString);
+    Checker<String> checker = new Checker<>(mapped);
+    checker.assertFailed(cause);
+  }
+
+  @Test
+  public void testMapValueFailure() {
+    Throwable cause = new Throwable();
+    Promise<String> p = Promise.promise();
+    Future<String> f = p.future();
+    Future<String> mapped = f.map("5");
+    Checker<String> checker = new Checker<>(mapped);
+    checker.assertNotCompleted();
+    p.fail(cause);
+    checker.assertFailed(cause);
+  }
+
+  @Test
+  public void testMapValueAlreadyFailure() {
+    Throwable cause = new Throwable();
+    Future<String> f = Future.failedFuture(cause);
+    Future<String> mapped = f.map("5");
+    Checker<String> checker = new Checker<>(mapped);
     checker.assertFailed(cause);
   }
 
@@ -789,6 +838,45 @@ public class FutureTest extends VertxTestBase {
   }
 
   @Test
+  public void testOtherwiseAlreadySuccessWithSuccess() {
+    AtomicBoolean called = new AtomicBoolean();
+    Future<String> f = Future.succeededFuture("yeah");
+    Future<String> r = f.otherwise(t -> {
+      called.set(true);
+      throw new AssertionError();
+    });
+    Checker<String> checker = new Checker<>(r);
+    assertTrue(r.succeeded());
+    checker.assertSucceeded("yeah");
+    assertFalse(called.get());
+  }
+
+  @Test
+  public void testOtherwiseValueSuccessWithSuccess() {
+    AtomicBoolean called = new AtomicBoolean();
+    Promise<String> p = Promise.promise();
+    Future<String> f = p.future();
+    Future<String> r = f.otherwise("other");
+    Checker<String> checker = new Checker<>(r);
+    checker.assertNotCompleted();
+    p.complete("yeah");
+    assertTrue(r.succeeded());
+    checker.assertSucceeded("yeah");
+    assertFalse(called.get());
+  }
+
+  @Test
+  public void testOtherwiseValueAlreadySuccessWithSuccess() {
+    AtomicBoolean called = new AtomicBoolean();
+    Future<String> f = Future.succeededFuture("yeah");
+    Future<String> r = f.otherwise("other");
+    Checker<String> checker = new Checker<>(r);
+    assertTrue(r.succeeded());
+    checker.assertSucceeded("yeah");
+    assertFalse(called.get());
+  }
+
+  @Test
   public void testOtherwiseFailureWithSuccess() {
     Promise<String> p = Promise.promise();
     Future<String> f = p.future();
@@ -797,6 +885,25 @@ public class FutureTest extends VertxTestBase {
     checker.assertNotCompleted();
     p.fail("recovered");
     checker.assertSucceeded("recovered");
+  }
+
+  @Test
+  public void testOtherwiseValueFailureWithSuccess() {
+    Promise<String> p = Promise.promise();
+    Future<String> f = p.future();
+    Future<String> r = f.otherwise("other");
+    Checker<String> checker = new Checker<>(r);
+    checker.assertNotCompleted();
+    p.fail("recovered");
+    checker.assertSucceeded("other");
+  }
+
+  @Test
+  public void testOtherwiseValueAlreadyFailureWithSuccess() {
+    Future<String> f = Future.failedFuture("recovered");
+    Future<String> r = f.otherwise("other");
+    Checker<String> checker = new Checker<>(r);
+    checker.assertSucceeded("other");
   }
 
   @Test


### PR DESCRIPTION
#### Motivation:

`Future.succeededFuture(100).otherwise(-1)` should be succeeded with `100` NOT succeeded with `-1`. But since  422477991692504b6e86cb5e7426e9d010488bb2 it's succeeded with `-1` instead.

I fixed it and added the test cases for the override methods in `SucceededFuture` & `FailedFuture` as well as the test cases for `Future#map(Object)` & `Future#otherwise(Object)`.

#### Conformance:

- [x] signed off commits
- [x] signed the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php)
- [x] followed [code style guidelines](https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines)
