### PR TITLE
Have BlockedThreadChecker release memory on shutdown

### DIFF
--- a/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
+++ b/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
@@ -75,5 +75,11 @@ public class BlockedThreadChecker {
 
   public void close() {
     timer.cancel();
+    synchronized (this) {
+      //Not strictly necessary, but it helps GC to break it all down
+      //when Vert.x is embedded and restarted multiple times
+      threads.clear();
+    }
   }
+
 }


### PR DESCRIPTION
Motivation:

In Quarkus we start & stop many instances of Vertx, and in integration tests for "dev-mode" this is happening quite frequently and intensively as the number of tests grow.

We do close and discard references to terminated instances, so technically there isn't a leak as things get eventually discarded correctly, but can't do this very aggressively.

So in practice, sampled heap snapshots contain several lingering instances of stopped `BlockedThreadChecker` instances - they will be collected eventually but they form rather large clusters of data which leads to spending significant cycles on GC.

This helps with the GC effort and looks harmless enough.
