### PR TITLE
New parser for length field based protocols

### DIFF
--- a/src/main/java/io/vertx/core/parsetools/LengthFieldParser.java
+++ b/src/main/java/io/vertx/core/parsetools/LengthFieldParser.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.parsetools;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.parsetools.impl.LengthFieldParserImpl;
+import io.vertx.core.streams.ReadStream;
+
+/**
+ *  Parser for length field frame protocols
+ * * <p/>
+ *  The parser handles length fields byte(1), short(2), medium(3), int(4) and long(8) in the {@link Buffer}
+ *  with length field offset to skip explicit length while parsing.
+ * * <p/>
+ *  the default maximum frame length is {@link Integer#MAX_VALUE} and can be changed explicitly.
+ * * <p/>
+ *  The {@link #exceptionHandler(Handler)} is called when the frame exceeds the maximum length
+ *  or the length is invalid "less or equal to zero".
+ * * <p/>
+ * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+ */
+
+@VertxGen
+public interface LengthFieldParser extends ReadStream<Buffer>, Handler<Buffer> {
+
+
+  /**
+   * Create a new {@code LengthFieldParser} instance.
+   *
+   * @param length the length of the field : byte(1), short(2), medium(3), int(4) or long(8)
+   */
+  static LengthFieldParser newParser(int length) {
+    return new LengthFieldParserImpl(length, 0, Integer.MAX_VALUE, null);
+  }
+
+  /**
+   * Create a new {@code LengthFieldParser} instance.
+   *
+   * @param length the length of the field : byte(1), short(2), medium(3), int(4) or long(8)
+   * @param stream the wrapped of read stream
+   */
+  static LengthFieldParser newParser(int length, ReadStream<Buffer> stream) {
+    return new LengthFieldParserImpl(length, 0, Integer.MAX_VALUE, stream);
+  }
+
+  /**
+   * Create a new {@code LengthFieldParser} instance.
+   *
+   * @param length the length of the field : byte(1), short(2), medium(3), int(4) or long(8)
+   * @param offset the offset of the field
+   * @param stream the wrapped of read stream
+   */
+  static LengthFieldParser newParser(int length, int offset, ReadStream<Buffer> stream) {
+    return new LengthFieldParserImpl(length, offset, Integer.MAX_VALUE, stream);
+  }
+
+  /**
+   * Create a new {@code LengthFieldParser} instance.
+   *
+   * @param length the length of the field : byte(1), short(2), medium(3), int(4) or long(8)
+   * @param offset the offset of the field
+   * @param max the maximum length of the frame
+   * @param stream the wrapped of read stream
+   */
+  static LengthFieldParser newParser(int length, int offset, int max, ReadStream<Buffer> stream) {
+    return new LengthFieldParserImpl(length, offset, max, stream);
+  }
+
+  /**
+   * Create a new {@code LengthFieldParser} instance.
+   *
+   * @param length the length of the field : byte(1), short(2), medium(3), int(4) or long(8)
+   * @param offset the offset of the field
+   * @param max the maximum length of the frame
+   */
+  static LengthFieldParser newParser(int length, int offset, int max) {
+    return new LengthFieldParserImpl(length, offset, max, null);
+  }
+
+  /**
+   * Create a new {@code LengthFieldParser} instance.
+   *
+   * @param length the length of the field : byte(1), short(2), medium(3), int(4) or long(8)
+   * @param offset the offset of the field
+   */
+  static LengthFieldParser newParser(int length, int offset) {
+    return new LengthFieldParserImpl(length, offset, Integer.MAX_VALUE, null);
+  }
+
+  @Override
+  LengthFieldParser pause();
+
+  @Override
+  LengthFieldParser resume();
+
+  @Override
+  LengthFieldParser fetch(long amount);
+
+  @Fluent
+  LengthFieldParser endHandler(Handler<Void> endHandler);
+
+  @Fluent
+  LengthFieldParser handler(Handler<Buffer> handler);
+
+  @Fluent
+  LengthFieldParser exceptionHandler(Handler<Throwable> handler);
+
+}

