### PR TITLE
Add SubstitutedContext and make DuplicatedContext use delegate TaskQueue

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -16,6 +16,7 @@ import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.ContextSubstitution;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.impl.VertxInternal;
@@ -204,7 +205,7 @@ public class HttpServerImpl extends TCPServerBase implements HttpServer, Closeab
     String serverOrigin = (options.isSsl() ? "https" : "http") + "://" + host + ":" + port;
 
     HttpServerConnectionHandler hello = new HttpServerConnectionHandler(this, requestStream.handler, wsStream.handler, connectionHandler, exceptionHandler == null ? DEFAULT_EXCEPTION_HANDLER : exceptionHandler);
-    Supplier<ContextInternal> streamContextSupplier = listenContext::duplicate;
+    Supplier<ContextInternal> streamContextSupplier = () -> listenContext.substitute(ContextSubstitution.TASK_QUEUE);
     Handler<Channel> channelHandler = childHandler(connContext, streamContextSupplier, hello, exceptionHandler, address, serverOrigin);
     io.netty.util.concurrent.Future<Channel> bindFuture = listen(address, listenContext, channelHandler);
 

--- a/src/main/java/io/vertx/core/impl/AbstractContext.java
+++ b/src/main/java/io/vertx/core/impl/AbstractContext.java
@@ -18,6 +18,7 @@ import io.vertx.core.impl.future.SucceededFuture;
 import io.vertx.core.impl.launcher.VertxCommandLauncher;
 
 import java.util.List;
+import java.util.function.Function;
 
 import static io.vertx.core.impl.VertxThread.DISABLE_TCCL;
 
@@ -227,4 +228,19 @@ abstract class AbstractContext implements ContextInternal {
       fut.onFailure(ctx::reportException);
     }
   }
+
+  abstract void runOnContext(AbstractContext ctx, Handler<Void> action);
+
+  abstract <T> void execute(AbstractContext ctx, Runnable task);
+
+  abstract <T> void execute(AbstractContext ctx, T argument, Handler<T> task);
+
+  abstract <T> void emit(AbstractContext ctx, T argument, Handler<T> task);
+
+  @Override
+  public ContextInternal substitute(Function<ContextInternal, ContextSubstitution> builder) {
+    return new SubstitutedContext(this, builder);
+  }
+
+  abstract AbstractContext root();
 }

