### PR TITLE
Replace deprecated javax.net.ssl.SSLSession getPeerCertificateChain

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -20,7 +20,7 @@ import io.vertx.core.net.SocketAddress;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
+import java.security.cert.Certificate;
 
 /**
  * Represents an HTTP connection.
@@ -285,18 +285,14 @@ public interface HttpConnection {
   SSLSession sslSession();
 
   /**
-   * Note: Java SE 5+ recommends to use javax.net.ssl.SSLSession#getPeerCertificates() instead of
-   * of javax.net.ssl.SSLSession#getPeerCertificateChain() which this method is based on. Use {@link #sslSession()} to
-   * access that method.
-   *
    * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
-   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
+   * @see javax.net.ssl.SSLSession#getPeerCertificates()
    * @see #sslSession()
    */
   @GenIgnore
-  X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
+  Certificate[] peerCertificates() throws SSLPeerUnverifiedException;
 
   /**
    * Returns the SNI server name presented during the SSL handshake by the client.

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -23,7 +23,7 @@ import io.vertx.core.streams.ReadStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
+import java.security.cert.Certificate;
 import java.util.Map;
 
 /**
@@ -192,18 +192,14 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   }
 
   /**
-   * Note: Java SE 5+ recommends to use javax.net.ssl.SSLSession#getPeerCertificates() instead of
-   * of javax.net.ssl.SSLSession#getPeerCertificateChain() which this method is based on. Use {@link #sslSession()} to
-   * access that method.
-   *
    * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
-   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
+   * @see javax.net.ssl.SSLSession#getPeerCertificates()
    * @see #sslSession()
    */
   @GenIgnore
-  X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
+  Certificate[] peerCertificates() throws SSLPeerUnverifiedException;
 
   /**
    * @return the absolute URI corresponding to the the HTTP request

--- a/src/main/java/io/vertx/core/http/ServerWebSocket.java
+++ b/src/main/java/io/vertx/core/http/ServerWebSocket.java
@@ -22,7 +22,7 @@ import io.vertx.core.buffer.Buffer;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
+import java.security.cert.Certificate;
 
 /**
  * Represents a server side WebSocket.
@@ -184,16 +184,12 @@ public interface ServerWebSocket extends WebSocketBase {
   SSLSession sslSession();
 
   /**
-   * Note: Java SE 5+ recommends to use javax.net.ssl.SSLSession#getPeerCertificates() instead of
-   * of javax.net.ssl.SSLSession#getPeerCertificateChain() which this method is based on. Use {@link #sslSession()} to
-   * access that method.
-   *
    * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
-   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
+   * @see javax.net.ssl.SSLSession#getPeerCertificates()
    * @see #sslSession()
    */
   @GenIgnore
-  X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
+  Certificate[] peerCertificates() throws SSLPeerUnverifiedException;
 }

--- a/src/main/java/io/vertx/core/http/WebSocketBase.java
+++ b/src/main/java/io/vertx/core/http/WebSocketBase.java
@@ -23,7 +23,7 @@ import io.vertx.core.streams.WriteStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
+import java.security.cert.Certificate;
 
 /**
  * Base WebSocket implementation.
@@ -381,16 +381,12 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
   SSLSession sslSession();
 
   /**
-   * Note: Java SE 5+ recommends to use javax.net.ssl.SSLSession#getPeerCertificates() instead of
-   * of javax.net.ssl.SSLSession#getPeerCertificateChain() which this method is based on. Use {@link #sslSession()} to
-   * access that method.
-   *
    * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
-   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
+   * @see javax.net.ssl.SSLSession#getPeerCertificates()
    * @see #sslSession()
    */
   @GenIgnore
-  X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
+  Certificate[] peerCertificates() throws SSLPeerUnverifiedException;
 }

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -20,7 +20,6 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
-import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.http.Cookie;
@@ -39,8 +38,8 @@ import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.streams.impl.InboundBuffer;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.security.cert.X509Certificate;
 import java.net.URISyntaxException;
