### PR TITLE
Fix HttpClientRequest setURI(uri), query(), path()

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -42,7 +42,6 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   private String uri;
   private String path;
   private String query;
-  private boolean newQuery = true;
   private final PromiseInternal<HttpClientResponse> responsePromise;
   private Handler<HttpClientRequest> pushHandler;
   private long currentTimeoutTimerId = -1;
@@ -54,7 +53,7 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
     this.stream = stream;
     this.responsePromise = responsePromise;
     this.context = responsePromise.context();
-    this.uri = uri;
+    setURI(uri);
     this.method = method;
     this.server = server;
     this.host = host;
@@ -92,10 +91,6 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   }
 
   public String query() {
-    if (newQuery) {
-      newQuery = false;
-      query = HttpUtils.parseQuery(uri);
-    }
     return query;
   }
 
@@ -115,8 +110,7 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
     Objects.requireNonNull(uri);
     this.uri = uri;
     this.path = null; // invalidate
-    this.newQuery = true; // invalidate
-    this.query = null;
+    this.query = HttpUtils.parseQuery(uri);
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -42,6 +42,7 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   private String uri;
   private String path;
   private String query;
+  private boolean newQuery = true;
   private final PromiseInternal<HttpClientResponse> responsePromise;
   private Handler<HttpClientRequest> pushHandler;
   private long currentTimeoutTimerId = -1;
@@ -91,16 +92,16 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   }
 
   public String query() {
-    if (query == null) {
+    if (newQuery) {
+      newQuery = false;
       query = HttpUtils.parseQuery(uri);
-
     }
     return query;
   }
 
   public String path() {
     if (path == null) {
-      path = uri.length() > 0 ? HttpUtils.parsePath(uri) : "";
+      path = HttpUtils.parsePath(uri);
     }
     return path;
   }
@@ -113,7 +114,9 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   public synchronized HttpClientRequest setURI(String uri) {
     Objects.requireNonNull(uri);
     this.uri = uri;
-    this.path = null; // Invalidate
+    this.path = null; // invalidate
+    this.newQuery = true; // invalidate
+    this.query = null;
     return this;
   }
 

--- a/src/test/java/io/vertx/core/http/impl/HttpClientRequestBaseTest.java
+++ b/src/test/java/io/vertx/core/http/impl/HttpClientRequestBaseTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+import org.junit.Test;
+
+import io.vertx.core.http.HttpTestBase;
+import io.vertx.core.http.RequestOptions;
+
+public class HttpClientRequestBaseTest extends HttpTestBase {
+
+  @Test
+  public void testPathCacheAndQueryCache() {
+    server.requestHandler(req -> {});
+    server.listen(testAddress, onSuccess(server -> {
+      client.request(new RequestOptions(requestOptions).setURI("/?"), onSuccess(req -> {
+        assertThat(req.getURI(), is("/?"));
+        assertThat(req.path(), is("/"));
+        assertThat(req.query(), is(""));
+        req.setURI("/foo?bar");
+        assertThat(req.getURI(), is("/foo?bar"));
+        assertThat(req.path(), is("/foo"));
+        assertThat(req.query(), is("bar"));
+        req.setURI("/baz?key=value");
+        assertThat(req.getURI(), is("/baz?key=value"));
+        assertThat(req.path(), is("/baz"));
+        assertThat(req.query(), is("key=value"));
+        req.setURI("");
+        assertThat(req.getURI(), is(""));
+        assertThat(req.path(), is(""));
+        assertThat(req.query(), is(nullValue()));
+        req.setURI("?");
+        assertThat(req.getURI(), is("?"));
+        assertThat(req.path(), is(""));
+        assertThat(req.query(), is(""));
+        testComplete();
+      }));
+    }));
+    await();
+  }
+}

--- a/src/test/java/io/vertx/core/http/impl/HttpClientRequestBaseTest.java
+++ b/src/test/java/io/vertx/core/http/impl/HttpClientRequestBaseTest.java
@@ -28,6 +28,10 @@ public class HttpClientRequestBaseTest extends HttpTestBase {
         assertThat(req.getURI(), is("/?"));
         assertThat(req.path(), is("/"));
         assertThat(req.query(), is(""));
+        req.setURI("/index.html");
+        assertThat(req.getURI(), is("/index.html"));
+        assertThat(req.path(), is("/index.html"));
+        assertThat(req.query(), is(nullValue()));
         req.setURI("/foo?bar");
         assertThat(req.getURI(), is("/foo?bar"));
         assertThat(req.path(), is("/foo"));


### PR DESCRIPTION
* Invalidate query cache in setURI(uri). This fixes a bug
  where query() returns an old and invalid value, the
  new unit test run against the old code demonstrates this.
* Use boolean newQuery to invalidate the query cache as
  HttpUtils.parseQuery(uri) may return null.
* Remove redundant code from path() as
  HttpUtils.parsePath(uri) never returns null.