### PR TITLE
Intermittent failure in testClusteredUnregistration

### DIFF
--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTestBase.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTestBase.java
@@ -13,7 +13,9 @@ package io.vertx.core.eventbus;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.spi.cluster.*;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.fakecluster.FakeClusterManager;
 import org.junit.Test;
@@ -22,6 +24,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -209,8 +212,23 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
   }
 
   @Test
-  public void testClusteredUnregistration() {
-    startNodes(2);
+  public void testClusteredUnregistration() throws Exception {
+    CountDownLatch updateLatch = new CountDownLatch(3);
+    Supplier<VertxOptions> options = () -> getOptions().setClusterManager(new WrappedClusterManager(getClusterManager()) {
+      @Override
+      public void init(Vertx vertx, NodeSelector nodeSelector) {
+        super.init(vertx, new WrappedNodeSelector(nodeSelector) {
+          @Override
+          public void registrationsUpdated(RegistrationUpdateEvent event) {
+            super.registrationsUpdated(event);
+            if (event.address().equals("foo") && event.registrations().isEmpty()) {
+              updateLatch.countDown();
+            }
+          }
+        });
+      }
+    });
+    startNodes(options.get(), options.get());
     MessageConsumer<Object> consumer = vertices[0].eventBus().consumer("foo", msg -> msg.reply(msg.body()));
     consumer.completionHandler(onSuccess(reg -> {
       vertices[0].eventBus().request("foo", "echo", onSuccess(reply1 -> {
@@ -218,17 +236,19 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
         vertices[1].eventBus().request("foo", "echo", onSuccess(reply2 -> {
           assertEquals("echo", reply1.body());
           consumer.unregister(onSuccess(unreg -> {
-            vertices[1].eventBus().request("foo", "echo", onFailure(fail1 -> {
-              assertThat(fail1, is(instanceOf(ReplyException.class)));
-              assertEquals(ReplyFailure.NO_HANDLERS, ((ReplyException) fail1).failureType());
-              vertices[0].eventBus().request("foo", "echo", onFailure(fail2 -> {
-                assertThat(fail2, is(instanceOf(ReplyException.class)));
-                assertEquals(ReplyFailure.NO_HANDLERS, ((ReplyException) fail2).failureType());
-                testComplete();
-              }));
-            }));
+            updateLatch.countDown();
           }));
         }));
+      }));
+    }));
+    awaitLatch(updateLatch);
+    vertices[1].eventBus().request("foo", "echo", onFailure(fail1 -> {
+      assertThat(fail1, is(instanceOf(ReplyException.class)));
+      assertEquals(ReplyFailure.NO_HANDLERS, ((ReplyException) fail1).failureType());
+      vertices[0].eventBus().request("foo", "echo", onFailure(fail2 -> {
+        assertThat(fail2, is(instanceOf(ReplyException.class)));
+        assertEquals(ReplyFailure.NO_HANDLERS, ((ReplyException) fail2).failureType());
+        testComplete();
       }));
     }));
     await();

--- a/src/test/java/io/vertx/core/spi/cluster/WrappedClusterManager.java
+++ b/src/test/java/io/vertx/core/spi/cluster/WrappedClusterManager.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.spi.cluster;
+
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.AsyncMap;
+import io.vertx.core.shareddata.Counter;
+import io.vertx.core.shareddata.Lock;
+
+import java.util.List;
+import java.util.Map;
+
+public class WrappedClusterManager implements ClusterManager {
+
+  private final ClusterManager delegate;
+
+  public WrappedClusterManager(ClusterManager delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void init(Vertx vertx, NodeSelector nodeSelector) {
+    delegate.init(vertx, nodeSelector);
+  }
+
+  @Override
+  public <K, V> void getAsyncMap(String name, Promise<AsyncMap<K, V>> promise) {
+    delegate.getAsyncMap(name, promise);
+  }
+
+  @Override
+  public <K, V> Map<K, V> getSyncMap(String name) {
+    return delegate.getSyncMap(name);
+  }
+
+  @Override
+  public void getLockWithTimeout(String name, long timeout, Promise<Lock> promise) {
+    delegate.getLockWithTimeout(name, timeout, promise);
+  }
+
+  @Override
+  public void getCounter(String name, Promise<Counter> promise) {
+    delegate.getCounter(name, promise);
+  }
+
+  @Override
+  public String getNodeId() {
+    return delegate.getNodeId();
+  }
+
+  @Override
+  public List<String> getNodes() {
+    return delegate.getNodes();
+  }
+
+  @Override
+  public void nodeListener(NodeListener listener) {
+    delegate.nodeListener(listener);
+  }
+
+  @Override
+  public void setNodeInfo(NodeInfo nodeInfo, Promise<Void> promise) {
+    delegate.setNodeInfo(nodeInfo, promise);
+  }
+
+  @Override
+  public NodeInfo getNodeInfo() {
+    return delegate.getNodeInfo();
+  }
+
+  @Override
+  public void getNodeInfo(String nodeId, Promise<NodeInfo> promise) {
+    delegate.getNodeInfo(nodeId, promise);
+  }
+
+  @Override
+  public void join(Promise<Void> promise) {
+    delegate.join(promise);
+  }
+
+  @Override
+  public void leave(Promise<Void> promise) {
+    delegate.leave(promise);
+  }
+
+  @Override
+  public boolean isActive() {
+    return delegate.isActive();
+  }
+
+  @Override
+  public void addRegistration(String address, RegistrationInfo registrationInfo, Promise<Void> promise) {
+    delegate.addRegistration(address, registrationInfo, promise);
+  }
+
+  @Override
+  public void removeRegistration(String address, RegistrationInfo registrationInfo, Promise<Void> promise) {
+    delegate.removeRegistration(address, registrationInfo, promise);
+  }
+
+  @Override
+  public void getRegistrations(String address, Promise<List<RegistrationInfo>> promise) {
+    delegate.getRegistrations(address, promise);
+  }
+
+  @Override
+  public String clusterHost() {
+    return delegate.clusterHost();
+  }
+
+  @Override
+  public String clusterPublicHost() {
+    return delegate.clusterPublicHost();
+  }
+
+  public ClusterManager getDelegate() {
+    return delegate;
+  }
+}

--- a/src/test/java/io/vertx/core/spi/cluster/WrappedNodeSelector.java
+++ b/src/test/java/io/vertx/core/spi/cluster/WrappedNodeSelector.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.spi.cluster;
+
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.Message;
+
+public class WrappedNodeSelector implements NodeSelector {
+
+  private final NodeSelector delegate;
+
+  public WrappedNodeSelector(NodeSelector delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void init(Vertx vertx, ClusterManager clusterManager) {
+    delegate.init(vertx, clusterManager);
+  }
+
+  @Override
+  public void eventBusStarted() {
+    delegate.eventBusStarted();
+  }
+
+  @Override
+  public void selectForSend(Message<?> message, Promise<String> promise) {
+    delegate.selectForSend(message, promise);
+  }
+
+  @Override
+  public void selectForPublish(Message<?> message, Promise<Iterable<String>> promise) {
+    delegate.selectForPublish(message, promise);
+  }
+
+  @Override
+  public void registrationsUpdated(RegistrationUpdateEvent event) {
+    delegate.registrationsUpdated(event);
+  }
+
+  @Override
+  public void registrationsLost() {
+    delegate.registrationsLost();
+  }
+}

--- a/src/test/java/io/vertx/test/core/VertxTestBase.java
+++ b/src/test/java/io/vertx/test/core/VertxTestBase.java
@@ -151,7 +151,7 @@ public class VertxTestBase extends AsyncTestBase {
   protected void startNodes(int numNodes, VertxOptions options) {
     VertxOptions[] array = new VertxOptions[numNodes];
     for (int i = 0;i < numNodes;i++) {
-      array[i] = options;
+      array[i] = new VertxOptions(options);
     }
     startNodes(array);
   }
@@ -162,19 +162,20 @@ public class VertxTestBase extends AsyncTestBase {
     vertices = new Vertx[numNodes];
     for (int i = 0; i < numNodes; i++) {
       int index = i;
-      options[i].setClusterManager(getClusterManager())
-        .getEventBusOptions().setHost("localhost").setPort(0);
+      if (options[i].getClusterManager() == null) {
+        options[i].setClusterManager(getClusterManager());
+      }
+      options[i].getEventBusOptions().setHost("localhost").setPort(0);
       clusteredVertx(options[i], ar -> {
-          try {
-            if (ar.failed()) {
-              ar.cause().printStackTrace();
-            }
-            assertTrue("Failed to start node", ar.succeeded());
-            vertices[index] = ar.result();
+        try {
+          if (ar.failed()) {
+            ar.cause().printStackTrace();
           }
-          finally {
-            latch.countDown();
-          }
+          assertTrue("Failed to start node", ar.succeeded());
+          vertices[index] = ar.result();
+        } finally {
+          latch.countDown();
+        }
       });
     }
     try {


### PR DESCRIPTION
The test failed intermittently with Hazelcast on CI.
It failed consistently with Vert.x nodes configured as lite members of the Hazelcast cluster.

When a subscription is removed, it can take some time before the cluster manager invokes our listeners.
It is then possible that we still have in cache a registration that has been effectively removed.

The fix consists in intercepting the registration update event to make sure it has been processed.
Then we can try sending again and we should get the NO_HANDLERS error as expected.