### PR TITLE
remove redundant call to set io.netty.noJdkZlibDecoder to false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test-tmp
 *.class
 *.swp
 .vertx
+.java-version

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -95,9 +95,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
         System.getProperty("io.netty.leakDetectionLevel") == null) {
       ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
     }
-
-    // Use the JDK deflater/inflater by default
-    System.setProperty("io.netty.noJdkZlibDecoder", "false");
   }
 
   private final FileSystem fileSystem = getFileSystem();


### PR DESCRIPTION
Following the discussion in the following google group thread: https://groups.google.com/g/vertx/c/uRU6PYd3CKs/m/2nRuqCaEAgAJ

I would like to remove the redundant `System.setProperty("io.netty.noJdkZlibDecoder", "false")`

Closes #3907
