### PR TITLE
Implement round robin address selection

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -59,6 +59,9 @@ Set the DNS queries <i>Recursion Desired</i> flag value.
 Set to <code>true</code> to enable round-robin selection of the dns server to use. It spreads the query load
  among the servers and avoids all lookup to hit the first server of the list.
 +++
+|[[roundRobinInetAddress]]`@roundRobinInetAddress`|`Boolean`|+++
+Set to <code>true</code> to enable round-robin inet address selection of the ip address to use.
++++
 |[[searchDomains]]`@searchDomains`|`Array of String`|+++
 Set the lists of DNS search domains.
  <p/>

--- a/src/main/generated/io/vertx/core/dns/AddressResolverOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/dns/AddressResolverOptionsConverter.java
@@ -69,6 +69,11 @@ import java.time.format.DateTimeFormatter;
             obj.setRotateServers((Boolean)member.getValue());
           }
           break;
+        case "roundRobinInetAddress":
+          if (member.getValue() instanceof Boolean) {
+            obj.setRoundRobinInetAddress((Boolean)member.getValue());
+          }
+          break;
         case "searchDomains":
           if (member.getValue() instanceof JsonArray) {
             java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
@@ -113,6 +118,7 @@ import java.time.format.DateTimeFormatter;
     json.put("queryTimeout", obj.getQueryTimeout());
     json.put("rdFlag", obj.getRdFlag());
     json.put("rotateServers", obj.isRotateServers());
+    json.put("roundRobinInetAddress", obj.isRoundRobinInetAddress());
     if (obj.getSearchDomains() != null) {
       JsonArray array = new JsonArray();
       obj.getSearchDomains().forEach(item -> array.add(item));

--- a/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
+++ b/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -84,6 +84,11 @@ public class AddressResolverOptions {
    */
   public static final boolean DEFAULT_ROTATE_SERVERS = AddressResolver.DEFAULT_ROTATE_RESOLV_OPTION;
 
+  /**
+   * The default round robin inet address = false
+   */
+  public static final boolean DEFAULT_ROUND_ROBIN_INET_ADDRESS = false;
+
   private String hostsPath;
   private Buffer hostsValue;
   private List<String> servers;
@@ -97,6 +102,7 @@ public class AddressResolverOptions {
   private List<String> searchDomains;
   private int ndots;
   private boolean rotateServers;
+  private boolean roundRobinInetAddress;
 
   public AddressResolverOptions() {
     servers = DEFAULT_SERVERS;
@@ -110,6 +116,7 @@ public class AddressResolverOptions {
     searchDomains = DEFAULT_SEACH_DOMAINS;
     ndots = DEFAULT_NDOTS;
     rotateServers = DEFAULT_ROTATE_SERVERS;
+    roundRobinInetAddress = DEFAULT_ROUND_ROBIN_INET_ADDRESS;
   }
 
   public AddressResolverOptions(AddressResolverOptions other) {
@@ -126,6 +133,7 @@ public class AddressResolverOptions {
     this.searchDomains = other.searchDomains != null ? new ArrayList<>(other.searchDomains) : null;
     this.ndots = other.ndots;
     this.rotateServers = other.rotateServers;
+    this.roundRobinInetAddress = other.roundRobinInetAddress;
   }
 
   public AddressResolverOptions(JsonObject json) {
@@ -430,6 +438,23 @@ public class AddressResolverOptions {
     return this;
   }
 
+  /**
+   * @return the value {@code true} when the inet address selection uses round robin
+   */
+  public boolean isRoundRobinInetAddress() {
+    return roundRobinInetAddress;
+  }
+
+  /**
+   * Set to {@code true} to enable round-robin inet address selection of the ip address to use.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  public AddressResolverOptions setRoundRobinInetAddress(boolean roundRobinInetAddress) {
+    this.roundRobinInetAddress = roundRobinInetAddress;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -444,8 +469,9 @@ public class AddressResolverOptions {
     if (rdFlag != that.rdFlag) return false;
     if (!Objects.equals(searchDomains, that.searchDomains)) return false;
     if (ndots != that.ndots) return false;
-    if  (servers != null ? !servers.equals(that.servers) : that.servers != null) return false;
-    return rotateServers == that.rotateServers;
+    if (servers != null ? !servers.equals(that.servers) : that.servers != null) return false;
+    if (rotateServers != that.rotateServers) return false;
+    return roundRobinInetAddress == that.roundRobinInetAddress;
   }
 
   @Override
@@ -461,6 +487,7 @@ public class AddressResolverOptions {
     result = 31 * result + ndots;
     result = 31 * result + Boolean.hashCode(rdFlag);
     result = 31 * result + Boolean.hashCode(rotateServers);
+    result = 31 * result + Boolean.hashCode(roundRobinInetAddress);
     return result;
   }
 

--- a/src/main/java/io/vertx/core/impl/resolver/DnsResolverProvider.java
+++ b/src/main/java/io/vertx/core/impl/resolver/DnsResolverProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,12 +14,7 @@ package io.vertx.core.impl.resolver;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.EventLoop;
 import io.netty.channel.socket.DatagramChannel;
-import io.netty.resolver.AddressResolverGroup;
-import io.netty.resolver.HostsFileEntries;
-import io.netty.resolver.HostsFileEntriesResolver;
-import io.netty.resolver.HostsFileParser;
-import io.netty.resolver.NameResolver;
-import io.netty.resolver.ResolvedAddressTypes;
+import io.netty.resolver.*;
 import io.netty.resolver.dns.*;
 import io.netty.util.NetUtil;
 import io.netty.util.concurrent.EventExecutor;
@@ -35,17 +30,8 @@ import io.vertx.core.spi.resolver.ResolverProvider;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
-import java.net.Inet4Address;
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
+import java.net.*;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.netty.util.internal.ObjectUtil.intValue;
@@ -135,6 +121,15 @@ public class DnsResolverProvider implements ResolverProvider {
       protected io.netty.resolver.AddressResolver<InetSocketAddress> newResolver(EventExecutor executor) throws Exception {
         ChannelFactory<DatagramChannel> channelFactory = () -> vertx.transport().datagramChannel();
         DnsAddressResolverGroup group = new DnsAddressResolverGroup(channelFactory, nameServerAddressProvider) {
+          @Override
+          protected final io.netty.resolver.AddressResolver<InetSocketAddress> newAddressResolver(EventLoop eventLoop, NameResolver<InetAddress> resolver) throws Exception {
+            if (options.isRoundRobinInetAddress()) {
+              return new RoundRobinInetAddressResolver(eventLoop, resolver).asAddressResolver();
+            } else {
+              return super.newAddressResolver(eventLoop, resolver);
+            }
+          }
+
           @Override
           protected NameResolver<InetAddress> newNameResolver(EventLoop eventLoop, ChannelFactory<? extends DatagramChannel> channelFactory, DnsServerAddressStreamProvider nameServerProvider) throws Exception {
             DnsNameResolverBuilder builder = new DnsNameResolverBuilder((EventLoop) executor);

--- a/src/test/java/io/vertx/core/dns/HostnameResolutionTest.java
+++ b/src/test/java/io/vertx/core/dns/HostnameResolutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -31,23 +31,22 @@ import io.vertx.core.net.NetServerOptions;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakedns.FakeDNSServer;
+import org.apache.directory.server.dns.messages.RecordClass;
+import org.apache.directory.server.dns.messages.RecordType;
+import org.apache.directory.server.dns.messages.ResourceRecord;
+import org.apache.directory.server.dns.store.DnsAttribute;
 import org.junit.Test;
 
 import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -73,9 +72,12 @@ public class HostnameResolutionTest extends VertxTestBase {
 
   @Override
   protected VertxOptions getOptions() {
-    VertxOptions options = super.getOptions();
-    options.getAddressResolverOptions().addServer(dnsServerAddress.getAddress().getHostAddress() + ":" + dnsServerAddress.getPort());
-    return options;
+    return super.getOptions().setAddressResolverOptions(getAddressResolverOptions());
+  }
+
+  private AddressResolverOptions getAddressResolverOptions() {
+    return new AddressResolverOptions()
+      .addServer(dnsServerAddress.getAddress().getHostAddress() + ":" + dnsServerAddress.getPort());
   }
 
   @Test
@@ -844,6 +846,69 @@ public class HostnameResolutionTest extends VertxTestBase {
     }
   }
 
+  @Test
+  public void testAddressSelectionDefault() throws Exception {
+    testAddressSelection(getAddressResolverOptions(), 1);
+  }
+
+  @Test
+  public void testAddressSelectionWithRoundRobin() throws Exception {
+    testAddressSelection(getAddressResolverOptions().setRoundRobinInetAddress(true), 2);
+  }
+
+  @Test
+  public void testAddressSelectionWithoutRoundRobin() throws Exception {
+    testAddressSelection(getAddressResolverOptions().setRoundRobinInetAddress(false), 1);
+  }
+
+  private void testAddressSelection(AddressResolverOptions options, int expected) throws Exception {
+    Function<String, ResourceRecord> createRecord = ipAddress -> new ResourceRecord() {
+      @Override
+      public String getDomainName() {
+        return "vertx.io";
+      }
+
+      @Override
+      public RecordType getRecordType() {
+        return RecordType.A;
+      }
+
+      @Override
+      public RecordClass getRecordClass() {
+        return RecordClass.IN;
+      }
+
+      @Override
+      public int getTimeToLive() {
+        return 100;
+      }
+
+      @Override
+      public String get(String s) {
+        return DnsAttribute.IP_ADDRESS.equals(s) ? ipAddress : null;
+      }
+    };
+
+    Set<ResourceRecord> records = new LinkedHashSet<>();
+    records.add(createRecord.apply("127.0.0.1"));
+    records.add(createRecord.apply("127.0.0.2"));
+
+    dnsServer.store(question -> records);
+
+    AddressResolver resolver = new AddressResolver(vertx, options);
+    Set<String> resolved = Collections.synchronizedSet(new HashSet<>());
+    //due to the random nature of netty's round robin algorithm
+    //the below outcome is generally non-deterministic and will fail once in about 2^100 runs (virtually never)
+    CountDownLatch latch = new CountDownLatch(100);
+    for (int i = 0; i < 100; i++) {
+      resolver.resolveHostname("vertx.io", onSuccess(inetAddress -> {
+        resolved.add(inetAddress.getHostAddress());
+        latch.countDown();
+      }));
+    }
+    awaitLatch(latch);
+    assertEquals(expected, resolved.size());
+  }
 
   @Test
   public void testServerFailover() throws Exception {


### PR DESCRIPTION
Fixes #3821

This PR brings the original contribution from @ybayk (yurgis.baykshtis[at]clarivate[dot]com) in #2902 with minor simplifications.

It adds a config property in AddressResolverOptions that is check in DnsResolverProvider in order to switch between the default Netty AddressResolver and RoundRobinInetAddressResolver.
