### PR TITLE
fix: typo in OpenOptions javadoc

### DIFF
--- a/src/main/java/io/vertx/core/file/OpenOptions.java
+++ b/src/main/java/io/vertx/core/file/OpenOptions.java
@@ -274,7 +274,7 @@ public class OpenOptions {
   }
 
   /**
-   * Set whether every write to the file's content  ill be written synchronously to the underlying hardware.
+   * Set whether every write to the file's content will be written synchronously to the underlying hardware.
    * @param dsync  true if sync
    * @return a reference to this, so the API can be used fluently
    */


### PR DESCRIPTION
Motivation:

Just find a little typo reading the javadoc :)
