### PR TITLE
JavaDoc that JsonObject#copy and JsonArray#copy make a deep copy

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -553,9 +553,9 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
   }
 
   /**
-   * Make a copy of the JSON array
+   * Deep copy of the JSON array.
    *
-   * @return a copy
+   * @return a copy where all elements have been copied recursively
    */
   @Override
   public JsonArray copy() {

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -747,9 +747,9 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   }
 
   /**
-   * Copy the JSON object
+   * Deep copy of this JSON object.
    *
-   * @return a copy of the object
+   * @return a copy where all elements have been copied recursively
    */
   @Override
   public JsonObject copy() {


### PR DESCRIPTION
The JavaDoc should state whether the copy is shallow or deep.