### PR TITLE
Fix completion handling when removing sub

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -409,19 +409,12 @@ public class ClusteredEventBus extends EventBusImpl {
 
   private void removeSub(String subName, ClusterNodeInfo node, Handler<AsyncResult<Void>> completionHandler) {
     subs.remove(subName, node, ar -> {
-      if (!ar.succeeded()) {
-        log.error("Failed to remove sub", ar.cause());
-      } else {
-        if (ar.result()) {
-          if (completionHandler != null) {
-            completionHandler.handle(Future.succeededFuture());
-          }
+      if (completionHandler != null) {
+        if (ar.succeeded()) {
+          completionHandler.handle(Future.succeededFuture());
         } else {
-          if (completionHandler != null) {
-            completionHandler.handle(Future.failedFuture("sub not found"));
-          }
+          completionHandler.handle(Future.failedFuture(new VertxException("Failed to remove sub", ar.cause())));
         }
-
       }
     });
   }


### PR DESCRIPTION
Fixes #3638

Completion handler, if present, should be called in all cases.
When the cluster manager could not find the subscription, it's not necessary to complete with a failure.
