### PR TITLE
Explicitly document and test the 'stream()' contract

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -12,7 +12,6 @@
 package io.vertx.core.json;
 
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.shareddata.Shareable;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 
@@ -584,12 +583,20 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
   }
 
   /**
-   * Get a Stream over the entries in the JSON array
+   * Get a Stream over the entries in the JSON array. The values in the stream will follow
+   * the same rules as defined in {@link #getValue(int)}, respecting the JSON requirements.
+   *
+   * To stream the raw values, use the storage object stream instead:
+   * <pre>{@code
+   *   jsonArray
+   *     .getList()
+   *     .stream()
+   * }</pre>
    *
    * @return a Stream
    */
   public Stream<Object> stream() {
-    return JsonObject.asStream(iterator());
+    return asStream(iterator());
   }
 
   @Override

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -795,7 +795,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   }
 
   /**
-   * Get a Stream over the entries in the JSON array. The values in the stream will follow
+   * Get a Stream over the entries in the JSON object. The values in the stream will follow
    * the same rules as defined in {@link #getValue(String)}, respecting the JSON requirements.
    *
    * To stream the raw values, use the storage object stream instead:

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -11,7 +11,6 @@
 package io.vertx.core.json;
 
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.shareddata.Shareable;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 
@@ -19,7 +18,6 @@ import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static io.vertx.core.json.impl.JsonUtil.*;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
@@ -797,9 +795,17 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   }
 
   /**
-   * Get a stream of the entries in the JSON object.
+   * Get a Stream over the entries in the JSON array. The values in the stream will follow
+   * the same rules as defined in {@link #getValue(String)}, respecting the JSON requirements.
    *
-   * @return a stream of the entries.
+   * To stream the raw values, use the storage object stream instead:
+   * <pre>{@code
+   *   jsonObject
+   *     .getMap()
+   *     .stream()
+   * }</pre>
+   *
+   * @return a Stream
    */
   public Stream<Map.Entry<String, Object>> stream() {
     return asStream(iterator());
@@ -999,10 +1005,4 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
       throw new UnsupportedOperationException();
     }
   }
-
-  static <T> Stream<T> asStream(Iterator<T> sourceIterator) {
-    Iterable<T> iterable = () -> sourceIterator;
-    return StreamSupport.stream(iterable.spliterator(), false);
-  }
-
 }

--- a/src/main/java/io/vertx/core/json/impl/JsonUtil.java
+++ b/src/main/java/io/vertx/core/json/impl/JsonUtil.java
@@ -17,9 +17,12 @@ import io.vertx.core.shareddata.Shareable;
 
 import java.time.Instant;
 import java.util.Base64;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
@@ -121,5 +124,10 @@ public final class JsonUtil {
       val = copier.apply(val);
     }
     return val;
+  }
+
+  public static <T> Stream<T> asStream(Iterator<T> sourceIterator) {
+    Iterable<T> iterable = () -> sourceIterator;
+    return StreamSupport.stream(iterable.spliterator(), false);
   }
 }

--- a/src/test/java/io/vertx/core/json/JsonArrayTest.java
+++ b/src/test/java/io/vertx/core/json/JsonArrayTest.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -1377,5 +1378,33 @@ public class JsonArrayTest {
     assertEquals(Short.MIN_VALUE + (42000 - Short.MAX_VALUE - 1), n.shortValue());
     // but not overflow if int
     assertEquals(42000, n.intValue());
+  }
+
+  @Test
+  public void testStreamRawVSJSON() {
+    JsonArray arr = new JsonArray().add(TimeUnit.DAYS).add(TimeUnit.MINUTES);
+
+    // assert that stream values are converted to String as per JSON rules
+    List <?> jsonData = arr
+      .stream()
+      .peek(t -> assertTrue(t instanceof String))
+      .collect(Collectors.toList());
+
+    for (Object o : jsonData) {
+      assertTrue(o instanceof String);
+    }
+
+    // test raw
+
+    // assert that stream values are converted to String as per JSON rules
+    List<?> rawData = (List<?>) arr
+      .getList()
+      .stream()
+      .peek(t -> assertTrue(t instanceof TimeUnit))
+      .collect(Collectors.toList());
+
+    for (Object o : rawData) {
+      assertTrue(o instanceof TimeUnit);
+    }
   }
 }

--- a/src/test/java/io/vertx/core/json/JsonObjectTest.java
+++ b/src/test/java/io/vertx/core/json/JsonObjectTest.java
@@ -22,6 +22,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -1893,4 +1894,42 @@ public class JsonObjectTest {
       assertNumberEquals(n, numbers.getNumber("missingKey", n));
     }
   }
+
+  @Test
+  public void testStreamRawVSJSON() {
+    JsonObject obj = new JsonObject()
+      .put("days", TimeUnit.DAYS)
+      .put("minutes", TimeUnit.MINUTES);
+
+    // assert that stream values are converted to String as per JSON rules
+    List <Map.Entry> jsonData = obj
+      .stream()
+      .peek(t -> {
+        assertTrue(t instanceof Map.Entry);
+        assertTrue(t.getValue() instanceof String);
+      })
+      .collect(Collectors.toList());
+
+    for (Map.Entry o : jsonData) {
+      assertTrue(o.getValue() instanceof String);
+    }
+
+    // test raw
+
+    // assert that stream values are converted to String as per JSON rules
+    List<Map.Entry<String, ?>> rawData = obj
+      .getMap()
+      .entrySet()
+      .stream()
+      .peek(t -> {
+        assertTrue(t instanceof Map.Entry);
+        assertTrue(t.getValue() instanceof TimeUnit);
+      })
+      .collect(Collectors.toList());
+
+    for (Map.Entry<String, ?> o : rawData) {
+      assertTrue(o.getValue() instanceof TimeUnit);
+    }
+  }
+
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Explicitly document and test the `stream()` contract on JSON types.

Fixes #3873 