### PR TITLE
Allow enabling Netty resource leak detection

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -88,8 +88,8 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   static {
     // Disable Netty's resource leak detection to reduce the performance overhead if not set by user
     // Supports both the default netty leak detection system property and the deprecated one
-    if (System.getProperty("io.netty.leakDetection.level") != null ||
-        System.getProperty("io.netty.leakDetectionLevel") != null) {
+    if (System.getProperty("io.netty.leakDetection.level") == null &&
+        System.getProperty("io.netty.leakDetectionLevel") == null) {
       ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
     }
 


### PR DESCRIPTION
The current code sets the Netty ResourceLeakDetector to disabled if either of the Netty system properties is set to a non-null value. I believe this is the exact opposite of what you want, you want to disable it if both are not set instead.

Motivation:

I'm trying to enable Netty resource leak detection in my own code, but because I'm setting the system property and I'm loading vert.x as well, the level gets set to disabled instead of the value I specified.