### PR TITLE
Hostname validation by default, fixes SSL/TLS certificate host mismatch

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -1211,8 +1211,8 @@ Add an enabled cipher suite, appended to the ordered suites.
 Sets the list of enabled SSL/TLS protocols.
 +++
 |[[hostnameVerificationAlgorithm]]`@hostnameVerificationAlgorithm`|`String`|+++
-Set the hostname verification algorithm interval
- To disable hostname verification, set hostnameVerificationAlgorithm to an empty String
+Set the hostname verification algorithm, either HTTPS, LDAPS, or an empty String
+ to disable hostname verification. The default is HTTPS.
 +++
 |[[idleTimeout]]`@idleTimeout`|`Number (int)`|+++
 Set the idle timeout, default time unit is seconds. Zero means don't timeout.

--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -448,9 +448,16 @@ To enable SSL on a NetClient the function setSSL(true) is called.
 
 ==== Client trust configuration
 
-If the {@link io.vertx.core.net.ClientOptionsBase#setTrustAll trustALl} is set to true on the client, then the client will
-trust all server certificates. The connection will still be encrypted but this mode is vulnerable to 'man in the middle' attacks. I.e. you can't
-be sure who you are connecting to. Use this with caution. Default value is false.
+By default, the client checks that the certificate presented by the server is trusted, and that the host name the
+client wants to connect to is listed in the server certificate.
+
+Disabling one or both of these checks makes the connection vulnerable to 'man in the middle' attacks. I.e. you can't
+be sure who you are connecting to. Use this with caution.
+
+If the {@link io.vertx.core.net.ClientOptionsBase#setTrustAll trustAll} is set to true on the client, then the client will
+trust all server certificates, i.e. certificates issued by an attacker.
+
+The default value for trustAll is false.
 
 [source,$lang]
 ----
@@ -460,8 +467,13 @@ be sure who you are connecting to. Use this with caution. Default value is false
 If {@link io.vertx.core.net.ClientOptionsBase#setTrustAll trustAll} is not set then a client trust store must be
 configured and should contain the certificates of the servers that the client trusts.
 
-By default, host verification is disabled on the client.
-To enable host verification, set the algorithm to use on your client (only HTTPS and LDAPS is currently supported):
+If the {@link io.vertx.core.net.NetClientOptions#setHostnameVerificationAlgorithm hostnameVerificationAlgorithm}
+is set to an empty string on the client, then the client will trust server certificates issued for wrong hosts. Use
+this with caution.
+
+By default, HTTPS host name verification is enabled on the client.
+Use {@link io.vertx.core.net.NetClientOptions#setHostnameVerificationAlgorithm setHostnameVerificationAlgorithm}
+to switch to "LDAPS", "HTTPS" or "".
 
 
 [source,$lang]

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -552,7 +552,7 @@ public class NetExamples {
   public void example46(Vertx vertx, JksOptions keyStoreOptions) {
     NetClientOptions options = new NetClientOptions().
       setSsl(true).
-      setHostnameVerificationAlgorithm("HTTPS");
+      setHostnameVerificationAlgorithm("");
     NetClient client = vertx.createNetClient(options);
   }
 

--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -38,9 +38,9 @@ public class NetClientOptions extends ClientOptionsBase {
   public static final long DEFAULT_RECONNECT_INTERVAL = 1000;
 
   /**
-   * Default value to determine hostname verification algorithm hostname verification (for SSL/TLS) = ""
+   * Default hostname verification algorithm (for SSL/TLS)
    */
-  public static final String DEFAULT_HOSTNAME_VERIFICATION_ALGORITHM = "";
+  public static final String DEFAULT_HOSTNAME_VERIFICATION_ALGORITHM = "HTTPS";
 
 
   private int reconnectAttempts;
@@ -309,7 +309,8 @@ public class NetClientOptions extends ClientOptionsBase {
   }
 
   /**
-   * @return  the value of the hostname verification algorithm
+   * @return  the hostname verification algorithm, either HTTPS, LDAPS, or
+   *            an empty String for no hostname validation
    */
 
   public String getHostnameVerificationAlgorithm() {
@@ -317,8 +318,8 @@ public class NetClientOptions extends ClientOptionsBase {
   }
 
   /**
-   * Set the hostname verification algorithm interval
-   * To disable hostname verification, set hostnameVerificationAlgorithm to an empty String
+   * Set the hostname verification algorithm, either HTTPS, LDAPS, or an empty String
+   * to disable hostname verification. The default is HTTPS.
    *
    * @param hostnameVerificationAlgorithm should be HTTPS, LDAPS or an empty String
    * @return a reference to this, so the API can be used fluently


### PR DESCRIPTION
Vert.x (and Netty) disable hostname validation of SSL/TLS
certificates by default. This opens a back door for man-in-the-middle
(MITM) attacks because attackers only need to present a valid SSL/TLS
certificate for a different hostname to successfully intercept the
connection.

Details: https://cwe.mitre.org/data/definitions/297.html

Developers using Vert.x can enable hostname validation if they call
`.setHostnameVerificationAlgorithm("HTTPS")`.
However, 6 out of 7 examples presented on
https://vertx.io/docs/vertx-core/java/#_client_trust_configuration
don't enable it. It is likely that some developers forget to
enable hostname verification.

Security by default is state of the art and required by GDPR articles
32 and 25. Libraries should ship with secure defaults.

Therefore Vert.x should enable SSL/TLS hostname validation by default.

Netty will enable hostname validation by default for Netty 5:
https://github.com/netty/netty/issues/8537
Netty got security vulnerability notices because of this issue:
https://snyk.io/vuln/SNYK-JAVA-IONETTY-1042268
https://github.com/netty/netty/issues/10362