--- a/src/main/java/io/vertx/core/parsetools/impl/LengthFieldParserImpl.java
+++ b/src/main/java/io/vertx/core/parsetools/impl/LengthFieldParserImpl.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.parsetools.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.Arguments;
+import io.vertx.core.parsetools.LengthFieldParser;
+import io.vertx.core.parsetools.RecordParser;
+import io.vertx.core.streams.ReadStream;
+
+/**
+ * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+ */
+
+public class LengthFieldParserImpl implements LengthFieldParser {
+
+  private Handler<Throwable> exceptionHandler;
+  private final RecordParser parser;
+
+  private long frameLength = -1;
+  private final int length;
+  private final int offset;
+  private final int max;
+
+  public LengthFieldParserImpl(int length, int offset, int max, ReadStream<Buffer> stream) {
+    Arguments.require(length == 1 || length == 2 || length == 3 || length == 4 || length == 8,
+      "Field length must be 1, 2, 3, 4, or 8");
+    Arguments.require(offset >= 0, "Field offset must be >= 0");
+    Arguments.require(max > 0, "Max frame length must be > 0");
+    this.length = length;
+    this.offset = offset;
+    this.max = max;
+    this.parser = RecordParser.newFixed(length + offset, stream);
+  }
+
+  @Override
+  public LengthFieldParser exceptionHandler(Handler<Throwable> handler) {
+    if (handler != null) {
+      exceptionHandler = handler;
+    }
+    return this;
+  }
+
+  @Override
+  public LengthFieldParser handler(Handler<Buffer> handler) {
+    if (handler == null) {
+      parser.handler(null);
+      parser.exceptionHandler(null);
+      parser.endHandler(null);
+      return this;
+    }
+    parser.handler(buffer -> {
+      try {
+        if (frameLength == -1) {
+          frameLength = handleFrameLength(buffer);
+          if (frameLength > max || frameLength <= 0) {
+            try {
+              String err = frameLength <= 0 ? "Frame length : " + frameLength + " <= 0" :
+                "Frame length is too large current: " + frameLength + " max: " + max;
+              IllegalStateException ex = new IllegalStateException(err);
+              if (exceptionHandler != null) {
+                exceptionHandler.handle(ex);
+              } else {
+                throw ex;
+              }
+            } finally {
+              frameLength = 0;
+            }
+          } else {
+            parser.fixedSizeMode((int) frameLength);
+            fetch(1);
+          }
+        } else {
+          parser.fixedSizeMode(length + offset);
+          frameLength = -1;
+          handler.handle(buffer);
+        }
+      } catch (Exception ex) {
+        if (exceptionHandler != null) {
+          exceptionHandler.handle(ex);
+        } else {
+          throw ex;
+        }
+      }
+    });
+    return this;
+  }
+
+  @Override
+  public LengthFieldParser pause() {
+    parser.pause();
+    return this;
+  }
+
+  @Override
+  public LengthFieldParser resume() {
+    parser.resume();
+    return this;
+  }
+
+  @Override
+  public LengthFieldParser fetch(long amount) {
+    parser.fetch(amount);
+    return this;
+  }
+
+  @Override
+  public LengthFieldParser endHandler(Handler<Void> handler) {
+    parser.endHandler(handler);
+    return this;
+  }
+
+  @Override
+  public void handle(Buffer buffer) {
+    parser.handle(buffer);
+  }
+
+  long handleFrameLength(Buffer buffer) {
+    if (length == 1) {
+      return buffer.getByte(offset);
+    } else if (length == 2) {
+      return buffer.getShort(offset);
+    } else if (length == 3) {
+      return buffer.getMedium(offset);
+    } else if (length == 4) {
+      return buffer.getInt(offset);
+    } else {
+      return buffer.getLong(offset);
+    }
+  }
+}

