### PR TITLE
Always throw IndexOutOfBoundsException in CompositeFuture

### DIFF
--- a/src/main/java/io/vertx/core/impl/future/CompositeFutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/future/CompositeFutureImpl.java
@@ -148,7 +148,7 @@ public class CompositeFutureImpl extends FutureImpl<CompositeFuture> implements 
   }
 
   private <T> Future<T> future(int index) {
-    if (index < 0 || index > results.length) {
+    if (index < 0 || index >= results.length) {
       throw new IndexOutOfBoundsException();
     }
     return (Future<T>) results[index];

--- a/src/test/java/io/vertx/core/CompositeFutureTest.java
+++ b/src/test/java/io/vertx/core/CompositeFutureTest.java
@@ -11,7 +11,11 @@
 
 package io.vertx.core;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import io.vertx.test.core.Repeat;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -508,6 +512,20 @@ public class CompositeFutureTest extends FutureTestBase {
     p1.complete("foo");
     p2.complete(4);
     assertEquals(2, count.get());
+  }
+
+  private void testIndexOutOfBounds(ThrowingCallable throwingCallable) {
+    assertThatThrownBy(throwingCallable)
+    .isExactlyInstanceOf(IndexOutOfBoundsException.class).hasMessage(null);
+  }
+
+  @Test
+  public void testIndexOutOfBounds() {
+    CompositeFuture composite = CompositeFuture.all(Future.succeededFuture(), Future.succeededFuture());
+    testIndexOutOfBounds(() -> composite.resultAt(-2));
+    testIndexOutOfBounds(() -> composite.resultAt(-1));
+    testIndexOutOfBounds(() -> composite.resultAt(2));
+    testIndexOutOfBounds(() -> composite.resultAt(3));
   }
 
   @Test


### PR DESCRIPTION
CompositeFutureImpl#future(index) throws
* ArrayIndexOutOfBoundsException if index == results.length
* IndexOutOfBoundsException if index < 0 or index > results.length

This fix changes the index == results.length case to also throw IndexOutOfBoundsException.