### PR TITLE
Disable fail-fast for tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   Test:
     name: Run tests
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         profile: [""]


### PR DESCRIPTION
By default github cancels matrix tests if one fails, this behavior makes debugging test failures more difficult to isolate as it is not obvious if a failure is common to other tests if they get cancelled automatically.