### PR TITLE
clear set all method when calling with Map.

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/headers/HeadersAdaptor.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/HeadersAdaptor.java
@@ -136,6 +136,7 @@ public class HeadersAdaptor implements MultiMap {
 
   @Override
   public MultiMap setAll(Map<String, String> headers) {
+    clear();  
     for (Map.Entry<String, String> entry: headers.entrySet()) {
       add(entry.getKey(), entry.getValue());
     }

--- a/src/main/java/io/vertx/core/http/impl/headers/Http2HeadersAdaptor.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/Http2HeadersAdaptor.java
@@ -211,6 +211,7 @@ public class Http2HeadersAdaptor implements MultiMap {
 
   @Override
   public MultiMap setAll(Map<String, String> headers) {
+    clear();
     for (Map.Entry<String, String> entry: headers.entrySet()) {
       add(entry.getKey(), entry.getValue());
     }

--- a/src/test/java/io/vertx/core/http/headers/HeadersTestBase.java
+++ b/src/test/java/io/vertx/core/http/headers/HeadersTestBase.java
@@ -11,8 +11,12 @@
 
 package io.vertx.core.http.headers;
 
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.impl.headers.HeadersAdaptor;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import io.vertx.core.http.impl.headers.Http2HeadersAdaptor;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -25,8 +29,8 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -593,5 +597,77 @@ public abstract class HeadersTestBase {
     mmap = newMultiMap();
     mmap.set("header", Arrays.asList(HttpHeaders.createOptimized("value1"), HttpHeaders.createOptimized("value2")));
     assertEquals(Arrays.asList("value1", "value2"), mmap.getAll("header"));
+  }
+  
+  @Test
+  public void testSetAllOnExistingMapUsingMultiMapHttp1() {
+    MultiMap mainMap = new HeadersAdaptor(HeadersMultiMap.httpHeaders());
+    mainMap.add("originalKey", "originalValue");
+    
+    MultiMap setAllMap = newMultiMap();
+    
+    setAllMap.add("originalKey", "newValue");
+    setAllMap.add("anotherKey", "anotherValue");
+    
+    MultiMap result = mainMap.setAll(setAllMap);
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertEquals(2, result.size());
+    assertEquals("newValue",result.get("originalKey"));
+    assertEquals("anotherValue",result.get("anotherKey"));
+  }
+  
+  @Test
+  public void testSetAllOnExistingMapUsingHashMapHttp1() {
+    MultiMap mainMap = new HeadersAdaptor(HeadersMultiMap.httpHeaders());
+    mainMap.add("originalKey", "originalValue");
+    
+    Map<String,String> setAllMap = new HashMap<>();
+    
+    setAllMap.put("originalKey", "newValue");
+    setAllMap.put("anotherKey", "anotherValue");
+    
+    MultiMap result = mainMap.setAll(setAllMap);
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertEquals(2, result.size());
+    assertEquals("newValue",result.get("originalKey"));
+    assertEquals("anotherValue",result.get("anotherKey"));
+  }
+  
+  @Test
+  public void testSetAllOnExistingMapUsingMultiMapHttp2() {
+    MultiMap mainMap = new Http2HeadersAdaptor(new DefaultHttp2Headers());
+    mainMap.add("originalKey", "originalValue");
+    
+    MultiMap setAllMap = newMultiMap();
+    
+    setAllMap.add("originalKey", "newValue");
+    setAllMap.add("anotherKey", "anotherValue");
+    
+    MultiMap result = mainMap.setAll(setAllMap);
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertEquals(2, result.size());
+    assertEquals("newValue",result.get("originalKey"));
+    assertEquals("anotherValue",result.get("anotherKey"));
+  }
+  
+  @Test
+  public void testSetAllOnExistingMapUsingHashMapHttp2() {
+    MultiMap mainMap = new Http2HeadersAdaptor(new DefaultHttp2Headers());
+    mainMap.add("originalKey", "originalValue");
+    
+    Map<String,String> setAllMap = new HashMap<>();
+    
+    setAllMap.put("originalKey", "newValue");
+    setAllMap.put("anotherKey", "anotherValue");
+    
+    MultiMap result = mainMap.setAll(setAllMap);
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertEquals(2, result.size());
+    assertEquals("newValue",result.get("originalKey"));
+    assertEquals("anotherValue",result.get("anotherKey"));
   }
 }


### PR DESCRIPTION
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>

Motivation:

See https://github.com/quarkusio/quarkus/issues/18503

When calling `setAll` with a MultiMap, the clear method is called first, but when calling it with Map, it's not.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
