### PR TITLE
Change the sharedTCPServers method to work with custom implementation of HttpServerImpl and NetServerImpl

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -435,9 +435,9 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public <S extends TCPServerBase> Map<ServerID, S> sharedTCPServers(Class<S> type) {
-    if (type == NetServerImpl.class) {
+    if (NetServerImpl.class.isAssignableFrom(type)) {
       return (Map<ServerID, S>) sharedNetServers;
-    } else if (type == HttpServerImpl.class) {
+    } else if (HttpServerImpl.class.isAssignableFrom(type)) {
       return (Map<ServerID, S>) sharedHttpServers;
     } else {
       throw new IllegalStateException();


### PR DESCRIPTION
Signed-off-by: Benjamin Roux <ben.dev@outlook.com>

Motivation:

In many of our projects we ended-up having to inherit from HttpServerImpl and NetServerImpl in order to do custom things that cannot be done elsewhere. After migrating to VertX 4, the server cannot start because it's checking for the exact type instead of type and subtypes (VertX 3 had two methods sharedHttpServers/sharedNetServers so it didn't cause a problem).
