### PR TITLE
Minor fixes to VertxOptions

### DIFF
--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -623,10 +623,21 @@ public class VertxOptions {
     return this;
   }
 
+  /**
+   * If tracing is disabled, the value will be {@code null}.
+   *
+   * @return the tracing options
+   */
   public TracingOptions getTracingOptions() {
     return tracingOptions;
   }
 
+  /**
+   * Set the tracing options
+   *
+   * @param tracingOptions the options
+   * @return a reference to this, so the API can be used fluently
+   */
   public VertxOptions setTracingOptions(TracingOptions tracingOptions) {
     this.tracingOptions = tracingOptions;
     return this;
@@ -656,6 +667,7 @@ public class VertxOptions {
         ", quorumSize=" + quorumSize +
         ", haGroup='" + haGroup + '\'' +
         ", metrics=" + metricsOptions +
+        ", tracing=" + tracingOptions +
         ", fileSystemOptions=" + fileSystemOptions +
         ", addressResolver=" + addressResolverOptions.toJson() +
         ", eventbus=" + eventBusOptions.toJson() +

--- a/src/test/java/io/vertx/core/VertxOptionsTest.java
+++ b/src/test/java/io/vertx/core/VertxOptionsTest.java
@@ -15,9 +15,11 @@ import io.vertx.core.file.FileSystemOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.core.tracing.TracingOptions;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakecluster.FakeClusterManager;
+import io.vertx.test.faketracer.FakeTracerFactory;
 import org.junit.Test;
 
 import java.util.Random;
@@ -249,6 +251,9 @@ public class VertxOptionsTest extends VertxTestBase {
     options.setMetricsOptions(
         new MetricsOptions().
             setEnabled(metricsEnabled));
+    options.setTracingOptions(
+        new TracingOptions().setFactory(new FakeTracerFactory())
+    );
     options.setWarningExceptionTime(warningExceptionTime);
     options.setMaxEventLoopExecuteTimeUnit(maxEventLoopExecuteTimeUnit);
     options.setMaxWorkerExecuteTimeUnit(maxWorkerExecuteTimeUnit);
@@ -274,6 +279,9 @@ public class VertxOptionsTest extends VertxTestBase {
     MetricsOptions metricsOptions = options.getMetricsOptions();
     assertNotNull(metricsOptions);
     assertEquals(metricsEnabled, metricsOptions.isEnabled());
+    TracingOptions tracingOptions = options.getTracingOptions();
+    assertNotNull(tracingOptions);
+    assertTrue(tracingOptions.getFactory() instanceof FakeTracerFactory);
     assertEquals(warningExceptionTime, options.getWarningExceptionTime());
     assertEquals(maxEventLoopExecuteTimeUnit, options.getMaxEventLoopExecuteTimeUnit());
     assertEquals(maxWorkerExecuteTimeUnit, options.getMaxWorkerExecuteTimeUnit());
@@ -386,6 +394,7 @@ public class VertxOptionsTest extends VertxTestBase {
             put("enabled", metricsEnabled).
             put("jmxEnabled", jmxEnabled).
             put("jmxDomain", jmxDomain)).
+        put("tracingOptions", new JsonObject()).
         put("maxEventLoopExecuteTimeUnit", maxEventLoopExecuteTimeUnit).
         put("maxWorkerExecuteTimeUnit", maxWorkerExecuteTimeUnit).
         put("warningExceptionTimeUnit", warningExceptionTimeUnit).
@@ -412,6 +421,7 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(fileResolverCachingEnabled, fileSystemOptions.isFileCachingEnabled());
     MetricsOptions metricsOptions = options.getMetricsOptions();
     assertEquals(metricsEnabled, metricsOptions.isEnabled());
+    assertNotNull(options.getTracingOptions());
     assertEquals(warningExceptionTime, options.getWarningExceptionTime());
     assertEquals(maxEventLoopExecuteTimeUnit, options.getMaxEventLoopExecuteTimeUnit());
     assertEquals(maxWorkerExecuteTimeUnit, options.getMaxWorkerExecuteTimeUnit());


### PR DESCRIPTION
Fixes #3875

- Document `null` indicating Tracing is disabled
- Add `TracerOptions` to `toString()`
- Add `TracerOptions` into `VertxOptionsTest`

Signed-off-by: Ken Finnigan <ken@kenfinnigan.me>