### PR TITLE
Give ClusterManager a chance to know if NodeSelector wants updates for an address

### DIFF
--- a/src/main/java/io/vertx/core/spi/cluster/NodeSelector.java
+++ b/src/main/java/io/vertx/core/spi/cluster/NodeSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,18 +13,12 @@ package io.vertx.core.spi.cluster;
 
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.impl.VertxBuilder;
-import io.vertx.core.impl.launcher.commands.BareCommand;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.spi.VertxServiceProvider;
 
-import static io.vertx.core.impl.launcher.commands.BareCommand.METRICS_OPTIONS_PROP_PREFIX;
-
 /**
- * Used by the {@link io.vertx.core.eventbus.EventBus clustered EventBus} to select a node for a given message..
+ * Used by the {@link io.vertx.core.eventbus.EventBus clustered EventBus} to select a node for a given message.
  * <p>
  * This selector is skipped only when the user raises the {@link io.vertx.core.eventbus.DeliveryOptions#setLocalOnly(boolean)} flag.
  * Consequently, implementations must be aware of local {@link io.vertx.core.eventbus.EventBus} registrations.
@@ -77,5 +71,15 @@ public interface NodeSelector extends VertxServiceProvider {
    * Invoked by the {@link ClusterManager} when some handler registrations have been lost.
    */
   void registrationsLost();
+
+  /**
+   * Invoked by the {@link ClusterManager} to determine if the node selector wants updates for the given {@code address}.
+   *
+   * @param address the event bus address
+   * @return {@code true} if the node selector wants updates for the given {@code address}, {@code false} otherwise
+   */
+  default boolean wantsUpdatesFor(String address) {
+    return true;
+  }
 
 }

--- a/src/main/java/io/vertx/core/spi/cluster/impl/DefaultNodeSelector.java
+++ b/src/main/java/io/vertx/core/spi/cluster/impl/DefaultNodeSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -60,5 +60,10 @@ public class DefaultNodeSelector implements NodeSelector {
   @Override
   public void registrationsLost() {
     selectors.dataLost();
+  }
+
+  @Override
+  public boolean wantsUpdatesFor(String address) {
+    return selectors.hasEntryFor(address);
   }
 }

--- a/src/main/java/io/vertx/core/spi/cluster/impl/selector/Selectors.java
+++ b/src/main/java/io/vertx/core/spi/cluster/impl/selector/Selectors.java
@@ -124,4 +124,8 @@ public class Selectors {
       }
     }
   }
+
+  public boolean hasEntryFor(String address) {
+    return map.containsKey(address);
+  }
 }

--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,6 +30,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -475,5 +476,39 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
         }));
       }));
     await();
+  }
+
+  @Test
+  public void testSelectorWantsUpdates() throws Exception {
+    AtomicReference<NodeSelector> nodeSelectorRef = new AtomicReference<>();
+    VertxOptions options = getOptions().setClusterManager(new WrappedClusterManager(getClusterManager()) {
+      @Override
+      public void init(Vertx vertx, NodeSelector nodeSelector) {
+        nodeSelectorRef.set(nodeSelector);
+        super.init(vertx, nodeSelector);
+      }
+    });
+    startNodes(options);
+    assertNotNull(nodeSelectorRef.get());
+    vertices[0].eventBus().consumer(ADDRESS1, msg -> {
+      assertTrue(nodeSelectorRef.get().wantsUpdatesFor(ADDRESS1));
+      testComplete();
+    }).completionHandler(onSuccess(v -> vertices[0].eventBus().send(ADDRESS1, "foo")));
+    await();
+  }
+
+  @Test
+  public void testSelectorDoesNotWantUpdates() throws Exception {
+    AtomicReference<NodeSelector> nodeSelectorRef = new AtomicReference<>();
+    VertxOptions options = getOptions().setClusterManager(new WrappedClusterManager(getClusterManager()) {
+      @Override
+      public void init(Vertx vertx, NodeSelector nodeSelector) {
+        nodeSelectorRef.set(nodeSelector);
+        super.init(vertx, nodeSelector);
+      }
+    });
+    startNodes(options);
+    assertNotNull(nodeSelectorRef.get());
+    assertFalse(nodeSelectorRef.get().wantsUpdatesFor(ADDRESS1));
   }
 }

--- a/src/test/java/io/vertx/core/spi/cluster/WrappedNodeSelector.java
+++ b/src/test/java/io/vertx/core/spi/cluster/WrappedNodeSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -51,5 +51,10 @@ public class WrappedNodeSelector implements NodeSelector {
   @Override
   public void registrationsLost() {
     delegate.registrationsLost();
+  }
+
+  @Override
+  public boolean wantsUpdatesFor(String address) {
+    return delegate.wantsUpdatesFor(address);
   }
 }


### PR DESCRIPTION
This can be useful to reduce load/traffic.
Indeed, cluster managers such as HZ/ISPN/Ignite must query the backend to get a fresh view of the data.
Consequently, if the NodeSelector is not interested, this query can be avoided