### PR TITLE
do not create HAManager when it is disabled

### DIFF
--- a/src/main/java/io/vertx/core/impl/HAManager.java
+++ b/src/main/java/io/vertx/core/impl/HAManager.java
@@ -107,7 +107,6 @@ public class HAManager {
   private final Map<String, String> clusterMap;
   private final String nodeID;
   private final Queue<Runnable> toDeployOnQuorum = new ConcurrentLinkedQueue<>();
-  private final boolean enabled;
 
   private long quorumTimerID;
   private long checkQuorumTimerID = -1L;
@@ -116,18 +115,16 @@ public class HAManager {
   private volatile boolean failDuringFailover;
   private volatile boolean stopped;
   private volatile boolean killed;
-  private Consumer<Set<String>> clusterViewChangedHandler;
 
   public HAManager(VertxInternal vertx, DeploymentManager deploymentManager, VerticleManager verticleFactoryManager, ClusterManager clusterManager,
-                   Map<String, String> clusterMap, int quorumSize, String group, boolean enabled) {
+                   Map<String, String> clusterMap, int quorumSize, String group) {
     this.vertx = vertx;
     this.deploymentManager = deploymentManager;
     this.verticleFactoryManager = verticleFactoryManager;
     this.clusterManager = clusterManager;
     this.clusterMap = clusterMap;
-    this.quorumSize = enabled ? quorumSize : 0;
-    this.group = enabled ? group : "__DISABLED__";
-    this.enabled = enabled;
+    this.quorumSize = quorumSize;
+    this.group = group;
     this.haInfo = new JsonObject().put("verticles", new JsonArray()).put("group", this.group);
     this.nodeID = clusterManager.getNodeId();
   }
@@ -256,10 +253,6 @@ public class HAManager {
 
   public boolean isKilled() {
     return killed;
-  }
-
-  public boolean isEnabled() {
-    return enabled;
   }
 
   // For testing:

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -216,18 +216,20 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   private void createHaManager(VertxOptions options, Promise<Void> initPromise) {
-    this.<HAManager>executeBlocking(fut -> {
-      Map<String, String> syncMap = clusterManager.getSyncMap(CLUSTER_MAP_NAME);
-      HAManager haManager = new HAManager(this, deploymentManager, verticleManager, clusterManager, syncMap, options.getQuorumSize(), options.getHAGroup(), options.isHAEnabled());
-      fut.complete(haManager);
-    }, false, ar -> {
-      if (ar.succeeded()) {
-        haManager = ar.result();
-        startEventBus(initPromise);
-      } else {
-        initPromise.fail(ar.cause());
-      }
-    });
+    if (options.isHAEnabled()) {
+      this.<HAManager>executeBlocking(fut -> {
+        haManager = new HAManager(this, deploymentManager, verticleManager, clusterManager, clusterManager.getSyncMap(CLUSTER_MAP_NAME), options.getQuorumSize(), options.getHAGroup());
+        fut.complete(haManager);
+      }, false, ar -> {
+        if (ar.succeeded()) {
+          startEventBus(initPromise);
+        } else {
+          initPromise.fail(ar.cause());
+        }
+      });
+    } else {
+      startEventBus(initPromise);
+    }
   }
 
   private void startEventBus(Promise<Void> initPromise) {
@@ -243,13 +245,14 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   private void initializeHaManager(Promise<Void> initPromise) {
-    this.executeBlocking(fut -> {
-      // Init the manager (i.e register listener and check the quorum)
-      // after the event bus has been fully started and updated its state
-      // it will have also set the clustered changed view handler on the ha manager
-      haManager.init();
-      fut.complete();
-    }, false, initPromise);
+    if (null != haManager()) {
+      this.executeBlocking(fut -> {
+        haManager().init();
+        fut.complete();
+      }, false, initPromise);
+    } else {
+      initPromise.complete();
+    }
   }
 
   /**
@@ -615,7 +618,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public Future<String> deployVerticle(String name, DeploymentOptions options) {
-    if (options.isHa() && haManager() != null && haManager().isEnabled()) {
+    if (options.isHa() && haManager() != null) {
       Promise<String> promise = getOrCreateContext().promise();
       haManager().deployVerticle(name, options, promise);
       return promise.future();
@@ -704,7 +707,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   public Future<Void> undeploy(String deploymentID) {
     Future<Void> future;
     HAManager haManager = haManager();
-    if (haManager != null && haManager.isEnabled()) {
+    if (haManager != null) {
       future = this.executeBlocking(fut -> {
         haManager.removeFromHA(deploymentID);
         fut.complete();

--- a/src/test/java/io/vertx/core/HATest.java
+++ b/src/test/java/io/vertx/core/HATest.java
@@ -237,16 +237,14 @@ public class HATest extends VertxTestBase {
     });
     awaitLatch(latch1);
 
-    ((VertxInternal) vertx2).failoverCompleteHandler((nodeID, haInfo, succeeded) -> {
-      fail("Should not failover here 2");
-    });
-    ((VertxInternal) vertx1).failoverCompleteHandler((nodeID, haInfo, succeeded) -> {
-      fail("Should not failover here 1");
-    });
+    ((VertxInternal) vertx2).failoverCompleteHandler((nodeID, haInfo, succeeded) -> fail("Should not failover here 2"));
+    ((VertxInternal) vertx1).failoverCompleteHandler((nodeID, haInfo, succeeded) -> fail("Should not failover here 1"));
     ((VertxInternal) vertx1).simulateKill();
     vertx2.close(ar -> {
       vertx.setTimer(500, tid -> {
         // Wait a bit in case failover happens
+        assertEquals("Verticle should still be deployed here 1", 1, vertx1.deploymentIDs().size());
+        assertTrue("Verticle should not failover here 2", vertx2.deploymentIDs().isEmpty());
         testComplete();
       });
     });

--- a/src/test/java/io/vertx/core/VertxStartFailureTest.java
+++ b/src/test/java/io/vertx/core/VertxStartFailureTest.java
@@ -79,7 +79,7 @@ public class VertxStartFailureTest extends AsyncTestBase {
         throw expected;
       }
     };
-    VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+    VertxOptions options = new VertxOptions().setClusterManager(clusterManager).setHAEnabled(true);
     Throwable failure = failStart(options);
     assertSame(expected,  failure);
   }
@@ -94,7 +94,7 @@ public class VertxStartFailureTest extends AsyncTestBase {
         throw expected;
       }
     };
-    VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+    VertxOptions options = new VertxOptions().setClusterManager(clusterManager).setHAEnabled(true);
     Throwable failure = failStart(options);
     assertSame(expected,  failure);
   }


### PR DESCRIPTION
Motivation:

since the rework of ClusteredEventBus it is no longer necessary to have HAManagerImpl around even if HA is disabled.
@tsegismont  what do you think?

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
