### PR TITLE
Allow for SPI provided ExecutorServiceFactory

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -780,6 +780,16 @@ Worker executors can be configured when created:
 
 NOTE: the configuration is set when the worker pool is created
 
+You can provide your own `ExecutorService` that backs the worker executors by implementing the `ExecutorServiceFactory`
+interface and making your implementation loadable by the Java `ServiceLoader` mechanism. Your
+`ExecutorService` should use the Vert.x `ThreadFactory` provided on the `createExecutor` call to create
+threads in the worker pool and respect the maximum concurrency limits Vert.x passes. 
+
+[source,$lang]
+----
+{@link examples.spi.executor.FixedThreadPoolExecutorServiceFactory#createExecutor}
+----
+
 == Metrics SPI
 
 By default Vert.x does not record any metrics. Instead it provides an SPI for others to implement which can be added

--- a/src/main/java/examples/spi/executor/FixedThreadPoolExecutorServiceFactory.java
+++ b/src/main/java/examples/spi/executor/FixedThreadPoolExecutorServiceFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package examples.spi.executor;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import io.vertx.core.spi.executor.ExecutorServiceFactory;
+
+/**
+ * This is a simple ExecutorServiceFactory that uses
+ * {@link Executors#newFixedThreadPool}. The {@link ThreadFactory} provided by
+ * Vert.x should be used to create threads. The ExecutorService can control
+ * scheduling aspects such as task queueing or pool size growth within the
+ * maxConcurrency parameter limit.
+ */
+public class FixedThreadPoolExecutorServiceFactory implements ExecutorServiceFactory {
+  @Override
+  public ExecutorService createExecutor(ThreadFactory threadFactory, Integer concurrency, Integer maxConcurrency) {
+    return Executors.newFixedThreadPool(maxConcurrency, threadFactory);
+  }
+}

--- a/src/main/java/examples/spi/executor/WorkerExample.java
+++ b/src/main/java/examples/spi/executor/WorkerExample.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package examples.spi.executor;
+
+import java.util.concurrent.TimeUnit;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
+
+/**
+ * This code could be any valid Vert.x worker API code as there are no API
+ * changes or restrictions introduced by using an SPI provided executor.
+ */
+public class WorkerExample {
+
+  public void workerExecutor3(Vertx vertx) {
+
+    int poolSize = 5;
+    long maxExecuteTime = 1;
+
+    // The Vert.x worker executor API is the same regardless of SPI use, e.g.:
+    WorkerExecutor executor = vertx.createSharedWorkerExecutor("my-worker-pool", poolSize, maxExecuteTime, TimeUnit.MINUTES);
+
+    // The executor delegates to one created by the SPI provided
+    // ExecutorServiceFactory
+    executor.executeBlocking(promise -> {
+      String result = blockingService("tired");
+      promise.complete(result);
+    }, res -> {
+      System.out.println("The result is: " + res.result());
+    });
+  }
+
+  // Imagine this is some longer running action
+  String blockingService(String str) {
+    System.out.println("Zzzz");
+    return "that's better!";
+  }
+
+}

--- a/src/main/java/examples/spi/executor/io.vertx.core.spi.executor.ExecutorServiceFactory
+++ b/src/main/java/examples/spi/executor/io.vertx.core.spi.executor.ExecutorServiceFactory
@@ -1,0 +1,16 @@
+# Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# A Java ServiceLoader provider-configuration file for the ExecutorServiceFactory SPI
+#
+# Place this file on the classpath and change the line below to match your
+# package qualified {@link ExecutorServiceFactory}, the class file of which
+# must also be on the classpath.
+
+examples.spi.executor.FixedThreadPoolExecutorServiceFactory

--- a/src/main/java/io/vertx/core/impl/ExecutorServiceResolver.java
+++ b/src/main/java/io/vertx/core/impl/ExecutorServiceResolver.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.impl;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import io.vertx.core.ServiceHelper;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.spi.executor.ExecutorServiceFactory;
+
+public class ExecutorServiceResolver {
+
+  private static final Logger log = LoggerFactory.getLogger(ExecutorServiceResolver.class);
+  private ExecutorServiceFactory spiExecutorServiceFactory;
+
+  /**
+   * We resolve any SPI ExecutorServiceFactory implementation at an instance level
+   * rather than statically or in the get methods to enable the SPI
+   * implementations that are on the classpath to be re-checked on creation of a
+   * new instance (for example in testing) but only checked once in normal
+   * operation.
+   */
+  ExecutorServiceResolver() {
+    this.spiExecutorServiceFactory = ServiceHelper.loadFactoryOrNull(ExecutorServiceFactory.class);
+    log.debug("External SPI ExecutorServiceFactory was " + this.spiExecutorServiceFactory);
+  }
+
+  /**
+   * This method returns an ExecutorService created using ServiceLoadable
+   * ExecutorServiceFactory or if none is present one based on a
+   * {@link ThreadPoolExecutor} in either case {@link VertxThreadFactory} is used
+   * as a source of threads.
+   * 
+   * @param name               used as a Thread name prefix
+   * @param poolSize           used as the thread pool size
+   * @param maxExecuteTime     the time a task can run before a blocked thread
+   *                           warning, used by {@code checker}
+   * @param maxExecuteTimeUnit the time periods for the maxExecuteTime parameter
+   * @param checker            used to monitor task completion times
+   * @return either an internal or SPI provided {@link ExecutorService}
+   */
+  ExecutorService getExecutorServiceForSharedWorkerPool(String name, int poolSize, long maxExecuteTime, TimeUnit maxExecuteTimeUnit,
+      BlockedThreadChecker checker) {
+
+    VertxThreadFactory threadFactory = new VertxThreadFactory(name + "-", checker, true, maxExecuteTime, maxExecuteTimeUnit);
+    ExecutorService es;
+    if (spiExecutorServiceFactory != null) {
+      es = spiExecutorServiceFactory.createExecutor(threadFactory, poolSize, poolSize);
+      log.debug("getExecutorServiceForSharedWorkerPool created: " + name + " " + es + " using " + spiExecutorServiceFactory);
+    } else {
+      es = Executors.newFixedThreadPool(poolSize, threadFactory);
+      log.debug("getExecutorServiceForSharedWorkerPool created: " + name + " " + es + "using Executors.newFixedThreadPool");
+    }
+    return es;
+  }
+
+  /**
+   * @param options        used to source the maximum worker execution time
+   * @param workerPoolSize the size of the thread pool
+   * @param checker        used to monitor task completion times
+   * @return either an internal or SPI provided {@link ExecutorService}
+   */
+  ExecutorService getExecutorServiceForDefaultWorkerPool(VertxOptions options, int workerPoolSize, BlockedThreadChecker checker) {
+
+    VertxThreadFactory threadFactory = new VertxThreadFactory("vert.x-worker-thread-", checker, true, options.getMaxWorkerExecuteTime(),
+        options.getMaxWorkerExecuteTimeUnit());
+    ExecutorService es;
+    if (spiExecutorServiceFactory != null) {
+      es = spiExecutorServiceFactory.createExecutor(threadFactory, workerPoolSize, workerPoolSize);
+      log.debug("getExecutorServiceForDefaultWorkerPool created: " + es + " using " + spiExecutorServiceFactory);
+    } else {
+      es = new ThreadPoolExecutor(workerPoolSize, workerPoolSize, 0L, TimeUnit.MILLISECONDS, new LinkedTransferQueue<>(), threadFactory);
+      log.debug("getExecutorServiceForDefaultWorkerPool created: " + es + "using JVM's ThreadPoolExecutor");
+    }
+    return es;
+  }
+}

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -11,14 +11,41 @@
 
 package io.vertx.core.impl;
 
+import java.io.File;
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Closeable;
+import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
-import io.vertx.core.*;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.TimeoutStream;
+import io.vertx.core.Verticle;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.datagram.impl.DatagramSocketImpl;
@@ -64,16 +91,6 @@ import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.ref.WeakReference;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
-
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -112,6 +129,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   final WorkerPool workerPool;
   final WorkerPool internalBlockingPool;
   private final ThreadFactory eventLoopThreadFactory;
+  private final ExecutorServiceResolver executorServiceResolver;
   private final EventLoopGroup eventLoopGroup;
   private final EventLoopGroup acceptorEventLoopGroup;
   private final BlockedThreadChecker checker;
@@ -142,6 +160,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     maxEventLoopExecTimeUnit = options.getMaxEventLoopExecuteTimeUnit();
     checker = new BlockedThreadChecker(options.getBlockedThreadCheckInterval(), options.getBlockedThreadCheckIntervalUnit(), options.getWarningExceptionTime(), options.getWarningExceptionTimeUnit());
     eventLoopThreadFactory = new VertxThreadFactory("vert.x-eventloop-thread-", checker, false, maxEventLoopExecTime, maxEventLoopExecTimeUnit);
+    executorServiceResolver = new ExecutorServiceResolver();
     eventLoopGroup = transport.eventLoopGroup(Transport.IO_EVENT_LOOP_GROUP, options.getEventLoopPoolSize(), eventLoopThreadFactory, NETTY_IO_RATIO);
     ThreadFactory acceptorEventLoopThreadFactory = new VertxThreadFactory("vert.x-acceptor-thread-", checker, false, options.getMaxEventLoopExecuteTime(), options.getMaxEventLoopExecuteTimeUnit());
     // The acceptor event loop thread needs to be from a different pool otherwise can get lags in accepted connections
@@ -149,9 +168,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     acceptorEventLoopGroup = transport.eventLoopGroup(Transport.ACCEPTOR_EVENT_LOOP_GROUP, 1, acceptorEventLoopThreadFactory, 100);
 
     int workerPoolSize = options.getWorkerPoolSize();
-    ExecutorService workerExec = new ThreadPoolExecutor(workerPoolSize, workerPoolSize,
-      0L, TimeUnit.MILLISECONDS, new LinkedTransferQueue<>(),
-      new VertxThreadFactory("vert.x-worker-thread-", checker, true, options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit()));
+    ExecutorService workerExec = executorServiceResolver.getExecutorServiceForDefaultWorkerPool(options, workerPoolSize, checker);
     PoolMetrics workerPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-worker-thread", options.getWorkerPoolSize()) : null;
     ExecutorService internalBlockingExec = Executors.newFixedThreadPool(options.getInternalBlockingPoolSize(),
         new VertxThreadFactory("vert.x-internal-blocking-", checker, true, options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit()));
@@ -1124,7 +1141,8 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     }
     SharedWorkerPool sharedWorkerPool = namedWorkerPools.get(name);
     if (sharedWorkerPool == null) {
-      ExecutorService workerExec = Executors.newFixedThreadPool(poolSize, new VertxThreadFactory(name + "-", checker, true, maxExecuteTime, maxExecuteTimeUnit));
+      ExecutorService workerExec = executorServiceResolver.getExecutorServiceForSharedWorkerPool(name, poolSize,
+          maxExecuteTime, maxExecuteTimeUnit, checker);
       PoolMetrics workerMetrics = metrics != null ? metrics.createPoolMetrics("worker", name, poolSize) : null;
       namedWorkerPools.put(name, sharedWorkerPool = new SharedWorkerPool(name, workerExec, workerMetrics));
     } else {
@@ -1132,6 +1150,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     }
     return sharedWorkerPool;
   }
