### PR TITLE
Update Http1xServerConnection.java

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -131,15 +131,15 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
       DefaultHttpRequest request = (DefaultHttpRequest) msg;
       ContextInternal requestCtx = streamContextSupplier.get();
       Http1xServerRequest req = new Http1xServerRequest(this, request, requestCtx);
+      if (METRICS_ENABLED) {
+        reportRequestBegin(req);
+      }
       requestInProgress = req;
       if (responseInProgress != null) {
         enqueueRequest(req);
         return;
       }
       responseInProgress = requestInProgress;
-      if (METRICS_ENABLED) {
-        reportRequestBegin(req);
-      }
       req.handleBegin();
       Handler<HttpServerRequest> handler = request.decoderResult().isSuccess() ? requestHandler : invalidRequestHandler;
       req.context.emit(req, handler);


### PR DESCRIPTION
Ensure `request.metric` is set for all requests regardless if response is in progress and using small buffers (HTTP Keep-Alive)

Motivation:

Fixes a NPE encountered when updating metrics due to the `request.metric` object not being set in `handleMessage` when a response is pending.
Conditions to trigger this NPE :
* return a response that is larger than the default quarkus.resteasy.vertx.response-buffer-size
* concurrent incomming requests using KeepAlive

Using Quarkus 2.2.2.FINAL and Vert.x 4.1.3

```
2021-09-11 13:07:17,071 ERROR [io.ver.ext.web.RoutingContext] (vert.x-eventloop-thread-3) Unhandled exception in router: java.lang.NullPointerException
        at io.quarkus.micrometer.runtime.binder.vertx.VertxHttpServerMetrics.requestRouted(VertxHttpServerMetrics.java:80)
        at io.quarkus.micrometer.runtime.binder.vertx.VertxHttpServerMetrics.requestRouted(VertxHttpServerMetrics.java:28)
        at io.vertx.core.http.impl.Http1xServerRequest.routed(Http1xServerRequest.java:658)
        at io.quarkus.vertx.http.runtime.AbstractRequestWrapper.routed(AbstractRequestWrapper.java:272)
        at io.vertx.ext.web.impl.HttpServerRequestWrapper.routed(HttpServerRequestWrapper.java:395)
        at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:142)
        at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:133)
        at io.vertx.ext.web.impl.RoutingContextImpl.doFail(RoutingContextImpl.java:591)
        at io.vertx.ext.web.impl.RoutingContextImpl.fail(RoutingContextImpl.java:184)
        at io.vertx.ext.web.impl.RoutingContextImpl.fail(RoutingContextImpl.java:173)
        at io.vertx.ext.web.impl.RoutingContextImplBase.handleInHandlerRuntimeFailure(RoutingContextImplBase.java:189)
        at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:156)
        at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:133)
        at io.vertx.ext.web.impl.RouterImpl.handle(RouterImpl.java:55)
        at io.vertx.ext.web.impl.RouterImpl.handle(RouterImpl.java:37)
        at io.quarkus.vertx.http.runtime.VertxHttpRecorder$10.handle(VertxHttpRecorder.java:436)
        at io.quarkus.vertx.http.runtime.VertxHttpRecorder$10.handle(VertxHttpRecorder.java:433)
        at io.quarkus.vertx.http.runtime.VertxHttpRecorder$1.handle(VertxHttpRecorder.java:151)
        at io.quarkus.vertx.http.runtime.VertxHttpRecorder$1.handle(VertxHttpRecorder.java:133)
        at io.vertx.core.http.impl.Http1xServerRequestHandler.handle(Http1xServerRequestHandler.java:67)
        at io.vertx.core.http.impl.Http1xServerRequestHandler.handle(Http1xServerRequestHandler.java:30)
        at io.vertx.core.http.impl.Http1xServerConnection.lambda$handleNext$1(Http1xServerConnection.java:239)
        at io.vertx.core.impl.EventLoopContext.emit(EventLoopContext.java:50)
        at io.vertx.core.impl.ContextImpl.emit(ContextImpl.java:274)
        at io.vertx.core.impl.EventLoopContext.emit(EventLoopContext.java:22)
        at io.vertx.core.http.impl.Http1xServerConnection.handleNext(Http1xServerConnection.java:236)
        at io.vertx.core.http.impl.Http1xServerConnection.responseComplete(Http1xServerConnection.java:221)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:497)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:834)
```

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
