### PR TITLE
Don't create a Promise from the finalizer and un-necessary remove HTTP client finalizer

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -646,13 +646,4 @@ public class HttpClientImpl implements HttpClient, MetricsProvider, Closeable {
       throw new IllegalStateException("Client is closed");
     }
   }
-
-  @Override
-  protected void finalize() throws Throwable {
-    // Make sure this gets cleaned up if there are no more references to it
-    // so as not to leave connections and resources dangling until the system is shutdown
-    // which could make the JVM run out of file handles.
-    close((Handler<AsyncResult<Void>>) Promise.<Void>promise());
-    super.finalize();
-  }
 }

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -280,7 +280,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
     // Make sure this gets cleaned up if there are no more references to it
     // so as not to leave connections and resources dangling until the system is shutdown
     // which could make the JVM run out of file handles.
-    close((Handler<AsyncResult<Void>>) Promise.<Void>promise());
+    closeFuture.close();
     super.finalize();
   }
 }


### PR DESCRIPTION
Motivation:

When this finalizer is run it attempts to notify the empty promise on the IO thread. 

This can result in spawning a new IO thread, which will then inherit the
TCCL and ThreadGroup of the finalizer thread.
    
This can still be an issue if the client is not closed properly, but
currently there is no way to avoid it even if you do close it properly.

In addition the HTTP client finaliser is not necessary as client cleanup is achieved by the closeFuture listener that is either close directly or by the NetClient finaliser.