### PR TITLE
TracingPolicy is used in public options so it should be annotated too

### DIFF
--- a/src/main/java/io/vertx/core/tracing/TracingPolicy.java
+++ b/src/main/java/io/vertx/core/tracing/TracingPolicy.java
@@ -10,11 +10,14 @@
  */
 package io.vertx.core.tracing;
 
+import io.vertx.codegen.annotations.VertxGen;
+
 /**
  * Policy controlling the behavior across boundaries.
  *
  * This control is applied for clients or servers reporting traces.
  */
+@VertxGen
 public enum TracingPolicy {
 
   /**


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Missing annotation on public enum