### PR TITLE
Introduce a flag to disable ContextClassLoader control by VertxThread

### DIFF
--- a/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -55,6 +55,9 @@ abstract class ContextImpl extends AbstractContext {
   private static final String DISABLE_TIMINGS_PROP_NAME = "vertx.disableContextTimings";
   static final boolean DISABLE_TIMINGS = Boolean.getBoolean(DISABLE_TIMINGS_PROP_NAME);
 
+  private static final String DISABLE_TCCLSWAPPING_PROP_NAME = "vertx.disableTCCLSwapping";
+  static final boolean DISABLE_TCCLSWAPPING = Boolean.getBoolean(DISABLE_TCCLSWAPPING_PROP_NAME);
+
   protected final VertxInternal owner;
   protected final JsonObject config;
   private final Deployment deployment;

--- a/src/main/java/io/vertx/core/impl/VertxThread.java
+++ b/src/main/java/io/vertx/core/impl/VertxThread.java
@@ -85,7 +85,7 @@ public class VertxThread extends FastThreadLocalThread implements BlockedThreadC
       executeStart();
     }
     ContextInternal prev = this.context;
-    if (prev == null) {
+    if (prev == null && !ContextImpl.DISABLE_TCCLSWAPPING) {
       topLevelTCCL = Thread.currentThread().getContextClassLoader();
     }
     this.context = context;
@@ -102,7 +102,7 @@ public class VertxThread extends FastThreadLocalThread implements BlockedThreadC
    */
   void endEmission(ContextInternal prev) {
     context = prev;
-    if (prev == null) {
+    if (prev == null && !ContextImpl.DISABLE_TCCLSWAPPING) {
       Thread.currentThread().setContextClassLoader(topLevelTCCL);
       topLevelTCCL = null;
     }


### PR DESCRIPTION
Motivation:

During the investigation of a classloader issue in Quarkus, we had reasons to believe that the ContextClassLoader reset mechanism in `VertxThread` had a good chance to be the cause of the problem.

After further analysis we figured that this wasn't the case, so there isn't a concrete known issue solved by this, but also it's not hard to think of situations in which this would cause real issues, and more in general in Quarkus it's not at all useful for Vert.x to control the TCCL.

So I'd suggest introducing this flag: should be harmless and it has the potential to prevent further related issues. Maybe even save some CPU cycles :)

cc/ @stuartwdouglas @gsmet 