### PR TITLE
Do not deliver remote message to localOnly consumers

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/ClusteredEventBusHandlers.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/ClusteredEventBusHandlers.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.eventbus.impl;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@SuppressWarnings("rawtypes")
+public class ClusteredEventBusHandlers implements Handlers {
+
+  private static final HandlerHolder[] EMPTY_ARRAY = new HandlerHolder[0];
+
+  private final HandlerHolder[] elements;
+  private final int localOnlyOffset;
+  private final AtomicInteger pos;
+
+  public ClusteredEventBusHandlers() {
+    this(EMPTY_ARRAY, 0, 0);
+  }
+
+  private ClusteredEventBusHandlers(HandlerHolder[] elements, int localOnlyOffset, int pos) {
+    this.elements = elements;
+    this.localOnlyOffset = localOnlyOffset;
+    this.pos = new AtomicInteger(pos);
+  }
+
+  @Override
+  public Handlers add(HandlerHolder holder) {
+    int len = elements.length;
+    HandlerHolder[] copy = new HandlerHolder[len + 1];
+    int offset;
+    if (holder.localOnly) {
+      offset = localOnlyOffset;
+      copy[len] = holder;
+      System.arraycopy(elements, 0, copy, 0, len);
+    } else {
+      offset = localOnlyOffset + 1;
+      copy[0] = holder;
+      System.arraycopy(elements, 0, copy, 1, len);
+    }
+    return new ClusteredEventBusHandlers(copy, offset, pos.get());
+  }
+
+  @Override
+  public Handlers remove(HandlerHolder holder) {
+    int len = elements.length;
+    for (int i = 0; i < len; i++) {
+      if (Objects.equals(holder, elements[i])) {
+        if (len > 1) {
+          HandlerHolder[] copy = new HandlerHolder[len - 1];
+          System.arraycopy(elements, 0, copy, 0, i);
+          System.arraycopy(elements, i + 1, copy, i, len - i - 1);
+          return new ClusteredEventBusHandlers(copy, Math.min(i, localOnlyOffset), pos.get() % copy.length);
+        } else {
+          return new ClusteredEventBusHandlers();
+        }
+      }
+    }
+    return this;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return elements.length == 0;
+  }
+
+  @Override
+  public HandlerHolder next(boolean includeLocalOnly) {
+    int len = count(includeLocalOnly);
+    switch (len) {
+      case 0:
+        return null;
+      case 1:
+        return elements[0];
+      default:
+        int p;
+        p = pos.getAndIncrement();
+        return elements[Math.abs(p % len)];
+    }
+  }
+
+  @Override
+  public int count(boolean includeLocalOnly) {
+    return includeLocalOnly ? elements.length : localOnlyOffset;
+  }
+
+  @Override
+  public Iterator<HandlerHolder> iterator(boolean includeLocalOnly) {
+    return new Iterator<HandlerHolder>() {
+      int index;
+
+      @Override
+      public boolean hasNext() {
+        return index < count(includeLocalOnly);
+      }
+
+      @Override
+      public HandlerHolder next() {
+        return elements[index++];
+      }
+    };
+  }
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusHandlers.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusHandlers.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.eventbus.impl;
+
+import io.vertx.core.impl.utils.ConcurrentCyclicSequence;
+
+import java.util.Iterator;
+
+@SuppressWarnings("rawtypes")
+public class EventBusHandlers implements Handlers {
+
+  private final ConcurrentCyclicSequence<HandlerHolder> sequence;
+
+  public EventBusHandlers() {
+    sequence = new ConcurrentCyclicSequence<>();
+  }
+
+  private EventBusHandlers(ConcurrentCyclicSequence<HandlerHolder> sequence) {
+    this.sequence = sequence;
+  }
+
+  @Override
+  public Handlers add(HandlerHolder holder) {
+    return new EventBusHandlers(sequence.add(holder));
+  }
+
+  @Override
+  public Handlers remove(HandlerHolder holder) {
+    return new EventBusHandlers(sequence.remove(holder));
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return sequence.size() == 0;
+  }
+
+  @Override
+  public HandlerHolder next(boolean includeLocalOnly) {
+    return sequence.next();
+  }
+
+  @Override
+  public int count(boolean includeLocalOnly) {
+    return sequence.size();
+  }
+
+  @Override
+  public Iterator<HandlerHolder> iterator(boolean includeLocalOnly) {
+    return sequence.iterator();
+  }
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/Handlers.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/Handlers.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.eventbus.impl;
+
+import java.util.Iterator;
+
+@SuppressWarnings("rawtypes")
+public interface Handlers {
+
+  Handlers add(HandlerHolder holder);
+
+  default Handlers add(Handlers other) {
+    return add(other.next(true));
+  }
+
+  Handlers remove(HandlerHolder holder);
+
+  boolean isEmpty();
+
+  HandlerHolder next(boolean includeLocalOnly);
+
+  int count(boolean includeLocalOnly);
+
+  Iterator<HandlerHolder> iterator(boolean includeLocalOnly);
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -24,11 +24,7 @@ import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
-import io.vertx.core.net.NetClient;
-import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.NetServer;
-import io.vertx.core.net.NetServerOptions;
-import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.*;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.cluster.NodeInfo;
@@ -144,6 +140,11 @@ public class ClusteredEventBus extends EventBusImpl {
     } else if (promise != null) {
       promise.complete();
     }
+  }
+
+  @Override
+  protected Handlers createHandlers() {
+    return new ClusteredEventBusHandlers();
   }
 
   @Override


### PR DESCRIPTION
Fixes #3959

Consider a node that has both local and clustered consumers registered for an address.
When a remote message is received (sent from another node), calling deliverMessageLocally would lead to message being possibly delivered to one of the local consumers.
This is not what users expect.

With a variation of ConcurrentCyclicSequence, we can make sure we deliver:

- to all consumers when a message was sent from this node
- to clustered consumers only when a message was sent from another node