### PR TITLE
Customized local port on Net/Http client

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -149,6 +149,10 @@ Set the idle timeout unit. If not specified, default is seconds.
 Set the local interface to bind for network connections. When the local address is null,
  it will pick any local address, the default local address is null.
 +++
+|[[localPort]]`@localPort`|`Number (int)`|+++
+Set the local port to bind for network connections. When the local port is 0,
+ then system will automatically pick ups an ephemeral port.
++++
 |[[logActivity]]`@logActivity`|`Boolean`|+++
 Set to true to enabled network activity logging: Netty's pipeline is configured for logging on Netty's logger.
 +++
@@ -715,6 +719,10 @@ Set the keep alive timeout for HTTP/1.x, in seconds.
 Set the local interface to bind for network connections. When the local address is null,
  it will pick any local address, the default local address is null.
 +++
+|[[localPort]]`@localPort`|`Number (int)`|+++
+Set the local port to bind for network connections. When the local port is 0,
+ then system will automatically pick ups an ephemeral port.
++++
 |[[logActivity]]`@logActivity`|`Boolean`|+++
 Set to true to enabled network activity logging: Netty's pipeline is configured for logging on Netty's logger.
 +++
@@ -1168,6 +1176,10 @@ Set the idle timeout unit. If not specified, default is seconds.
 |[[localAddress]]`@localAddress`|`String`|+++
 Set the local interface to bind for network connections. When the local address is null,
  it will pick any local address, the default local address is null.
++++
+|[[localPort]]`@localPort`|`Number (int)`|+++
+Set the local port to bind for network connections. When the local port is 0,
+ then system will automatically pick ups an ephemeral port.
 +++
 |[[logActivity]]`@logActivity`|`Boolean`|+++
 Set to true to enabled network activity logging: Netty's pipeline is configured for logging on Netty's logger.

--- a/src/main/generated/io/vertx/core/net/ClientOptionsBaseConverter.java
+++ b/src/main/generated/io/vertx/core/net/ClientOptionsBaseConverter.java
@@ -26,6 +26,11 @@ public class ClientOptionsBaseConverter {
             obj.setLocalAddress((String)member.getValue());
           }
           break;
+        case "localPort":
+          if (member.getValue() instanceof Number) {
+            obj.setLocalPort(((Number)member.getValue()).intValue());
+          }
+          break;
         case "metricsName":
           if (member.getValue() instanceof String) {
             obj.setMetricsName((String)member.getValue());
@@ -54,6 +59,7 @@ public class ClientOptionsBaseConverter {
     if (obj.getLocalAddress() != null) {
       json.put("localAddress", obj.getLocalAddress());
     }
+    json.put("localPort", obj.getLocalPort());
     if (obj.getMetricsName() != null) {
       json.put("metricsName", obj.getMetricsName());
     }

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -1113,6 +1113,11 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public HttpClientOptions setLocalPort(int localPort) {
+    return (HttpClientOptions) super.setLocalPort(localPort);
+  }
+
+  @Override
   public HttpClientOptions setLogActivity(boolean logEnabled) {
     return (HttpClientOptions) super.setLogActivity(logEnabled);
   }

--- a/src/main/java/io/vertx/core/net/ClientOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/ClientOptionsBase.java
@@ -13,9 +13,9 @@ package io.vertx.core.net;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.Arguments;
 import io.vertx.core.json.JsonObject;
 
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -41,11 +41,17 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
    */
   public static final String DEFAULT_METRICS_NAME = "";
 
+  /**
+   * The default value of local port is 0, which will let the system pick up an ephemeral port
+   */
+  public static final int DEFAULT_LOCAL_PORT = 0;
+
   private int connectTimeout;
   private boolean trustAll;
   private String metricsName;
   private ProxyOptions proxyOptions;
   private String localAddress;
+  private int localPort;
 
   /**
    * Default constructor
@@ -67,6 +73,7 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
     this.metricsName = other.metricsName;
     this.proxyOptions = other.proxyOptions != null ? new ProxyOptions(other.proxyOptions) : null;
     this.localAddress = other.localAddress;
+    this.localPort = other.localPort;
   }
 
   /**
@@ -95,6 +102,7 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
     this.connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     this.trustAll = DEFAULT_TRUST_ALL;
     this.metricsName = DEFAULT_METRICS_NAME;
+    this.localPort = DEFAULT_LOCAL_PORT;
     this.proxyOptions = null;
     this.localAddress = null;
   }
@@ -194,6 +202,26 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
    */
   public ClientOptionsBase setLocalAddress(String localAddress) {
     this.localAddress = localAddress;
+    return this;
+  }
+
+  /**
+   * @return the local port to bind for network connections.
+   */
+  public int getLocalPort() {
+    return localPort;
+  }
+
+  /**
+   * Set the local port to bind for network connections. When the local port is 0,
+   * then system will automatically pick ups an ephemeral port.
+   *
+   * @param localPort the local port
+   * @return a reference to this, so the API can be used fluently
+   */
+  public ClientOptionsBase setLocalPort(int localPort) {
+    Arguments.require(localPort >= 0, "localPort must be >= 0");
+    this.localPort = localPort;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -352,6 +352,11 @@ public class NetClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public NetClientOptions setLocalPort(int localPort) {
+    return (NetClientOptions) super.setLocalPort(localPort);
+  }
+
+  @Override
   public NetClientOptions setEnabledSecureTransportProtocols(Set<String> enabledSecureTransportProtocols) {
     return (NetClientOptions) super.setEnabledSecureTransportProtocols(enabledSecureTransportProtocols);
   }

--- a/src/main/java/io/vertx/core/net/impl/transport/Transport.java
+++ b/src/main/java/io/vertx/core/net/impl/transport/Transport.java
@@ -232,7 +232,9 @@ public class Transport {
       bootstrap.option(ChannelOption.SO_KEEPALIVE, options.isTcpKeepAlive());
     }
     if (options.getLocalAddress() != null) {
-      bootstrap.localAddress(options.getLocalAddress(), 0);
+      bootstrap.localAddress(options.getLocalAddress(), options.getLocalPort());
+    } else {
+      bootstrap.localAddress(options.getLocalPort());
     }
     if (options.getSendBufferSize() != -1) {
       bootstrap.option(ChannelOption.SO_SNDBUF, options.getSendBufferSize());


### PR DESCRIPTION
**Support for setting local source port**
*Enhancement link*: https://github.com/eclipse-vertx/vert.x/issues/3617

Added new options to `HttpClientOptions` and `NetClientOptions` named `localPort` which is then passed to underlying `io.netty.bootstrap.Bootstrap` at `Transport#configure`.

If  `localPort` is not specified then default value - `0` is used, which means that system will picks the port by itself (ephemeral port), no change in functionality in comparing to current behavior.