### PR TITLE
Fix typo in fetch sentence

### DIFF
--- a/src/main/asciidoc/streams.adoc
+++ b/src/main/asciidoc/streams.adoc
@@ -127,7 +127,7 @@ set a handler which will receive items from the ReadStream.
 - {@link io.vertx.core.streams.ReadStream#pause}:
 pause the stream. When paused no items will be received in the handler.
 - {@link io.vertx.core.streams.ReadStream#fetch}:
-fetch a specified amount of item fro the stream. The handler will be called if any item arrives. Fetches
+fetch a specified amount of item from the stream. The handler will be called if any item arrives. Fetches
 are cumulative.
 - {@link io.vertx.core.streams.ReadStream#resume}:
 resume the stream. The handler will be called if any item arrives. Resuming is equivalent of fetching `Long.MAX_VALUE` items.


### PR DESCRIPTION
Motivation:

Fix typo in fetch sentence

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
