### PR TITLE
#3859 Fix for reply handler still there but timeout has been fired

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
@@ -91,7 +91,7 @@ class ReplyHandler<T> extends HandlerRegistration<T> {
       fail((ReplyException) reply.body());
     } else {
       trace(reply, null);
-      result.complete(reply);
+      result.tryComplete(reply);
     }
   }
 }


### PR DESCRIPTION
Motivation:

Avoid an exception under heavy load, then there have been timeout on the event bus
Under load, we can see the following exception:

```
java.lang.IllegalStateException: Result is already complete
	at io.vertx.core.Promise.complete(Promise.java:67)
	at io.vertx.core.eventbus.impl.ReplyHandler.dispatch(ReplyHandler.java:94)
	at io.vertx.core.eventbus.impl.HandlerRegistration$InboundDeliveryContext.next(HandlerRegistration.java:163)
	at io.vertx.core.eventbus.impl.HandlerRegistration$InboundDeliveryContext.dispatch(HandlerRegistration.java:128)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:107)
	at io.vertx.core.eventbus.impl.HandlerRegistration.dispatch(HandlerRegistration.java:104)
	at io.vertx.core.eventbus.impl.ReplyHandler.doReceive(ReplyHandler.java:75)
	at io.vertx.core.eventbus.impl.HandlerRegistration.lambda$receive$0(HandlerRegistration.java:54)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:834)

```

This is because the reply handler call complete instead of tryComplete() when the message reply timeout has been fired.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
