### PR TITLE
Implement shared HttpClient support

### DIFF
--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -177,6 +177,30 @@ public interface Vertx extends Measured {
   HttpClient createHttpClient(HttpClientOptions options);
 
   /**
+   * Like {@link #createSharedHttpClient(HttpClientOptions)}, using default options.
+   */
+  HttpClient createSharedHttpClient();
+
+  /**
+   * Like {@link #createSharedHttpClient(String, HttpClientOptions)}, using the default shared client name.
+   */
+  HttpClient createSharedHttpClient(HttpClientOptions options);
+
+  /**
+   * Like {@link #createSharedHttpClient(String, HttpClientOptions)}, using default options.
+   */
+  HttpClient createSharedHttpClient(String name);
+
+  /**
+   * Create a HTTP/HTTPS client using the specified name and options.
+   *
+   * @param name    the shared client name
+   * @param options the options to use
+   * @return the client
+   */
+  HttpClient createSharedHttpClient(String name, HttpClientOptions options);
+
+  /**
    * Create a HTTP/HTTPS client using default options
    *
    * @return the client

--- a/src/main/java/io/vertx/core/http/impl/HttpClientHolder.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientHolder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.http.impl;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.impl.CloseFuture;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.shareddata.Shareable;
+
+public class HttpClientHolder implements Shareable {
+
+  private final int count;
+  private final HttpClient client;
+  private final CloseFuture closeFuture;
+
+  public HttpClientHolder() {
+    count = 1;
+    client = null;
+    closeFuture = null;
+  }
+
+  private HttpClientHolder(int count, HttpClient client, CloseFuture closeFuture) {
+    this.count = count;
+    this.client = client;
+    this.closeFuture = closeFuture;
+  }
+
+  public HttpClient get() {
+    return client;
+  }
+
+  public HttpClientHolder increment() {
+    return client == null ? null : new HttpClientHolder(count + 1, client, closeFuture);
+  }
+
+  public HttpClientHolder init(VertxInternal vertx, HttpClientOptions options) {
+    CloseFuture closeFuture = new CloseFuture();
+    HttpClient client = new HttpClientImpl(vertx, options, closeFuture);
+    return new HttpClientHolder(count, client, closeFuture);
+  }
+
+  public HttpClientHolder decrement() {
+    return count == 1 ? null : new HttpClientHolder(count - 1, client, closeFuture);
+  }
+
+  public Future<Void> close() {
+    return CompositeFuture.all(client.close(), closeFuture.close()).mapEmpty();
+  }
+
+  @Override
+  public String toString() {
+    return "HttpClientHolder{" +
+      "count=" + count +
+      '}';
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -169,7 +169,8 @@ public class HttpClientImpl implements HttpClient, MetricsProvider, Closeable {
     httpCM = httpConnectionManager();
     if (options.getPoolCleanerPeriod() > 0 && (options.getKeepAliveTimeout() > 0L || options.getHttp2KeepAliveTimeout() > 0L)) {
       PoolChecker checker = new PoolChecker(this);
-      timerID = vertx.setTimer(options.getPoolCleanerPeriod(), checker);
+      ContextInternal timerContext = vertx.createEventLoopContext();
+      timerID = timerContext.setTimer(options.getPoolCleanerPeriod(), checker);
     }
 
     closeFuture.add(netClient);

--- a/src/main/java/io/vertx/core/http/impl/SharedHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/SharedHttpClient.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.http.impl;
+
+import io.vertx.core.*;
+import io.vertx.core.http.*;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.shareddata.LocalMap;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class SharedHttpClient implements HttpClient, Closeable {
+
+  private static final String MAP_NAME = "__vertx.shared.httpClients";
+  public static final String DEFAULT_CLIENT_NAME = "SharedHttpClient.DEFAULT";
+
+  private final VertxInternal vertx;
+  private final String name;
+  private final HttpClient delegate;
+
+  private SharedHttpClient(VertxInternal vertx, String name, HttpClient delegate) {
+    this.vertx = vertx;
+    this.name = name;
+    this.delegate = delegate;
+  }
+
+  public static SharedHttpClient create(VertxInternal vertx, String name, HttpClientOptions options) {
+    LocalMap<String, HttpClientHolder> localMap = vertx.sharedData().getLocalMap(MAP_NAME);
+    HttpClient client;
+    HttpClientHolder current, candidate;
+    for (; ; ) {
+      current = localMap.get(name);
+      if (current != null) {
+        candidate = current.increment();
+        if (candidate != null && localMap.replaceIfPresent(name, current, candidate)) {
+          client = candidate.get();
+          break;
+        }
+      } else {
+        candidate = new HttpClientHolder();
+        if (localMap.putIfAbsent(name, candidate) == null) {
+          candidate = candidate.init(vertx, options);
+          client = candidate.get();
+          localMap.put(name, candidate);
+          break;
+        }
+      }
+    }
+    return new SharedHttpClient(vertx, name, client);
+  }
+
+  @Override
+  public void close(Handler<AsyncResult<Void>> handler) {
+    Future<Void> future = close();
+    if (handler != null) {
+      future.onComplete(handler);
+    }
+  }
+
+  @Override
+  public Future<Void> close() {
+    Promise<Void> promise = vertx.promise();
+    LocalMap<String, HttpClientHolder> localMap = vertx.sharedData().getLocalMap(MAP_NAME);
+    HttpClientHolder current, candidate;
+    for (; ; ) {
+      current = localMap.get(name);
+      candidate = current.decrement();
+      if (candidate == null) {
+        if (localMap.removeIfPresent(name, current)) {
+          current.close().onComplete(promise);
+          break;
+        }
+      } else if (localMap.replace(name, current, candidate)) {
+        promise.complete();
+        break;
+      }
+    }
+    return promise.future();
+  }
+
+  @Override
+  public void close(Promise<Void> completion) {
+    close().onComplete(completion);
+  }
+
+  @Override
+  protected void finalize() throws Throwable {
+    // Make sure the shared client count gets decreased if there are no more references to this instance
+    close();
+    super.finalize();
+  }
+
+  @Override
+  public void request(RequestOptions options, Handler<AsyncResult<HttpClientRequest>> handler) {
+    delegate.request(options, handler);
+  }
+
+  @Override
+  public Future<HttpClientRequest> request(RequestOptions options) {
+    return delegate.request(options);
+  }
+
+  @Override
+  public void request(HttpMethod method, int port, String host, String requestURI, Handler<AsyncResult<HttpClientRequest>> handler) {
+    delegate.request(method, port, host, requestURI, handler);
+  }
+
+  @Override
+  public Future<HttpClientRequest> request(HttpMethod method, int port, String host, String requestURI) {
+    return delegate.request(method, port, host, requestURI);
+  }
+
+  @Override
+  public void request(HttpMethod method, String host, String requestURI, Handler<AsyncResult<HttpClientRequest>> handler) {
+    delegate.request(method, host, requestURI, handler);
+  }
+
+  @Override
+  public Future<HttpClientRequest> request(HttpMethod method, String host, String requestURI) {
+    return delegate.request(method, host, requestURI);
+  }
+
+  @Override
+  public void request(HttpMethod method, String requestURI, Handler<AsyncResult<HttpClientRequest>> handler) {
+    delegate.request(method, requestURI, handler);
+  }
+
+  @Override
+  public Future<HttpClientRequest> request(HttpMethod method, String requestURI) {
+    return delegate.request(method, requestURI);
+  }
+
+  @Override
+  public void webSocket(int port, String host, String requestURI, Handler<AsyncResult<WebSocket>> handler) {
+    delegate.webSocket(port, host, requestURI, handler);
+  }
+
+  @Override
+  public Future<WebSocket> webSocket(int port, String host, String requestURI) {
+    return delegate.webSocket(port, host, requestURI);
+  }
+
+  @Override
+  public void webSocket(String host, String requestURI, Handler<AsyncResult<WebSocket>> handler) {
+    delegate.webSocket(host, requestURI, handler);
+  }
+
+  @Override
+  public Future<WebSocket> webSocket(String host, String requestURI) {
+    return delegate.webSocket(host, requestURI);
+  }
+
+  @Override
+  public void webSocket(String requestURI, Handler<AsyncResult<WebSocket>> handler) {
+    delegate.webSocket(requestURI, handler);
+  }
+
+  @Override
+  public Future<WebSocket> webSocket(String requestURI) {
+    return delegate.webSocket(requestURI);
+  }
+
+  @Override
+  public void webSocket(WebSocketConnectOptions options, Handler<AsyncResult<WebSocket>> handler) {
+    delegate.webSocket(options, handler);
+  }
+
+  @Override
+  public Future<WebSocket> webSocket(WebSocketConnectOptions options) {
+    return delegate.webSocket(options);
+  }
+
+  @Override
+  public void webSocketAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols, Handler<AsyncResult<WebSocket>> handler) {
+    delegate.webSocketAbs(url, headers, version, subProtocols, handler);
+  }
+
+  @Override
+  public Future<WebSocket> webSocketAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
+    return delegate.webSocketAbs(url, headers, version, subProtocols);
+  }
+
+  @Override
+  public HttpClient connectionHandler(Handler<HttpConnection> handler) {
+    return delegate.connectionHandler(handler);
+  }
+
+  @Override
+  public HttpClient redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
+    return delegate.redirectHandler(handler);
+  }
+
+  @Override
+  public Function<HttpClientResponse, Future<RequestOptions>> redirectHandler() {
+    return delegate.redirectHandler();
+  }
+}

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -40,6 +40,7 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.impl.HttpClientImpl;
 import io.vertx.core.http.impl.HttpServerImpl;
+import io.vertx.core.http.impl.SharedHttpClient;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
@@ -71,7 +72,10 @@ import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -355,6 +359,31 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     HttpClient client = createHttpClient(options, closeFuture);
     CloseFuture fut = resolveCloseFuture();
     fut.add(closeFuture);
+    return client;
+  }
+
+  @Override
+  public HttpClient createSharedHttpClient() {
+    return createSharedHttpClient(SharedHttpClient.DEFAULT_CLIENT_NAME, new HttpClientOptions());
+  }
+
+  @Override
+  public HttpClient createSharedHttpClient(HttpClientOptions options) {
+    return createSharedHttpClient(SharedHttpClient.DEFAULT_CLIENT_NAME, options);
+  }
+
+  @Override
+  public HttpClient createSharedHttpClient(String name) {
+    return createSharedHttpClient(name, new HttpClientOptions());
+  }
+
+  @Override
+  public HttpClient createSharedHttpClient(String name, HttpClientOptions options) {
+    CloseFuture closeFuture = new CloseFuture(log);
+    SharedHttpClient client = SharedHttpClient.create(this, name, options);
+    closeFuture.add(client);
+    CloseFuture parentCloseFuture = resolveCloseFuture();
+    parentCloseFuture.add(closeFuture);
     return client;
   }
 

--- a/src/test/java/io/vertx/core/http/SharedHttpClientTest.java
+++ b/src/test/java/io/vertx/core/http/SharedHttpClientTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.http;
+
+import io.vertx.core.*;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.json.JsonObject;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static io.vertx.core.http.HttpMethod.GET;
+
+public class SharedHttpClientTest extends VertxTestBase {
+
+  int sharedPoolSize = 7;
+  int clientVerticleInstances = 8;
+
+  int requestsPerVerticle = 50 * sharedPoolSize;
+  int requestsTotal = clientVerticleInstances * requestsPerVerticle;
+
+  @Test
+  public void testVerticlesUseSamePool() throws Exception {
+    CountDownLatch receivedLatch = new CountDownLatch(requestsTotal);
+    ServerVerticle serverVerticle = new ServerVerticle();
+
+    vertx.deployVerticle(serverVerticle, onSuccess(serverId -> {
+
+      HttpClientOptions clientOptions = httpClientOptions(serverVerticle, sharedPoolSize);
+      DeploymentOptions deploymentOptions = deploymentOptions(clientVerticleInstances, clientOptions);
+
+      Supplier<Verticle> verticleSupplier = () -> new ClientVerticle(clientVerticle -> {
+        // Verify the reply context is the same as of the deployment
+        // We can't compare to the verticle context because the reply context is a DuplicatedContext
+        assertEquals(clientVerticle.context.deploymentID(), Vertx.currentContext().deploymentID());
+        receivedLatch.countDown();
+      });
+
+      vertx.deployVerticle(verticleSupplier, deploymentOptions, onSuccess(clientId -> {
+        vertx.eventBus().publish(ClientVerticle.TRIGGER_ADDRESS, requestsPerVerticle);
+      }));
+    }));
+
+    waitUntil(() -> serverVerticle.connections.size() == sharedPoolSize);
+    serverVerticle.replyLatch.complete();
+    awaitLatch(receivedLatch);
+    assertEquals(serverVerticle.maxConnections, sharedPoolSize);
+  }
+
+  @Test
+  public void testSharedPoolClosedAutomatically() throws Exception {
+    CountDownLatch receivedLatch = new CountDownLatch(requestsTotal);
+    ServerVerticle serverVerticle = new ServerVerticle();
+    AtomicReference<String> clientDeploymentId = new AtomicReference<>();
+
+    vertx.deployVerticle(serverVerticle, onSuccess(serverId -> {
+
+      HttpClientOptions clientOptions = httpClientOptions(serverVerticle, sharedPoolSize)
+        // Make sure connections stay alive for the duration of the test if the server is not closed
+        .setKeepAliveTimeout(3600);
+      DeploymentOptions deploymentOptions = deploymentOptions(clientVerticleInstances, clientOptions);
+
+      Supplier<Verticle> verticleSupplier = () -> new ClientVerticle(clientVerticle -> receivedLatch.countDown());
+
+      vertx.deployVerticle(verticleSupplier, deploymentOptions, onSuccess(clientId -> {
+        clientDeploymentId.set(clientId);
+        vertx.eventBus().publish(ClientVerticle.TRIGGER_ADDRESS, requestsPerVerticle);
+      }));
+    }));
+
+    waitUntil(() -> serverVerticle.connections.size() == sharedPoolSize);
+    serverVerticle.replyLatch.complete();
+    awaitLatch(receivedLatch);
+
+    CountDownLatch undeployLatch = new CountDownLatch(1);
+    vertx.undeploy(clientDeploymentId.get(), onSuccess(v -> {
+      undeployLatch.countDown();
+    }));
+
+    awaitLatch(undeployLatch);
+    assertWaitUntil(() -> serverVerticle.connections.size() == 0);
+  }
+
+  @Test
+  public void testSharedPoolRetainedByOtherDeployment() throws Exception {
+    int keepAliveTimeoutSeconds = 3;
+
+    CountDownLatch receivedLatch = new CountDownLatch(requestsTotal);
+    ServerVerticle serverVerticle = new ServerVerticle();
+    AtomicReference<String> clientDeploymentId = new AtomicReference<>();
+
+    vertx.deployVerticle(serverVerticle, onSuccess(serverId -> {
+
+      HttpClientOptions clientOptions = httpClientOptions(serverVerticle, sharedPoolSize)
+        .setKeepAliveTimeout(keepAliveTimeoutSeconds);
+      DeploymentOptions deploymentOptions = deploymentOptions(clientVerticleInstances, clientOptions);
+
+      Supplier<Verticle> verticleSupplier = () -> new ClientVerticle(clientVerticle -> receivedLatch.countDown());
+
+      vertx.deployVerticle(verticleSupplier, deploymentOptions, onSuccess(clientId -> {
+        clientDeploymentId.set(clientId);
+        vertx.eventBus().publish(ClientVerticle.TRIGGER_ADDRESS, requestsPerVerticle);
+      }));
+    }));
+
+    waitUntil(() -> serverVerticle.connections.size() == sharedPoolSize);
+
+    CountDownLatch deployLatch = new CountDownLatch(1);
+    vertx.deployVerticle(new AbstractVerticle() {
+      @Override
+      public void start() throws Exception {
+        vertx.createSharedHttpClient(ClientVerticle.SHARED_CLIENT_NAME, new HttpClientOptions());
+      }
+    }, onSuccess(v -> {
+      deployLatch.countDown();
+    }));
+    awaitLatch(deployLatch);
+
+    serverVerticle.replyLatch.complete();
+    awaitLatch(receivedLatch);
+
+    CountDownLatch undeployLatch = new CountDownLatch(1);
+    vertx.undeploy(clientDeploymentId.get(), onSuccess(v -> {
+      undeployLatch.countDown();
+    }));
+
+    awaitLatch(undeployLatch);
+
+    waitFor(2);
+    vertx.setTimer((1000 * keepAliveTimeoutSeconds) / 2, l -> {
+      assertTrue(serverVerticle.connections.size() > 0);
+      complete();
+    });
+    vertx.setTimer(2 * 1000 * keepAliveTimeoutSeconds, l -> {
+      assertTrue(serverVerticle.connections.size() == 0);
+      complete();
+    });
+    await();
+  }
+
+  private static class ClientVerticle extends AbstractVerticle implements Handler<Message<Integer>> {
+
+    static final String TRIGGER_ADDRESS = UUID.randomUUID().toString();
+    static final String SHARED_CLIENT_NAME = UUID.randomUUID().toString();
+
+    final Consumer<ClientVerticle> onResponseReceived;
+
+    volatile Context context;
+    HttpClient client;
+
+    ClientVerticle(Consumer<ClientVerticle> onResponseReceived) {
+      this.onResponseReceived = onResponseReceived;
+    }
+
+    @Override
+    public void start(Promise<Void> startPromise) throws Exception {
+      context = super.context;
+      client = vertx.createSharedHttpClient(SHARED_CLIENT_NAME, new HttpClientOptions(config().getJsonObject("httpClientOptions")));
+      vertx.eventBus().consumer(TRIGGER_ADDRESS, this).completionHandler(startPromise);
+    }
+
+    @Override
+    public void handle(Message<Integer> message) {
+      for (int i = 0; i < message.body(); i++) {
+        client.request(GET, "/").compose(HttpClientRequest::send).onComplete(ar -> onResponseReceived.accept(this));
+      }
+    }
+  }
+
+  private static class ServerVerticle extends AbstractVerticle implements Handler<HttpServerRequest> {
+
+    volatile Promise<Void> replyLatch;
+    volatile int port;
+    Set<HttpConnection> connections = Collections.synchronizedSet(new HashSet<>());
+    volatile int maxConnections;
+
+    @Override
+    public void start(Promise<Void> startPromise) throws Exception {
+      replyLatch = ((VertxInternal) vertx).promise();
+      vertx.createHttpServer()
+        .requestHandler(this)
+        .listen(0)
+        .onSuccess(server -> port = server.actualPort())
+        .<Void>mapEmpty()
+        .onComplete(startPromise);
+    }
+
+    @Override
+    public void handle(HttpServerRequest req) {
+      HttpConnection connection = req.connection();
+      connections.add(connection);
+      connection.closeHandler(v -> connections.remove(connection));
+      maxConnections = Math.max(maxConnections, connections.size());
+      replyLatch.future().onComplete(ar -> req.response().end());
+    }
+  }
+
+  private static HttpClientOptions httpClientOptions(ServerVerticle serverVerticle, int sharedPoolSize) {
+    return new HttpClientOptions()
+      .setDefaultPort(serverVerticle.port)
+      .setMaxPoolSize(sharedPoolSize);
+  }
+
+  private static DeploymentOptions deploymentOptions(int instances, HttpClientOptions options) {
+    return new DeploymentOptions()
+      .setInstances(instances)
+      .setConfig(new JsonObject()
+        .put("httpClientOptions", options.toJson()));
+  }
+}


### PR DESCRIPTION
Closes #3361

The shared client operates on its own context instead of the creation context.
This is to avoid keeping around a context that could be closed (like the context of an undeployed verticle).

However, we make sure replies to requests are emitted on the sender context.