### PR TITLE
New parser for length field frame protocols

### DIFF
--- a/src/main/java/io/vertx/core/parsetools/LengthFieldParser.java
+++ b/src/main/java/io/vertx/core/parsetools/LengthFieldParser.java
@@ -1,0 +1,111 @@
+package io.vertx.core.parsetools;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.parsetools.impl.LengthFieldParserImpl;
+import io.vertx.core.streams.ReadStream;
+
+/**
+ *  Parser for length field frame protocols
+ * * <p/>
+ *  The parser handles length fields byte(1), short(2), medium(3), int(4) and long(8) in the {@link Buffer}
+ *  with length field offset to skip explicit length while parsing.
+ * * <p/>
+ *  the default maximum frame length is {@link Integer#MAX_VALUE} and can be changed explicitly to have more control of
+ *  the parsed frame length.
+ * * <p/>
+ *  The {@link #exceptionHandler(Handler)} is called when the frame exceeds the maximum length
+ *  or less than zero.
+ * * <p/>
+ * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+ */
+
+@VertxGen
+public interface LengthFieldParser extends ReadStream<Buffer>, Handler<Buffer> {
+
+
+  /**
+   * Create a new {@code LengthFieldFrameParser} instance.
+   *
+   * @param length the length of the field : byte(1), short(2), medium(3), int(4) or long(8)
+   */
+  static LengthFieldParser newParser(int length) {
+    return new LengthFieldParserImpl(length, 0, Integer.MAX_VALUE, null);
+  }
+
+  /**
+   * Create a new {@code LengthFieldFrameParser} instance.
+   *
+   * @param length the length of the field : byte(1), short(2), medium(3), int(4) or long(8)
+   * @param stream the wrapped of read stream
+   */
+  static LengthFieldParser newParser(int length, ReadStream<Buffer> stream) {
+    return new LengthFieldParserImpl(length, 0, Integer.MAX_VALUE, stream);
+  }
+
+  /**
+   * Create a new {@code LengthFieldFrameParser} instance.
+   *
+   * @param length the length of the field : byte(1), short(2), medium(3), int(4) or long(8)
+   * @param offset the offset of the field
+   * @param stream the wrapped of read stream
+   */
+  static LengthFieldParser newParser(int length, int offset, ReadStream<Buffer> stream) {
+    return new LengthFieldParserImpl(length, offset, Integer.MAX_VALUE, stream);
+  }
+
+  /**
+   * Create a new {@code LengthFieldFrameParser} instance.
+   *
+   * @param length the length of the field : byte(1), short(2), medium(3), int(4) or long(8)
+   * @param offset the offset of the field
+   * @param max the maximum length of the frame
+   * @param stream the wrapped of read stream
+   */
+  static LengthFieldParser newParser(int length, int offset, int max, ReadStream<Buffer> stream) {
+    return new LengthFieldParserImpl(length, offset, max, stream);
+  }
+
+  /**
+   * Create a new {@code LengthFieldFrameParser} instance.
+   *
+   * @param length the length of the field : byte(1), short(2), medium(3), int(4) or long(8)
+   * @param offset the offset of the field
+   * @param max the maximum length of the frame
+   */
+  static LengthFieldParser newParser(int length, int offset, int max) {
+    return new LengthFieldParserImpl(length, offset, max, null);
+  }
+
+  /**
+   * Create a new {@code LengthFieldFrameParser} instance.
+   *
+   * @param length the length of the field : byte(1), short(2), medium(3), int(4) or long(8)
+   * @param offset the offset of the field
+   */
+  static LengthFieldParser newParser(int length, int offset) {
+    return new LengthFieldParserImpl(length, offset, Integer.MAX_VALUE, null);
+  }
+
+  @Override
+  LengthFieldParser pause();
+
+  @Override
+  LengthFieldParser resume();
+
+  @Override
+  LengthFieldParser fetch(long amount);
+
+  @Fluent
+  LengthFieldParser endHandler(Handler<Void> endHandler);
+
+  @Fluent
+  LengthFieldParser handler(Handler<Buffer> handler);
+
+  @Fluent
+  LengthFieldParser exceptionHandler(Handler<Throwable> handler);
+
+
+}

