### PR TITLE
EventBus node selector should always initialize with initial state request

### DIFF
--- a/src/main/java/io/vertx/core/spi/cluster/impl/DefaultNodeSelector.java
+++ b/src/main/java/io/vertx/core/spi/cluster/impl/DefaultNodeSelector.java
@@ -54,7 +54,7 @@ public class DefaultNodeSelector implements NodeSelector {
 
   @Override
   public void registrationsUpdated(RegistrationUpdateEvent event) {
-    selectors.dataReceived(event.address(), event.registrations());
+    selectors.dataReceived(event.address(), event.registrations(), true);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/spi/cluster/impl/selector/Selectors.java
+++ b/src/main/java/io/vertx/core/spi/cluster/impl/selector/Selectors.java
@@ -61,7 +61,7 @@ public class Selectors {
     clusterManager.getRegistrations(address, getPromise);
     getPromise.future().onComplete(ar -> {
       if (ar.succeeded()) {
-        dataReceived(address, ar.result());
+        dataReceived(address, ar.result(), false);
       } else {
         SelectorEntry entry = map.remove(address);
         if (entry != null && entry.isNotReady()) {
@@ -71,11 +71,11 @@ public class Selectors {
     });
   }
 
-  public void dataReceived(String address, List<RegistrationInfo> registrations) {
+  public void dataReceived(String address, List<RegistrationInfo> registrations, boolean isUpdate) {
     List<String> accessible = computeAccessible(registrations);
     while (true) {
       SelectorEntry previous = map.get(address);
-      if (previous == null) {
+      if (previous == null || (isUpdate && previous.isNotReady())) {
         break;
       }
       SelectorEntry next = previous.data(accessible);


### PR DESCRIPTION
Otherwise some tests can fail because selector is initialized with intermediate data.