### PR TITLE
Log a warning if the tracing factory or the metrics factory are not configured

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxBuilder.java
+++ b/src/main/java/io/vertx/core/impl/VertxBuilder.java
@@ -32,8 +32,6 @@ import io.vertx.core.tracing.TracingOptions;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Vertx builder for creating vertx instances with SPI overrides.
@@ -248,7 +246,7 @@ public class VertxBuilder {
   public VertxBuilder init() {
     initTransport();
     initFileResolver();
-    Set<VertxServiceProvider> providers = new HashSet<>();
+    Collection<VertxServiceProvider> providers = new ArrayList<>();
     initMetrics(options, providers);
     initTracing(options, providers);
     initClusterManager(options, providers);


### PR DESCRIPTION
While using the tracing feature, together with the new vertx-opentelemetry module, I had some problems in my packaging, where i was mistakenly overwriting `META-INF/services/io.vertx.core.spi.VertxServiceProvider`, hence not loading the proper tracing factory. This PR adds a check that prints a warning when such situation happens.