+
 
   @Override
   public Vertx exceptionHandler(Handler<Throwable> handler) {

--- a/src/main/java/io/vertx/core/spi/executor/ExecutorServiceFactory.java
+++ b/src/main/java/io/vertx/core/spi/executor/ExecutorServiceFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.spi.executor;
+
+import java.util.ServiceLoader;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * The interface for a factory used to obtain an external
+ * {@code ExecutorService}. If an implementation of this interface is on the
+ * classpath and pointed to by a {@link ServiceLoader} provider-configuration
+ * file, Vert.x will use it to create {@link ExecutorService} instances to run
+ * worker tasks.
+ */
+public interface ExecutorServiceFactory {
+
+  /**
+   * Create an ExecutorService
+   * 
+   * @param threadFactory  A {@link ThreadFactory} which must be used by the
+   *                       created {@link ExecutorService} to create threads. Null
+   *                       indicates there is no requirement to use a specific
+   *                       factory.
+   * @param concurrency    The target level of concurrency or 0 which indicates
+   *                       unspecified
+   * @param maxConcurrency A hard limit to the level of concurrency required,
+   *                       should be greater than {@code concurrency} or 0 which
+   *                       indicates unspecified.
+   * 
+   * @return an {@link ExecutorService} that can be used to run tasks
+   */
+  ExecutorService createExecutor(ThreadFactory threadFactory, Integer concurrency, Integer maxConcurrency);
+
+}

--- a/src/test/externals/ExternalLoadableExecutorServiceFactory.java
+++ b/src/test/externals/ExternalLoadableExecutorServiceFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+/**
+ * This source file is not in the usual Vert.x IDE project's classpath but instead
+ * compiled (and the .class file place on the classpath) by some tests. This is
+ * to more closely emulate typical use of the {@link ExecutorServiceFactory} SPI
+ * interface and to allow for testing with different SPI implementations on the
+ * classpath.
+ */
+package io.vertx.core.externals;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.spi.executor.ExecutorServiceFactory;
+
+/**
+ * This is a base {@link ExecutorServiceFactory} used in the junit tests for the
+ * SPI that delegates to a simple {@link ThreadPoolExecutor}. The delegate is
+ * wrapped in a proxy that logs all the method calls the it receives. Many of
+ * the tests will then inspect the log to ensure that the expected methods were
+ * called on the correct {@link ExecutorService} class.
+ */
+public class ExternalLoadableExecutorServiceFactory implements ExecutorServiceFactory {
+
+  /*
+   * All of the test ExecutorServiceFactory implementations use the
+   * ExecutorServiceFactory SPI Interface for the log records so that tests can
+   * access messages without having to refer to a specific implementation class.
+   */
+  static final Logger log = LoggerFactory.getLogger(ExecutorServiceFactory.class);
+
+  /**
+   * Using this over-ridable method allows subclasses to easily replace the core
+   * {@link ExecutorService} with their own but inherit the logging
+   * 
+   * @param threadFactory  used to create new threads
+   * @param maxConcurrency the size of the thread pool desired
+   * @return an ExecutorService that can be used to run tasks
+   */
+  ExecutorService getBaseExecutorService(ThreadFactory threadFactory, Integer maxConcurrency) {
+    // We create a anonymous inner subclass as this makes it easy to trace the
+    // source of the object in tests
+    return new ThreadPoolExecutor(maxConcurrency, maxConcurrency, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(),
+        threadFactory) {
+    };
+  }
+
+  /*
+   * We return a logging wrapper around the getBaseExecutorService delegate. For
+   * javadoc, see interface
+   */
+  @Override
+  public ExecutorService createExecutor(ThreadFactory threadFactory, Integer concurrency, Integer maxConcurrency) {
+    // Using this.getClass allows us to distinguish subclasses in the log messages
+    log.debug(this.getClass() + "::createExecutor(" + threadFactory + ", " + concurrency + ", " + maxConcurrency + ")");
+    return LoggingProxy.proxy(getBaseExecutorService(threadFactory, maxConcurrency));
+  }
+
+  /**
+   * toString is specified as it is a component of log messages that are searched
+   * for in tests
+   */
+  @Override
+  public String toString() {
+    return this.getClass().getName() + ":" + this.hashCode();
+  }
+
+  /**
+   * A simple dynamic proxy class that logs invoked methods and passes through
+   * checked exceptions that are used by Vert.x
+   */
+  public static class LoggingProxy implements InvocationHandler {
+    private final Object delegate;
+
+    /**
+     * @param coreExecutorService delegate for all {@link ExecutorService} methods
+     */
+    public LoggingProxy(ExecutorService coreExecutorService) {
+      this.delegate = coreExecutorService;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+
+      /* Edits to the line below may need matching changes in junit tests */
+      log.debug(delegate.getClass() + "::" + method.getName() + "(" + args + ")");
+      try {
+        return method.invoke(delegate, args);
+      } catch (InvocationTargetException ex) {
+        // We can be here for any checked exception not in the ExecutorService
+        // interface.
+        // For example, java.util.concurrent.RejectedExecutionException
+        throw ex.getCause();
+      }
+    }
+
+    /**
+     * Helper method to create a proxy to the delegate that logs all method calls to
+     * the {@link ExecutorServiceFactory} log
+     * 
+     * @param delegate the {@ExecutorService} used to run all tasks.
+     * @return
+     */
+    public static ExecutorService proxy(ExecutorService delegate) {
+      return (ExecutorService) Proxy.newProxyInstance(ExecutorService.class.getClassLoader(), new Class[] { ExecutorService.class },
+          new LoggingProxy(delegate));
+    }
+  }
+}

--- a/src/test/externals/FixedThreadPoolExecutorServiceFactory.java
+++ b/src/test/externals/FixedThreadPoolExecutorServiceFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+/**
+ * This source file is not in the usual Vert.x IDE project's classpath but instead
+ * compiled (and the .class file place on the classpath) by some tests. This is
+ * to more closely emulate typical use of the {@link ExecutorServiceFactory} SPI
+ * interface and to allow for testing with different SPI implementations on the
+ * classpath.
+ */
+package io.vertx.core.externals;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import io.vertx.core.spi.executor.ExecutorServiceFactory;
+
+/**
+ * This is a simple test ExecutorServiceFactory that overrides the base executor
+ * service to use {@link Executors#newFixedThreadPool}
+ */
+public class FixedThreadPoolExecutorServiceFactory extends ExternalLoadableExecutorServiceFactory {
+  @Override
+  ExecutorService getBaseExecutorService(ThreadFactory threadFactory, Integer maxConcurrency) {
+    return Executors.newFixedThreadPool(maxConcurrency, threadFactory);
+  }
+}

--- a/src/test/externals/META-INF/services/ExternalLoadableExecutorServiceFactory
+++ b/src/test/externals/META-INF/services/ExternalLoadableExecutorServiceFactory
@@ -1,0 +1,12 @@
+# Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# A ServiceLoader provider-configuration file for the ExecutorServiceFactory SPI tests
+
+io.vertx.core.externals.ExternalLoadableExecutorServiceFactory

--- a/src/test/externals/META-INF/services/FixedThreadPoolExecutorServiceFactory
+++ b/src/test/externals/META-INF/services/FixedThreadPoolExecutorServiceFactory
@@ -1,0 +1,12 @@
+# Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# A ServiceLoader provider-configuration file for the ExecutorServiceFactory SPI tests
+
+io.vertx.core.externals.FixedThreadPoolExecutorServiceFactory

--- a/src/test/java/io/vertx/core/spi/executor/ExecutorFactoryBlockedThreadCheckerTest.java
+++ b/src/test/java/io/vertx/core/spi/executor/ExecutorFactoryBlockedThreadCheckerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.spi.executor;
+
+import static io.vertx.core.spi.executor.Utils.EXECUTE;
+import static io.vertx.core.spi.executor.Utils.SHUTDOWN_NOW;
+
+import java.util.concurrent.ExecutorService;
+
+import org.junit.ClassRule;
+import org.junit.rules.TestRule;
+
+import io.vertx.core.BlockedThreadCheckerTest;
+
+/**
+ * This test class checks that the blocked thread checker functionality of
+ * Vert.x is not impacted by using a service loaded
+ * {@link io.vertx.core.spi.executor.ExecutorServiceFactory} to create an
+ * {@link ExecutorService} that is then used to run the blocked worker tasks.
+ * 
+ * It performs the same tests as BlockedThreadCheckerTest but using an external
+ * {@link java.util.concurrent.ExecutorService}
+ * 
+ * To enable different tests to have particular ExecutorServiceFactory's (or
+ * none), we only put the particular ExecutorServiceFactory .class file on the
+ * classpath and make it service loadable as part of each test and are careful
+ * to remove it afterwards.
+ */
+public class ExecutorFactoryBlockedThreadCheckerTest extends BlockedThreadCheckerTest {
+
+  private static final String FACTORY = "ExternalLoadableExecutorServiceFactory";
+  private static final String EXECUTOR = FACTORY + "$1";
+
+  /*
+   * We use a Junit test rule to setup and tear down the classpath to have the
+   * correct ExecutorServiceFactory SPI implementation and then check the logs
+   * after the tests are run. That means we can inherit all the test setup, tests
+   * and tear down from the parent class. We pass in the factory, the name of the
+   * executor class that should appear in the logs and a ... of the methods we
+   * expect to be used.
+   */
+  @ClassRule
+  public static TestRule chain = Utils.setupAndCheckSpiImpl(FACTORY, EXECUTOR, EXECUTE, SHUTDOWN_NOW);
+
+}

--- a/src/test/java/io/vertx/core/spi/executor/ExecutorFactoryContextTest.java
+++ b/src/test/java/io/vertx/core/spi/executor/ExecutorFactoryContextTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.spi.executor;
+
+import static io.vertx.core.spi.executor.Utils.EXECUTE;
+import static io.vertx.core.spi.executor.Utils.SHUTDOWN_NOW;
+
+import java.util.concurrent.ExecutorService;
+
+import org.junit.ClassRule;
+import org.junit.rules.TestRule;
+
+import io.vertx.core.ContextTest;
+
+/**
+ * This test class checks the Context functionality of Vert.x is not impacted by
+ * using a service loaded
+ * {@link io.vertx.core.spi.executor.ExecutorServiceFactory} to create an
+ * {@link ExecutorService} that is then used to run worker tasks.
+ * 
+ * It performs the same tests as ContextTest but using an external
+ * {@link java.util.concurrent.ExecutorService} for worker tasks
+ * 
+ * To enable different tests to have particular ExecutorServiceFactory's (or
+ * none), we only put the particular ExecutorServiceFactory .class file on the
+ * classpath and make it service loadable as part of each test and are careful
+ * to remove it afterwards.
+ */
+public class ExecutorFactoryContextTest extends ContextTest {
+
+  private static final String FACTORY = "ExternalLoadableExecutorServiceFactory";
+  private static final String EXECUTOR = FACTORY + "$1";
+
+  /*
+   * We use a Junit test rule to setup and tear down the classpath to have the
+   * correct ExecutorServiceFactory SPI implementation and then check the logs
+   * after the tests are run. That means we can inherit all the test setup, tests
+   * and tear down from the parent class. We pass in the factory, the name of the
+   * executor class that should appear in the logs and a ... of the methods we
+   * expect to be used.
+   */
+  @ClassRule
+  public static TestRule chain = Utils.setupAndCheckSpiImpl(FACTORY, EXECUTOR, EXECUTE, SHUTDOWN_NOW);
+
+}

--- a/src/test/java/io/vertx/core/spi/executor/ExecutorFactoryMetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/executor/ExecutorFactoryMetricsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.spi.executor;
+
+import static io.vertx.core.spi.executor.Utils.EXECUTE;
+import static io.vertx.core.spi.executor.Utils.SHUTDOWN_NOW;
+
+import java.util.concurrent.ExecutorService;
+
+import org.junit.ClassRule;
+import org.junit.rules.TestRule;
+
+import io.vertx.core.spi.metrics.MetricsContextTest;
+
+/**
+ * This test class checks the Metrics functionality of Vert.x is not impacted by
+ * using a service loaded
+ * {@link io.vertx.core.spi.executor.ExecutorServiceFactory} to create an
+ * {@link ExecutorService} that is then used to run worker tasks.
+ * 
+ * It performs the same tests as MetricsContextTest but using an external
+ * {@link java.util.concurrent.ExecutorService} for worker tasks
+ * 
+ * To enable different tests to have particular ExecutorServiceFactory's (or
+ * none), we only put the particular ExecutorServiceFactory .class file on the
+ * classpath and make it service loadable as part of each test and are careful
+ * to remove it afterwards.
+ */
+public class ExecutorFactoryMetricsTest extends MetricsContextTest {
+
+  private static final String FACTORY = "ExternalLoadableExecutorServiceFactory";
+  private static final String EXECUTOR = FACTORY + "$1";
+
+  /*
+   * We use a Junit test rule to setup and tear down the classpath to have the
+   * correct ExecutorServiceFactory SPI implementation and then check the logs
+   * after the tests are run. That means we can inherit all the test setup, tests
+   * and tear down from the parent class. We pass in the factory, the name of the
+   * executor class that should appear in the logs and a ... of the methods we
+   * expect to be used.
+   */
+  @ClassRule
+  public static TestRule chain = Utils.setupAndCheckSpiImpl(FACTORY, EXECUTOR, EXECUTE, SHUTDOWN_NOW);
+
+}

--- a/src/test/java/io/vertx/core/spi/executor/ExecutorFactoryMultiplePoolsTest.java
+++ b/src/test/java/io/vertx/core/spi/executor/ExecutorFactoryMultiplePoolsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.spi.executor;
+
+import static io.vertx.core.spi.executor.Utils.EXECUTE;
+import static io.vertx.core.spi.executor.Utils.SHUTDOWN_NOW;
+
+import java.util.concurrent.ExecutorService;
+
+import org.junit.ClassRule;
+import org.junit.rules.TestRule;
+
+import io.vertx.core.NamedWorkerPoolTest;
+
+/**
+ * This test class checks the multiple named worker Thread pools functionality
+ * of Vert.x is not impacted by using a service loaded
+ * {@link io.vertx.core.spi.executor.ExecutorServiceFactory} to create an
+ * {@link ExecutorService} that is then used to run worker tasks.
+ * 
+ * It performs the same tests as NamedWorkerPoolTest but using an external
+ * {@link java.util.concurrent.ExecutorService} for worker tasks
+ * 
+ * To enable different tests to have particular ExecutorServiceFactory's (or
+ * none), we only put the particular ExecutorServiceFactory .class file on the
+ * classpath and make it service loadable as part of each test and are careful
+ * to remove it afterwards.
+ */
+public class ExecutorFactoryMultiplePoolsTest extends NamedWorkerPoolTest {
+
+  private static final String FACTORY = "ExternalLoadableExecutorServiceFactory";
+  private static final String EXECUTOR = FACTORY + "$1";
+
+  /*
+   * We use a Junit test rule to setup and tear down the classpath to have the
+   * correct ExecutorServiceFactory SPI implementation and then check the logs
+   * after the tests are run. That means we can inherit all the test setup, tests
+   * and tear down from the parent class. We pass in the factory, the name of the
+   * executor class that should appear in the logs and a ... of the methods we
+   * expect to be used.
+   */
+  @ClassRule
+  public static TestRule chain = Utils.setupAndCheckSpiImpl(FACTORY, EXECUTOR, EXECUTE, SHUTDOWN_NOW);
+
+}

--- a/src/test/java/io/vertx/core/spi/executor/ExecutorFactoryOptionsTest.java
+++ b/src/test/java/io/vertx/core/spi/executor/ExecutorFactoryOptionsTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.spi.executor;
+
+import static io.vertx.core.spi.executor.Utils.EXECUTE;
+import static io.vertx.core.spi.executor.Utils.SHUTDOWN_NOW;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.test.core.BlockedThreadWarning;
+import io.vertx.test.core.TestUtils;
+import io.vertx.test.core.VertxTestBase;
+
+/**
+ * Test a mixture of options being in effect when a SPI implementation of
+ * ExecutorServiceFactory is in place
+ */
+public class ExecutorFactoryOptionsTest extends VertxTestBase {
+
+  private static final String FACTORY = "ExternalLoadableExecutorServiceFactory";
+  private static final String EXECUTOR = FACTORY + "$1";
+
+  /*
+   * We use a Junit test rule to setup and tear down the classpath to have the
+   * correct ExecutorServiceFactory SPI implementation and then check the logs
+   * after the tests are run. That means we can inherit all the test setup, tests
+   * and tear down from the parent class. We pass in the factory, the name of the
+   * executor class that should appear in the logs and a ... of the methods we
+   * expect to be used.
+   */
+  @ClassRule
+  public static TestRule chain = Utils.setupAndCheckSpiImpl(FACTORY, EXECUTOR, EXECUTE, SHUTDOWN_NOW);
+
+  /*
+   * This rule can be used to check for 'blocking' task messages in the logs
+   */
+  @Rule
+  public BlockedThreadWarning blockedThreadWarning = new BlockedThreadWarning();
+
+
+  /**
+   * Check that verticle deployment options pool name is used with an SPI provided
+   * executor.
+   */
+  @Test
+  public void testSpiDeployOptionsDefaultWorkerPoolName() {
+    DeploymentOptions options = new DeploymentOptions();
+    String poolName = "spiExecutorTest";
+    options.setWorkerPoolName(poolName);
+    AbstractVerticle v = new AbstractVerticle() {
+      @Override
+      public void start(Promise<Void> resultHandler) throws Exception {
+        vertx.executeBlocking(finished -> {
+          Assert.assertTrue(Thread.currentThread().getName().contains(poolName));
+          finished.complete();
+        }, resultHandler);
+      }
+    };
+    vertx.deployVerticle(v, options, onSuccess(did -> {
+      testComplete();
+    }));
+    await();
+  }
+
+  /**
+   * Test that pool names work with an SPI provided {@link ExecutorServiceFactory}
+   * when a shared worker executor is created
+   */
+  @Test
+  public void testSpiSpecificWorkerPoolName() {
+    String specific = "namedPool";
+    WorkerExecutor es = vertx.createSharedWorkerExecutor(specific);
+    es.executeBlocking(fut -> {
+      Assert.assertTrue(Thread.currentThread().getName().contains(specific));
+      fut.complete(null);
+    }, false, ar -> {
+      complete();
+    });
+    await();
+  }
+
+  /**
+   * Check that tasks that take too long are allowed to finish but warning
+   * messages appear in the log file when verticle deployment options are used
+   * under an SPI provided {@link ExecutorServiceFactory}
+   */
+  @Test
+  public void testVerticleDeploymentOptionsMaxTimeSoft() {
+    DeploymentOptions options = new DeploymentOptions();
+    options.setMaxWorkerExecuteTime(2).setMaxWorkerExecuteTimeUnit(TimeUnit.SECONDS);
+    String poolName = "testDeploymentMaxTimeSoft";
+    options.setWorkerPoolName(poolName);
+    AbstractVerticle sleep = new AbstractVerticle() {
+      @Override
+      public void start(Promise<Void> resultHandler) throws Exception {
+        vertx.executeBlocking(finished -> {
+          try {
+            SECONDS.sleep(5);
+            finished.complete();
+          } catch (InterruptedException e) {
+            finished.fail(e);
+          }
+        }, resultHandler);
+      }
+    };
+    vertx.deployVerticle(sleep, options, onSuccess(did -> {
+      testComplete();
+    }));
+    await();
+    blockedThreadWarning.expectMessage(poolName, 2000, MILLISECONDS);
+  }
+
+  /**
+   * Check that tasks that take too long are allowed to finish but warning
+   * messages appear in the log file when cross Vertx options are used under an
+   * SPI provided {@link ExecutorServiceFactory}
+   */
+  @Test
+  public void testVertxOptionsMaxTimeSoft() {
+    VertxOptions vertxOptions = new VertxOptions();
+    vertxOptions.setMaxWorkerExecuteTime(100);
+    vertxOptions.setMaxWorkerExecuteTimeUnit(TimeUnit.MILLISECONDS);
+    vertxOptions.setBlockedThreadCheckInterval(100);
+    vertxOptions.setBlockedThreadCheckIntervalUnit(TimeUnit.MILLISECONDS);
+
+    Vertx newVertx = vertx(vertxOptions);
+    Thread mainThread = Thread.currentThread();
+    newVertx.executeBlocking(fut -> {
+      Thread current = Thread.currentThread();
+      assertNotSame(mainThread, current);
+      try {
+        MILLISECONDS.sleep(200);
+        fut.complete();
+      } catch (InterruptedException e) {
+        fut.fail(e);
+      }
+    }, true, onSuccess(v -> complete()));
+    await();
+    blockedThreadWarning.expectMessage("vert.x-worker-thread", 100, MILLISECONDS);
+  }
+
+  @Test
+  public void testMaxExecuteWorkerTime() throws Exception {
+    String poolName = TestUtils.randomAlphaString(10);
+    long maxWorkerExecuteTime = NANOSECONDS.convert(3, SECONDS);
+    DeploymentOptions deploymentOptions = new DeploymentOptions().setWorkerPoolName(poolName).setMaxWorkerExecuteTime(maxWorkerExecuteTime);
+    vertx.deployVerticle(new AbstractVerticle() {
+      @Override
+      public void start(Promise<Void> startFuture) throws Exception {
+        vertx.executeBlocking(fut -> {
+          try {
+            SECONDS.sleep(5);
+            fut.complete();
+          } catch (InterruptedException e) {
+            fut.fail(e);
+          }
+        }, startFuture);
+      }
+    }, deploymentOptions, onSuccess(did -> {
+      testComplete();
+    }));
+    await();
+    blockedThreadWarning.expectMessage(poolName, maxWorkerExecuteTime, NANOSECONDS);
+  }
+}

--- a/src/test/java/io/vertx/core/spi/executor/Utils.java
+++ b/src/test/java/io/vertx/core/spi/executor/Utils.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.spi.executor;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.ExecutorService;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+
+import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import io.vertx.core.impl.ExecutorServiceResolver;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.test.core.LogContainsRule;
+
+public class Utils {
+
+  private static final Logger log = LoggerFactory.getLogger(ExecutorServiceFactory.class);
+
+  static final String EXTERNALS = "src/test/externals/";
+  static final String SERVICES = "META-INF/services/";
+
+  static final String PACKAGE = "io.vertx.core.externals.";
+  static final String CLASSPATH_LOCATION = "target/test-classes";
+  static final String PROVIDER_CONFIG_DIR = "target/test-classes/META-INF/services/";
+
+  static final String ES_FACTORY = "io.vertx.core.spi.executor.ExecutorServiceFactory";
+  static final String BASE_FACTORY = "ExternalLoadableExecutorServiceFactory";
+  static final String BASE_TEST_EXECUTOR = "ExternalLoadableExecutorServiceFactory";
+
+  /*
+   * Set up some typesafe tokens for the testcases to refer to ExecutorService
+   * methods
+   */
+  static Method EXECUTE = null;
+  static Method SHUTDOWN_NOW = null;
+  static {
+    try {
+      EXECUTE = ExecutorService.class.getMethod("execute", Runnable.class);
+      SHUTDOWN_NOW = ExecutorService.class.getMethod("shutdownNow");
+    } catch (NoSuchMethodException | SecurityException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /**
+   * This will take the indicated .java file and compile it to the classpath along
+   * with the required standard test superclasses and set up Java ServiceLoader
+   * configuration to load it into Vert.x
+   * 
+   * @param impl the {@link ExecutorServiceFactory} desired
+   * @throws IOException
+   */
+  static void putExecutorServiceFactoryOnClasspath(String impl) throws IOException {
+    Utils.compileToClassPath(Utils.BASE_FACTORY);
+    Utils.compileToClassPath(Utils.BASE_TEST_EXECUTOR);
+    compileToClassPath(impl);
+    configureServiceLoaded(ES_FACTORY, impl);
+  }
+
+  /**
+   * A utility function to set the Java {@link ServiceLoader}
+   * provider-configuration file for a SPI test.
+   * 
+   * @param service the name of the service being supplied
+   * @param impl    the name of the implementation
+   * @throws IOException
+   */
+  static void configureServiceLoaded(String service, String impl) throws IOException {
+    File source = new File(EXTERNALS + SERVICES + impl);
+    File out = new File(PROVIDER_CONFIG_DIR + service);
+    out.getParentFile().mkdirs();
+    Files.deleteIfExists(out.toPath());
+    Files.copy(source.toPath(), out.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+    log.debug("Placed " + impl + " as service loadable for " + service);
+  }
+
+  /**
+   * Compiles a particular .java file, in the conventional test source directory
+   * src/test/externals to the classpath of a test. If we have SPI implementation
+   * files and {@link ServiceLoader} provider-configuration files in the normal
+   * IDE classpath they all interfere with each other's tests.
+   * 
+   * @param impl the non package qualified class name
+   * @throws IOException
+   */
+  static void compileToClassPath(String impl) throws IOException {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
+    File output = new File(CLASSPATH_LOCATION);
+    output.mkdirs();
+    fileManager.setLocation(StandardLocation.CLASS_OUTPUT, Collections.singletonList(output));
+
+    List<File> classesToCompile = new ArrayList<>();
+    classesToCompile.add(new File(EXTERNALS + impl + ".java"));
+
+    Iterable<? extends JavaFileObject> compilationUnits1 = fileManager.getJavaFileObjectsFromFiles(classesToCompile);
+    compiler.getTask(null, fileManager, null, null, null, compilationUnits1).call();
+  }
+
+  /**
+   * Checks that a particular {@link ExecutorServiceFactory} makes an appearance
+   * in the test logs
+   * 
+   * @param factory
+   * @return a JUnit test rule that checks the Vert.x log files
+   */
+  static LogContainsRule checkFactoryLoaded(String factory) {
+    return new LogContainsRule(ExecutorServiceResolver.class, factory);
+  }
+
+  /**
+   * Checks that a particular {@link ExecutorService} implementation's method
+   * makes an appearance in the test logs
+   * 
+   * @param executor the class name of the {@link ExecutorService}
+   * @param method   the name of the expected method
+   * @return a JUnit test rule that checks the Vert.x log files
+   */
+  static LogContainsRule executorMethodLogged(String executor, String method) {
+    return new LogContainsRule(ExecutorServiceFactory.class, Utils.PACKAGE + executor + "::" + method);
+  }
+
+  /**
+   * A helper method that checks a set of {@link ExecutorService} methods are in
+   * the log file
+   * 
+   * @param factory  the {@link ExecutorServiceFactory} expected
+   * @param executor the {@link ExecutorService} expected
+   * @param meth     a Varargs list of expected {@link ExecutorService} methods
+   * @return
+   */
+  public static TestRule setupAndCheckSpiImpl(String factory, String executor, Method... meth) {
+
+    RuleChain chain = RuleChain.outerRule(checkFactoryLoaded(factory));
+
+    for (Method method : meth) {
+      LogContainsRule rule = executorMethodLogged(executor, method.getName());
+      chain = chain.around(rule);
+    }
+    chain = chain.around(new SpiPopulator(factory));
+    return chain;
+  }
+
+  /**
+   * A JUnit {@ExternalResource} manager that sets up and tears down a particular
+   * {@link ExecutorServiceFactory} provider
+   */
+  static class SpiPopulator extends ExternalResource {
+    private final String factory;
+
+    /**
+     * Create a Junit external resource manager for {@link ExecutorServiceFactory}
+     * SPI providers
+     * 
+     * @param factory the {@link ExecutorServiceFactory} name expected, the .java
+     *                file should exist in the conventional directory
+     *                (src/test/externals)
+     */
+    SpiPopulator(String factory) {
+      this.factory = factory;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+      putExecutorServiceFactoryOnClasspath(factory);
+    }
+
+    @Override
+    protected void after() {
+      new File(PROVIDER_CONFIG_DIR).delete();
+    }
+  }
+
+}

--- a/src/test/java/io/vertx/test/core/LogContainsRule.java
+++ b/src/test/java/io/vertx/test/core/LogContainsRule.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.test.core;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * A generic log scanner used by testcases to check that messages have appeared
+ * in the JUnit test logs.
+ *
+ */
+public class LogContainsRule implements TestRule {
+
+  private Logger logger;
+  private List<String> logs = new ArrayList<>(); // guarded by this
+  private String logMustContainString;
+
+  public LogContainsRule(Class loggingClass, String logMustContain) {
+    this.logger = Logger.getLogger(loggingClass.getName());
+    this.logMustContainString = logMustContain;
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        synchronized (LogContainsRule.this) {
+          logs.clear();
+          logger.setLevel(Level.ALL);
+        }
+        Handler handler = new Handler() {
+          public void publish(LogRecord record) {
+            synchronized (LogContainsRule.this) {
+              logs.add(record.getMessage());
+            }
+          }
+
+          public void flush() {
+          }
+
+          public void close() throws SecurityException {
+          }
+        };
+        logger.addHandler(handler);
+        try {
+          base.evaluate();
+          doTest();
+        } finally {
+          logger.removeHandler(handler);
+        }
+      }
+    };
+  }
+
+  private synchronized void doTest() {
+    assertThat(logs, hasItem(allOf(containsString(logMustContainString))));
+  }
+}


### PR DESCRIPTION
Signed-off-by: Gordon Hutchison <Gordon.Hutchison@gmail.com>

Motivation:

My goal is to open a code based discussion for an approach that might address #3434. 
This have a Vert.x SPI that provides the ability to use a foreign ExecutorService
for worker tasks.

This is to enable easier consumption of SmallRye technologies that make use of Vert.x in
environments with custom ExecutorServices (in the first instance OpenLiberty).

This is a draft PR for now and I am very happy to make any further improvements or changes that might make
this change more likely to be adopted either while it is a draft or when it is turned into a 'standard' PR.