### PR TITLE
Add Future.toCompletableFuture()

### DIFF
--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -317,14 +317,14 @@ public interface Future<T> extends AsyncResult<T> {
   }
 
   /**
-   * Bridges this Vert.x future to a {@link CompletionStage} instance.
+   * Bridges this Vert.x future to a {@link CompletableFuture} instance.
    * <p>
-   * The {@link CompletionStage} handling methods will be called from the thread that resolves this future.
+   * The {@link CompletableFuture} handling methods will be called from the thread that resolves this future.
    *
-   * @return a {@link CompletionStage} that completes when this future resolves
+   * @return a {@link CompletableFuture} that completes when this future resolves
    */
   @GenIgnore
-  default CompletionStage<T> toCompletionStage() {
+  default CompletableFuture<T> toCompletableFuture() {
     CompletableFuture<T> completableFuture = new CompletableFuture<>();
     onComplete(ar -> {
       if (ar.succeeded()) {
@@ -334,6 +334,18 @@ public interface Future<T> extends AsyncResult<T> {
       }
     });
     return completableFuture;
+  }
+
+  /**
+   * Bridges this Vert.x future to a {@link CompletionStage} instance.
+   * <p>
+   * The {@link CompletionStage} handling methods will be called from the thread that resolves this future.
+   *
+   * @return a {@link CompletionStage} that completes when this future resolves
+   */
+  @GenIgnore
+  default CompletionStage<T> toCompletionStage() {
+    return toCompletableFuture();
   }
 
   /**

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -1632,6 +1632,13 @@ public class FutureTest extends VertxTestBase {
   }
 
   @Test
+  public void testToCompletableFuture() {
+    assertEquals("Yo", Future.succeededFuture("Yo").toCompletableFuture().getNow(null));
+    assertTrue(Future.failedFuture("Woops").toCompletableFuture().isCompletedExceptionally());
+    // for more tests of toCompletableFuture() see testToCompletionStage...()
+  }
+
+  @Test
   public void testToCompletionStageTrampolining() {
     waitFor(2);
     Thread mainThread = Thread.currentThread();


### PR DESCRIPTION
 Many use cases require a CompletableFuture, for example
`future.toCompletionStage().toCompletableFuture().get()`
`future.toCompletionStage().toCompletableFuture().isDone()`
`future.toCompletionStage().toCompletableFuture().completeExceptionally(failure)`

Use the shorthand Future.toCompletableFuture method for concise code:
`future.toCompletableFuture().get()`
`future.toCompletableFuture().isDone()`
`future.toCompletableFuture().completeExceptionally(failure)`

Reference:
https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html#toCompletableFuture--