### PR TITLE
Don't share ports between tls and plain

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/ServerID.java
+++ b/src/main/java/io/vertx/core/net/impl/ServerID.java
@@ -19,15 +19,15 @@ import java.util.Objects;
  */
 public class ServerID implements Serializable {
 
-  public int port;
-  public String host;
+  public final int port;
+  public final String host;
+  public final boolean ssl;
 
-  public ServerID(int port, String host) {
+
+  public ServerID(int port, String host, boolean ssl) {
     this.port = port;
     this.host = host;
-  }
-
-  public ServerID() {
+    this.ssl = ssl;
   }
 
   @Override
@@ -36,13 +36,16 @@ public class ServerID implements Serializable {
     if (!(o instanceof ServerID)) return false;
 
     ServerID that = (ServerID) o;
-    return port == that.port && Objects.equals(host, that.host);
+    return port == that.port && ssl == that.ssl && Objects.equals(host, that.host);
   }
 
   @Override
   public int hashCode() {
     int result = port;
     result = 31 * result + host.hashCode();
+    if (ssl) {
+      result *= 2;
+    }
     return result;
   }
 

--- a/src/main/java/io/vertx/core/net/impl/TCPServerBase.java
+++ b/src/main/java/io/vertx/core/net/impl/TCPServerBase.java
@@ -99,16 +99,16 @@ public abstract class TCPServerBase implements Closeable, MetricsProvider {
       TCPServerBase main;
       boolean shared;
       if (actualPort != 0) {
-        id = new ServerID(actualPort, hostOrPath);
+        id = new ServerID(actualPort, hostOrPath, options.isSsl());
         main = sharedNetServers.get(id);
         shared = true;
       } else {
         if (creatingContext != null && creatingContext.deploymentID() != null) {
-          id = new ServerID(actualPort, hostOrPath + "/" + creatingContext.deploymentID());
+          id = new ServerID(actualPort, hostOrPath + "/" + creatingContext.deploymentID(), options.isSsl());
           main = sharedNetServers.get(id);
           shared = true;
         } else {
-          id = new ServerID(actualPort, hostOrPath);
+          id = new ServerID(actualPort, hostOrPath, options.isSsl());
           main = null;
           shared = false;
         }
@@ -136,7 +136,7 @@ public abstract class TCPServerBase implements Closeable, MetricsProvider {
               if (actualPort != -1) {
                 actualPort = ((InetSocketAddress)ch.localAddress()).getPort();
               }
-              id = new ServerID(TCPServerBase.this.actualPort, id.host);
+              id = new ServerID(TCPServerBase.this.actualPort, id.host, options.isSsl());
               listenContext.addCloseHook(this);
               metrics = createMetrics(localAddress);
             } else {


### PR DESCRIPTION
Currently if you start both a TLS and a plain server with port=0 then
you will end up with both the TLS and non-TLS servers sharing a port,
which for obvious reasons does not really work.

Fixes #3994