### PR TITLE
Fixed typos and commas in asciidocs. Removed duplicated words in comm…

### DIFF
--- a/src/main/asciidoc/cli.adoc
+++ b/src/main/asciidoc/cli.adoc
@@ -72,7 +72,7 @@ the command line:
 An option can be _hidden_ using the {@link io.vertx.core.cli.Option#setHidden(boolean)} method. Hidden option are
 not listed in the usage, but can still be used in the user command line (for power-users).
 
-If the option value is contrained to a fixed set, you can set the different acceptable choices:
+If the option value is constrained to a fixed set, you can set the different acceptable choices:
 
 [source,$lang]
 ----
@@ -122,7 +122,7 @@ Once your {@link io.vertx.core.cli.CLI} instance is configured, you can generate
 {@link examples.cli.CLIExamples#example6}
 ----
 
-It generates an usage message like this one:
+It generates a usage message like this one:
 
 [source]
 ----

--- a/src/main/asciidoc/datagrams.adoc
+++ b/src/main/asciidoc/datagrams.adoc
@@ -4,17 +4,17 @@ Using User Datagram Protocol (UDP) with Vert.x is a piece of cake.
 
 UDP is a connection-less transport which basically means you have no persistent connection to a remote peer.
 
-Instead you can send and receive packages and the remote address is contained in each of them.
+Instead, you can send and receive packages and the remote address is contained in each of them.
 
 Beside this UDP is not as safe as TCP to use, which means there are no guarantees that a send Datagram packet will
 receive it's endpoint at all.
 
 The only guarantee is that it will either receive complete or not at all.
 
-Also you usually can't send data which is bigger then the MTU size of your network interface, this is because each
+Also, you usually can't send data which is bigger then the MTU size of your network interface, this is because each
 packet will be send as one packet.
 
-But be aware even if the packet size is smaller then the MTU it may still fail.
+But, be aware even if the packet size is smaller then the MTU it may still fail.
 
 At which size it will fail depends on the Operating System etc. So rule of thumb is to try to send small packets.
 
@@ -87,7 +87,7 @@ to which you can then send packets.
 
 We will look at how you can join a Multicast Group and receive packets in the next section.
 
-Sending multicast packets is not different than sending normal Datagram packets.  The difference is that you pass
+Sending multicast packets is not different from sending normal Datagram packets. The difference is that you pass
 in a multicast group address to the send method.
 
 This is show here:

--- a/src/main/asciidoc/dns.adoc
+++ b/src/main/asciidoc/dns.adoc
@@ -122,7 +122,7 @@ The {@link io.vertx.core.dns.MxRecord} allows you to access the priority and the
 
 === resolveTXT
 
-Try to resolve all TXT records for a given name. TXT records are often used to define extra informations for a domain.
+Try to resolve all TXT records for a given name. TXT records are often used to define extra information for a domain.
 
 To resolve all the TXT records for "vertx.io" you could use something along these lines:
 
@@ -145,8 +145,8 @@ To resolve all the NS records for "vertx.io" you could use something along these
 
 === resolveSRV
 
-Try to resolve all SRV records for a given name. The SRV records are used to define extra informations like port and
-hostname of services. Some protocols need this extra informations.
+Try to resolve all SRV records for a given name. The SRV records are used to define extra information like port and
+hostname of services. Some protocols need this extra information.
 
 To lookup all the SRV records for "vertx.io" you would typically do:
 
@@ -158,7 +158,7 @@ To lookup all the SRV records for "vertx.io" you would typically do:
 Be aware that the List will contain the SrvRecords sorted by the priority of them, which means SrvRecords
 with smaller priority coming first in the List.
 
-The {@link io.vertx.core.dns.SrvRecord} allows you to access all informations contained in the SRV record itself:
+The {@link io.vertx.core.dns.SrvRecord} allows you to access all information contained in the SRV record itself:
 
 [source,$lang]
 ----

--- a/src/main/asciidoc/eventbus.adoc
+++ b/src/main/asciidoc/eventbus.adoc
@@ -26,7 +26,7 @@ First some theory:
 Messages are sent on the event bus to an *address*.
 
 Vert.x doesn't bother with any fancy addressing schemes. In Vert.x an address is simply a string.
-Any string is valid. However it is wise to use some kind of scheme, _e.g._ using periods to demarcate a namespace.
+Any string is valid. However, it is wise to use some kind of scheme, _e.g._ using periods to demarcate a namespace.
 
 Some examples of valid addresses are +europe.news.feed1+, +acme.games.pacman+, +sausages+, and +X+.
 
@@ -79,12 +79,12 @@ to retry after recovery.
 Out of the box Vert.x allows any primitive/simple type, String, or {@link io.vertx.core.buffer.Buffer buffers} to
 be sent as messages.
 
-However it's a convention and common practice in Vert.x to send messages as http://json.org/[JSON]
+However, it's a convention and common practice in Vert.x to send messages as http://json.org/[JSON]
 
-JSON is very easy to create, read and parse in all the languages that Vert.x supports so it has become a kind of
+JSON is very easy to create, read and parse in all the languages that Vert.x supports, so it has become a kind of
 _lingua franca_ for Vert.x.
 
-However you are not forced to use JSON if you don't want to.
+However, you are not forced to use JSON if you don't want to.
 
 The event bus is very flexible and also supports sending arbitrary objects over the event bus.
 You can do this by defining a {@link io.vertx.core.eventbus.MessageCodec codec} for the objects you want to send.

--- a/src/main/asciidoc/filesystem.adoc
+++ b/src/main/asciidoc/filesystem.adoc
@@ -111,7 +111,7 @@ In the `OpenOptions`, you can enable/disable the automatic synchronisation of th
 {@link io.vertx.core.file.OpenOptions#setDsync(boolean)}. In that case, you can manually flush any writes from the OS
 cache by calling the {@link io.vertx.core.file.AsyncFile#flush()} method.
 
-This method can also be called with an handler which will be called when the flush is complete.
+This method can also be called with a handler which will be called when the flush is complete.
 
 ==== Using AsyncFile as ReadStream and WriteStream
 
@@ -152,7 +152,7 @@ property `vertx.cacheDirBase`.
 The whole classpath resolving feature can be disabled system-wide by setting the system
 property `vertx.disableFileCPResolving` to `true`.
 
-NOTE: these system properties are evaluated once when the the `io.vertx.core.file.FileSystemOptions` class is loaded, so
+NOTE: these system properties are evaluated once when the `io.vertx.core.file.FileSystemOptions` class is loaded, so
 these properties should be set before loading this class or as a JVM system property when launching it.
 
 If you want to disable classpath resolving for a particular application but keep it enabled by default system-wide,

--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -356,7 +356,7 @@ of cookies are enabled using the setter: {@link io.vertx.core.http.Cookie#setSam
 Same site cookies can have one of 3 values:
 
 * None - The browser will send cookies with both cross-site requests and same-site requests.
-* Strict - he browser will only send cookies for same-site requests (requests originating from the site that set the
+* Strict - The browser will only send cookies for same-site requests (requests originating from the site that set the
   cookie). If the request originated from a different URL than the URL of the current location, none of the cookies
   tagged with the Strict attribute will be included.
 * Lax - Same-site cookies are withheld on cross-site subrequests, such as calls to load images or frames, but will be
@@ -377,7 +377,7 @@ algorithms.
 To enable decompression set {@link io.vertx.core.http.HttpServerOptions#setDecompressionSupported(boolean)} on the
 options when creating the server.
 
-By default decompression is disabled.
+By default, decompression is disabled.
 
 ==== Receiving custom HTTP/2 frames
 
@@ -392,7 +392,7 @@ this will get called every time a custom frame arrives. Here's an example:
 {@link examples.HTTP2Examples#example1}
 ----
 
-HTTP/2 frames are not subject to flow control - the frame handler will be called immediatly when a
+HTTP/2 frames are not subject to flow control - the frame handler will be called immediately when a
 custom frame is received whether the request is paused or is not
 
 === Sending back responses
@@ -443,7 +443,7 @@ result written to the wire.
 {@link examples.HTTPExamples#example18}
 ----
 
-Writing to a response is asynchronous and always returns immediately after the write has been queued.
+Writing to a response is asynchronous and always returns immediately after write has been queued.
 
 If you are just writing a single string or buffer to the HTTP response you can write it and end the response in a
 single call to the {@link io.vertx.core.http.HttpServerResponse#end(String)}
@@ -562,7 +562,7 @@ Here's a very simple web server that serves files from the file system using sen
 ----
 
 Sending a file is asynchronous and may not complete until some time after the call has returned. If you want to
-be notified when the file has been writen you can use {@link io.vertx.core.http.HttpServerResponse#sendFile(String,io.vertx.core.Handler)}
+be notified when the file has been written you can use {@link io.vertx.core.http.HttpServerResponse#sendFile(String,io.vertx.core.Handler)}
 
 Please see the chapter about <<classpath, serving files from the classpath>> for restrictions about the classpath resolution or disabling it.
 
@@ -641,7 +641,7 @@ HTTP/2 supports stream reset at any time during the request/response:
 {@link examples.HTTP2Examples#example3}
 ----
 
-By default the `NO_ERROR` (0) error code is sent, another code can sent instead:
+By default, the `NO_ERROR` (0) error code is sent, another code can sent instead:
 
 [source,$lang]
 ----
@@ -681,7 +681,7 @@ the pushed response can be written after.
 
 You can set an {@link io.vertx.core.http.HttpServer#exceptionHandler(io.vertx.core.Handler)} to receive any
 exceptions that happens before the connection is passed to the {@link io.vertx.core.http.HttpServer#requestHandler(io.vertx.core.Handler)}
-or to the {@link io.vertx.core.http.HttpServer#webSocketHandler(io.vertx.core.Handler)}, e.g during the TLS handshake.
+or to the {@link io.vertx.core.http.HttpServer#webSocketHandler(io.vertx.core.Handler)}, e.g. during the TLS handshake.
 
 === HTTP Compression
 
@@ -695,7 +695,7 @@ This allows to handle Client that support HTTP Compression and those that not su
 
 To enable compression use can configure it with {@link io.vertx.core.http.HttpServerOptions#setCompressionSupported}.
 
-By default compression is not enabled.
+By default, compression is not enabled.
 
 When HTTP compression is enabled the server will check if the client includes an `Accept-Encoding` header which
 includes the supported compressions. Commonly used are deflate and gzip. Both are supported by Vert.x.
@@ -745,7 +745,7 @@ If you want to configure options for the client, you create it as follows:
 
 Vert.x supports HTTP/2 over TLS `h2` and over TCP `h2c`.
 
-By default the http client performs HTTP/1.1 requests, to perform HTTP/2 requests the {@link io.vertx.core.http.HttpClientOptions#setProtocolVersion}
+By default, the http client performs HTTP/1.1 requests, to perform HTTP/2 requests the {@link io.vertx.core.http.HttpClientOptions#setProtocolVersion}
 must be set to {@link io.vertx.core.http.HttpVersion#HTTP_2}.
 
 For `h2` requests, TLS must be enabled with _Application-Layer Protocol Negotiation_:
@@ -762,7 +762,7 @@ For `h2c` requests, TLS must be disabled, the client will do an HTTP/1.1 request
 {@link examples.HTTP2Examples#example8}
 ----
 
-`h2c` connections can also be established directly, i.e connection started with a prior knowledge, when
+`h2c` connections can also be established directly, i.e. connection started with a prior knowledge, when
 {@link io.vertx.core.http.HttpClientOptions#setHttp2ClearTextUpgrade(boolean)} options is set to false: after the
 connection is established, the client will send the HTTP/2 connection preface and expect to receive
 the same preface from the server.
@@ -912,7 +912,7 @@ to the request, as it will be too late otherwise.
 If you are calling one of the `end` methods that take a string or buffer then Vert.x will automatically calculate
 and set the `Content-Length` header before writing the request body.
 
-If you are using HTTP chunking a a `Content-Length` header is not required, so you do not have to calculate the size
+If you are using HTTP chunking a `Content-Length` header is not required, so you do not have to calculate the size
 up-front.
 
 ==== Ending streamed HTTP requests
@@ -1311,7 +1311,7 @@ will result in the following header added:
 
  Accept-Encoding: gzip, deflate
 
-The server will choose then from one of these. You can detect if a server ompressed the body by checking for the
+The server will choose then from one of these. You can detect if a server compressed the body by checking for the
 `Content-Encoding` header in the response sent back from it.
 
 If the body of the response was compressed via gzip it will include for example the following header:
@@ -1360,7 +1360,7 @@ Pipe-lining means another request is sent on the same connection before the resp
 returned. Pipe-lining is not appropriate for all requests.
 
 To enable pipe-lining, it must be enabled using {@link io.vertx.core.http.HttpClientOptions#setPipelining(boolean)}.
-By default pipe-lining is disabled.
+By default, pipe-lining is disabled.
 
 When pipe-lining is enabled requests will be written to connections without waiting for previous responses to return.
 
@@ -1839,7 +1839,7 @@ NOTE: A given host should always use the same proxy options: as HTTP requests ar
 options are used when establishing the connection
 
 You can use {@link io.vertx.core.http.HttpClientOptions#setNonProxyHosts} to configure a list of host bypassing
-the proxy. The lists accepts `*` wildcard for matching domains:
+the proxy. The lists accept `*` wildcard for matching domains:
 
 [source,$lang]
 ----
@@ -1851,7 +1851,7 @@ the proxy. The lists accepts `*` wildcard for matching domains:
 The HTTP proxy implementation supports getting ftp:// urls if the proxy supports
 that.
 
-When the HTTP request URI contains contains the full URL then the client will not compute a full HTTP url and instead
+When the HTTP request URI contains the full URL then the client will not compute a full HTTP url and instead
 use the full URL specified in the request URI:
 
 [source,$lang]

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1057,7 +1057,7 @@ set of file to _watch_. This set can use Ant-style patterns (with `\**`, `*` and
 several sets by separating them using a comma (`,`). Patterns are relative to the current working directory.
 
 Parameters passed to the `run` command are passed to the application. Java Virtual Machine options can be
-configured using `--java-opts`. For instance, to pass the the `conf` parameter or a system property, you need to
+configured using `--java-opts`. For instance, to pass the `conf` parameter or a system property, you need to
 use: `--java-opts="-conf=my-conf.json -Dkey=value"`
 
 The `--launcher-class` option determine with with _main_ class the application is launcher. It's generally

--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -43,7 +43,7 @@ Or to specify the host and port in the call to listen, ignoring what is configur
 The default host is `0.0.0.0` which means 'listen on all available addresses' and the default port is `0`, which is a
 special value that instructs the server to find a random unused local port and use that.
 
-The actual bind is asynchronous so the server might not actually be listening until some time *after* the call to
+The actual bind is asynchronous, so the server might not actually be listening until some time *after* the call to
 listen has returned.
 
 If you want to be notified when the server is actually listening you can provide a handler to the `listen` call.
@@ -154,7 +154,7 @@ classpath resolution or disabling it.
 === Streaming sockets
 
 Instances of {@link io.vertx.core.net.NetSocket} are also {@link io.vertx.core.streams.ReadStream} and
-{@link io.vertx.core.streams.WriteStream} instances so they can be used to pipe data to or from other
+{@link io.vertx.core.streams.WriteStream} instances, so they can be used to pipe data to or from other
 read and write streams.
 
 See the chapter on <<streams, streams >> for more information.
@@ -266,7 +266,7 @@ A client can be configured to automatically retry connecting to the server in th
 This is configured with {@link io.vertx.core.net.NetClientOptions#setReconnectInterval(long)} and
 {@link io.vertx.core.net.NetClientOptions#setReconnectAttempts(int)}.
 
-NOTE: Currently Vert.x will not attempt to reconnect if a connection fails, reconnect attempts and interval
+NOTE: Currently, Vert.x will not attempt to reconnect if a connection fails, reconnect attempts and interval
 only apply to creating initial connections.
 
 [source,$lang]
@@ -380,7 +380,7 @@ WARNING: Keep in mind that the keys contained in an unencrypted PKCS8 or a PKCS1
 anybody who can read the file. Thus, make sure to put proper access restrictions on such PEM files in order to
 prevent misuse.
 
-Finally you can also load generic Java keystore, it is useful for using other KeyStore implementations
+Finally, you can also load generic Java keystore, it is useful for using other KeyStore implementations
 like Bouncy Castle:
 
 [source,$lang]

--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -250,7 +250,7 @@ public interface Future<T> extends AsyncResult<T> {
    * and this mapper returns another future object. This returned future completion will complete the future returned
    * by this method call with the original result of the future.
    *
-   * <p>The outcome of the future returned by the {@code mapper} will not influence the the nature
+   * <p>The outcome of the future returned by the {@code mapper} will not influence the nature
    * of the returned future.
    *
    * @param mapper the function returning the future.

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -305,7 +305,7 @@ public interface Vertx extends Measured {
   void runOnContext(Handler<Void> action);
 
   /**
-   * Stop the the Vertx instance and release any resources held by it.
+   * Stop the Vertx instance and release any resources held by it.
    * <p>
    * The instance cannot be used after it has been closed.
    * <p>

--- a/src/main/java/io/vertx/core/eventbus/EventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBus.java
@@ -59,7 +59,7 @@ public interface EventBus extends Measured {
   EventBus send(String address, @Nullable Object message, DeliveryOptions options);
 
   /**
-   * Sends a message and and specify a {@code replyHandler} that will be called if the recipient
+   * Sends a message and specify a {@code replyHandler} that will be called if the recipient
    * subsequently replies to the message.
    * <p>
    * The message will be delivered to at most one of the handlers registered to the address.

--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -143,7 +143,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   HttpClientRequest setMethod(HttpMethod method);
 
   /**
-   * @return the absolute URI corresponding to the the HTTP request
+   * @return the absolute URI corresponding to the HTTP request
    */
   String absoluteURI();
 

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -207,7 +207,7 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
 
   /**
-   * @return the absolute URI corresponding to the the HTTP request
+   * @return the absolute URI corresponding to the HTTP request
    */
   String absoluteURI();
 

--- a/src/main/java/io/vertx/core/json/pointer/JsonPointerIterator.java
+++ b/src/main/java/io/vertx/core/json/pointer/JsonPointerIterator.java
@@ -66,7 +66,7 @@ public interface JsonPointerIterator {
   Object getObjectParameter(@Nullable Object currentValue, String key, boolean createOnMissing);
 
   /**
-   * Move the iterator the the array element at specified index
+   * Move the iterator the array element at specified index
    *
    * @param currentValue
    * @param i array index

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -338,7 +338,7 @@ public class SSLHelper {
 
   /*
   Proxy the specified trust managers with an implementation checking first the provided certificates
-  against the the Certificate Revocation List (crl) before delegating to the original trust managers.
+  against the Certificate Revocation List (crl) before delegating to the original trust managers.
    */
   private static TrustManager[] createUntrustRevokedCertTrustManager(TrustManager[] trustMgrs, ArrayList<CRL> crls) {
     trustMgrs = trustMgrs.clone();

--- a/src/test/java/io/vertx/core/dns/HostnameResolutionTest.java
+++ b/src/test/java/io/vertx/core/dns/HostnameResolutionTest.java
@@ -621,7 +621,7 @@ public class HostnameResolutionTest extends VertxTestBase {
     }));
     awaitLatch(latch2);
 
-    // "host3" resolves via the the "foo.com" search path as it is the first one
+    // "host3" resolves via the "foo.com" search path as it is the first one
     CountDownLatch latch3 = new CountDownLatch(1);
     vertx.resolveAddress("host3", onSuccess(resolved -> {
       assertEquals("127.0.0.4", resolved.getHostAddress());


### PR DESCRIPTION
Found some typos and a lack of commas in asciidocs and javadocs,
