### PR TITLE
calling completion handler for HttpClientResponse. fixes issue #3721

### DIFF
--- a/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
@@ -111,6 +111,11 @@ public class HttpServerOptionsConverter {
             obj.setWebSocketAllowServerNoContext((Boolean)member.getValue());
           }
           break;
+        case "webSocketClosingTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setWebSocketClosingTimeout(((Number)member.getValue()).intValue());
+          }
+          break;
         case "webSocketCompressionLevel":
           if (member.getValue() instanceof Number) {
             obj.setWebSocketCompressionLevel(((Number)member.getValue()).intValue());
@@ -166,6 +171,7 @@ public class HttpServerOptionsConverter {
       json.put("tracingPolicy", obj.getTracingPolicy().name());
     }
     json.put("webSocketAllowServerNoContext", obj.getWebSocketAllowServerNoContext());
+    json.put("webSocketClosingTimeout", obj.getWebSocketClosingTimeout());
     json.put("webSocketCompressionLevel", obj.getWebSocketCompressionLevel());
     json.put("webSocketPreferredClientNoContext", obj.getWebSocketPreferredClientNoContext());
     if (obj.getWebSocketSubProtocols() != null) {

--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -389,6 +389,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
       setChunked(true);
     }
     body.pipeTo(this);
+    response(handler);
   }
 
   /**

--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -388,8 +388,8 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
     if (headers == null || !headers.contains(HttpHeaders.CONTENT_LENGTH)) {
       setChunked(true);
     }
-    body.pipeTo(this);
     response(handler);
+    body.pipeTo(this);
   }
 
   /**


### PR DESCRIPTION
Motivation:

fixing the issue reported in #3721 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
