### PR TITLE
Use Netty's DecoderResult.isSuccess()

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -121,7 +121,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
   public void handleMessage(Object msg) {
     if (msg instanceof HttpRequest) {
       DefaultHttpRequest request = (DefaultHttpRequest) msg;
-      if (request.decoderResult() != DecoderResult.SUCCESS) {
+      if (!request.decoderResult().isSuccess()) {
         handleError(request);
         return;
       }
@@ -171,7 +171,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
 
   private void onContent(Object msg) {
     HttpContent content = (HttpContent) msg;
-    if (content.decoderResult() != DecoderResult.SUCCESS) {
+    if (!content.decoderResult().isSuccess()) {
       handleError(content);
       return;
     }


### PR DESCRIPTION
Motivation:

This is a small fix. I was investigating a build failure [here](https://github.com/yuzawa-san/googolplex-theater/pull/110/checks?check_run_id=2267749072) related to upgrading to netty 4.1.63 and eventually found an issue here relating to the DecoderResult check which will fail in newer versions of netty (in the upgrade from 4.1.60 to 4.1.61). It was specifically [this change](https://github.com/netty/netty/pull/11068) with the introduction of a [subclass](https://github.com/netty/netty/pull/11068/files#diff-e26989b9171ef22c27c9f7d80689cfb059d568c9bd10e75970d96c02d0654878R633) which broke Vert.x since this project uses an instance comparison currently. The solution is to use the DecoderResult.isSuccess() method which [compares within the "Signal" in the DecoderResult class](https://github.com/netty/netty/blob/netty-4.1.60.Final/codec/src/main/java/io/netty/handler/codec/DecoderResult.java#L43). I did not upgrade the Netty dependency in this PR, but I could if you want to. I am simply making this future proof for if/when that is done. This should be safe since isSuccess() exists in netty 4.1.60.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