--- a/src/test/java/io/vertx/core/parsetools/LengthFieldParserTest.java
+++ b/src/test/java/io/vertx/core/parsetools/LengthFieldParserTest.java
@@ -1,0 +1,496 @@
+package io.vertx.core.parsetools;
+
+import io.vertx.core.buffer.Buffer;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.vertx.test.core.TestUtils.*;
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.*;
+
+/**
+ * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
+ */
+
+public class LengthFieldParserTest {
+
+  String msg = Buffer.buffer("Vert.x is really awesome!").toString();
+  Buffer byteField = Buffer.buffer().appendByte((byte) msg.length()).appendString(msg);
+  Buffer shortField = Buffer.buffer().appendShort((short) msg.length()).appendString(msg);
+  Buffer medField = Buffer.buffer().appendMedium(msg.length()).appendString(msg);
+  Buffer intField = Buffer.buffer().appendInt(msg.length()).appendString(msg);
+  Buffer longField = Buffer.buffer().appendLong(msg.length()).appendString(msg);
+  Buffer preField = Buffer.buffer()
+    .appendByte(Byte.MAX_VALUE)
+    .appendShort(Short.MAX_VALUE)
+    .appendMedium(Integer.MAX_VALUE)
+    .appendInt(Integer.MAX_VALUE)
+    .appendLong(Integer.MAX_VALUE);
+
+  @Test
+  public void testIllegalArgumentsLength() {
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(0, 0, 1, null));
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(-1, 0, 1, null));
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(5, 0, 1, null));
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(6, 0, 1, null));
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(7, 0, 1, null));
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(9, 0, 1, null));
+  }
+
+  @Test
+  public void testIllegalArgumentsOffset() {
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(1, -1, 1, null));
+  }
+
+  @Test
+  public void testIllegalArgumentsMax() {
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(1, 0, 0, null));
+    assertIllegalArgumentException(() -> LengthFieldParser.newParser(1, 0, -1, null));
+  }
+
+  @Test
+  public void testByte() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer data = byteField.copy();
+    parser.handle(data);
+  }
+
+  @Test
+  public void testByteOffset() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 18, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = byteField.copy();
+    parser.handle(preFields.appendBuffer(data));
+  }
+
+  @Test
+  public void testByteOffsetMax() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 18, msg.length(), null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = byteField.copy();
+    parser.handle(preFields.appendBuffer(data));
+  }
+
+  @Test
+  public void testByteOffsetMaxException() {
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 18, 5, null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handler(event -> {
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = byteField.copy();
+    parser.handle(preFields.appendBuffer(data));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void testByteOffsetMaxInvalidLengthException() {
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 18, msg.length(), null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handler(event -> {
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = byteField.copy();
+    data.setByte(0, (byte) -1);
+    parser.handle(preFields.appendBuffer(data));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void testShort() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(2, 0, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer data = shortField.copy();
+    parser.handle(data);
+  }
+
+  @Test
+  public void testShortOffset() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(2, 18, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = shortField.copy();
+    parser.handle(preFields.appendBuffer(data));
+  }
+
+  @Test
+  public void testShortOffsetMax() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(2, 18, msg.length(), null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = shortField.copy();
+    parser.handle(preFields.appendBuffer(data));
+  }
+
+  @Test
+  public void testShortOffsetMaxException() {
+    LengthFieldParser parser = LengthFieldParser.newParser(2, 18, 5, null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handler(event -> {});
+    Buffer preFields = preField.copy();
+    Buffer data = shortField.copy();
+    parser.handle(preFields.appendBuffer(data));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void testShortOffsetMaxInvalidLengthException() {
+    LengthFieldParser parser = LengthFieldParser.newParser(2, 18, msg.length(), null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handler(event -> {});
+    Buffer preFields = preField.copy();
+    Buffer data = shortField.copy();
+    data.setShort(0, (short) -1);
+    parser.handle(preFields.appendBuffer(data));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void testMedium() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(3, 0, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer data = medField.copy();
+    parser.handle(data);
+  }
+
+  @Test
+  public void testMediumOffset() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(3, 18, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = medField.copy();
+    parser.handle(preFields.appendBuffer(data));
+  }
+
+  @Test
+  public void testMediumOffsetMax() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(3, 18, msg.length(), null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = medField.copy();
+    parser.handle(preFields.appendBuffer(data));
+  }
+
+  @Test
+  public void testMediumOffsetMaxException() {
+    LengthFieldParser parser = LengthFieldParser.newParser(3, 18, 5, null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handler(event -> {
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = medField.copy();
+    parser.handle(preFields.appendBuffer(data));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void testMediumOffsetMaxInvalidLengthException() {
+    LengthFieldParser parser = LengthFieldParser.newParser(3, 18, msg.length(), null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handler(event -> {});
+    Buffer preFields = preField.copy();
+    Buffer data = medField.copy();
+    data.setMedium(0, -1);
+    parser.handle(preFields.appendBuffer(data));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void testInt() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(4, 0, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer data = intField.copy();
+    parser.handle(data);
+  }
+
+  @Test
+  public void testIntOffset() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(4, 18, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = intField.copy();
+    parser.handle(preFields.appendBuffer(data));
+  }
+
+  @Test
+  public void testIntOffsetMax() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(4, 18, msg.length(), null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = intField.copy();
+    parser.handle(preFields.appendBuffer(data));
+  }
+
+  @Test
+  public void testIntOffsetMaxException() {
+    LengthFieldParser parser = LengthFieldParser.newParser(4, 18, 5, null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handler(event -> {});
+    Buffer preFields = preField.copy();
+    Buffer data = intField.copy();
+    parser.handle(preFields.appendBuffer(data));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void testIntOffsetMaxInvalidLengthException() {
+    LengthFieldParser parser = LengthFieldParser.newParser(4, 18, msg.length(), null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handler(event -> {});
+    Buffer preFields = preField.copy();
+    Buffer data = intField.copy();
+    data.setInt(0, -1);
+    parser.handle(preFields.appendBuffer(data));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void testLong() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(8, 0, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer data = longField.copy();
+    parser.handle(data);
+  }
+
+  @Test
+  public void testLongOffset() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(8, 18, Integer.MAX_VALUE, null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = longField.copy();
+    parser.handle(preFields.appendBuffer(data));
+  }
+
+  @Test
+  public void testLongOffsetMax() {
+    AtomicInteger count = new AtomicInteger();
+    LengthFieldParser parser = LengthFieldParser.newParser(8, 18, msg.length(), null);
+    parser.endHandler(v -> count.incrementAndGet());
+    parser.handler(buf -> {
+      assertNotNull(buf);
+      assertEquals(msg.length(), buf.length());
+      assertEquals(msg, buf.toString());
+    });
+    Buffer preFields = preField.copy();
+    Buffer data = longField.copy();
+    parser.handle(preFields.appendBuffer(data));
+  }
+
+  @Test
+  public void testLongOffsetMaxException() {
+    LengthFieldParser parser = LengthFieldParser.newParser(8, 18, 5, null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handler(event -> {});
+    Buffer preFields = preField.copy();
+    Buffer data = longField.copy();
+    parser.handle(preFields.appendBuffer(data));
+    assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void testLongOffsetMaxInvalidLengthException() {
+    LengthFieldParser parser = LengthFieldParser.newParser(8, 18, msg.length(), null);
+    List<Throwable> errors = new ArrayList<>();
+    parser.exceptionHandler(errors::add);
+    parser.handler(event -> {});
+    Buffer preFields = preField.copy();
+    Buffer data = longField.copy();
+    data.setLong(0, -1);
+    parser.handle(preFields.appendBuffer(data));
+    assertEquals(1, errors.size());
+  }
+
+
+  @Test
+  public void testStreamHandle() {
+    FakeStream stream = new FakeStream();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, stream);
+    List<Buffer> events = new ArrayList<>();
+    parser.handler(events::add);
+    for (int i = 0; i < 10; i++) {
+      Buffer data1 = byteField.copy();
+      Buffer data2 = byteField.copy();
+      stream.handle(data1.appendBuffer(data2));
+    }
+    assertFalse(stream.isPaused());
+    assertEquals(20, events.size());
+  }
+
+  @Test
+  public void testStreamPause() {
+    FakeStream stream = new FakeStream();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, stream);
+    List<Buffer> events = new ArrayList<>();
+    parser.handler(events::add);
+    parser.pause();
+    Buffer data = byteField.copy();
+    parser.handle(data);
+    assertTrue(stream.isPaused());
+    assertEquals(0, events.size());
+  }
+
+  @Test
+  public void testStreamResume() {
+    FakeStream stream = new FakeStream();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, stream);
+    List<Buffer> events = new ArrayList<>();
+    parser.handler(events::add);
+    parser.pause();
+    Buffer data1 = byteField.copy();
+    Buffer data2 = byteField.copy();
+    Buffer data3 = byteField.copy();
+    stream.handle(data1.appendBuffer(data2.appendBuffer(data3)));
+    parser.resume();
+    assertEquals(3, events.size());
+    assertFalse(stream.isPaused());
+  }
+
+  @Test
+  public void testStreamFetch() {
+    FakeStream stream = new FakeStream();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, stream);
+    List<Buffer> events = new ArrayList<>();
+    parser.handler(events::add);
+    parser.pause();
+    Buffer data1 = byteField.copy();
+    Buffer data2 = byteField.copy();
+    stream.handle(data1.appendBuffer(data2));
+    parser.fetch(1);
+    assertEquals(1, events.size());
+    assertTrue(stream.isPaused());
+  }
+
+  @Test
+  public void testStreamPauseInHandler() {
+    FakeStream stream = new FakeStream();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, stream);
+    List<Buffer> events = new ArrayList<>();
+    parser.handler(event -> {
+      assertTrue(events.isEmpty());
+      events.add(event);
+      parser.pause();
+    });
+    Buffer data1 = byteField.copy();
+    stream.handle(data1);
+    assertEquals(1, events.size());
+    assertTrue(stream.isPaused());
+  }
+
+  @Test
+  public void testStreamFetchInHandler() {
+    FakeStream stream = new FakeStream();
+    LengthFieldParser parser = LengthFieldParser.newParser(1, 0, Integer.MAX_VALUE, stream);
+    List<Buffer> events = new ArrayList<>();
+    parser.handler(event -> {
+      events.add(event);
+      stream.fetch(1);
+    });
+    stream.pause();
+    stream.fetch(1);
+    Buffer data1 = byteField.copy();
+    Buffer data2 = byteField.copy();
+    stream.handle(data1.appendBuffer(data2));
+    assertEquals(2, events.size());
+    assertFalse(stream.isPaused());
+  }
+
+}


### PR DESCRIPTION
Signed-off-by: Emad Alblueshi <emad.albloushi@gmail.com>

Motivation:

A new `LengthFieldParser` that handles length field based protocols it uses the `RecordParser` internally with simple API it supports the following :

1. Length fields `byte(1)`, `short(2)`, `medium(3)`, `int(4)` and `long(8)`.
2. Maximum frame length the default is `Integer.MAX_VALUE` and can be changed explicitly.
3. Length field offset to skip explicit length while parsing.

It's rewritten instead of https://github.com/eclipse-vertx/vert.x/pull/3742 as @vietj and @tsegismont suggested in [vertx-dev google group](https://groups.google.com/g/vertx-dev/c/iLX9aYgcRwU).

Thanks!