### PR TITLE
Bugfixes for  HAManager and Clustered EventBus

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -372,8 +372,8 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   }
 
   <T> ReplyHandler<T> createReplyHandler(MessageImpl message,
-                                         boolean src,
-                                         DeliveryOptions options) {
+                                                boolean src,
+                                                DeliveryOptions options) {
     long timeout = options.getSendTimeout();
     String replyAddress = generateReplyAddress();
     message.setReplyAddress(replyAddress);
@@ -383,7 +383,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   }
 
   public <T> OutboundDeliveryContext<T> newSendContext(MessageImpl message, DeliveryOptions options,
-                                                       ReplyHandler<T> handler, Promise<Void> writePromise) {
+                                               ReplyHandler<T> handler, Promise<Void> writePromise) {
     return new OutboundDeliveryContext<>(vertx.getOrCreateContext(), message, options, handler, writePromise);
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -372,8 +372,8 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   }
 
   <T> ReplyHandler<T> createReplyHandler(MessageImpl message,
-                                                boolean src,
-                                                DeliveryOptions options) {
+                                                 boolean src,
+                                                 DeliveryOptions options) {
     long timeout = options.getSendTimeout();
     String replyAddress = generateReplyAddress();
     message.setReplyAddress(replyAddress);

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -282,7 +282,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     promise.complete();
   }
 
-  private <T> void removeLocalRegistration(HandlerHolder<T> holder) {
+  protected <T> void removeLocalRegistration(HandlerHolder<T> holder) {
     String address = holder.getHandler().address;
     handlerMap.compute(address, (key, val) -> {
       if (val == null) {
@@ -372,8 +372,8 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   }
 
   <T> ReplyHandler<T> createReplyHandler(MessageImpl message,
-                                                 boolean src,
-                                                 DeliveryOptions options) {
+                                         boolean src,
+                                         DeliveryOptions options) {
     long timeout = options.getSendTimeout();
     String replyAddress = generateReplyAddress();
     message.setReplyAddress(replyAddress);
@@ -383,7 +383,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   }
 
   public <T> OutboundDeliveryContext<T> newSendContext(MessageImpl message, DeliveryOptions options,
-                                               ReplyHandler<T> handler, Promise<Void> writePromise) {
+                                                       ReplyHandler<T> handler, Promise<Void> writePromise) {
     return new OutboundDeliveryContext<>(vertx.getOrCreateContext(), message, options, handler, writePromise);
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -19,12 +19,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.AddressHelper;
 import io.vertx.core.eventbus.EventBusOptions;
 import io.vertx.core.eventbus.MessageCodec;
-import io.vertx.core.eventbus.impl.CodecManager;
-import io.vertx.core.eventbus.impl.EventBusImpl;
-import io.vertx.core.eventbus.impl.HandlerHolder;
-import io.vertx.core.eventbus.impl.HandlerRegistration;
-import io.vertx.core.eventbus.impl.MessageImpl;
-import io.vertx.core.eventbus.impl.OutboundDeliveryContext;
+import io.vertx.core.eventbus.impl.*;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.logging.Logger;
@@ -66,8 +61,7 @@ public class ClusteredEventBus extends EventBusImpl {
   private String nodeId;
   private NetServer server;
 
-  public ClusteredEventBus(VertxInternal vertx, VertxOptions options, ClusterManager clusterManager,
-                           NodeSelector nodeSelector) {
+  public ClusteredEventBus(VertxInternal vertx, VertxOptions options, ClusterManager clusterManager, NodeSelector nodeSelector) {
     super(vertx);
     this.options = options.getEventBusOptions();
     this.clusterManager = clusterManager;
@@ -138,18 +132,15 @@ public class ClusteredEventBus extends EventBusImpl {
         handlerHolder.getSeq(),
         handlerHolder.isLocalOnly()
       );
-      clusterManager
-        .addRegistration(handlerHolder.getHandler().address, registrationInfo, Objects.requireNonNull(promise));
+      clusterManager.addRegistration(handlerHolder.getHandler().address, registrationInfo, Objects.requireNonNull(promise));
     } else if (promise != null) {
       promise.complete();
     }
   }
 
   @Override
-  protected <T> HandlerHolder<T> createHandlerHolder(HandlerRegistration<T> registration, boolean replyHandler,
-                                                     boolean localOnly, ContextInternal context) {
-    return new ClusteredHandlerHolder<>(registration, replyHandler, localOnly, context,
-      handlerSequence.getAndIncrement());
+  protected <T> HandlerHolder<T> createHandlerHolder(HandlerRegistration<T> registration, boolean replyHandler, boolean localOnly, ContextInternal context) {
+    return new ClusteredHandlerHolder<>(registration, replyHandler, localOnly, context, handlerSequence.getAndIncrement());
   }
 
   @Override

--- a/src/test/java/io/vertx/core/VertxStartFailureTest.java
+++ b/src/test/java/io/vertx/core/VertxStartFailureTest.java
@@ -94,7 +94,10 @@ public class VertxStartFailureTest extends AsyncTestBase {
         throw expected;
       }
     };
-    VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+    VertxOptions options = new VertxOptions()
+      .setClusterManager(clusterManager)
+      .setHAEnabled(true);
+
     Throwable failure = failStart(options);
     assertSame(expected,  failure);
   }

--- a/src/test/java/io/vertx/core/datagram/DatagramTest.java
+++ b/src/test/java/io/vertx/core/datagram/DatagramTest.java
@@ -17,8 +17,6 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.datagram.DatagramSocket;
-import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetworkOptions;
 import io.vertx.core.streams.WriteStream;


### PR DESCRIPTION
### Motivation:

The intent of this PR is to solve two problems.

- It was observed that Verticle was starting up with high availabilty even after setting HAEnabled as false. On further inspection we found that HAManager class was missing checks on the enabled flag, so added that which enabled us to run without High Availability.

- If a container has multiple verticle deployed in isolation, if we restart one of those verticles, It was noticed that two handlers registered locally at the exact same address. It turns out that the restarted vertcile did not remove the handler registration from the address, On further debugging it was noted that the registration flow of ClusteredEventBus was not matching the unregistration flow (ClusteredEventBus should have overloaded was the onLocalUnregistration method, not removeRegisgration (they have the same signature). After this change our issue got resolved.
- Change the signature of removeRegistration to onLocalUnregistration in ClusteredEventBus. This is done to match the registration codePath.

This PR fixes  issue-> https://github.com/eclipse-vertx/vert.x/issues/3637 && https://github.com/eclipse-vertx/vert.x/issues/3635

### Conformance:

Signed-off-by: Aashish Radhakrishnan aradhakrishnan@tracelink.com