+import java.security.cert.Certificate;
 import java.util.Map;
 
 import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
@@ -358,8 +357,8 @@ public class Http1xServerRequest implements HttpServerRequest, io.vertx.core.spi
   }
 
   @Override
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    return conn.peerCertificateChain();
+  public Certificate[] peerCertificates() throws SSLPeerUnverifiedException {
+    return conn.peerCertificates();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
@@ -47,9 +47,9 @@ import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingPolicy;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.security.cert.X509Certificate;
 import java.net.URISyntaxException;
 import java.nio.channels.ClosedChannelException;
+import java.security.cert.Certificate;
 import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
@@ -384,8 +384,8 @@ public class Http2ServerRequestImpl extends Http2ServerStream implements HttpSer
   }
 
   @Override
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    return conn.peerCertificateChain();
+  public Certificate[] peerCertificates() throws SSLPeerUnverifiedException {
+    return conn.peerCertificates();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradedClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradedClientConnection.java
@@ -33,7 +33,7 @@ import io.vertx.core.net.SocketAddress;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
+import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -591,8 +591,8 @@ public class Http2UpgradedClientConnection implements HttpClientConnection {
   }
 
   @Override
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    return current.peerCertificateChain();
+  public Certificate[] peerCertificates() throws SSLPeerUnverifiedException {
+    return current.peerCertificates();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
@@ -17,23 +17,20 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
-import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.AsyncFile;
-import io.vertx.core.http.StreamResetException;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.ConnectionBase;
-import io.vertx.core.streams.Pipe;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import java.nio.channels.ClosedChannelException;
+import java.security.cert.Certificate;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -328,8 +325,8 @@ class HttpNetSocket implements NetSocket {
   }
 
   @Override
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    return conn.peerCertificateChain();
+  public Certificate[] peerCertificates() throws SSLPeerUnverifiedException {
+    return conn.peerCertificates();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -29,7 +29,8 @@ import io.vertx.core.spi.metrics.HttpServerMetrics;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
+
+import java.security.cert.Certificate;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
@@ -136,8 +137,8 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocketImpl> 
   }
 
   @Override
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    return conn.peerCertificateChain();
+  public Certificate[] peerCertificates() throws SSLPeerUnverifiedException {
+    return conn.peerCertificates();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -44,7 +44,7 @@ import io.vertx.core.streams.impl.InboundBuffer;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
+import java.security.cert.Certificate;
 import java.util.UUID;
 
 import static io.vertx.core.net.impl.VertxHandler.safeBuffer;
@@ -202,8 +202,8 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
   }
 
   @Override
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    return conn.peerCertificateChain();
+  public Certificate[] peerCertificates() throws SSLPeerUnverifiedException {
+    return conn.peerCertificates();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/src/main/java/io/vertx/core/net/NetSocket.java
@@ -21,7 +21,7 @@ import io.vertx.core.streams.WriteStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
+import java.security.cert.Certificate;
 
 /**
  * Represents a socket-like interface to a TCP connection on either the
@@ -280,18 +280,14 @@ public interface NetSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
   SSLSession sslSession();
 
   /**
-   * Note: Java SE 5+ recommends to use javax.net.ssl.SSLSession#getPeerCertificates() instead of
-   * of javax.net.ssl.SSLSession#getPeerCertificateChain() which this method is based on. Use {@link #sslSession()} to
-   * access that method.
-   *
    * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
-   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
+   * @see javax.net.ssl.SSLSession#getPeerCertificates()
    * @see #sslSession()
    */
   @GenIgnore
-  X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
+  Certificate[] peerCertificates() throws SSLPeerUnverifiedException;
 
   /**
    * Returns the SNI server name presented during the SSL handshake by the client.

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -30,10 +30,10 @@ import io.vertx.core.spi.metrics.TCPMetrics;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
+import java.security.cert.Certificate;
 
 import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
 
@@ -521,10 +521,10 @@ public abstract class ConnectionBase {
     }
   }
 
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+  public Certificate[] peerCertificates() throws SSLPeerUnverifiedException {
     SSLSession session = sslSession();
     if (session != null) {
-      return session.getPeerCertificateChain();
+      return session.getPeerCertificates();
     } else {
       return null;
     }

--- a/src/test/java/io/vertx/core/http/Http1xTLSTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTLSTest.java
@@ -11,9 +11,6 @@
 
 package io.vertx.core.http;
 
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.net.NetServer;
-import io.vertx.core.net.NetServerOptions;
 import io.vertx.test.tls.Cert;
 import io.vertx.test.tls.Trust;
 import org.junit.Test;
@@ -21,7 +18,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /**

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -24,12 +24,15 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import javax.net.ssl.*;
-import javax.security.cert.X509Certificate;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.security.*;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -435,7 +438,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
   @Test
   // Client provides SNI and server responds with a matching certificate for the indicated server name
   public void testSNITrustPKCS12() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_PKCS12, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_PKCS12, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("host2.com"))
         .pass()
@@ -446,7 +449,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
   @Test
   // Client provides SNI and server responds with a matching certificate for the indicated server name
   public void testSNITrustPEM() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_PEM, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_PEM, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("host2.com"))
         .pass()
@@ -465,7 +468,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
   @Test
   // Client provides SNI but server ignores it and provides a different cerficate - check we get a certificate
   public void testSNIServerIgnoresExtension2() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SNI_JKS, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SNI_JKS, Trust.NONE)
         .clientVerifyHost(false)
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("host2.com"))
         .pass()
@@ -507,7 +510,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
   @Test
   // Client provides SNI matched on the server by a wildcard certificate
   public void testSNIWildcardMatchPKCS12() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST3, Cert.SNI_PKCS12, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST3, Cert.SNI_PKCS12, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("sub.host3.com"))
         .pass()
@@ -518,7 +521,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
   @Test
   // Client provides SNI matched on the server by a wildcard certificate
   public void testSNIWildcardMatchPEM() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST3, Cert.SNI_PEM, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST3, Cert.SNI_PEM, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("sub.host3.com"))
         .pass()
@@ -528,7 +531,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNISubjectAlternativeNameMatch1() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST4, Cert.SNI_JKS, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST4, Cert.SNI_JKS, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("host4.com"))
         .pass()
@@ -538,7 +541,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNISubjectAlternativeNameMatch1PKCS12() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST4, Cert.SNI_PKCS12, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST4, Cert.SNI_PKCS12, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("host4.com"))
         .pass()
@@ -548,7 +551,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNISubjectAlternativeNameMatch1PEM() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST4, Cert.SNI_PEM, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST4, Cert.SNI_PEM, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("host4.com"))
         .pass()
@@ -558,7 +561,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNISubjectAlternativeNameMatch2() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST4, Cert.SNI_JKS, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST4, Cert.SNI_JKS, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("www.host4.com"))
         .pass()
@@ -568,7 +571,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNISubjectAlternativeNameMatch2PKCS12() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST4, Cert.SNI_PKCS12, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST4, Cert.SNI_PKCS12, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("www.host4.com"))
         .pass()
@@ -578,7 +581,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNISubjectAlternativeNameMatch2PEM() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST4, Cert.SNI_PEM, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST4, Cert.SNI_PEM, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("www.host4.com"))
         .pass()
@@ -588,7 +591,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNISubjectAlternativeNameWildcardMatch() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST5, Cert.SNI_JKS, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST5, Cert.SNI_JKS, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("www.host5.com"))
         .pass()
@@ -598,7 +601,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNISubjectAlternativeNameWildcardMatchPKCS12() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST5, Cert.SNI_PKCS12, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST5, Cert.SNI_PKCS12, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("www.host5.com"))
         .pass()
@@ -608,7 +611,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNISubjectAlternativeNameWildcardMatchPEM() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST5, Cert.SNI_PEM, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST5, Cert.SNI_PEM, Trust.NONE)
         .serverSni()
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("www.host5.com"))
         .pass()
@@ -645,7 +648,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNISubjectAltenativeNameCNMatch2() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST5, Cert.SNI_JKS, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST5, Cert.SNI_JKS, Trust.NONE)
         .serverSni()
         .clientVerifyHost(false)
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("host5.com"))
@@ -656,7 +659,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNISubjectAltenativeNameCNMatch2PKCS12() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST5, Cert.SNI_PKCS12, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST5, Cert.SNI_PKCS12, Trust.NONE)
         .serverSni()
         .clientVerifyHost(false)
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("host5.com"))
@@ -667,7 +670,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNISubjectAltenativeNameCNMatch2PEM() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST5, Cert.SNI_PEM, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST5, Cert.SNI_PEM, Trust.NONE)
         .serverSni()
         .clientVerifyHost(false)
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("host5.com"))
@@ -678,7 +681,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNIWithALPN() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_JKS, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_JKS, Trust.NONE)
         .serverSni()
         .clientUsesAlpn()
         .serverUsesAlpn()
@@ -692,7 +695,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
   // Client provides SNI and server responds with a matching certificate for the indicated server name
   public void testSNIWithHostHeader() throws Exception {
 
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_JKS, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_JKS, Trust.NONE)
         .serverSni()
         .requestProvider(client -> client.request(new RequestOptions()
           .setServer(SocketAddress.inetSocketAddress(4043, "localhost"))
@@ -707,7 +710,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testSNIWithOpenSSL() throws Exception {
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_JKS, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_JKS, Trust.NONE)
         .clientOpenSSL()
         .serverOpenSSL()
         .serverSni()
@@ -804,7 +807,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
           @Override
           protected void engineInit(ManagerFactoryParameters managerFactoryParameters) throws
-              InvalidAlgorithmParameterException {
+            InvalidAlgorithmParameterException {
           }
 
           @Override
@@ -966,7 +969,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
         .setPort(httpPort)
         .setURI(DEFAULT_TEST_URI));
     };
-    X509Certificate clientPeerCert;
+    Certificate clientPeerCert;
     String indicatedServerName;
 
     public TLSTest(Cert<?> clientCert, Trust<?> clientTrust, Cert<?> serverCert, Trust<?> serverTrust) {
@@ -1112,7 +1115,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
       return this;
     }
 
-    public X509Certificate clientPeerCert() {
+    public Certificate clientPeerCert() {
       return clientPeerCert;
     }
 
@@ -1241,7 +1244,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
                 HttpConnection conn = response.request().connection();
                 if (conn.isSsl()) {
                   try {
-                    clientPeerCert = conn.peerCertificateChain()[0];
+                    clientPeerCert = conn.peerCertificates()[0];
                   } catch (SSLPeerUnverifiedException ignore) {
                   }
                 }
@@ -1490,7 +1493,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   private void testProxyWithSNI(ProxyType proxyType) throws Exception {
     startProxy(null, proxyType);
-    X509Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_JKS, Trust.NONE)
+    Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_JKS, Trust.NONE)
         .serverSni()
         .useProxy(proxyType)
         .requestOptions(new RequestOptions().setSsl(true).setPort(4043).setHost("host2.com"))

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -1313,7 +1313,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testPKCS12MissingPassword() {
-    testInvalidKeyStore(Cert.SERVER_PKCS12.get().setPassword(null), "Get Key failed: Cannot read the array length because \"password\" is null", null);
+    testInvalidKeyStore(Cert.SERVER_PKCS12.get().setPassword(null), Arrays.asList("Get Key failed", "Get Key failed: Cannot read the array length because \"password\" is "), "null");
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -1313,7 +1313,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testPKCS12MissingPassword() {
-    testInvalidKeyStore(Cert.SERVER_PKCS12.get().setPassword(null), "Get Key failed: null", null);
+    testInvalidKeyStore(Cert.SERVER_PKCS12.get().setPassword(null), "Get Key failed: Cannot read the array length because \"password\" is null", null);
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -53,6 +53,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
 import java.util.*;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -457,7 +458,7 @@ public class WebSocketTest extends VertxTestBase {
             WebSocket ws = ar2.result();
             if (clientSsl && sni) {
               try {
-                X509Certificate clientPeerCert = ws.peerCertificateChain()[0];
+                Certificate clientPeerCert = ws.peerCertificates()[0];
                 assertEquals("host2.com", cnOf(clientPeerCert));
               } catch (Exception err) {
                 fail(err);

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -47,10 +47,10 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import java.io.*;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1521,7 +1521,7 @@ public class NetTest extends VertxTestBase {
     SocketAddress bindAddress = SocketAddress.inetSocketAddress(4043, "localhost");
     SocketAddress connectAddress = bindAddress;
     String serverName;
-    X509Certificate clientPeerCert;
+    Certificate clientPeerCert;
     String indicatedServerName;
 
     public TLSTest clientCert(Cert<?> clientCert) {
@@ -1595,7 +1595,7 @@ public class NetTest extends VertxTestBase {
       return this;
     }
 
-    public X509Certificate clientPeerCert() {
+    public Certificate clientPeerCert() {
       return clientPeerCert;
     }
 
@@ -1623,7 +1623,7 @@ public class NetTest extends VertxTestBase {
 
       Consumer<NetSocket> certificateChainChecker = socket -> {
         try {
-          X509Certificate[] certs = socket.peerCertificateChain();
+          Certificate[] certs = socket.peerCertificates();
           if (clientCert != Cert.NONE) {
             assertNotNull(certs);
             assertEquals(1, certs.length);
@@ -1719,7 +1719,7 @@ public class NetTest extends VertxTestBase {
 
             if (socket.isSsl()) {
               try {
-                clientPeerCert = socket.peerCertificateChain()[0];
+                clientPeerCert = socket.peerCertificates()[0];
               } catch (SSLPeerUnverifiedException ignore) {
               }
             }
@@ -1739,7 +1739,7 @@ public class NetTest extends VertxTestBase {
                   handler = onSuccess(v -> {
                     assertTrue(socket.isSsl());
                     try {
-                      clientPeerCert = socket.peerCertificateChain()[0];
+                      clientPeerCert = socket.peerCertificates()[0];
                     } catch (SSLPeerUnverifiedException ignore) {
                     }
                     // Now send the rest

--- a/src/test/java/io/vertx/test/core/TestUtils.java
+++ b/src/test/java/io/vertx/test/core/TestUtils.java
@@ -23,18 +23,18 @@ import io.vertx.core.net.*;
 import io.vertx.core.net.impl.KeyStoreHelper;
 import io.vertx.test.netty.TestLoggerFactory;
 
-import javax.security.cert.X509Certificate;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.jar.JarEntry;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import java.util.zip.GZIPOutputStream;
@@ -419,10 +419,13 @@ public class TestUtils {
     );
   }
 
-  public static String cnOf(X509Certificate cert) throws Exception {
-    String dn = cert.getSubjectDN().getName();
-    List<String> names = KeyStoreHelper.getX509CertificateCommonNames(dn);
-    return names.isEmpty() ? null : names.get(0);
+  public static String cnOf(Certificate cert) throws Exception {
+    if (cert instanceof X509Certificate) {
+      String dn = ((X509Certificate) cert).getSubjectDN().getName();
+      List<String> names = KeyStoreHelper.getX509CertificateCommonNames(dn);
+      return names.isEmpty() ? null : names.get(0);
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
Motivation:

running tests with jdk 15 is nearly impossible with the old and deprecated security api

there was already an issue targeted for 4.0 but it was closed without a code change referenced
https://github.com/eclipse-vertx/vert.x/issues/2320

@vietj would this be the chance to get this api change merged yet?