### PR TITLE
Add AsyncMap put then put ttl Test

### DIFF
--- a/src/test/java/io/vertx/core/shareddata/AsyncMapTest.java
+++ b/src/test/java/io/vertx/core/shareddata/AsyncMapTest.java
@@ -145,6 +145,20 @@ public abstract class AsyncMapTest extends VertxTestBase {
   }
 
   @Test
+  public void testMapPutThenPutTtl() {
+    getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map -> {
+      map.put("pipo", "molo", onSuccess(vd -> {
+        map.put("pipo", "mili", 10, onSuccess(vd2 -> {
+          getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map2 -> {
+            assertWaitUntil(map2, "pipo", 15, Objects::isNull);
+          }));
+        }));
+      }));
+    }));
+    await();
+  }
+
+  @Test
   public void testMapPutIfAbsentGetByte() {
     testMapPutIfAbsentGet((byte)1, (byte)2);
   }


### PR DESCRIPTION
Motivation:

Tests the case were a map entry is overridden by a new one with ttl set
This is especially important for cluster setups were the underlying map policies can change this behavior
