### PR TITLE
Expose AsyncFile size

### DIFF
--- a/src/main/java/io/vertx/core/file/AsyncFile.java
+++ b/src/main/java/io/vertx/core/file/AsyncFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -181,4 +181,30 @@ public interface AsyncFile extends ReadStream<Buffer>, WriteStream<Buffer> {
    */
   @Fluent
   AsyncFile setReadBufferSize(int readBufferSize);
+
+  /**
+   * Like {@link #size()} but blocking.
+   *
+   * @throws FileSystemException if an error occurs
+   */
+  default long sizeBlocking() {
+    return -1;
+  }
+
+  /**
+   * Like {@link #size()} but the {@code handler} will be called when the operation is complete or if an error occurs.
+   */
+  default void size(Handler<AsyncResult<Long>> handler) {
+    Future<Long> future = size();
+    if (handler != null) {
+      future.onComplete(handler);
+    }
+  }
+
+  /**
+   * @return the size of the file, or {@code -1} if not supported
+   */
+  default Future<Long> size() {
+    return Future.succeededFuture(-1L);
+  }
 }

--- a/src/main/java/io/vertx/core/file/AsyncFile.java
+++ b/src/main/java/io/vertx/core/file/AsyncFile.java
@@ -200,7 +200,7 @@ public interface AsyncFile extends ReadStream<Buffer>, WriteStream<Buffer> {
   }
 
   /**
-   * @return the size of the file, or {@code -1} if not supported
+   * @return the size of the file
    */
   Future<Long> size();
 }

--- a/src/main/java/io/vertx/core/file/AsyncFile.java
+++ b/src/main/java/io/vertx/core/file/AsyncFile.java
@@ -187,9 +187,7 @@ public interface AsyncFile extends ReadStream<Buffer>, WriteStream<Buffer> {
    *
    * @throws FileSystemException if an error occurs
    */
-  default long sizeBlocking() {
-    return -1;
-  }
+  long sizeBlocking();
 
   /**
    * Like {@link #size()} but the {@code handler} will be called when the operation is complete or if an error occurs.
@@ -204,7 +202,5 @@ public interface AsyncFile extends ReadStream<Buffer>, WriteStream<Buffer> {
   /**
    * @return the size of the file, or {@code -1} if not supported
    */
-  default Future<Long> size() {
-    return Future.succeededFuture(-1L);
-  }
+  Future<Long> size();
 }

--- a/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -587,11 +587,7 @@ public class AsyncFileImpl implements AsyncFile {
   @Override
   public Future<Long> size() {
     return vertx.getOrCreateContext().executeBlockingInternal(prom -> {
-      try {
-        prom.complete(ch.size());
-      } catch (IOException e) {
-        prom.fail(e);
-      }
+      prom.complete(sizeBlocking());
     });
   }
 }

--- a/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -573,5 +573,25 @@ public class AsyncFileImpl implements AsyncFile {
     } else {
       closedDeferred = () -> doClose(handler);
     }
+  }
+
+  @Override
+  public long sizeBlocking() {
+    try {
+      return ch.size();
+    } catch (IOException e) {
+      throw new FileSystemException(e);
+    }
+  }
+
+  @Override
+  public Future<Long> size() {
+    return vertx.getOrCreateContext().executeBlockingInternal(prom -> {
+      try {
+        prom.complete(ch.size());
+      } catch (IOException e) {
+        prom.fail(e);
+      }
+    });
   }
 }

--- a/src/test/java/io/vertx/core/file/FileSystemTest.java
+++ b/src/test/java/io/vertx/core/file/FileSystemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -2310,5 +2311,29 @@ public class FileSystemTest extends VertxTestBase {
     assertTrue(Files.exists(path));
     String perms = PosixFilePermissions.toString(Files.getPosixFilePermissions(path));
     assertEquals(perms, DEFAULT_FILE_PERMS);
+  }
+
+  @Test
+  public void testFileSize() throws Exception {
+    String fileName = "some-file.dat";
+    int expected = ThreadLocalRandom.current().nextInt(1000, 2000);
+    createFileWithJunk(fileName, expected);
+    AsyncFile file = vertx.fileSystem().openBlocking(testDir + pathSep + fileName, new OpenOptions());
+    file.size(onSuccess(size -> {
+      assertEquals(expected, size.longValue());
+      file.close(onSuccess(v -> testComplete()));
+    }));
+    await();
+  }
+
+  @Test
+  public void testFileSizeBlocking() throws Exception {
+    String fileName = "some-file.dat";
+    int expected = ThreadLocalRandom.current().nextInt(1000, 2000);
+    createFileWithJunk(fileName, expected);
+    AsyncFile file = vertx.fileSystem().openBlocking(testDir + pathSep + fileName, new OpenOptions());
+    assertEquals(expected, file.sizeBlocking());
+    file.close(onSuccess(v -> testComplete()));
+    await();
   }
 }


### PR DESCRIPTION
Closes #3892

AsyncFileImpl can get the file size from the underlying AsynchronousFileChannel.
But it was not exposed.