### PR TITLE
SharedWorkerPool close method should not force executor termination

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -1069,15 +1069,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
     @Override
     void close() {
-      synchronized (VertxImpl.this) {
-        if (refCount > 0) {
-          refCount = 0;
-          super.close();
-        }
-      }
-    }
-
-    void release() {
       synchronized (VertxImpl.this) {
         if (--refCount == 0) {
           namedWorkerPools.remove(name);

--- a/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
+++ b/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -90,7 +90,7 @@ class WorkerExecutorImpl implements MetricsProvider, WorkerExecutorInternal {
       if (!closed) {
         closed = true;
         closeHooks.remove(this);
-        pool.release();
+        pool.close();
       }
     }
     completion.complete();


### PR DESCRIPTION
Instead, it should update the refCounf and eventually remove the pool for the shared pools map.

Fixes #3786