### PR TITLE
Add `ContextManager` service abstraction

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxFactory.java
+++ b/src/main/java/io/vertx/core/impl/VertxFactory.java
@@ -13,6 +13,7 @@ package io.vertx.core.impl;
 
 import io.vertx.core.*;
 import io.vertx.core.file.impl.FileResolver;
+import io.vertx.core.impl.context.ContextManagerImpl;
 import io.vertx.core.net.impl.transport.Transport;
 import io.vertx.core.spi.VertxMetricsFactory;
 import io.vertx.core.spi.VertxTracerFactory;
@@ -21,6 +22,7 @@ import io.vertx.core.spi.cluster.NodeSelector;
 import io.vertx.core.spi.cluster.impl.DefaultNodeSelector;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.spi.context.ContextManager;
 
 import java.util.Collection;
 import java.util.Objects;
@@ -75,13 +77,13 @@ public class VertxFactory {
   }
 
   public Vertx vertx() {
-    VertxImpl vertx = new VertxImpl(options, null, null, createMetrics(), createTracer(), createTransport(), createFileResolver());
+    VertxImpl vertx = new VertxImpl(options, null, null, createMetrics(), createTracer(), createTransport(), createFileResolver(), createContextManager());
     vertx.init();
     return vertx;
   }
 
   public void clusteredVertx(Handler<AsyncResult<Vertx>> handler) {
-    VertxImpl vertx = new VertxImpl(options, createClusterManager(), createNodeSelector(), createMetrics(), createTracer(), createTransport(), createFileResolver());
+    VertxImpl vertx = new VertxImpl(options, createClusterManager(), createNodeSelector(), createMetrics(), createTracer(), createTransport(), createFileResolver(), createContextManager());
     vertx.initClustered(options, handler);
   }
 
@@ -157,6 +159,14 @@ public class VertxFactory {
       }
     }
     return tracer;
+  }
+
+  private ContextManager createContextManager() {
+    ContextManager contextManager = ServiceHelper.loadFactoryOrNull(ContextManager.class);
+    if (contextManager == null) {
+      contextManager = new ContextManagerImpl();
+    }
+    return contextManager;
   }
 
   private FileResolver createFileResolver() {

--- a/src/main/java/io/vertx/core/impl/context/ContextManagerImpl.java
+++ b/src/main/java/io/vertx/core/impl/context/ContextManagerImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.impl.context;
+
+import io.vertx.core.*;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.spi.context.ContextManager;
+import java.lang.ref.WeakReference;
+
+public class ContextManagerImpl implements ContextManager {
+  private final ThreadLocal<WeakReference<Context>> stickyContext = new ThreadLocal<>();
+
+  @Override
+  public Context getContext(Vertx vertx) {
+    Context ctx = ContextInternal.current();
+    if (ctx != null && ctx.owner() == vertx) {
+      return ctx;
+    } else {
+      WeakReference<Context> ref = stickyContext.get();
+      return ref != null ? ref.get() : null;
+    }
+  }
+
+  @Override
+  public void setContext(Context ctx) {
+    stickyContext.set(new WeakReference<>(ctx));
+    return;
+  }
+}

--- a/src/main/java/io/vertx/core/spi/context/ContextManager.java
+++ b/src/main/java/io/vertx/core/spi/context/ContextManager.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.spi.context;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+/**
+ * A context manager that will propagate the vert.x context when it's being
+ * used outside of managed vert.x threads, e.g. in a different thread pool.
+ *
+ * The context manager guarantees that vert.x operations running in the
+ * same "execution trace" share the same context to avoid race conditions
+ * when executing vert.x handlers.
+ *
+ * The default implementation of this context manager propagates the context
+ * using a thread local, so that code running subsequent to the first context
+ * creation can access it. Users can bring their own manager implementation
+ * to use a different mechanism different to thread locals.
+ */
+public interface ContextManager {
+
+  /**
+   * Gets the context stored in this manager by the last `setContext`
+   * operation, null otherwise.
+   *
+   * @param vertx is the vertx instance that wants to access the context.
+   */
+  Context getContext(Vertx vertx);
+
+  /**
+   * Sets the context stored in this manager.
+   *
+   * The manager implementation should not try to enrich or change the
+   * underlying context as vert.x expects to get the same context it puts in.
+   *
+   * @param ctx is the context we want to store.
+   */
+  void setContext(Context ctx);
+}


### PR DESCRIPTION
This PR implements a prototype for #3619.  This is my first non-trivial
contribution to the project, please let me know if I got something
wrong. I hope this prototype informs a bit better what I intend to do,
I'm not sure I explained my intentions correctly in the ticket.

----

The context manager is a new abstraction that allow users to implement
their own service providers to change the default, thread-local-based
mechanism to guarantee that the same context is used from threads that
are not managed by vert.x (for example, when users use the `WebClient`
in an external thread pool).

This new abstraction intends to imitate how the `ContextInternal` API
works.  As the previous code already had a cast from
`ContextInternal.currentContext` to `AbstractContext`, which is an
internal class, the new context manager returns a generic public
instance of `Context` and relies on `VertxImpl` to cast it to whichever
context it wants to use.

The new interface is designed so that implementors don't need to use
internal classes (e.g. `ContextInternal` or `AbstractContext`) to
implement the new interface.

Context manager implementors should not change the stored context
reference and the java doc clearly specifies that. That is to guarantee
context manager implementors don't change the context stored by vert.x
and possibly change its type, causing the internal cast to fail.