### PR TITLE
Fix Typos. Duplicate word  `length` in sendFile method

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -437,7 +437,7 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    *
    * @param filename path to the file to serve
    * @param offset the offset to serve from
-   * @param length length the number of bytes to send
+   * @param length the number of bytes to send
    * @param resultHandler  handler that will be called on completion
    * @return a reference to this, so the API can be used fluently
    */


### PR DESCRIPTION
Remove duplicate `length` in sendFile method.

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
