### PR TITLE
Fix #3865: Allow VertxHttpHeaders to process none-CharSequence headers to restore compatibility with Netty 4.1.60

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -143,12 +143,20 @@ public final class VertxHttpHeaders extends HttpHeaders implements MultiMap {
 
   @Override
   public VertxHttpHeaders set(String name, Object value) {
-    return set((CharSequence)name, (CharSequence) value);
+    if (value == null || value instanceof CharSequence) {
+      return set((CharSequence) name, (CharSequence) value);
+    } else {
+      return set((CharSequence) name, String.valueOf(value));
+    }
   }
 
   @Override
   public VertxHttpHeaders set(CharSequence name, Object value) {
-    return set(name, (CharSequence)value);
+    if (value == null || value instanceof CharSequence) {
+      return set(name, (CharSequence) value);
+    } else {
+      return set(name, String.valueOf(value));
+    }
   }
 
   @Override

--- a/src/test/java/io/vertx/core/http/VertxHttpHeadersTest.java
+++ b/src/test/java/io/vertx/core/http/VertxHttpHeadersTest.java
@@ -11,9 +11,12 @@
 
 package io.vertx.core.http;
 
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.util.AsciiString;
 import io.vertx.core.MultiMap;
+import io.vertx.core.http.impl.HeadersAdaptor;
 import io.vertx.core.http.impl.headers.VertxHttpHeaders;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -140,6 +143,22 @@ public class VertxHttpHeadersTest extends HeadersTestBase {
     ArrayList<CharSequence> values = new ArrayList<>();
     values.add("somevalue");
     assertEquals(": somevalue\n", mmap.set(name, values).toString());
+  }
+
+  @Test
+  public void testSetStringNameLongValue() {
+    MultiMap mmap = newMultiMap();
+    Assume.assumeTrue(mmap instanceof HttpHeaders);
+    String name = "longvalue";
+    assertEquals("longvalue: 1234\n", ((HttpHeaders) mmap).set(name, 1234L).toString());
+  }
+
+  @Test
+  public void testSetCharSequenceNameLongValue() {
+    MultiMap mmap = newMultiMap();
+    Assume.assumeTrue(mmap instanceof HttpHeaders);
+    CharSequence name = "longvalue";
+    assertEquals("longvalue: 1234\n", ((HttpHeaders) mmap).set(name, 1234L).toString());
   }
 
   @Test


### PR DESCRIPTION
Motivation:

The background is explained in #3865. The intent of this change to to reintroduce compatibility between Vertx 3.9 and Netty 4.1.60 by allowing VertxHttpHeaders#set to process none-CharSequence header values. 


Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
