### PR TITLE
Allow to register default codecs that can handle sub-types

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/EventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBus.java
@@ -245,7 +245,7 @@ public interface EventBus extends Measured {
    * @return a reference to this, so the API can be used fluently
    */
   @GenIgnore
-  <T> EventBus registerDefaultCodec(Class<T> clazz, MessageCodec<T, ?> codec);
+  <T> EventBus registerDefaultCodec(Class<T> clazz, MessageCodec<? super T, ?> codec);
 
   /**
    * Unregister a default message codec.

--- a/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
@@ -123,7 +123,7 @@ public class CodecManager {
     userCodecMap.remove(name);
   }
 
-  public <T> void registerDefaultCodec(Class<T> clazz, MessageCodec<T, ?> codec) {
+  public <T> void registerDefaultCodec(Class<T> clazz, MessageCodec<? super T, ?> codec) {
     Objects.requireNonNull(clazz);
     Objects.requireNonNull(codec, "codec");
     Objects.requireNonNull(codec.name(), "code.name()");

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -192,7 +192,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   }
 
   @Override
-  public <T> EventBus registerDefaultCodec(Class<T> clazz, MessageCodec<T, ?> codec) {
+  public <T> EventBus registerDefaultCodec(Class<T> clazz, MessageCodec<? super T, ?> codec) {
     codecManager.registerDefaultCodec(clazz, codec);
     return this;
   }

--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
@@ -142,7 +142,7 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
   }
 
   @Test
-  public void testDefaultDecoderSendSymetric() throws Exception {
+  public void testDefaultDecoderSendSymmetric() throws Exception {
     startNodes(2);
     MessageCodec codec = new MyPOJOEncoder2();
     vertices[0].eventBus().registerDefaultCodec(MyPOJO.class, codec);
@@ -153,7 +153,21 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
   }
 
   @Test
-  public void testDefaultDecoderReplySymetric() throws Exception {
+  public void testDefaultDecoderSendSubSymmetric() throws Exception {
+    startNodes(2);
+    MessageCodec codec = new MyPOJOEncoder2();
+    vertices[0].eventBus().registerDefaultCodec(MySubPOJO.class, codec);
+    vertices[1].eventBus().registerDefaultCodec(MyPOJO.class, codec);
+    String str = TestUtils.randomAlphaString(100);
+    MyPOJO pojo = new MySubPOJO(str);
+    testSend(pojo, pojo, recPojo -> {
+      assertEquals(recPojo.getStr(), pojo.getStr());
+      assertTrue(recPojo.getClass() != MySubPOJO.class);
+    }, null);
+  }
+
+  @Test
+  public void testDefaultDecoderReplySymmetric() throws Exception {
     startNodes(2);
     MessageCodec codec = new MyPOJOEncoder2();
     vertices[0].eventBus().registerDefaultCodec(MyPOJO.class, codec);
@@ -161,6 +175,20 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
     String str = TestUtils.randomAlphaString(100);
     MyPOJO pojo = new MyPOJO(str);
     testReply(pojo, pojo, null, null);
+  }
+
+  @Test
+  public void testDefaultDecoderReplySubSymmetric() throws Exception {
+    startNodes(2);
+    MessageCodec codec = new MyPOJOEncoder2();
+    vertices[0].eventBus().registerDefaultCodec(MyPOJO.class, codec);
+    vertices[1].eventBus().registerDefaultCodec(MySubPOJO.class, codec);
+    String str = TestUtils.randomAlphaString(100);
+    MyPOJO pojo = new MySubPOJO(str);
+    testReply(pojo, pojo, recPojo -> {
+      assertEquals(recPojo.getStr(), pojo.getStr());
+      assertTrue(recPojo.getClass() != MySubPOJO.class);
+    }, null);
   }
 
   @Test

--- a/src/test/java/io/vertx/core/eventbus/EventBusTestBase.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusTestBase.java
@@ -628,6 +628,12 @@ public abstract class EventBusTestBase extends VertxTestBase {
     }
   }
 
+  public static class MySubPOJO extends MyPOJO {
+    public MySubPOJO(String str) {
+      super(str);
+    }
+  }
+
   public static class MyReplyException extends ReplyException {
 
     public MyReplyException(int failureCode, String message) {


### PR DESCRIPTION
Implements #4087. Imagine having multiple "Ducks" that you want to send via the wire:

- `GreatDuck`
- `SmallDuck`
- `DuckyMcDuck`

All ducks implement the `Duck` interface and a `toJson` method.

This change allows to implement one `DuckMessageCodec` which can handle any duck by calling the `toJson` method on the object.