### PR TITLE
Reuse emit func in FutureBase

### DIFF
--- a/src/main/java/io/vertx/core/impl/future/FutureBase.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureBase.java
@@ -47,37 +47,11 @@ abstract class FutureBase<T> implements FutureInternal<T> {
   }
 
   protected final void emitSuccess(T value, Listener<T> listener) {
-    if (context != null && !context.isRunningOnContext()) {
-      context.execute(() -> {
-        ContextInternal prev = context.beginDispatch();
-        try {
-          listener.onSuccess(value);
-        } catch (Throwable t) {
-          context.reportException(t);
-        } finally {
-          context.endDispatch(prev);
-        }
-      });
-    } else {
-      listener.onSuccess(value);
-    }
+    emit(value, listener::onSuccess);
   }
 
   protected final void emitFailure(Throwable cause, Listener<T> listener) {
-    if (context != null && !context.isRunningOnContext()) {
-      context.execute(() -> {
-        ContextInternal prev = context.beginDispatch();
-        try {
-          listener.onFailure(cause);
-        } catch (Throwable t) {
-          context.reportException(t);
-        } finally {
-          context.endDispatch(prev);
-        }
-      });
-    } else {
-      listener.onFailure(cause);
-    }
+    emit(cause, listener::onFailure);
   }
 
   protected final <U> void emit(U value, Handler<U> handler) {


### PR DESCRIPTION
A refactor of the emitSuccess/emitFailure func, removed duplicated code blocks