### PR TITLE
using empty array for Collection.toArray()

### DIFF
--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -73,7 +73,7 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    * When the list is empty, the returned future will be already completed.
    */
   static CompositeFuture all(List<Future> futures) {
-    return CompositeFutureImpl.all(futures.toArray(new Future[futures.size()]));
+    return CompositeFutureImpl.all(futures.toArray(new Future[0]));
   }
 
   /**
@@ -123,7 +123,7 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    * When the list is empty, the returned future will be already completed.
    */
   static CompositeFuture any(List<Future> futures) {
-    return CompositeFutureImpl.any(futures.toArray(new Future[futures.size()]));
+    return CompositeFutureImpl.any(futures.toArray(new Future[0]));
   }
 
   /**
@@ -173,7 +173,7 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    * When the list is empty, the returned future will be already completed.
    */
   static CompositeFuture join(List<Future> futures) {
-    return CompositeFutureImpl.join(futures.toArray(new Future[futures.size()]));
+    return CompositeFutureImpl.join(futures.toArray(new Future[0]));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
@@ -607,7 +607,7 @@ public class FileSystemImpl implements FileSystem {
     Objects.requireNonNull(to);
     Objects.requireNonNull(options);
     Set<CopyOption> copyOptionSet = toCopyOptionSet(options);
-    CopyOption[] copyOptions = copyOptionSet.toArray(new CopyOption[copyOptionSet.size()]);
+    CopyOption[] copyOptions = copyOptionSet.toArray(new CopyOption[0]);
     return new BlockingAction<Void>() {
       public Void perform() {
         try {
@@ -669,7 +669,7 @@ public class FileSystemImpl implements FileSystem {
     Objects.requireNonNull(to);
     Objects.requireNonNull(options);
     Set<CopyOption> copyOptionSet = toCopyOptionSet(options);
-    CopyOption[] copyOptions = copyOptionSet.toArray(new CopyOption[copyOptionSet.size()]);
+    CopyOption[] copyOptions = copyOptionSet.toArray(new CopyOption[0]);
     return new BlockingAction<Void>() {
       public Void perform() {
         try {

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -798,7 +798,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
       ArrayList<WebSocketClientExtensionHandshaker> extensionHandshakers = initializeWebSocketExtensionHandshakers(client.getOptions());
       if (!extensionHandshakers.isEmpty()) {
         p.addBefore("handler", "webSocketsExtensionsHandler", new WebSocketClientExtensionHandler(
-          extensionHandshakers.toArray(new WebSocketClientExtensionHandshaker[extensionHandshakers.size()])));
+          extensionHandshakers.toArray(new WebSocketClientExtensionHandshaker[0])));
       }
 
       String subp = null;

--- a/src/main/java/io/vertx/core/http/impl/HttpServerConnectionHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerConnectionHandler.java
@@ -92,7 +92,7 @@ public class HttpServerConnectionHandler implements Handler<HttpServerConnection
     }
     if (!extensionHandshakers.isEmpty()) {
       WebSocketServerExtensionHandler extensionHandler = new WebSocketServerExtensionHandler(
-        extensionHandshakers.toArray(new WebSocketServerExtensionHandshaker[extensionHandshakers.size()]));
+        extensionHandshakers.toArray(new WebSocketServerExtensionHandshaker[0]));
       pipeline.addBefore("handler", "webSocketExtensionHandler", extensionHandler);
     }
   }

--- a/src/main/java/io/vertx/core/impl/LoaderManager.java
+++ b/src/main/java/io/vertx/core/impl/LoaderManager.java
@@ -93,7 +93,7 @@ class LoaderManager {
     }
     // And add the URLs of the Vert.x classloader
     urls.addAll(Arrays.asList(parent.getURLs()));
-    return new IsolatingClassLoader(urls.toArray(new URL[urls.size()]), parent,
+    return new IsolatingClassLoader(urls.toArray(new URL[0]), parent,
       options.getIsolatedClasses());
   }
 }

--- a/src/main/java/io/vertx/core/impl/launcher/commands/FileSelector.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/FileSelector.java
@@ -360,6 +360,6 @@ public final class FileSelector {
     while (st.hasMoreTokens()) {
       ret.add(st.nextToken());
     }
-    return ret.toArray(new String[ret.size()]);
+    return ret.toArray(new String[0]);
   }
 }

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -393,7 +393,7 @@ public class RunCommand extends BareCommand {
     // Enable stream redirection
     args.add("--redirect-output");
 
-    executionContext.execute("start", args.toArray(new String[args.size()]));
+    executionContext.execute("start", args.toArray(new String[0]));
     if (onCompletion != null) {
       onCompletion.handle(null);
     }

--- a/src/main/java/io/vertx/core/impl/resolver/DnsResolverProvider.java
+++ b/src/main/java/io/vertx/core/impl/resolver/DnsResolverProvider.java
@@ -212,7 +212,7 @@ public class DnsResolverProvider implements ResolverProvider {
   @Override
   public void close(Handler<Void> doneHandler) {
     Context context = vertx.getOrCreateContext();
-    ResolverRegistration[] registrations = this.resolvers.toArray(new ResolverRegistration[this.resolvers.size()]);
+    ResolverRegistration[] registrations = this.resolvers.toArray(new ResolverRegistration[0]);
     if (registrations.length == 0) {
       context.runOnContext(doneHandler);
       return;

--- a/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
@@ -127,7 +127,7 @@ public class KeyStoreHelper {
             }
             @Override
             public X509Certificate[] getCertificateChain(String s) {
-              return chain.toArray(new X509Certificate[chain.size()]);
+              return chain.toArray(new X509Certificate[0]);
             }
             @Override
             public PrivateKey getPrivateKey(String s) {
@@ -350,7 +350,7 @@ public class KeyStoreHelper {
     if (certs.isEmpty()) {
       throw new RuntimeException("Missing -----BEGIN CERTIFICATE----- delimiter");
     }
-    return certs.toArray(new X509Certificate[certs.size()]);
+    return certs.toArray(new X509Certificate[0]);
   }
 
   /**


### PR DESCRIPTION
Motivation:

There are two styles to convert a collection to an array: either using a pre-sized array (like c.toArray(new String[c.size()])) or using an empty array (like c.toArray(new String[0]).
    
In older Java versions using pre-sized array was recommended, as the reflection call which is necessary to create an array of proper size was quite slow. However since late updates of OpenJDK 6 this call was intrinsified, making the performance of the empty array version the same and sometimes even better, compared to the pre-sized version. Also passing pre-sized array is dangerous for a concurrent or synchronized collection as a data race is possible between the size and toArray call which may result in extra nulls at the end of the array, if the collection was concurrently shrunk during the operation.