--- a/src/main/java/io/vertx/core/parsetools/impl/LengthFieldParserImpl.java
+++ b/src/main/java/io/vertx/core/parsetools/impl/LengthFieldParserImpl.java
@@ -1,0 +1,200 @@
+package io.vertx.core.parsetools.impl;
+
+import io.netty.buffer.Unpooled;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.Arguments;
+import io.vertx.core.parsetools.LengthFieldParser;
+import io.vertx.core.streams.ReadStream;
+
+/**
+ * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+ */
+
+public class LengthFieldParserImpl implements LengthFieldParser {
+
+  private final Buffer EMPTY_BUFFER = Buffer.buffer(Unpooled.EMPTY_BUFFER);
+
+  private long demand = Long.MAX_VALUE;
+  private Handler<Buffer> eventHandler;
+  private Handler<Void> endHandler;
+  private Handler<Throwable> exceptionHandler;
+  private final ReadStream<Buffer> stream;
+  private boolean ended;
+
+  private Buffer acc = EMPTY_BUFFER;
+  private long frameLength;
+  private final int length;
+  private final int offset;
+  private final int max;
+
+  public LengthFieldParserImpl(int length, int offset, int max, ReadStream<Buffer> stream) {
+    Arguments.require(length == 1 || length == 2 || length == 3 || length == 4 || length == 8,
+      "Field length must be 1, 2, 3, 4, or 8");
+    Arguments.require(offset >= 0, "Field offset must be >= 0");
+    Arguments.require(max > 0, "Max frame length must be > 0");
+    this.length = length;
+    this.offset = offset;
+    this.max = max;
+    this.stream = stream;
+  }
+
+
+  @Override
+  public LengthFieldParser exceptionHandler(Handler<Throwable> handler) {
+    exceptionHandler = handler;
+    return this;
+  }
+
+  @Override
+  public LengthFieldParser handler(Handler<Buffer> handler) {
+    eventHandler = handler;
+    if (stream != null) {
+      if (handler != null) {
+        stream.endHandler(v -> end());
+        stream.exceptionHandler(ex -> {
+          if (exceptionHandler != null) {
+            exceptionHandler.handle(ex);
+          }
+        });
+        stream.handler(this);
+      } else {
+        stream.handler(null);
+        stream.endHandler(null);
+        stream.exceptionHandler(null);
+      }
+    }
+    return this;
+  }
+
+  @Override
+  public LengthFieldParser pause() {
+    demand = 0L;
+    return this;
+  }
+
+  @Override
+  public LengthFieldParser resume() {
+    return fetch(Long.MAX_VALUE);
+  }
+
+  @Override
+  public LengthFieldParser fetch(long amount) {
+    Arguments.require(amount > 0L, "Fetch amount must be > 0L");
+    demand += amount;
+    if (demand < 0L) {
+      demand = Long.MAX_VALUE;
+    }
+    handleParsing();
+    return this;
+  }
+
+  @Override
+  public LengthFieldParser endHandler(Handler<Void> handler) {
+    endHandler = handler;
+    return this;
+  }
+
+  @Override
+  public void handle(Buffer buffer) {
+    if (acc.length() == 0) {
+      acc = buffer;
+    } else {
+      acc.appendBuffer(buffer);
+    }
+    handleParsing();
+  }
+
+  void end() {
+    ended = true;
+    handleParsing();
+  }
+
+  void clear() {
+    frameLength = 0;
+    acc = EMPTY_BUFFER;
+  }
+
+  void handleEvent(Buffer event) {
+    if (demand != Long.MAX_VALUE) {
+      demand--;
+    }
+    Handler<Buffer> handler = this.eventHandler;
+    if (handler != null) {
+      handler.handle(event);
+    }
+  }
+
+  private void handleParsing() {
+    try {
+      while (true) {
+        boolean next = (acc.length() >= length + offset + frameLength);
+        if (!next) {
+          if (ended) {
+            if (endHandler != null) {
+              endHandler.handle(null);
+            }
+            return;
+          }
+          break;
+        } else {
+          if (demand > 0L) {
+            handleFieldFrame();
+          } else {
+            break;
+          }
+        }
+      }
+      if (demand == 0L) {
+        if (stream != null) {
+          stream.pause();
+        }
+      } else {
+        if (stream != null) {
+          stream.resume();
+        }
+      }
+    } catch (Exception e) {
+      if (exceptionHandler != null) {
+        exceptionHandler.handle(e);
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  void handleFieldFrame() {
+    if (length == 1) {
+      frameLength = acc.getByte(offset);
+    } else if (length == 2) {
+      frameLength = acc.getShort(offset);
+    } else if (length == 3) {
+      frameLength = acc.getMedium(offset);
+    } else if(length == 4) {
+      frameLength = acc.getInt(offset);
+    } else if(length == 8) {
+      frameLength = acc.getLong(offset);
+    }
+    if(frameLength > max || frameLength < 0) {
+      try {
+        String err = frameLength < 0 ? "Frame length is corrupted < 0"
+          : "Frame length is too large current: " + frameLength + " max: " + max;
+        IllegalStateException ex = new IllegalStateException(err);
+        if (exceptionHandler != null) {
+          exceptionHandler.handle(ex);
+        } else {
+          throw ex;
+        }
+      } finally {
+        clear();
+      }
+    } else {
+      int len = length + offset + (int) frameLength;
+      if(acc.length() >= len) {
+        Buffer event = acc.getBuffer(length + offset, len);
+        handleEvent(event);
+        acc = acc.getBuffer(len, acc.length());
+      }
+    }
+  }
+}

--- a/src/test/java/io/vertx/core/parsetools/LengthFieldParserTest.java
+++ b/src/test/java/io/vertx/core/parsetools/LengthFieldParserTest.java
@@ -1,0 +1,436 @@
+package io.vertx.core.parsetools;
+
+import io.vertx.core.buffer.Buffer;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.vertx.test.core.TestUtils.*;
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.*;
+
+/**
+ * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+ */
+
+public class LengthFieldParserTest {
+
+  String msg = Buffer.buffer("Vert.x is really awesome!").toString();
+  Buffer byteField = Buffer.buffer().appendByte((byte) msg.length()).appendString(msg);
+  Buffer shortField = Buffer.buffer().appendShort((short) msg.length()).appendString(msg);
+  Buffer medField = Buffer.buffer().appendMedium(msg.length()).appendString(msg);
+  Buffer intField = Buffer.buffer().appendInt(msg.length()).appendString(msg);
+  Buffer longField = Buffer.buffer().appendLong(msg.length()).appendString(msg);
+  Buffer preField = Buffer.buffer()
+    .appendByte(Byte.MAX_VALUE)
+    .appendShort(Short.MAX_VALUE)
+    .appendMedium(Integer.MAX_VALUE)
+    .appendInt(Integer.MAX_VALUE)
+    .appendLong(Integer.MAX_VALUE);
+
+  @Test
+  public void test_illegal_arguments_length() {
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(0, 0, 1, null));
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(-1, 0, 1, null));
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(5, 0, 1, null));
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(6, 0, 1, null));
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(7, 0, 1, null));
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(9, 0, 1, null));
+  }
+
+  @Test
+  public void test_illegal_arguments_offset() {
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(1, -1, 1, null));
+  }
+
+  @Test
+  public void test_illegal_arguments_max() {
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(1, 0, 0, null));
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(1, 0, -1, null));
+  }
+
+  @Test
+  public void test_byte() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(byteField.copy()));
+  }
+
+  @Test
+  public void test_byte_offset() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 18, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(byteField.copy()));
+  }
+
+  @Test
+  public void test_byte_offset_max() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 18, msg.length(), null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(byteField.copy()));
+  }
+
+  @Test
+  public void test_byte_offset_max_exception() {
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 18, 5, null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(byteField.copy()));
+    assertEquals(1, errors.size());
+  }
+
+    @Test
+    public void test_byte_offset_max_invalid_length_exception() {
+      LengthFieldParser parser = LengthFieldParser.newParser(1, 18, msg.length(), null);
+      List<Throwable> errors = new ArrayList<>();
+      parser.exceptionHandler(errors::add);
+      parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(
+        byteField.copy().setByte(0, (byte) -1)
+      ));
+      assertEquals(1, errors.size());
+    }
+
+    @Test
+    public void test_short() {
+      AtomicInteger count = new AtomicInteger();
+      LengthFieldParser parser = LengthFieldParser.newParser(2, 0, Integer.MAX_VALUE, null);
+      parser.endHandler(v -> count.incrementAndGet());
+      parser.handler(buf -> {
+        assertNotNull(buf);
+        assertEquals(msg.length(), buf.length());
+        assertEquals(msg, buf.toString());
+      });
+      parser.handle(Buffer.buffer().appendBuffer(shortField.copy()));
+    }
+
+  @Test
+  public void test_short_offset() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(2, 18, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(shortField.copy()));
+  }
+
+  @Test
+  public void test_short_offset_max() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(2, 18, msg.length(), null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(shortField.copy()));
+  }
+
+  @Test
+  public void test_short_offset_max_exception() {
+    LengthFieldParser parser = LengthFieldParser.newParser(2, 18, 5, null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(shortField.copy()));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void test_short_offset_max_invalid_length_exception() {
+    LengthFieldParser parser = LengthFieldParser.newParser(2, 18, msg.length(), null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(
+      shortField.copy().setShort(0, (short) -1)
+    ));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void test_medium() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(3, 0, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(medField.copy()));
+  }
+
+  @Test
+  public void test_medium_offset() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(3, 18, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(medField.copy()));
+  }
+
+  @Test
+  public void test_medium_offset_max() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(3, 18, msg.length(), null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(medField.copy()));
+  }
+
+  @Test
+  public void test_medium_offset_max_exception() {
+    LengthFieldParser parser = LengthFieldParser.newParser(3, 18, 5, null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(medField.copy()));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void test_medium_offset_max_invalid_length_exception() {
+    LengthFieldParser parser = LengthFieldParser.newParser(3, 18, msg.length(), null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(
+      medField.copy().setMedium(0, -1)
+    ));
+    assertEquals(1, errors.size());
+  }
+
+
+  @Test
+  public void test_int() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(4, 0, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(intField.copy()));
+  }
+
+  @Test
+  public void test_int_offset() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(4, 18, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(intField.copy()));
+  }
+
+  @Test
+  public void test_int_offset_max() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(4, 18, msg.length(), null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(intField.copy()));
+  }
+
+  @Test
+  public void test_int_offset_max_exception() {
+    LengthFieldParser parser = LengthFieldParser.newParser(4, 18, 5, null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(intField.copy()));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void test_int_offset_max_invalid_length_exception() {
+    LengthFieldParser parser = LengthFieldParser.newParser(4, 18, msg.length(), null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(
+      intField.copy().setInt(0, -1)
+    ));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void test_long() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(8, 0, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(longField.copy()));
+  }
+
+  @Test
+  public void test_long_offset() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(8, 18, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(longField.copy()));
+  }
+
+  @Test
+  public void test_long_offset_max() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(8, 18, msg.length(), null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(longField.copy()));
+  }
+
+  @Test
+  public void test_long_offset_max_exception() {
+    LengthFieldParser parser = LengthFieldParser.newParser(8, 18, 5, null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(longField.copy()));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void test_long_offset_max_invalid_length_exception() {
+    LengthFieldParser parser = LengthFieldParser.newParser(8, 18, msg.length(), null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handle(Buffer.buffer().appendBuffer(preField.copy()).appendBuffer(
+      longField.copy().setLong(0, -1)
+    ));
+    assertEquals(1, errors.size());
+  }
+
+
+  @Test
+  public void test_byte_stream_handle() {
+    FakeStream stream = new FakeStream();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, stream);
+    List<Buffer> events = new ArrayList<>();
+    parser.handler(events::add);
+    for (int i = 0; i < 10; i++) {
+      stream.handle(Buffer.buffer().appendBuffer(byteField.copy()).appendBuffer(byteField.copy()));
+    }
+    assertFalse(stream.isPaused());
+    assertEquals(20, events.size());
+  }
+
+  @Test
+  public void test_byte_stream_pause() {
+    FakeStream stream = new FakeStream();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, stream);
+    List<Buffer> events = new ArrayList<>();
+    parser.handler(events::add);
+    parser.pause();
+    parser.handle(Buffer.buffer().appendBuffer(byteField.copy()));
+    assertTrue(stream.isPaused());
+    assertEquals(0, events.size());
+  }
+
+  @Test
+  public void test_byte_stream_resume() {
+    FakeStream stream = new FakeStream();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, stream);
+    List<Buffer> events = new ArrayList<>();
+    parser.handler(events::add);
+    parser.pause();
+    stream.handle(Buffer.buffer()
+      .appendBuffer(byteField.copy())
+      .appendBuffer(byteField.copy())
+      .appendBuffer(byteField.copy()));
+    parser.resume();
+    assertEquals(3, events.size());
+    assertFalse(stream.isPaused());
+  }
+
+  @Test
+  public void test_byte_stream_fetch() {
+    FakeStream stream = new FakeStream();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, stream);
+    List<Buffer> events = new ArrayList<>();
+    parser.handler(events::add);
+    parser.pause();
+    stream.handle(Buffer.buffer().appendBuffer(byteField.copy()).appendBuffer(byteField.copy()));
+    parser.fetch(1);
+    assertEquals(1, events.size());
+    assertTrue(stream.isPaused());
+  }
+
+  @Test
+  public void test_byte_stream_pause_in_handler() {
+    FakeStream stream = new FakeStream();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, stream);
+    List<Buffer> events = new ArrayList<>();
+    parser.handler(event -> {
+      assertTrue(events.isEmpty());
+      events.add(event);
+      parser.pause();
+    });
+    stream.handle(Buffer.buffer().appendBuffer(byteField.copy()));
+    assertEquals(1, events.size());
+    assertTrue(stream.isPaused());
+  }
+
+  @Test
+  public void test_byte_stream_fetch_in_handler() {
+    FakeStream stream = new FakeStream();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, stream);
+    List<Buffer> events = new ArrayList<>();
+    parser.handler(event -> {
+      events.add(event);
+      stream.fetch(1);
+    });
+    stream.pause();
+    stream.fetch(1);
+    stream.handle(Buffer.buffer().appendBuffer(byteField.copy()).appendBuffer(byteField.copy()));
+    assertEquals(2, events.size());
+    assertFalse(stream.isPaused());
+  }
+
+}


### PR DESCRIPTION
Signed-off-by: Emad Alblueshi <emad.albloushi@gmail.com>

Motivation:

The parser handles length fields byte(1), short(2), medium(3), int(4) and long(8) for field based protocols

addresses https://github.com/eclipse-vertx/vert.x/issues/3613 with simple API

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