--- a/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -65,10 +65,10 @@ abstract class ContextImpl extends AbstractContext {
   private ConcurrentMap<Object, Object> data;
   private ConcurrentMap<Object, Object> localData;
   private volatile Handler<Throwable> exceptionHandler;
-  final TaskQueue internalOrderedTasks;
-  final WorkerPool internalBlockingPool;
-  final WorkerPool workerPool;
-  final TaskQueue orderedTasks;
+  private final TaskQueue internalOrderedTasks;
+  private final WorkerPool internalBlockingPool;
+  private final WorkerPool workerPool;
+  private final TaskQueue orderedTasks;
 
   ContextImpl(VertxInternal vertx,
               VertxTracer<?, ?> tracer,
@@ -217,6 +217,21 @@ abstract class ContextImpl extends AbstractContext {
   }
 
   @Override
+  public WorkerPool workerPoolInternal() {
+    return this.internalBlockingPool;
+  }
+
+  @Override
+  public TaskQueue orderedTasks() {
+    return this.orderedTasks;
+  }
+
+  @Override
+  public TaskQueue orderedTasksInternal() {
+    return this.internalOrderedTasks;
+  }
+
+  @Override
   public synchronized ConcurrentMap<Object, Object> contextData() {
     if (data == null) {
       data = new ConcurrentHashMap<>();
@@ -273,31 +288,38 @@ abstract class ContextImpl extends AbstractContext {
     runOnContext(this, action);
   }
 
-  abstract void runOnContext(AbstractContext ctx, Handler<Void> action);
-
   @Override
   public void execute(Runnable task) {
     execute(this, task);
   }
-
-  abstract <T> void execute(AbstractContext ctx, Runnable task);
 
   @Override
   public final <T> void execute(T argument, Handler<T> task) {
     execute(this, argument, task);
   }
 
-  abstract <T> void execute(AbstractContext ctx, T argument, Handler<T> task);
-
   @Override
   public <T> void emit(T argument, Handler<T> task) {
     emit(this, argument, task);
   }
 
-  abstract <T> void emit(AbstractContext ctx, T argument, Handler<T> task);
-
   @Override
   public final ContextInternal duplicate() {
     return new DuplicatedContext(this);
+  }
+
+  @Override
+  public ContextInternal substituteParent() {
+    return null;
+  }
+
+  @Override
+  public AbstractContext root() {
+    return this;
+  }
+
+  @Override
+  public ContextInternal duplicateDelegate() {
+    return this;
   }
 }

--- a/src/main/java/io/vertx/core/impl/ContextInternal.java
+++ b/src/main/java/io/vertx/core/impl/ContextInternal.java
@@ -18,6 +18,7 @@ import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.spi.tracing.VertxTracer;
 
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 
 /**
  * This interface provides an api for vert.x core internal use only
@@ -240,30 +241,65 @@ public interface ContextInternal extends Context {
   WorkerPool workerPool();
 
   /**
+   * @return the context internal worker pool
+   */
+  WorkerPool workerPoolInternal();
+
+  /**
+   * @return the context task queue
+   */
+  TaskQueue orderedTasks();
+
+  /**
+   * @return the context internal task queue
+   */
+  TaskQueue orderedTasksInternal();
+
+  /**
    * @return the tracer for this context
    */
   VertxTracer tracer();
 
   /**
-   * Returns a context sharing with this context
+   * @return a context that maintains separate local data and forwards all operations to this context
+   */
+  ContextInternal duplicate();
+
+  /**
+   * @return the delegate of this duplicated context or this if not a duplicated context
+   */
+  ContextInternal duplicateDelegate();
+
+  /**
+   * Returns a substitute of this context
    * <ul>
    *   <li>the same concurrency</li>
    *   <li>the same exception handler</li>
-   *   <li>the same context data</li>
    *   <li>the same deployment</li>
    *   <li>the same config</li>
    *   <li>the same classloader</li>
    * </ul>
    * <p>
-   * The duplicate context has its own
+   * The substitute might have its own
    * <ul>
-   *   <li>local context data</li>
-   *   <li>worker task queue</li>
+   *   <li>context data</li>
+   *   <li>worker pool (includes internal)</li>
+   *   <li>blocking task queues (includes internal)</li>
    * </ul>
+   * </p>
+   * The substitute will have its own local context data
+   *
+   * Using substitutes should be avoided if at all possible as they break many of the assumption that surround contexts
+   * in vertx. Handlers that return a substituted context should always be documented to avoid end user issues.
    *
    * @return a duplicate of this context
    */
-  ContextInternal duplicate();
+  ContextInternal substitute(Function<ContextInternal, ContextSubstitution> builder);
+
+  /**
+   * @return the delegate of this substituted context or {@code null} if there is no parent
+   */
+  ContextInternal substituteParent();
 
   /**
    * Like {@link Vertx#setPeriodic(long, Handler)} except the periodic timer will fire on this context.

--- a/src/main/java/io/vertx/core/impl/ContextSubstitution.java
+++ b/src/main/java/io/vertx/core/impl/ContextSubstitution.java
@@ -1,0 +1,92 @@
+package io.vertx.core.impl;
+
+import io.vertx.core.Context;
+
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+/**
+ * Used to substitute certain functionality of a context. The constructor should be supplied to
+ * {@link ContextInternal#substitute(Function)} to get a context that substitutes some of the parent behavior with what
+ * is provided by this.
+ *
+ * @author <a href="mailto:greg@thetracys.net">Gregory Tracy (Gattag)</a>
+ */
+public abstract class ContextSubstitution {
+
+  private final ContextInternal context;
+
+  public ContextSubstitution(ContextInternal context) {
+    this.context = context;
+  }
+
+  /**
+   * @return the context which has the substituted items
+   */
+  public final ContextInternal getContext(){
+    return this.context;
+  }
+
+  /**
+   * @return the delegate of the substituted context ({@link #getContext()})
+   */
+  public final ContextInternal getParent(){
+    return this.context.substituteParent();
+  }
+
+  /**
+   * @return the base implementing context (a {@link ContextImpl})
+   */
+  public final ContextInternal getRoot() { return ((AbstractContext)this.context).root(); }
+
+  /**
+   * @return the {@link ConcurrentMap} used to store context data
+   * @see Context#get(String)
+   * @see Context#put(String, Object)
+   */
+  ConcurrentMap<Object, Object> contextData(){
+    return this.getParent().contextData();
+  }
+
+  /**
+   * @return the context worker pool
+   */
+  WorkerPool workerPool(){
+    return this.getParent().workerPool();
+  }
+
+  /**
+   * @return the context internal worker pool
+   */
+  WorkerPool workerPoolInternal(){
+    return this.getParent().workerPoolInternal();
+  }
+
+  /**
+   * @return the context task queue
+   */
+  TaskQueue orderedTasks(){
+    return this.getParent().orderedTasks();
+  }
+
+  /**
+   * @return the context internal task queue
+   */
+  TaskQueue orderedTasksInternal(){
+    return this.getParent().orderedTasksInternal();
+  }
+
+  public static final Function<ContextInternal, ContextSubstitution> TASK_QUEUE = c -> new ContextSubstitution(c) {
+
+    private TaskQueue taskQueue;
+
+    @Override
+    synchronized TaskQueue orderedTasks() {
+      if(this.taskQueue == null){
+        this.taskQueue = new TaskQueue();
+      }
+      return this.taskQueue;
+    }
+  };
+
+}

--- a/src/main/java/io/vertx/core/impl/SubstitutedContext.java
+++ b/src/main/java/io/vertx/core/impl/SubstitutedContext.java
@@ -1,0 +1,250 @@
+package io.vertx.core.impl;
+
+import io.netty.channel.EventLoop;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.*;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.tracing.VertxTracer;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+
+/**
+ * A context which is built from a delegate context with some differences.
+ * <br><br>
+ * Compared to the delegate, this context has
+ * <ul>
+ *   <li>the same concurrency</li>
+ *   <li>the same exception handler</li>
+ *   <li>the same deployment</li>
+ *   <li>the same config</li>
+ *   <li>the same classloader</li>
+ * </ul>
+ * This context might have its own
+ * <ul>
+ *   <li>context data</li>
+ *   <li>worker pool (includes internal)</li>
+ *   <li>blocking task queues (includes internal)</li>
+ * </ul>
+ * This will have its own local context data.
+ * <br><br>
+ * Using substitutes should be avoided if at all possible as they break many of the assumption that surround contexts
+ * in vertx. Handlers that return a substituted context should always be documented to avoid end user issues.
+ *
+ * @see ContextSubstitution
+ *
+ * @author <a href="mailto:greg@thetracys.net">Gregory Tracy (Gattag)</a>
+ */
+final class SubstitutedContext extends AbstractContext {
+
+  private final AbstractContext root;
+  private final AbstractContext parent;
+  private final ContextSubstitution substitution;
+  private ConcurrentMap<Object, Object> localData;
+
+  SubstitutedContext(AbstractContext parent, Function<ContextInternal, ContextSubstitution> builder){
+    this.parent = parent;
+    this.root = parent.root();
+    this.substitution = builder.apply(this);
+  }
+
+  @Override
+  public final String deploymentID() {
+    return this.root.deploymentID();
+  }
+
+  @Override
+  public final @Nullable JsonObject config() {
+    return this.root.config();
+  }
+
+  @Override
+  public final boolean isEventLoopContext() {
+    return this.root.isEventLoopContext();
+  }
+
+  @Override
+  final boolean inThread() {
+    return this.root.inThread();
+  }
+
+  @Override
+  public final CloseHooks closeHooks() {
+    return this.root.closeHooks();
+  }
+
+  @Override
+  public final void runOnContext(Handler<Void> action) {
+    this.root.runOnContext(this, action);
+  }
+
+  @Override
+  final void runOnContext(AbstractContext ctx, Handler<Void> action) {
+    this.root.runOnContext(this, action);
+  }
+
+  @Override
+  public final void execute(Runnable task) {
+    this.root.execute(this, task);
+  }
+
+  @Override
+  final <T> void execute(AbstractContext ctx, Runnable task) {
+    this.root.execute(this, task);
+  }
+
+  @Override
+  public final <T> void execute(T argument, Handler<T> task) {
+    this.root.execute(this, argument, task);
+  }
+
+  @Override
+  final <T> void execute(AbstractContext ctx, T argument, Handler<T> task) {
+    this.root.execute(this, argument, task);
+  }
+
+  @Override
+  public final <T> void emit(T argument, Handler<T> task) {
+    this.root.emit(this, argument, task);
+  }
+
+  @Override
+  final <T> void emit(AbstractContext ctx, T argument, Handler<T> task) {
+    this.root.emit(this, argument, task);
+  }
+
+  @Override
+  public final EventLoop nettyEventLoop() {
+    return this.root.nettyEventLoop();
+  }
+
+  @Override
+  public final <T> Future<T> executeBlockingInternal(Handler<Promise<T>> action) {
+    return ContextImpl.executeBlocking(this, action, this.workerPoolInternal(), this.orderedTasksInternal());
+  }
+
+  @Override
+  public final <T> Future<T> executeBlockingInternal(Handler<Promise<T>> action, boolean ordered) {
+    return ContextImpl.executeBlocking(this, action, this.workerPoolInternal(), ordered ? this.orderedTasksInternal() : null);
+  }
+
+  @Override
+  public final <T> Future<T> executeBlocking(Handler<Promise<T>> action, boolean ordered) {
+    return ContextImpl.executeBlocking(this, action, this.workerPool(), ordered ? this.orderedTasks(): null);
+  }
+
+  @Override
+  public final <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, TaskQueue queue) {
+    return ContextImpl.executeBlocking(this, blockingCodeHandler, this.workerPool(), queue);
+  }
+
+  @Override
+  public final Deployment getDeployment() {
+    return this.root.getDeployment();
+  }
+
+  @Override
+  public final VertxInternal owner() {
+    return this.root.owner();
+  }
+
+  @Override
+  public final int getInstanceCount() {
+    return this.root.getInstanceCount();
+  }
+
+  @Override
+  public final Context exceptionHandler(@Nullable Handler<Throwable> handler) {
+    return this.root.exceptionHandler(handler);
+  }
+
+  @Override
+  public final @Nullable Handler<Throwable> exceptionHandler() {
+    return this.root.exceptionHandler();
+  }
+
+  @Override
+  public final void reportException(Throwable t) {
+    this.root.reportException(t);
+  }
+
+  @Override
+  public final ConcurrentMap<Object, Object> contextData() {
+    return this.substitution.contextData();
+  }
+
+  @Override
+  public final synchronized ConcurrentMap<Object, Object> localContextData() {
+    if (this.localData == null) {
+      this.localData = new ConcurrentHashMap<>();
+    }
+    return this.localData;
+  }
+
+  @Override
+  public final ClassLoader classLoader() {
+    return this.root.classLoader();
+  }
+
+  @Override
+  public final WorkerPool workerPool() {
+    return this.substitution.workerPool();
+  }
+
+  @Override
+  public final WorkerPool workerPoolInternal() {
+    return this.substitution.workerPoolInternal();
+  }
+
+  @Override
+  public final TaskQueue orderedTasks() {
+    return this.substitution.orderedTasks();
+  }
+
+  @Override
+  public final TaskQueue orderedTasksInternal() {
+    return this.substitution.orderedTasksInternal();
+  }
+
+  @Override
+  public final VertxTracer tracer() {
+    return this.root.tracer();
+  }
+
+  @Override
+  public final ContextInternal duplicate() {
+    return new DuplicatedContext(this);
+  }
+
+  @Override
+  public final ContextInternal duplicateDelegate() {
+    return this;
+  }
+
+  @Override
+  public final ContextInternal substituteParent() {
+    return this.parent;
+  }
+
+  @Override
+  public final AbstractContext root() {
+    return this.root;
+  }
+
+  @Override
+  public final boolean isDeployment() {
+    return this.root.isDeployment();
+  }
+
+  @Override
+  public final void addCloseHook(Closeable hook) {
+    this.root.addCloseHook(hook);
+  }
+
+  @Override
+  public final void removeCloseHook(Closeable hook) {
+    this.root.removeCloseHook(hook);
+  }
+}

--- a/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
+++ b/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
@@ -56,16 +56,15 @@ class WorkerExecutorImpl implements MetricsProvider, WorkerExecutorInternal {
   }
 
   @Override
-  public <T> Future<@Nullable T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered) {
+  public synchronized <T> Future<@Nullable T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered) {
     if (closed) {
       throw new IllegalStateException("Worker executor closed");
     }
-    ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
-    ContextImpl impl = context instanceof DuplicatedContext ? ((DuplicatedContext)context).delegate : (ContextImpl) context;
-    return ContextImpl.executeBlocking(context, blockingCodeHandler, pool, ordered ? impl.orderedTasks : null);
+    ContextInternal context = vertx.getOrCreateContext();
+    return ContextImpl.executeBlocking(context, blockingCodeHandler, pool, ordered ? context.orderedTasks() : null);
   }
 
-  public synchronized <T> void executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> asyncResultHandler) {
+  public <T> void executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> asyncResultHandler) {
     Future<T> fut = executeBlocking(blockingCodeHandler, ordered);
     if (asyncResultHandler != null) {
       fut.onComplete(asyncResultHandler);

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -513,12 +513,12 @@ public class ContextTest extends VertxTestBase {
   }
 
   @Test
-  public void testDuplicateWorkerConcurrency() throws Exception {
+  public void testTaskQueueSubstituteWorkerConcurrency() throws Exception {
     ContextInternal ctx = createWorkerContext();
-    ContextInternal dup1 = ctx.duplicate();
-    ContextInternal dup2 = ctx.duplicate();
+    ContextInternal sub1 = ctx.substitute(ContextSubstitution.TASK_QUEUE);
+    ContextInternal sub2 = ctx.substitute(ContextSubstitution.TASK_QUEUE);
     CyclicBarrier barrier = new CyclicBarrier(3);
-    dup1.runOnContext(v -> {
+    sub1.runOnContext(v -> {
       assertTrue(Context.isOnWorkerThread());
       try {
         barrier.await(10, TimeUnit.SECONDS);
@@ -526,7 +526,7 @@ public class ContextTest extends VertxTestBase {
         fail(e);
       }
     });
-    dup2.runOnContext(v -> {
+    sub2.runOnContext(v -> {
       assertTrue(Context.isOnWorkerThread());
       try {
         barrier.await(10, TimeUnit.SECONDS);
@@ -538,20 +538,20 @@ public class ContextTest extends VertxTestBase {
   }
 
   @Test
-  public void testDuplicateEventLoopExecuteBlocking() throws Exception {
-    testDuplicateExecuteBlocking((ContextInternal) vertx.getOrCreateContext());
+  public void testTaskQueueSubstituteEventLoopExecuteBlocking() throws Exception {
+    testTaskQueueSubstituteExecuteBlocking((ContextInternal) vertx.getOrCreateContext());
   }
 
   @Test
-  public void testDuplicateWorkerExecuteBlocking() throws Exception {
-    testDuplicateExecuteBlocking(createWorkerContext());
+  public void testTaskQueueSubstituteWorkerExecuteBlocking() throws Exception {
+    testTaskQueueSubstituteExecuteBlocking(createWorkerContext());
   }
 
-  private void testDuplicateExecuteBlocking(ContextInternal ctx) throws Exception {
-    ContextInternal dup1 = ctx.duplicate();
-    ContextInternal dup2 = ctx.duplicate();
+  private void testTaskQueueSubstituteExecuteBlocking(ContextInternal ctx) throws Exception {
+    ContextInternal sub1 = ctx.substitute(ContextSubstitution.TASK_QUEUE);
+    ContextInternal sub2 = ctx.substitute(ContextSubstitution.TASK_QUEUE);
     CyclicBarrier barrier = new CyclicBarrier(3);
-    dup1.executeBlocking(p -> {
+    sub1.executeBlocking(p -> {
       assertTrue(Context.isOnWorkerThread());
       try {
         barrier.await(10, TimeUnit.SECONDS);
@@ -560,7 +560,7 @@ public class ContextTest extends VertxTestBase {
       }
       p.complete();
     });
-    dup2.executeBlocking(p -> {
+    sub2.executeBlocking(p -> {
       assertTrue(Context.isOnWorkerThread());
       try {
         barrier.await(10, TimeUnit.SECONDS);
@@ -573,21 +573,21 @@ public class ContextTest extends VertxTestBase {
   }
 
   @Test
-  public void testDuplicateEventLoopExecuteBlockingOrdering() {
-    testDuplicateExecuteBlockingOrdering((ContextInternal) vertx.getOrCreateContext());
+  public void testTaskQueueSubstituteEventLoopExecuteBlockingOrdering() {
+    testTaskQueueSubstituteExecuteBlockingOrdering((ContextInternal) vertx.getOrCreateContext());
   }
 
   @Test
-  public void testDuplicateWorkerExecuteBlockingOrdering() {
-    testDuplicateExecuteBlockingOrdering(createWorkerContext());
+  public void testTaskQueueSubstituteWorkerExecuteBlockingOrdering() {
+    testTaskQueueSubstituteExecuteBlockingOrdering(createWorkerContext());
   }
 
-  private void testDuplicateExecuteBlockingOrdering(ContextInternal context) {
+  private void testTaskQueueSubstituteExecuteBlockingOrdering(ContextInternal context) {
     List<Consumer<Handler<Promise<Object>>>> lst = new ArrayList<>();
     for (int i = 0;i < 2;i++) {
-      ContextInternal duplicate = context.duplicate();
+      ContextInternal substitute = context.substitute(ContextSubstitution.TASK_QUEUE);
       lst.add(task -> {
-        duplicate.executeBlocking(task, ar -> {});
+        substitute.executeBlocking(task, ar -> {});
       });
     }
     testInternalExecuteBlockingWithQueue(lst);


### PR DESCRIPTION
- `DuplicatedContext` uses delegate `TaskQueue` instead of its own
- Adds a `SubstitutedContext`, a context based off a delegate with certain elements that can be changed
- Also fixed a synchronization issue in `WorkerExecutorImpl` (Noticed it and through it in there)

Still needs more tests, working on it, but waiting till I get some feedback on this.

This will required a change or two in JDBC, but otherwise shouldn't break anything.

Fixes #3790

Signed-off-by: Gregory Tracy greg@thetracys.net