### PR TITLE
Add a lock-free implementation of a CloseFuture

### DIFF
--- a/src/main/java/io/vertx/core/impl/CloseFuture.java
+++ b/src/main/java/io/vertx/core/impl/CloseFuture.java
@@ -16,56 +16,106 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 /**
  * An helper class for managing close operations.
+ * <p>
+ * A thread-safe / lock-free implementation of a {@link CloseFuture} relying on compare-and-swap, busy-waiting
+ * and piggybacking.
  */
 public class CloseFuture implements Future<Void>, Closeable {
 
+  /**
+   * All possible states of the {@code CloseFuture}, the initial state is <i>NEW</i> then the possible state transitions are:
+   * <p>
+   * <ul>
+   *   <li><i>NEW</i> -> <i>INITIALIZING</i> -> <i>INITIALIZED</i> -> <i>CLOSED</i>
+   * </ul>
+   *
+   * <p>
+   * The description of all possible states:
+   * <table>
+   *   <col width="25%"/>
+   *   <col width="75%"/>
+   *   <thead>
+   *     <tr><th>State</th><th>Description</th></tr>
+   *   <thead>
+   *   <tbody>
+   *      <tr><td>{@link CloseFuture#NEW}</td><td>The initial state</td></tr>
+   *      <tr><td>{@link CloseFuture#INITIALIZED}</td><td>The state in case the underlying resource has been set</td></tr>
+   *      <tr><td>{@link CloseFuture#INITIALIZING}</td><td>The state in case the {@code CloseFuture} is currently being initialized</td></tr>
+   *      <tr><td>{@link CloseFuture#CLOSED}</td><td>The state in case the {@code CloseFuture} has been closed</td></tr>
+   *   </tbody>
+   * </table>
+   */
+  private static final int NEW          = 0;
+  private static final int INITIALIZED  = 1;
+  private static final int INITIALIZING = 2;
+  private static final int CLOSED       = 3;
+
   private final Promise<Void> promise;
   private Closeable resource;
-  private boolean closed;
+  /**
+   * The current state of the {@code CloseFuture}.
+   */
+  private final AtomicInteger state;
 
   public CloseFuture() {
     this.promise = Promise.promise();
+    this.state = new AtomicInteger(NEW);
   }
 
   public CloseFuture(Closeable resource) {
     this.promise = Promise.promise();
     this.resource = resource;
+    this.state = new AtomicInteger(resource == null ? NEW : INITIALIZED);
   }
 
-  public synchronized void init(Closeable closeable) {
-    if (closed) {
-      throw new IllegalStateException();
+  public void init(Closeable closeable) {
+    for (;;) {
+      int s = this.state.get();
+      if (s == CLOSED) {
+        throw new IllegalStateException();
+      } else if (closeable == null) {
+        if (s == NEW) {
+          return;
+        } else if (s == INITIALIZED && this.state.compareAndSet(s, INITIALIZING)) {
+          this.resource = null;
+          this.state.set(NEW);
+          return;
+        }
+      } else if (s <= INITIALIZED && this.state.compareAndSet(s, INITIALIZING)) {
+        this.resource = closeable;
+        this.state.set(INITIALIZED);
+        return;
+      }
     }
-    this.resource = closeable;
   }
 
   /**
    * Called by client
    */
   public void close(Promise<Void> promise) {
-    boolean close;
-    Closeable resource;
-    synchronized (this) {
-      close = !closed;
-      resource = this.resource;
-      this.closed = true;
-    }
-    if (resource == null) {
-      promise.fail("Close future not initialized");
-    } else if (close) {
-      resource.close(promise);
-      promise.future().onComplete(this.promise);
-    } else {
-      this.promise.future().onComplete(promise);
+    for (;;) {
+      int s = this.state.get();
+      if (s == NEW) {
+        promise.fail("Close future not initialized");
+        return;
+      } else if (s == INITIALIZED && this.state.compareAndSet(s, CLOSED)) {
+        this.resource.close(promise);
+        promise.future().onComplete(this.promise);
+        return;
+      } else if (s == CLOSED) {
+        this.promise.future().onComplete(promise);
+        return;
+      }
     }
   }
 
-  public synchronized boolean isClosed() {
-    return closed;
+  public boolean isClosed() {
+    return state.get() == CLOSED;
   }
 
   @Override


### PR DESCRIPTION
## Motivation:

Avoid the overhead of synchronized blocks by using a volatile reads and writes instead.

## Modifications:

* Use an `AtomicInteger` to store the state of the `CloseFuture` in order to make compare-and-swap and `volatile` reads and writes
* Rely on piggybacking to read/modify the member field `resource`

**NB 1:** The code is meant to be backward compatible so it supports the fact that we can call `init(null)` after having initialized the `CloseFuture` with a non null value
**NB 2:** Please note that I did not use `Unsafe` / `VarHandle` instead of  an `AtomicInteger` for a better compatibility with the different Java versions
