### PR TITLE
Local codecs

### DIFF
--- a/src/main/asciidoc/override/eventbus.adoc
+++ b/src/main/asciidoc/override/eventbus.adoc
@@ -22,3 +22,22 @@ You unregister a message codec with {@link io.vertx.core.eventbus.EventBus#unreg
 
 Message codecs don't always have to encode and decode as the same type. For example you can write a codec that
 allows a MyPOJO class to be sent, but when that message is sent to a handler it arrives as a MyOtherPOJO class.
+
+===== Local codecs
+
+When sending messages to local consumers, you often don't need serialization and deserialization, but you still need to
+ensure no thread unsafe data is going to be shared in the message body.
+In order to do that, you can create a local codec using {@link io.vertx.core.eventbus.MessageCodec#localCodec},
+specifying either a {@link io.vertx.core.shareddata.Shareable} class, or any class and an associated function to perform the copy:
+
+[source,java]
+----
+{@link docoverride.eventbus.Examples#example12}
+----
+
+If the type is immutable, you can just use the identity function:
+
+[source,java]
+----
+{@link docoverride.eventbus.Examples#example13}
+----

--- a/src/main/asciidoc/override/eventbus.adoc
+++ b/src/main/asciidoc/override/eventbus.adoc
@@ -27,8 +27,8 @@ allows a MyPOJO class to be sent, but when that message is sent to a handler it 
 
 When sending messages to local consumers, you often don't need serialization and deserialization, but you still need to
 ensure no thread unsafe data is going to be shared in the message body.
-In order to do that, you can create a local codec using {@link io.vertx.core.eventbus.MessageCodec#localCodec},
-specifying either a {@link io.vertx.core.shareddata.Shareable} class, or any class and an associated function to perform the copy:
+In order to do that, you can create a local codec, that is a codec that works only for local event bus dispatch and makes sure the copy function is properly invoked.
+Using {@link io.vertx.core.eventbus.EventBus#registerLocalCodec}, specifying either a {@link io.vertx.core.shareddata.Shareable} class, or a class and the associated function to perform the copy, you create a local codec and register it as default:
 
 [source,java]
 ----
@@ -41,3 +41,5 @@ If the type is immutable, you can just use the identity function:
 ----
 {@link docoverride.eventbus.Examples#example13}
 ----
+
+You can also create a local codec manually using {@link io.vertx.core.eventbus.MessageCodec#localCodec}.

--- a/src/main/java/docoverride/eventbus/Examples.java
+++ b/src/main/java/docoverride/eventbus/Examples.java
@@ -14,7 +14,10 @@ package docoverride.eventbus;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.core.shareddata.Shareable;
 import io.vertx.docgen.Source;
+
+import java.util.function.Function;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -38,14 +41,29 @@ public class Examples {
     eventBus.send("orders", new MyPOJO());
   }
 
+  public void example12(EventBus eventBus) {
+    // Class does not implement Shareable
+    eventBus.registerDefaultCodec(MyPOJO.class, MessageCodec.localCodec(MyPOJO.class, MyPOJO::copy));
+
+    // Class implements Shareable
+    eventBus.registerDefaultCodec(MyPOJO.class, MessageCodec.localCodec(MyPOJO.class));
+  }
+
+  public void example13(EventBus eventBus) {
+    // Class is immutable, so there's no need to copy
+    eventBus.registerDefaultCodec(MyPOJO.class, MessageCodec.localCodec(MyPOJO.class, Function.identity()));
+  }
+
   public void headers(EventBus eventBus) {
     DeliveryOptions options = new DeliveryOptions();
     options.addHeader("some-header", "some-value");
     eventBus.send("news.uk.sport", "Yay! Someone kicked a ball", options);
   }
 
-  class MyPOJO {
-
+  class MyPOJO implements Shareable {
+    public MyPOJO copy() {
+      return null;
+    }
   }
 
 }

--- a/src/main/java/docoverride/eventbus/Examples.java
+++ b/src/main/java/docoverride/eventbus/Examples.java
@@ -43,15 +43,15 @@ public class Examples {
 
   public void example12(EventBus eventBus) {
     // Class does not implement Shareable
-    eventBus.registerDefaultCodec(MyPOJO.class, MessageCodec.localCodec(MyPOJO.class, MyPOJO::copy));
+    eventBus.registerLocalCodec(MyPOJO.class, MyPOJO::copy);
 
     // Class implements Shareable
-    eventBus.registerDefaultCodec(MyPOJO.class, MessageCodec.localCodec(MyPOJO.class));
+    eventBus.registerLocalCodec(MyPOJO.class);
   }
 
   public void example13(EventBus eventBus) {
     // Class is immutable, so there's no need to copy
-    eventBus.registerDefaultCodec(MyPOJO.class, MessageCodec.localCodec(MyPOJO.class, Function.identity()));
+    eventBus.registerLocalCodec(MyPOJO.class, Function.identity());
   }
 
   public void headers(EventBus eventBus) {

--- a/src/main/java/io/vertx/core/eventbus/EventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBus.java
@@ -19,6 +19,9 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.metrics.Measured;
+import io.vertx.core.shareddata.Shareable;
+
+import java.util.function.Function;
 
 /**
  * A Vert.x event-bus is a light-weight distributed messaging system which allows different parts of your application,
@@ -250,16 +253,42 @@ public interface EventBus extends Measured {
   /**
    * Unregister a default message codec.
    * <p>
-   * @param clazz  the class for which the codec was registered
+   *
+   * @param clazz the class for which the codec was registered
    * @return a reference to this, so the API can be used fluently
    */
   @GenIgnore
   EventBus unregisterDefaultCodec(Class clazz);
 
   /**
+   * Register a default local message codec for a shareable class.
+   * This is equivalent to creating a {@link MessageCodec#localCodec(Class)} and registering it with {@link #registerDefaultCodec(Class, MessageCodec)}.
+   *
+   * @param clazz the shareable class
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore
+  default <T extends Shareable> EventBus registerLocalCodec(Class<T> clazz) {
+    return this.registerDefaultCodec(clazz, MessageCodec.localCodec(clazz));
+  }
+
+  /**
+   * Register a default local message codec for a class, providing a copy method.
+   * This is equivalent to creating a {@link MessageCodec#localCodec(Class, Function)} and registering it with {@link #registerDefaultCodec(Class, MessageCodec)}.
+   *
+   * @param clazz the class
+   * @param copy  the copy function to copy clazz instances
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore
+  default <T extends Shareable> EventBus registerLocalCodec(Class<T> clazz, Function<T, T> copy) {
+    return this.registerDefaultCodec(clazz, MessageCodec.localCodec(clazz, copy));
+  }
+
+  /**
    * Add an interceptor that will be called whenever a message is sent from Vert.x
    *
-   * @param interceptor  the interceptor
+   * @param interceptor the interceptor
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent

--- a/src/main/java/io/vertx/core/eventbus/MessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/MessageCodec.java
@@ -103,7 +103,7 @@ public interface MessageCodec<S, R> {
    * Like {@link #localCodec(Class)}, but specifying the copy function manually.
    */
   @GenIgnore
-  static <T extends Shareable> MessageCodec<T, T> localCodec(Class<T> clazz, Function<T, T> copy) {
+  static <T> MessageCodec<T, T> localCodec(Class<T> clazz, Function<T, T> copy) {
     return new LocalShareableCodec<T>("local." + clazz.getSimpleName(), copy);
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/LocalShareableCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/LocalShareableCodec.java
@@ -1,0 +1,45 @@
+package io.vertx.core.eventbus.impl.codecs;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+
+import java.util.function.Function;
+
+/**
+ * @author <a href="http://slinkydeveloper.com">Francesco Guardiani</a>
+ */
+public class LocalShareableCodec<T> implements MessageCodec<T, T> {
+
+  private final String name;
+  private final Function<T, T> copyFunction;
+
+  public LocalShareableCodec(String name, Function<T, T> copyFunction) {
+    this.name = name;
+    this.copyFunction = copyFunction;
+  }
+
+  @Override
+  public void encodeToWire(Buffer buffer, T o) {
+    throw new UnsupportedOperationException("This class doesn't support encoding to the wire");
+  }
+
+  @Override
+  public T decodeFromWire(int pos, Buffer buffer) {
+    throw new UnsupportedOperationException("This class doesn't support decoding from the wire");
+  }
+
+  @Override
+  public T transform(T o) {
+    return this.copyFunction.apply(o);
+  }
+
+  @Override
+  public String name() {
+    return this.name;
+  }
+
+  @Override
+  public byte systemCodecID() {
+    return -1;
+  }
+}


### PR DESCRIPTION
Fix #3378

This PR adds the concept of local codecs, which is a way to simplify sending copyable and immutable data through the local event bus.