### PR TITLE
The HTTP/2 connection metric is registered agains the TCP metrics whe…

### DIFF
--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -347,7 +347,7 @@ public class NetClientOptions extends ClientOptionsBase {
    * @param protocols the protocols
    * @return a reference to this, so the API can be used fluently
    */
-  public ClientOptionsBase setApplicationLayerProtocols(List<String> protocols) {
+  public NetClientOptions setApplicationLayerProtocols(List<String> protocols) {
     this.applicationLayerProtocols = protocols;
     return this;
   }


### PR DESCRIPTION
…n the HTTP/2 connection preface is received. When an HTTP/2 connection is closed before the connection preface is received, the TCP metrics is signaled the connection unregistration without a prior connection registration. As side effect his can lead to incorrect state in a metrics implementation, such as a negative connection count.

We should perform the TCP metrics after the SSL handshake is performed and before the HTTP/2 connection preface is received in order to avoid this situation.