### PR TITLE
Do not create a VertxTracer if TracingOptions are null

### DIFF
--- a/src/main/java/io/vertx/core/spi/VertxTracerFactory.java
+++ b/src/main/java/io/vertx/core/spi/VertxTracerFactory.java
@@ -31,7 +31,7 @@ public interface VertxTracerFactory extends VertxServiceProvider {
 
   @Override
   default void init(VertxBuilder builder) {
-    if (builder.tracer() == null) {
+    if (builder.options().getTracingOptions() != null && builder.tracer() == null) {
       builder.tracer(tracer(builder.options().getTracingOptions()));
     }
   }


### PR DESCRIPTION
A fix for the Issue https://github.com/eclipse-vertx/vertx-tracing/issues/24

Starting with the Vert.x 4.0.3, if there is a `vertx-opentracing` artifact in the classpath and no TracingOptions set for a Vertx instance, the `IllegalArgumentException: Service name must not be null or empty` exception is raised on a Vertx instance initialization.

This patch avoids instantiation of a new VertxTracer if the TracingOptions are null.