### PR TITLE
duplicate message in `ClusteredEventBusTestBase.testPublish`

### DIFF
--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTestBase.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTestBase.java
@@ -185,7 +185,6 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
     reg.completionHandler(new MyRegisterHandler());
     reg = vertices[1].eventBus().<T>consumer(ADDRESS1).handler(new MyHandler());
     reg.completionHandler(new MyRegisterHandler());
-    vertices[0].eventBus().publish(ADDRESS1, val);
     await();
   }
 


### PR DESCRIPTION
I think the intention of `ClusteredEventBusTestBase.testPublish` is to

1. start 3 nodes, register handlers on 2 of these nodes
1. wait for both handlers to be registered
1. publish *one* message on the remaining node
1. wait for both handlers to receive the message

However, `testPublish` currently publishes *two* messages, one without waiting. Depending on timing, this can cause `testComplete` to be called prematurely. As a consequence, tests [sometimes fail for `vertx-ignite`](https://github.com/vert-x3/vertx-ignite/issues/105).

This PR fixes this and I've also verified that tests for `vertx-hazelcast`, `vertx-zookeeper` and `vertx-infinispan` still pass with this change.