### PR TITLE
Fix issue 3980 - NPE when a websocket connection fails and metrics are enabled

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -879,12 +879,11 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
         } else {
           webSocket = (WebSocketImpl) wsRes.result();
           webSocket.registerHandler(vertx.eventBus());
-
-        }
-        log.debug("WebSocket handshake complete");
-        HttpClientMetrics metrics = client.metrics();
-        if (metrics != null) {
-          webSocket.setMetric(metrics.connected(webSocket));
+          log.debug("WebSocket handshake complete");
+          HttpClientMetrics metrics = client.metrics();
+          if (metrics != null) {
+            webSocket.setMetric(metrics.connected(webSocket));
+          }
         }
         getContext().emit(wsRes, res -> {
           if (res.succeeded()) {


### PR DESCRIPTION
Motivation:

Fix this issue : https://github.com/eclipse-vertx/vert.x/issues/3980

Vert.x used to throw a NullPointerException when the websocket connection fails and metrics are enabled.
