### PR TITLE
Fixes #3629: runs the upload handler on the caller context

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -142,7 +142,7 @@ public class Http1xServerRequest implements HttpServerRequest, io.vertx.core.spi
         conn.doPause();
       }
     } else {
-      onData(buffer);
+      context.execute(buffer, this::onData);
     }
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
@@ -189,8 +189,9 @@ public class Http2ServerRequestImpl extends Http2ServerStream implements HttpSer
 
   @Override
   void handleCustomFrame(HttpFrame frame) {
-    if (customFrameHandler != null) {
-      customFrameHandler.handle(frame);
+    Handler<HttpFrame> handler = this.customFrameHandler;
+    if (handler != null) {
+      context.dispatch(frame, handler);
     }
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
@@ -101,7 +101,7 @@ public class Http2ServerResponseImpl implements HttpServerResponse, HttpResponse
       handler = exceptionHandler;
     }
     if (handler != null) {
-      handler.handle(cause);
+      stream.context.dispatch(cause, handler);
     }
   }
 
@@ -537,8 +537,9 @@ public class Http2ServerResponseImpl implements HttpServerResponse, HttpResponse
   }
 
   void handlerWritabilityChanged(boolean writable) {
-    if (!ended && writable && drainHandler != null) {
-      drainHandler.handle(null);
+    Handler<Void> handler = this.drainHandler;
+    if (!ended && writable && handler != null) {
+      stream.context.dispatch(handler);
     }
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpServerFileUploadImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerFileUploadImpl.java
@@ -17,6 +17,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.AsyncFile;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.core.http.HttpServerFileUpload;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.streams.Pipe;
 import io.vertx.core.streams.ReadStream;
 
@@ -34,7 +35,7 @@ import java.nio.charset.Charset;
 class HttpServerFileUploadImpl implements HttpServerFileUpload {
 
   private final ReadStream<Buffer> stream;
-  private final Context context;
+  private final ContextInternal context;
   private final String name;
   private final String filename;
   private final String contentType;
@@ -49,7 +50,7 @@ class HttpServerFileUploadImpl implements HttpServerFileUpload {
   private long size;
   private boolean lazyCalculateSize;
 
-  HttpServerFileUploadImpl(Context context, ReadStream<Buffer> stream, String name, String filename, String contentType,
+  HttpServerFileUploadImpl(ContextInternal context, ReadStream<Buffer> stream, String name, String filename, String contentType,
                            String contentTransferEncoding,
                            Charset charset, long size) {
     this.context = context;
@@ -73,7 +74,7 @@ class HttpServerFileUploadImpl implements HttpServerFileUpload {
       size += data.length();
     }
     if (h != null) {
-      h.handle(data);
+      context.dispatch(data, h);
     }
   }
 

--- a/src/main/java/io/vertx/core/http/impl/NettyFileUploadDataFactory.java
+++ b/src/main/java/io/vertx/core/http/impl/NettyFileUploadDataFactory.java
@@ -46,7 +46,8 @@ class NettyFileUploadDataFactory extends DefaultHttpDataFactory {
       size);
     Handler<HttpServerFileUpload> uploadHandler = lazyUploadHandler.get();
     if (uploadHandler != null) {
-      uploadHandler.handle(upload);
+      // run the handler on the caller context
+      context.runOnContext(v -> uploadHandler.handle(upload));
     }
     return nettyUpload;
   }

--- a/src/main/java/io/vertx/core/http/impl/NettyFileUploadDataFactory.java
+++ b/src/main/java/io/vertx/core/http/impl/NettyFileUploadDataFactory.java
@@ -46,7 +46,7 @@ class NettyFileUploadDataFactory extends DefaultHttpDataFactory {
       size);
     Handler<HttpServerFileUpload> uploadHandler = lazyUploadHandler.get();
     if (uploadHandler != null) {
-      context.execute(upload, uploadHandler);
+      context.dispatch(upload, uploadHandler);
     }
     return nettyUpload;
   }

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -63,7 +63,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
       } else {
         Buffer data = (Buffer) item;
         int len = data.length();
-        conn.getContext().emit(null, v -> conn.consumeCredits(this.stream, len));
+        conn.getContext().execute(null, v -> conn.consumeCredits(this.stream, len));
         bytesRead += data.length();
         handleData(data);
       }
@@ -86,15 +86,15 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
   }
 
   void onError(Throwable cause) {
-    context.emit(cause, this::handleException);
+    context.execute(cause, this::handleException);
   }
 
   void onReset(long code) {
-    context.emit(code, this::handleReset);
+    context.execute(code, this::handleReset);
   }
 
   void onPriorityChange(StreamPriority newPriority) {
-    context.emit(newPriority, priority -> {
+    context.execute(newPriority, priority -> {
       if (!this.priority.equals(priority)) {
         this.priority = priority;
         handlePriorityChange(priority);
@@ -103,7 +103,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
   }
 
   void onCustomFrame(HttpFrame frame) {
-    context.emit(frame, this::handleCustomFrame);
+    context.execute(frame, this::handleCustomFrame);
   }
 
   void onHeaders(Http2Headers headers, StreamPriority streamPriority) {
@@ -115,7 +115,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
   }
 
   void onWritabilityChanged() {
-    context.emit(null, v -> {
+    context.execute(null, v -> {
       boolean w;
       synchronized (VertxHttp2Stream.this) {
         writable = !writable;
@@ -131,7 +131,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
 
   void onEnd(MultiMap trailers) {
     conn.flushBytesRead();
-    context.emit(trailers, pending::write);
+    context.execute(trailers, pending::write);
     if (isConnect) {
       doWriteData(Unpooled.EMPTY_BUFFER, true, null);
     }

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -111,7 +111,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
 
   void onData(Buffer data) {
     conn.reportBytesRead(data.length());
-    context.emit(data, pending::write);
+    context.execute(data, pending::write);
   }
 
   void onWritabilityChanged() {

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -3278,9 +3278,12 @@ public abstract class HttpTest extends HttpTestBase {
         assertEquals(req.path(), "/form");
         req.response().setChunked(true);
         req.setExpectMultipart(true);
-        req.uploadHandler(upload -> upload.handler(buffer -> {
+        req.uploadHandler(upload -> {
           assertNotNull(Vertx.currentContext());
-        }));
+          upload.handler(buffer -> {
+            assertNotNull(Vertx.currentContext());
+          });
+        });
         req.endHandler(v -> {
           req.response().end();
         });


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fixes #3629

The upload handler (not being a future) was being called without any guarantees on the caller context. This PR ensures that calls always run on the right context.
