### PR TITLE
Fix IDE generic type warning

### DIFF
--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -72,8 +72,8 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    *
    * When the list is empty, the returned future will be already completed.
    */
-  static CompositeFuture all(List<Future> futures) {
-    return CompositeFutureImpl.all(futures.toArray(new Future[0]));
+  static CompositeFuture all(List<Future<?>> futures) {
+    return CompositeFutureImpl.all(futures.toArray(new Future<?>[0]));
   }
 
   /**
@@ -122,8 +122,8 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    *
    * When the list is empty, the returned future will be already completed.
    */
-  static CompositeFuture any(List<Future> futures) {
-    return CompositeFutureImpl.any(futures.toArray(new Future[0]));
+  static CompositeFuture any(List<Future<?>> futures) {
+    return CompositeFutureImpl.any(futures.toArray(new Future<?>[0]));
   }
 
   /**
@@ -172,8 +172,8 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    *
    * When the list is empty, the returned future will be already completed.
    */
-  static CompositeFuture join(List<Future> futures) {
-    return CompositeFutureImpl.join(futures.toArray(new Future[0]));
+  static CompositeFuture join(List<Future<?>> futures) {
+    return CompositeFutureImpl.join(futures.toArray(new Future<?>[0]));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -402,7 +402,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
 
   private Future<Void> unregisterAll() {
     // Unregister all handlers explicitly - don't rely on context hooks
-    List<Future> futures = new ArrayList<>();
+    List<Future<?>> futures = new ArrayList<>();
     for (ConcurrentCyclicSequence<HandlerHolder> handlers : handlerMap.values()) {
       for (HandlerHolder holder : handlers) {
         futures.add(holder.getHandler().unregister());

--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -101,7 +101,7 @@ public class DeploymentManager {
         deploymentIDs.add(entry.getKey());
       }
     }
-    List<Future> completionList = new ArrayList<>();
+    List<Future<?>> completionList = new ArrayList<>();
     if (!deploymentIDs.isEmpty()) {
       for (String deploymentID : deploymentIDs) {
         Promise<Void> promise = Promise.promise();
@@ -302,7 +302,7 @@ public class DeploymentManager {
 
     private synchronized Future<Void> doUndeployChildren(ContextInternal undeployingContext) {
       if (!children.isEmpty()) {
-        List<Future> childFuts = new ArrayList<>();
+        List<Future<?>> childFuts = new ArrayList<>();
         for (Deployment childDeployment: new HashSet<>(children)) {
           Promise<Void> p = Promise.promise();
           childFuts.add(p.future());
@@ -326,7 +326,7 @@ public class DeploymentManager {
         return doUndeployChildren(undeployingContext).compose(v -> doUndeploy(undeployingContext));
       } else {
         status = ST_UNDEPLOYED;
-        List<Future> undeployFutures = new ArrayList<>();
+        List<Future<?>> undeployFutures = new ArrayList<>();
         if (parent != null) {
           parent.removeChild(this);
         }

--- a/src/main/java/io/vertx/core/net/impl/TCPServerBase.java
+++ b/src/main/java/io/vertx/core/net/impl/TCPServerBase.java
@@ -247,7 +247,7 @@ public abstract class TCPServerBase implements Closeable, MetricsProvider {
    * Internal method that closes all servers when Vert.x is closing
    */
   public void closeAll(Handler<AsyncResult<Void>> handler) {
-    List<Future> futures = new ArrayList<>(actualServer.servers)
+    List<Future<?>> futures = new ArrayList<>(actualServer.servers)
       .stream()
       .map(TCPServerBase::close)
       .collect(Collectors.toList());

--- a/src/test/java/io/vertx/core/CompositeFutureTest.java
+++ b/src/test/java/io/vertx/core/CompositeFutureTest.java
@@ -123,12 +123,12 @@ public class CompositeFutureTest extends FutureTestBase {
     });
   }
 
-  private void testConcurrentCompletion(BiConsumer<Integer, Promise<String>> completer, Function<List<Future>, CompositeFuture> fact, Consumer<CompositeFuture> check) throws Exception {
+  private void testConcurrentCompletion(BiConsumer<Integer, Promise<String>> completer, Function<List<Future<?>>, CompositeFuture> fact, Consumer<CompositeFuture> check) throws Exception {
     disableThreadChecks();
     List<Promise<String>> promises = IntStream.range(0, NUM_THREADS)
       .mapToObj(i -> Promise.<String>promise())
       .collect(Collectors.toList());
-    List<Future> futures = promises.stream()
+    List<Future<?>> futures = promises.stream()
       .map(Promise::future)
       .collect(Collectors.toList());
     CompositeFuture compositeFuture = fact.apply(futures);
@@ -225,7 +225,7 @@ public class CompositeFutureTest extends FutureTestBase {
   }
 
   private void testAllLargeList(int size) {
-    List<Future> list = new ArrayList<>();
+    List<Future<?>> list = new ArrayList<>();
     for (int i = 0;i < size;i++) {
       list.add(Future.succeededFuture());
     }
@@ -339,7 +339,7 @@ public class CompositeFutureTest extends FutureTestBase {
   }
 
   private void testAnyLargeList(int size) {
-    List<Future> list = new ArrayList<>();
+    List<Future<?>> list = new ArrayList<>();
     for (int i = 0;i < size;i++) {
       list.add(Future.failedFuture(new Exception()));
     }

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -598,7 +598,7 @@ public class ContextTest extends VertxTestBase {
     int n = 2;
     List<ContextInternal> dup1 = Stream.generate(supplier).limit(n).collect(Collectors.toList());
     AtomicInteger cnt = new AtomicInteger();
-    List<Future> futures = dup1.stream().map(c -> c.<Void>executeBlocking(duplicate -> {
+    List<Future<?>> futures = dup1.stream().map(c -> c.<Void>executeBlocking(duplicate -> {
       assertTrue(Context.isOnWorkerThread());
       int val = cnt.incrementAndGet();
       if (ordered) {

--- a/src/test/java/io/vertx/core/shareddata/AsyncMapTest.java
+++ b/src/test/java/io/vertx/core/shareddata/AsyncMapTest.java
@@ -765,9 +765,9 @@ public abstract class AsyncMapTest extends VertxTestBase {
   }
 
   protected void loadData(Map<JsonObject, Buffer> map, BiConsumer<Vertx, AsyncMap<JsonObject, Buffer>> test) {
-    List<Future> futures = new ArrayList<>(map.size());
+    List<Future<?>> futures = new ArrayList<>(map.size());
     map.forEach((key, value) -> {
-      Promise future = Promise.promise();
+      Promise<Void> future = Promise.promise();
       getVertx().sharedData().getAsyncMap("foo", onSuccess(asyncMap -> {
         asyncMap.put(key, value, future);
       }));

--- a/src/test/java/io/vertx/core/shareddata/AsynchronousLockTest.java
+++ b/src/test/java/io/vertx/core/shareddata/AsynchronousLockTest.java
@@ -252,7 +252,7 @@ public class AsynchronousLockTest extends VertxTestBase {
     int numWaiters = 10;
     SharedData sharedData = vertx.sharedData();
     sharedData.getLocalLock("foo", onSuccess(lock -> {
-      List<Future> locks = new ArrayList<>();
+      List<Future<?>> locks = new ArrayList<>();
       for (int i = 0;i < numWaiters;i++) {
         locks.add(sharedData.getLocalLockWithTimeout("foo", 200));
       }

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -788,7 +788,7 @@ public class MetricsTest extends VertxTestBase {
       servers.add(server);
     }
     try {
-      List<Future> collect = servers.stream().map(server -> server.listen(8080)).collect(Collectors.toList());
+      List<Future<?>> collect = servers.stream().map(server -> server.listen(8080)).collect(Collectors.toList());
       CompositeFuture
         .all(collect)
         .onSuccess(v -> {

--- a/src/test/java/io/vertx/test/verticles/FaultToleranceVerticle.java
+++ b/src/test/java/io/vertx/test/verticles/FaultToleranceVerticle.java
@@ -40,7 +40,7 @@ public class FaultToleranceVerticle extends AbstractVerticle {
     JsonObject config = config();
     id = config.getInteger("id");
     numAddresses = config.getInteger("addressesCount");
-    List<Future> registrationFutures = new ArrayList<>(numAddresses);
+    List<Future<?>> registrationFutures = new ArrayList<>(numAddresses);
     for (int i = 0; i < numAddresses; i++) {
       Promise<Void> registrationFuture = Promise.promise();
       registrationFutures.add(registrationFuture.future());


### PR DESCRIPTION
Signed-off-by: aomsweet <aomsweet@tutanota.com>

Motivation:

To fix IDE generic type warnings, But this is destructive to the original API.

![image](https://user-images.githubusercontent.com/70388114/133881936-babdb16c-5605-4864-9c7d-ed9e0df85e43.png)


Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
