### PR TITLE
Context: allow storage and retrieval of instances of any type

### DIFF
--- a/src/main/java/io/vertx/core/Context.java
+++ b/src/main/java/io/vertx/core/Context.java
@@ -196,7 +196,7 @@ public interface Context {
    * @param <T>  the type of the data
    * @return the data
    */
-  <T> T get(String key);
+  <T> T get(Object key);
 
   /**
    * Put some data in the context.
@@ -206,7 +206,7 @@ public interface Context {
    * @param key  the key of the data
    * @param value  the data
    */
-  void put(String key, Object value);
+  void put(Object key, Object value);
 
   /**
    * Remove some data from the context.
@@ -214,7 +214,7 @@ public interface Context {
    * @param key  the key to remove
    * @return true if removed successfully, false otherwise
    */
-  boolean remove(String key);
+  boolean remove(Object key);
 
   /**
    * Get some local data from the context.
@@ -223,7 +223,7 @@ public interface Context {
    * @param <T>  the type of the data
    * @return the data
    */
-  <T> T getLocal(String key);
+  <T> T getLocal(Object key);
 
   /**
    * Put some local data in the context.
@@ -233,7 +233,7 @@ public interface Context {
    * @param key  the key of the data
    * @param value  the data
    */
-  void putLocal(String key, Object value);
+  void putLocal(Object key, Object value);
 
   /**
    * Remove some local data from the context.
@@ -241,7 +241,7 @@ public interface Context {
    * @param key  the key to remove
    * @return true if removed successfully, false otherwise
    */
-  boolean removeLocal(String key);
+  boolean removeLocal(Object key);
 
   /**
    * @return The Vertx instance that created the context

--- a/src/main/java/io/vertx/core/impl/AbstractContext.java
+++ b/src/main/java/io/vertx/core/impl/AbstractContext.java
@@ -194,33 +194,33 @@ abstract class AbstractContext implements ContextInternal {
 
   @SuppressWarnings("unchecked")
   @Override
-  public final <T> T get(String key) {
+  public final <T> T get(Object key) {
     return (T) contextData().get(key);
   }
 
   @Override
-  public final void put(String key, Object value) {
+  public final void put(Object key, Object value) {
     contextData().put(key, value);
   }
 
   @Override
-  public final boolean remove(String key) {
+  public final boolean remove(Object key) {
     return contextData().remove(key) != null;
   }
 
   @SuppressWarnings("unchecked")
   @Override
-  public final <T> T getLocal(String key) {
+  public final <T> T getLocal(Object key) {
     return (T) localContextData().get(key);
   }
 
   @Override
-  public final void putLocal(String key, Object value) {
+  public final void putLocal(Object key, Object value) {
     localContextData().put(key, value);
   }
 
   @Override
-  public final boolean removeLocal(String key) {
+  public final boolean removeLocal(Object key) {
     return localContextData().remove(key) != null;
   }
 

--- a/src/main/java/io/vertx/core/impl/ContextInternal.java
+++ b/src/main/java/io/vertx/core/impl/ContextInternal.java
@@ -219,8 +219,8 @@ public interface ContextInternal extends Context {
 
   /**
    * @return the {@link ConcurrentMap} used to store context data
-   * @see Context#get(String)
-   * @see Context#put(String, Object)
+   * @see Context#get(Object)
+   * @see Context#put(Object, Object)
    */
   ConcurrentMap<Object, Object> contextData();
 


### PR DESCRIPTION
Closes #3952

The Context interface used to restrict storage and retrieval of objects in context to String instances.

But the underlying storage permits to use instances of any type.

With this change, users can now store any type of objects in the context, without having to cast to ContextInternal and work with data maps directly.

Signed-off-by: Thomas Segismont <tsegismont@gmail.com>

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
