### PR TITLE
feat: completion function to MessageConsumer returns a future

### DIFF
--- a/src/main/java/examples/EventBusExamples.java
+++ b/src/main/java/examples/EventBusExamples.java
@@ -46,7 +46,7 @@ public class EventBusExamples {
   }
 
   public void example3(MessageConsumer<String> consumer) {
-    consumer.completionHandler(res -> {
+    consumer.registrationCompletion(res -> {
       if (res.succeeded()) {
         System.out.println("The handler registration has reached all nodes");
       } else {

--- a/src/main/java/io/vertx/core/eventbus/MessageConsumer.java
+++ b/src/main/java/io/vertx/core/eventbus/MessageConsumer.java
@@ -87,8 +87,20 @@ public interface MessageConsumer<T> extends ReadStream<Message<T>> {
    * Optional method which can be called to indicate when the registration has been propagated across the cluster.
    *
    * @param completionHandler the completion handler
+   * @deprecated Please use {@link #registrationCompletion(Handler)} or {@link #registrationCompletion()}
    */
+  @Deprecated
   void completionHandler(Handler<AsyncResult<Void>> completionHandler);
+
+  /**
+   * Optional method which can be called to indicate when the registration has been propagated across the cluster.
+   */
+  void registrationCompletion(Handler<AsyncResult<Void>> completionHandler);
+
+  /**
+   * Like {@link #registrationCompletion(Handler)} but returns a {@code Future} of the asynchronous result.
+   */
+  Future<Void> registrationCompletion();
 
   /**
    * Unregisters the handler which created this registration

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
@@ -99,11 +99,23 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
 
   @Override
   public synchronized void completionHandler(Handler<AsyncResult<Void>> handler) {
+    registrationCompletion(handler);
+  }
+
+  @Override
+  public synchronized void registrationCompletion(Handler<AsyncResult<Void>> handler) {
     Objects.requireNonNull(handler);
+    registrationCompletion().onComplete(handler);
+  }
+
+  @Override
+  public synchronized Future<Void> registrationCompletion() {
     if (result != null) {
-      result.future().onComplete(handler);
+      return result.future();
     } else {
-      completionHandler = handler;
+      final Promise<Void> completion = context.promise();
+      completionHandler = completion;
+      return completion.future();
     }
   }
 

--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTestBase.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTestBase.java
@@ -66,7 +66,7 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
       }
       testComplete();
     });
-    reg.completionHandler(ar -> {
+    reg.registrationCompletion(ar -> {
       assertTrue(ar.succeeded());
       if (options == null) {
         vertices[0].eventBus().send(ADDRESS1, val);
@@ -101,7 +101,7 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
         msg.reply(val, options);
       }
     });
-    reg.completionHandler(ar -> {
+    reg.registrationCompletion(ar -> {
       assertTrue(ar.succeeded());
       vertices[0].eventBus().request(ADDRESS1, str, onSuccess((Message<R> reply) -> {
         if (consumer == null) {
@@ -131,7 +131,7 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
     vertices[0].eventBus().<String>consumer(ADDRESS1).handler((Message<String> msg) -> {
       assertEquals(str, msg.body());
       testComplete();
-    }).completionHandler(ar -> {
+    }).registrationCompletion(ar -> {
       assertTrue(ar.succeeded());
       vertices[1].eventBus().send(ADDRESS1, str);
     });
@@ -145,7 +145,7 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
     vertices[0].eventBus().consumer(ADDRESS1, (Message<String> msg) -> {
       assertEquals(str, msg.body());
       testComplete();
-    }).completionHandler(ar -> {
+    }).registrationCompletion(ar -> {
       assertTrue(ar.succeeded());
       vertices[1].eventBus().send(ADDRESS1, str);
     });
@@ -182,9 +182,9 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
       }
     }
     MessageConsumer reg = vertices[2].eventBus().<T>consumer(ADDRESS1).handler(new MyHandler());
-    reg.completionHandler(new MyRegisterHandler());
+    reg.registrationCompletion(new MyRegisterHandler());
     reg = vertices[1].eventBus().<T>consumer(ADDRESS1).handler(new MyHandler());
-    reg.completionHandler(new MyRegisterHandler());
+    reg.registrationCompletion(new MyRegisterHandler());
     await();
   }
 
@@ -197,7 +197,7 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
     vertices[0].eventBus().registerCodec(new StringLengthCodec()).<Integer>consumer("whatever", msg -> {
       assertEquals(content.length(), (int) msg.body());
       complete();
-    }).completionHandler(ar -> latch.countDown());
+    }).registrationCompletion(ar -> latch.countDown());
     awaitLatch(latch);
     StringLengthCodec codec = new StringLengthCodec();
     vertices[1].eventBus().registerCodec(codec).addOutboundInterceptor(sc -> {
@@ -229,7 +229,7 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
     });
     startNodes(options.get(), options.get());
     MessageConsumer<Object> consumer = vertices[0].eventBus().consumer("foo", msg -> msg.reply(msg.body()));
-    consumer.completionHandler(onSuccess(reg -> {
+    consumer.registrationCompletion(onSuccess(reg -> {
       vertices[0].eventBus().request("foo", "echo", onSuccess(reply1 -> {
         assertEquals("echo", reply1.body());
         vertices[1].eventBus().request("foo", "echo", onSuccess(reply2 -> {

--- a/src/test/java/io/vertx/core/eventbus/CustomNodeSelectorTest.java
+++ b/src/test/java/io/vertx/core/eventbus/CustomNodeSelectorTest.java
@@ -68,7 +68,7 @@ public class CustomNodeSelectorTest extends VertxTestBase {
       }))
       .map(consumer -> {
         Promise promise = Promise.promise();
-        consumer.completionHandler(promise);
+        consumer.registrationCompletion(promise);
         return promise.future();
       })
       .collect(collectingAndThen(toList(), CompositeFuture::all));

--- a/src/test/java/io/vertx/core/eventbus/EventBusTestBase.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusTestBase.java
@@ -340,7 +340,7 @@ public abstract class EventBusTestBase extends VertxTestBase {
       public void start() throws Exception {
         vertices[1].eventBus().<String>consumer(ADDRESS1, msg -> {
           msg.reply(expectedBody);
-        }).completionHandler(ar -> {
+        }).registrationCompletion(ar -> {
           assertTrue(ar.succeeded());
           latch.countDown();
         });
@@ -363,7 +363,7 @@ public abstract class EventBusTestBase extends VertxTestBase {
     vertices[1].eventBus().<String>consumer(ADDRESS1, msg -> {
       assertEquals(expectedBody, msg.body());
       receivedLatch.countDown();
-    }).completionHandler(ar -> {
+    }).registrationCompletion(ar -> {
       assertTrue(ar.succeeded());
       vertices[0].executeBlocking(fut -> {
         vertices[0].eventBus().send(ADDRESS1, expectedBody);

--- a/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
@@ -155,7 +155,7 @@ public class LocalEventBusTest extends EventBusTestBase {
     eb.<String>localConsumer(ADDRESS1).handler((Message<String> msg) -> {
       assertEquals(str, msg.body());
       testComplete();
-    }).completionHandler(ar -> {
+    }).registrationCompletion(ar -> {
       assertTrue(ar.succeeded());
       eb.send(ADDRESS1, str);
     });
@@ -168,7 +168,7 @@ public class LocalEventBusTest extends EventBusTestBase {
     eb.localConsumer(ADDRESS1, (Message<String> msg) -> {
       assertEquals(str, msg.body());
       testComplete();
-    }).completionHandler(ar -> {
+    }).registrationCompletion(ar -> {
       assertTrue(ar.succeeded());
       eb.send(ADDRESS1, str);
     });
@@ -182,7 +182,7 @@ public class LocalEventBusTest extends EventBusTestBase {
       assertEquals(str, msg.body());
       testComplete();
     });
-    reg.completionHandler(ar -> {
+    reg.registrationCompletion(ar -> {
       assertTrue(ar.succeeded());
       eb.send(ADDRESS1, str);
     });
@@ -692,7 +692,7 @@ public class LocalEventBusTest extends EventBusTestBase {
           }
           msg.reply("bar");
         });
-        reg.completionHandler(ar -> {
+        reg.registrationCompletion(ar -> {
           assertTrue(ar.succeeded());
           assertSame(ctx, context);
           if (!worker) {
@@ -1298,7 +1298,7 @@ public class LocalEventBusTest extends EventBusTestBase {
     MessageConsumer<Object> consumer = eb.consumer(ADDRESS1);
     ThreadLocal<Object> stack = new ThreadLocal<>();
     stack.set(true);
-    consumer.completionHandler(v -> {
+    consumer.registrationCompletion(v -> {
       assertNull(stack.get());
       assertTrue(Vertx.currentContext().isEventLoopContext());
       testComplete();
@@ -1315,7 +1315,7 @@ public class LocalEventBusTest extends EventBusTestBase {
     });
     ThreadLocal<Object> stack = new ThreadLocal<>();
     stack.set(true);
-    consumer.completionHandler(v -> {
+    consumer.registrationCompletion(v -> {
       assertNull(stack.get());
       assertTrue(Vertx.currentContext().isEventLoopContext());
       testComplete();
@@ -1327,7 +1327,7 @@ public class LocalEventBusTest extends EventBusTestBase {
   public void testUpdateDeliveryOptionsOnProducer() {
     MessageProducer<String> producer = eb.sender(ADDRESS1);
     MessageConsumer<String> consumer = eb.<String>consumer(ADDRESS1);
-    consumer.completionHandler(v -> {
+    consumer.registrationCompletion(v -> {
       assertTrue(v.succeeded());
       producer.write("no-header");
     });
@@ -1362,7 +1362,7 @@ public class LocalEventBusTest extends EventBusTestBase {
         testComplete();
       });
       consumer.handler(msg -> {});
-      consumer.completionHandler(ar -> {
+      consumer.registrationCompletion(ar -> {
         assertTrue(ar.succeeded());
         registered.countDown();
       });
@@ -1411,7 +1411,7 @@ public class LocalEventBusTest extends EventBusTestBase {
   public void testImmediateUnregistration() {
     MessageConsumer<Object> consumer = vertx.eventBus().consumer(ADDRESS1);
     AtomicInteger completionCount = new AtomicInteger();
-    consumer.completionHandler(ar -> {
+    consumer.registrationCompletion(ar -> {
       int val = completionCount.getAndIncrement();
       assertEquals(0, val);
       assertTrue(ar.succeeded());

--- a/src/test/java/io/vertx/core/eventbus/ReplyFailureErrorTest.java
+++ b/src/test/java/io/vertx/core/eventbus/ReplyFailureErrorTest.java
@@ -32,7 +32,7 @@ public class ReplyFailureErrorTest extends VertxTestBase {
     vertices[0].eventBus().registerCodec(codec);
     vertices[1].eventBus().consumer("foo", msg -> {
       fail("Should not receive message");
-    }).completionHandler(onSuccess(v -> {
+    }).registrationCompletion(onSuccess(v -> {
       DeliveryOptions options = new DeliveryOptions().setCodecName(codec.name());
       vertices[0].eventBus().request("foo", new MyPOJO("bar"), options, onFailure(t -> {
         assertThat(t, instanceOf(ReplyException.class));

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
@@ -803,7 +803,7 @@ public class MetricsContextTest extends VertxTestBase {
             }));
           });
         });
-      }).completionHandler(onSuccess(v2 -> {
+      }).registrationCompletion(onSuccess(v2 -> {
         t.start();
       }));
     });

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -116,7 +116,7 @@ public class MetricsTest extends VertxTestBase {
     AtomicInteger receiveCount = new AtomicInteger();
     for (Vertx vertx : to) {
       MessageConsumer<Object> consumer = vertx.eventBus().consumer(ADDRESS1);
-      consumer.completionHandler(onSuccess(v -> {
+      consumer.registrationCompletion(onSuccess(v -> {
         if (broadcastCount.incrementAndGet() == to.length) {
           String msg = TestUtils.randomAlphaString(10);
           if (publish) {
@@ -151,7 +151,7 @@ public class MetricsTest extends VertxTestBase {
   private void testReceiveMessageSent(Vertx from, Vertx to, boolean expectedLocal, int expectedHandlers) {
     FakeEventBusMetrics eventBusMetrics = FakeMetricsBase.getMetrics(to.eventBus());
     MessageConsumer<Object> consumer = to.eventBus().consumer(ADDRESS1);
-    consumer.completionHandler(done -> {
+    consumer.registrationCompletion(done -> {
       assertTrue(done.succeeded());
       String msg = TestUtils.randomAlphaString(10);
       from.eventBus().send(ADDRESS1, msg);
@@ -179,7 +179,7 @@ public class MetricsTest extends VertxTestBase {
     AtomicInteger count = new AtomicInteger();
     for (int i = 0; i < expectedHandlers; i++) {
       MessageConsumer<Object> consumer = to.eventBus().consumer(ADDRESS1);
-      consumer.completionHandler(done -> {
+      consumer.registrationCompletion(done -> {
         assertTrue(done.succeeded());
         if (count.incrementAndGet() == expectedHandlers) {
           String msg = TestUtils.randomAlphaString(10);
@@ -213,7 +213,7 @@ public class MetricsTest extends VertxTestBase {
     FakeEventBusMetrics toMetrics = FakeMetricsBase.getMetrics(to.eventBus());
     MessageConsumer<Object> consumer = to.eventBus().consumer(ADDRESS1);
     CountDownLatch latch = new CountDownLatch(1);
-    consumer.completionHandler(onSuccess(v -> {
+    consumer.registrationCompletion(onSuccess(v -> {
       String msg = TestUtils.randomAlphaString(10);
       from.eventBus().request(ADDRESS1, msg, reply -> {
         latch.countDown();
@@ -247,7 +247,7 @@ public class MetricsTest extends VertxTestBase {
     int num = 10;
     consumer.setMaxBufferedMessages(num);
     consumer.pause();
-    consumer.completionHandler(onSuccess(v -> {
+    consumer.registrationCompletion(onSuccess(v -> {
       for (int i = 0;i < num;i++) {
         from.eventBus().send(ADDRESS1, "" + i);
       }
@@ -269,7 +269,7 @@ public class MetricsTest extends VertxTestBase {
     int num = 10;
     consumer.setMaxBufferedMessages(num);
     consumer.pause();
-    consumer.completionHandler(onSuccess(v -> {
+    consumer.registrationCompletion(onSuccess(v -> {
       for (int i = 0;i < num;i++) {
         from.eventBus().send(ADDRESS1, "" + i);
       }
@@ -289,7 +289,7 @@ public class MetricsTest extends VertxTestBase {
     FakeEventBusMetrics toMetrics = FakeMetricsBase.getMetrics(to.eventBus());
     MessageConsumer<Object> consumer = to.eventBus().consumer(ADDRESS1);
     consumer.pause();
-    consumer.completionHandler(onSuccess(v -> {
+    consumer.registrationCompletion(onSuccess(v -> {
       from.eventBus().send(ADDRESS1, "last");
     }));
     consumer.handler(msg -> fail());
@@ -306,7 +306,7 @@ public class MetricsTest extends VertxTestBase {
     MessageConsumer<Object> consumer = vertx.eventBus().consumer(ADDRESS1, msg -> {
     });
     CountDownLatch latch = new CountDownLatch(1);
-    consumer.completionHandler(ar -> {
+    consumer.registrationCompletion(ar -> {
       assertTrue(ar.succeeded());
       latch.countDown();
     });
@@ -334,7 +334,7 @@ public class MetricsTest extends VertxTestBase {
       MessageConsumer<Object> consumer = vertices[0].eventBus().consumer(ADDRESS1, ar -> {
         fail("Should not receive message");
       });
-      consumer.completionHandler(onSuccess(v2 -> {
+      consumer.registrationCompletion(onSuccess(v2 -> {
         consumer.unregister(onSuccess(v3 -> {
           assertSame(Vertx.currentContext(), ctx);
           List<HandlerMetric> registrations = metrics.getRegistrations();
@@ -375,7 +375,7 @@ public class MetricsTest extends VertxTestBase {
         assertEquals(expectedLocalCount, registration.localScheduleCount.get());
         assertEquals(1, registration.deliveredCount.get());
         msg.reply("pong");
-      }).completionHandler(onSuccess(v2 -> {
+      }).registrationCompletion(onSuccess(v2 -> {
         to.runOnContext(v3 -> {
           latch1.countDown();
         });
@@ -417,7 +417,7 @@ public class MetricsTest extends VertxTestBase {
       assertEquals(0, registration.localDeliveredCount.get());
       replyRegistration.set(registration);
       msg.reply("pong");
-    }).completionHandler(ar -> {
+    }).registrationCompletion(ar -> {
       assertTrue(ar.succeeded());
       latch.countDown();
     });
@@ -452,7 +452,7 @@ public class MetricsTest extends VertxTestBase {
       assertTrue("Expected to have more " + encoded + " > 1000 encoded bytes", encoded > 1000);
       assertTrue("Expected to have more " + decoded + " > 1000 decoded bytes", decoded > 1000);
       testComplete();
-    }).completionHandler(ar -> {
+    }).registrationCompletion(ar -> {
       assertTrue(ar.succeeded());
       assertEquals(0, fromMetrics.getEncodedBytes(ADDRESS1));
       assertEquals(0, toMetrics.getDecodedBytes(ADDRESS1));
@@ -521,7 +521,7 @@ public class MetricsTest extends VertxTestBase {
     eb.consumer("foo", msg -> {
       replyAddress.set(msg.replyAddress());
       msg.fail(0, "whatever");
-    }).completionHandler(onSuccess(v -> {
+    }).registrationCompletion(onSuccess(v -> {
       regLatch.countDown();
     }));
     awaitLatch(regLatch);

--- a/src/test/java/io/vertx/core/spi/tracing/EventBusTracerTestBase.java
+++ b/src/test/java/io/vertx/core/spi/tracing/EventBusTracerTestBase.java
@@ -131,7 +131,7 @@ public abstract class EventBusTracerTestBase extends VertxTestBase {
         assertNotSame(Vertx.currentContext(), ctx);
         assertSameEventLoop(ctx, Vertx.currentContext());
         assertEquals("msg", msg.body());
-      }).completionHandler(onSuccess(v2 -> {
+      }).registrationCompletion(onSuccess(v2 -> {
         latch.countDown();
       }));
     });
@@ -176,7 +176,7 @@ public abstract class EventBusTracerTestBase extends VertxTestBase {
         ConcurrentMap<Object, Object> tracerMap = ((ContextInternal) vertx.getOrCreateContext()).localContextData();
         tracerMap.put(ebTracer.sendKey, ebTracer.sendVal);
         msg.reply("msg_2");
-      }).completionHandler(onSuccess(v2 -> {
+      }).registrationCompletion(onSuccess(v2 -> {
         latch.countDown();
       }));
     });
@@ -205,7 +205,7 @@ public abstract class EventBusTracerTestBase extends VertxTestBase {
       ConcurrentMap<Object, Object> tracerMap = ((ContextInternal) vertx.getOrCreateContext()).localContextData();
       tracerMap.put(ebTracer.sendKey, ebTracer.sendVal);
       msg.fail(10, "it failed");
-    }).completionHandler(onSuccess(v -> {
+    }).registrationCompletion(onSuccess(v -> {
       latch.countDown();
     }));
     awaitLatch(latch);
@@ -243,7 +243,7 @@ public abstract class EventBusTracerTestBase extends VertxTestBase {
     CountDownLatch latch = new CountDownLatch(1);
     vertx1.eventBus().consumer("the_address", msg -> {
       // Let timeout
-    }).completionHandler(onSuccess(v -> {
+    }).registrationCompletion(onSuccess(v -> {
       latch.countDown();
     }));
     awaitLatch(latch);
@@ -277,7 +277,7 @@ public abstract class EventBusTracerTestBase extends VertxTestBase {
           assertSame(consumerCtx, vertx2.getOrCreateContext());
           assertSameEventLoop(consumerCtx, vertx2.getOrCreateContext());
         });
-      }).completionHandler(onSuccess(v2 -> {
+      }).registrationCompletion(onSuccess(v2 -> {
         latch.countDown();
       }));
     });

--- a/src/test/java/io/vertx/test/verticles/FaultToleranceVerticle.java
+++ b/src/test/java/io/vertx/test/verticles/FaultToleranceVerticle.java
@@ -44,11 +44,11 @@ public class FaultToleranceVerticle extends AbstractVerticle {
     for (int i = 0; i < numAddresses; i++) {
       Promise<Void> registrationFuture = Promise.promise();
       registrationFutures.add(registrationFuture.future());
-      vertx.eventBus().consumer(createAddress(id, i), msg -> msg.reply("pong")).completionHandler(registrationFuture);
+      vertx.eventBus().consumer(createAddress(id, i), msg -> msg.reply("pong")).registrationCompletion(registrationFuture);
     }
     Promise<Void> registrationFuture = Promise.promise();
     registrationFutures.add(registrationFuture.future());
-    vertx.eventBus().consumer("ping", this::ping).completionHandler(registrationFuture);
+    vertx.eventBus().consumer("ping", this::ping).registrationCompletion(registrationFuture);
     CompositeFuture.all(registrationFutures).onSuccess(ar -> vertx.eventBus().send("control", "start"));
   }
 


### PR DESCRIPTION
feat: completion function to MessageConsumer returns a future

Alternative to completionHandler.

Motivation:

https://github.com/vert-x3/vertx-lang-kotlin/issues/190