### PR TITLE
add mimetype for es6 js modules

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/MimeMapping.java
+++ b/src/main/java/io/vertx/core/http/impl/MimeMapping.java
@@ -56,6 +56,7 @@ public class MimeMapping {
     m.put("ser", "application/java-serialized-object");
     m.put("class", "application/java-vm");
     m.put("js", "application/javascript");
+    m.put("mjs", "application/javascript");
     m.put("json", "application/json");
     m.put("jsonml", "application/jsonml+json");
     m.put("lostxml", "application/lost+xml");

--- a/src/main/java/io/vertx/core/http/impl/MimeMapping.java
+++ b/src/main/java/io/vertx/core/http/impl/MimeMapping.java
@@ -55,8 +55,8 @@ public class MimeMapping {
     m.put("jar", "application/java-archive");
     m.put("ser", "application/java-serialized-object");
     m.put("class", "application/java-vm");
-    m.put("js", "application/javascript");
-    m.put("mjs", "application/javascript");
+    m.put("js", "text/javascript");
+    m.put("mjs", "text/javascript");
     m.put("json", "application/json");
     m.put("jsonml", "application/jsonml+json");
     m.put("lostxml", "application/lost+xml");


### PR DESCRIPTION
Motivation:

Current vertx static handler serves mjs files with the wrong content type. This simple addition fixes that

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
