### PR TITLE
Add a lock-free implementation of a Future

### DIFF
--- a/src/main/java/io/vertx/core/impl/future/FutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureImpl.java
@@ -19,19 +19,64 @@ import io.vertx.core.impl.NoStackTraceThrowable;
 
 import java.util.ArrayList;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Future implementation.
+ * A thread-safe / lock-free implementation of a {@link Future} relying on compare-and-swap, busy-waiting
+ * and piggybacking.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ * @param <T> The result type of the future.
  */
 class FutureImpl<T> extends FutureBase<T> {
 
-  private static final Object NULL_VALUE = new Object();
-
+  /**
+   * All possible states of the future, the initial state is <i>NEW</i> then the possible state transitions are:
+   * <p>
+   * <ul>
+   *   <li><i>NEW</i> -> <i>COMPLETING</i> -> <i>SUCCESS</i></li>
+   *   <li><i>NEW</i> -> <i>COMPLETING</i> -> <i>FAILURE</i></li>
+   *   <li><i>NEW</i> -> <i>REGISTERING</i> -> <i>REGISTERED</i> -> <i>COMPLETING</i> -> <i>SUCCESS</i></li>
+   *   <li><i>NEW</i> -> <i>REGISTERING</i> -> <i>REGISTERED</i> -> <i>COMPLETING</i> -> <i>FAILURE</i></li>
+   * </ul>
+   *
+   * <p>
+   * The description of all possible states:
+   * <table>
+   *   <col width="25%"/>
+   *   <col width="75%"/>
+   *   <thead>
+   *     <tr><th>State</th><th>Description</th></tr>
+   *   <thead>
+   *   <tbody>
+   *      <tr><td>{@link FutureImpl#NEW}</td><td>The initial state</td></tr>
+   *      <tr><td>{@link FutureImpl#REGISTERED}</td><td>The state in case at least one listener has been registered</td></tr>
+   *      <tr><td>{@link FutureImpl#COMPLETING}</td><td>The state in case the result of the future has been received</td></tr>
+   *      <tr><td>{@link FutureImpl#REGISTERING}</td><td>The state in case a listener is currently being registered</td></tr>
+   *      <tr><td>{@link FutureImpl#FAILURE}</td><td>The state in case the future failed</td></tr>
+   *      <tr><td>{@link FutureImpl#SUCCESS}</td><td>The state in case the future could be executed with success</td></tr>
+   *   </tbody>
+   * </table>
+   */
+  private static final int NEW         = 0;
+  private static final int REGISTERED  = 1;
+  private static final int COMPLETING  = 2;
+  private static final int REGISTERING = 3;
+  private static final int FAILURE     = 4;
+  private static final int SUCCESS     = 5;
+  /**
+   * The resulting value of the future. It will be of type T in case of a success and of type {@code Throwable}
+   * in case of a failure.
+   */
   private Object value;
+  /**
+   * The listener to call once the result of the future will be received.
+   */
   private Listener<T> listener;
+  /**
+   * The current state of the future.
+   */
+  private final AtomicInteger state = new AtomicInteger(NEW);
 
   /**
    * Create a future that hasn't completed yet
@@ -50,36 +95,42 @@ class FutureImpl<T> extends FutureBase<T> {
   /**
    * The result of the operation. This will be null if the operation failed.
    */
-  public synchronized T result() {
-    return value instanceof Throwable ? null : value == NULL_VALUE ? null : (T) value;
+  public T result() {
+    if (this.state.get() == SUCCESS) {
+      return (T) value;
+    }
+    return null;
   }
 
   /**
    * An exception describing failure. This will be null if the operation succeeded.
    */
-  public synchronized Throwable cause() {
-    return value instanceof Throwable ? (Throwable) value : null;
+  public Throwable cause() {
+    if (this.state.get() == FAILURE) {
+      return (Throwable) value;
+    }
+    return null;
   }
 
   /**
    * Did it succeed?
    */
-  public synchronized boolean succeeded() {
-    return value != null && !(value instanceof Throwable);
+  public boolean succeeded() {
+    return state.get() == SUCCESS;
   }
 
   /**
    * Did it fail?
    */
-  public synchronized boolean failed() {
-    return value instanceof Throwable;
+  public boolean failed() {
+    return state.get() == FAILURE;
   }
 
   /**
    * Has it completed?
    */
-  public synchronized boolean isComplete() {
-    return value != null;
+  public boolean isComplete() {
+    return isComplete(this.state.get());
   }
 
   @Override
@@ -136,84 +187,103 @@ class FutureImpl<T> extends FutureBase<T> {
 
   @Override
   public void addListener(Listener<T> listener) {
-    Object v;
-    synchronized (this) {
-      v = value;
-      if (v == null) {
-        if (this.listener == null) {
-          this.listener = listener;
+    for (;;) {
+      int s = this.state.get();
+      if (isComplete(s)) {
+        if (value instanceof Throwable) {
+          emitFailure((Throwable) value, listener);
         } else {
-          ListenerArray<T> listeners;
-          if (this.listener instanceof FutureImpl.ListenerArray) {
-            listeners = (ListenerArray<T>) this.listener;
-          } else {
-            listeners = new ListenerArray<>();
-            listeners.add(this.listener);
-            this.listener = listeners;
-          }
-          listeners.add(listener);
+          emitSuccess((T) value, listener);
         }
         return;
+      } else if (s <= REGISTERED && this.state.compareAndSet(s, REGISTERING)) {
+        register(listener);
+        this.state.set(REGISTERED);
+        return;
       }
-    }
-    if (v instanceof Throwable) {
-      emitFailure((Throwable) v, listener);
-    } else {
-      if (v == NULL_VALUE) {
-        v = null;
-      }
-      emitSuccess((T) v, listener);
     }
   }
 
   public boolean tryComplete(T result) {
-    Listener<T> l;
-    synchronized (this) {
-      if (value != null) {
+    for (;;) {
+      int s = this.state.get();
+      if (isComplete(s)) {
         return false;
+      } else if (s <= REGISTERED && this.state.compareAndSet(s, COMPLETING)) {
+        Listener<T> l = listener;
+        this.listener = null;
+        this.value = result;
+        this.state.set(SUCCESS);
+        if (l != null) {
+          emitSuccess(result, l);
+        }
+        return true;
       }
-      value = result == null ? NULL_VALUE : result;
-      l = listener;
-      listener = null;
     }
-    if (l != null) {
-      emitSuccess(result, l);
-    }
-    return true;
   }
 
   public boolean tryFail(Throwable cause) {
-    if (cause == null) {
-      cause = new NoStackTraceThrowable(null);
-    }
-    Listener<T> l;
-    synchronized (this) {
-      if (value != null) {
+    for (;;) {
+      int s = this.state.get();
+      if (isComplete(s)) {
         return false;
+      } else if (s <= REGISTERED && this.state.compareAndSet(s, COMPLETING)) {
+        Listener<T> l = listener;
+        this.listener = null;
+        this.value = cause == null ? new NoStackTraceThrowable(null) : cause;
+        this.state.set(FAILURE);
+        if (l != null) {
+          emitFailure(cause, l);
+        }
+        return true;
       }
-      value = cause;
-      l = listener;
-      listener = null;
     }
-    if (l != null) {
-      emitFailure(cause, l);
-    }
-    return true;
   }
 
   @Override
   public String toString() {
-    synchronized (this) {
-      if (value instanceof Throwable) {
-        return "Future{cause=" + ((Throwable)value).getMessage() + "}";
+    int s = this.state.get();
+    if (s == SUCCESS) {
+      return String.format("Future{result=%s}", value);
+    } else if (s == FAILURE) {
+      return String.format("Future{cause=%s}", ((Throwable) value).getMessage());
+    }
+    return "Future{unresolved}";
+  }
+
+  /**
+   * Indicates whether the given state is either a success or a failure.
+   * @param state the state to test.
+   * @return {@code true} if the state is either a success or a failure, {@code false} otherwise.
+   */
+  private boolean isComplete(int state) {
+    return state >= FAILURE;
+  }
+
+  /**
+   * Registers the given listener.
+   * @param listener the listener to register.
+   */
+  private void register(Listener<T> listener) {
+    if (this.listener == null) {
+      this.listener = listener;
+    } else {
+      ListenerArray<T> listeners;
+      if (this.listener instanceof FutureImpl.ListenerArray) {
+        listeners = (ListenerArray<T>) this.listener;
+      } else {
+        listeners = new ListenerArray<>();
+        listeners.add(this.listener);
+        this.listener = listeners;
       }
-      if (value != null) {
-        return "Future{result=" + (value == NULL_VALUE ? "null" : value) + "}";
-      }
-      return "Future{unresolved}";
+      listeners.add(listener);
     }
   }
 
+  /**
+   * A type of collection of {@code Listener<T>} that will be used if several listeners are registered.
+   * @param <T> the result type of the future.
+   */
   private static class ListenerArray<T> extends ArrayList<Listener<T>> implements Listener<T> {
     @Override
     public void onSuccess(T value) {


### PR DESCRIPTION
## Motivation:

Avoid the overhead of synchronized blocks by using a `volatile` reads and writes instead 

## Modifications:

* Use an `AtomicInteger` to store the state of the `Future` in order to make compare-and-swap and `volatile` reads and writes
* Rely on piggybacking to read/modify the member fields `value` and `listener`

**NB:** Please note that I did not use `Unsafe` / `VarHandle` instead of  an `AtomicInteger` for a better compatibility with the different Java versions