### PR TITLE
Do not publish local consumer addressses to cluster

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -237,11 +237,11 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
 
   protected <T> HandlerHolder<T> addRegistration(String address, HandlerRegistration<T> registration, boolean replyHandler, boolean localOnly, Promise<Void> promise) {
     HandlerHolder<T> holder = addLocalRegistration(address, registration, replyHandler, localOnly);
-    onLocalRegistration(holder, promise);
+    onLocalRegistration(holder, promise, localOnly);
     return holder;
   }
 
-  protected <T> void onLocalRegistration(HandlerHolder<T> handlerHolder, Promise<Void> promise) {
+  protected <T> void onLocalRegistration(HandlerHolder<T> handlerHolder, Promise<Void> promise, boolean localOnly) {
     if (promise != null) {
       promise.complete();
     }
@@ -398,6 +398,10 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
                                     ReplyHandler<T> handler, Promise<Void> writePromise) {
     checkStarted();
     sendOrPubInternal(newSendContext(message, options, handler, writePromise));
+  }
+
+  public boolean isAddressLocal(String address) {
+    return handlerMap.containsKey(address);
   }
 
   private Future<Void> unregisterAll() {


### PR DESCRIPTION
Motivation:

Provides a solution for bug reported in #3882.  TLDR; local only addresses should not be published to cluster, this returns behavior closer to what is observer in Vert.X 3.9.x where a `localOnly` consumer will not generate a registration in the cluster.


