### PR TITLE
Remove tracer tags ArrayList

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -200,9 +200,6 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
       }
       VertxTracer tracer = context.tracer();
       if (tracer != null) {
-        List<Map.Entry<String, String>> tags = new ArrayList<>();
-        tags.add(new AbstractMap.SimpleEntry<>("http.url", "todo"));
-        tags.add(new AbstractMap.SimpleEntry<>("http.method", request.method.name()));
         BiConsumer<String, String> headers = (key, val) -> nettyRequest.headers().add(key, val);
         stream.trace = tracer.sendRequest(stream.context, SpanKind.RPC, options.getTracingPolicy(), request, request.method.name(), headers, HttpUtils.CLIENT_HTTP_REQUEST_TAG_EXTRACTOR);
       }

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -115,9 +115,6 @@ public class Http2ServerRequest extends Http2ServerStream implements HttpServerR
   void dispatch(Handler<HttpServerRequest> handler) {
     VertxTracer tracer = context.tracer();
     if (tracer != null) {
-      List<Map.Entry<String, String>> tags = new ArrayList<>();
-      tags.add(new AbstractMap.SimpleEntry<>("http.url", absoluteURI()));
-      tags.add(new AbstractMap.SimpleEntry<>("http.method", method.name()));
       trace = tracer.receiveRequest(context, SpanKind.RPC, tracingPolicy, this, method().name(), headers(), HttpUtils.SERVER_REQUEST_TAG_EXTRACTOR);
     }
     context.emit(this, handler);


### PR DESCRIPTION
The HttpUtils.CLIENT_HTTP_REQUEST_TAG_EXTRACTOR extracts the tags, the tags ArrayList is no longer needed.