### PR TITLE
Add an option to omit the origin header in the WebSocket client handshake request.

### DIFF
--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -1725,6 +1725,23 @@ The handler will be called with an instance of {@link io.vertx.core.http.WebSock
 {@link examples.HTTPExamples#example54}
 ----
 
+By default, the client sets the `origin` header to the server host, e.g http://www.example.com. Some servers will refuse
+such request, you can configure the client to not set this header.
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#exampleWebSocketDisableOriginHeader}
+----
+
+You can also set a different header:
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#exampleWebSocketSetOriginHeader}
+----
+
+NOTE: older versions of the WebSocket protocol use `sec-websocket-origin` instead
+
 ==== Writing messages to WebSockets
 
 If you wish to write a single WebSocket message to the WebSocket you can do this with

--- a/src/main/generated/io/vertx/core/http/WebSocketConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/WebSocketConnectOptionsConverter.java
@@ -16,6 +16,11 @@ public class WebSocketConnectOptionsConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, WebSocketConnectOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "allowOriginHeader":
+          if (member.getValue() instanceof Boolean) {
+            obj.setAllowOriginHeader((Boolean)member.getValue());
+          }
+          break;
         case "subProtocols":
           if (member.getValue() instanceof JsonArray) {
             java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
@@ -40,6 +45,7 @@ public class WebSocketConnectOptionsConverter {
   }
 
   public static void toJson(WebSocketConnectOptions obj, java.util.Map<String, Object> json) {
+    json.put("allowOriginHeader", obj.getAllowOriginHeader());
     if (obj.getSubProtocols() != null) {
       JsonArray array = new JsonArray();
       obj.getSubProtocols().forEach(item -> array.add(item));

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -956,6 +956,34 @@ public class HTTPExamples {
     });
   }
 
+  public void exampleWebSocketDisableOriginHeader(HttpClient client, String host, int port, String requestUri) {
+    WebSocketConnectOptions options = new WebSocketConnectOptions()
+      .setHost(host)
+      .setPort(port)
+      .setURI(requestUri)
+      .setAllowOriginHeader(false);
+    client.webSocket(options, res -> {
+      if (res.succeeded()) {
+        WebSocket ws = res.result();
+        System.out.println("Connected!");
+      }
+    });
+  }
+
+  public void exampleWebSocketSetOriginHeader(HttpClient client, String host, int port, String requestUri, String origin) {
+    WebSocketConnectOptions options = new WebSocketConnectOptions()
+      .setHost(host)
+      .setPort(port)
+      .setURI(requestUri)
+      .addHeader(HttpHeaders.ORIGIN, origin);
+    client.webSocket(options, res -> {
+      if (res.succeeded()) {
+        WebSocket ws = res.result();
+        System.out.println("Connected!");
+      }
+    });
+  }
+
   public void example55(WebSocket webSocket) {
     // Write a simple binary message
     Buffer buffer = Buffer.buffer().appendInt(123).appendFloat(1.23f);

--- a/src/main/java/io/vertx/core/http/WebSocketConnectOptions.java
+++ b/src/main/java/io/vertx/core/http/WebSocketConnectOptions.java
@@ -42,14 +42,21 @@ public class WebSocketConnectOptions extends RequestOptions {
    */
   public static final List<String> DEFAULT_SUB_PROTOCOLS = null;
 
+  /**
+   * The default WebSocket allow origin header = {@code true}
+   */
+  public static final boolean DEFAULT_ALLOW_ORIGIN_HEADER = true;
+
   private ProxyOptions proxyOptions;
   private WebsocketVersion version;
   private List<String> subProtocols;
+  private boolean allowOriginHeader;
 
   public WebSocketConnectOptions() {
     proxyOptions = DEFAULT_PROXY_OPTIONS;
     version = DEFAULT_VERSION;
     subProtocols = DEFAULT_SUB_PROTOCOLS;
+    allowOriginHeader = DEFAULT_ALLOW_ORIGIN_HEADER;
   }
 
   public WebSocketConnectOptions(WebSocketConnectOptions other) {
@@ -57,6 +64,7 @@ public class WebSocketConnectOptions extends RequestOptions {
     this.proxyOptions = other.proxyOptions != null ? new ProxyOptions(other.proxyOptions) : null;
     this.version = other.version;
     this.subProtocols = other.subProtocols;
+    this.allowOriginHeader = other.allowOriginHeader;
   }
 
   public WebSocketConnectOptions(JsonObject json) {
@@ -132,6 +140,26 @@ public class WebSocketConnectOptions extends RequestOptions {
     return this;
   }
 
+  /**
+   * @return whether to add the {@code origin} header to the WebSocket handshake request
+   */
+  public boolean getAllowOriginHeader() {
+    return allowOriginHeader;
+  }
+
+  /**
+   * Set whether to add the {@code origin} header to the WebSocket handshake request, enabled by default.
+   *
+   * <p> Set to {@code false} when a server does not accept WebSocket with an origin header.
+   *
+   * @param allowOriginHeader whether to add the {@code origin} header to the WebSocket handshake request
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketConnectOptions setAllowOriginHeader(boolean allowOriginHeader) {
+    this.allowOriginHeader = allowOriginHeader;
+    return this;
+  }
+
   @Override
   public WebSocketConnectOptions setHost(String host) {
     return (WebSocketConnectOptions) super.setHost(host);
@@ -155,6 +183,31 @@ public class WebSocketConnectOptions extends RequestOptions {
   @Override
   public WebSocketConnectOptions addHeader(String key, String value) {
     return (WebSocketConnectOptions) super.addHeader(key, value);
+  }
+
+  @Override
+  public WebSocketConnectOptions addHeader(CharSequence key, CharSequence value) {
+    return (WebSocketConnectOptions) super.addHeader(key, value);
+  }
+
+  @Override
+  public WebSocketConnectOptions addHeader(CharSequence key, Iterable<CharSequence> values) {
+    return (WebSocketConnectOptions) super.addHeader(key, values);
+  }
+
+  @Override
+  public WebSocketConnectOptions putHeader(String key, String value) {
+    return (WebSocketConnectOptions) super.putHeader(key, value);
+  }
+
+  @Override
+  public WebSocketConnectOptions putHeader(CharSequence key, CharSequence value) {
+    return (WebSocketConnectOptions) super.putHeader(key, value);
+  }
+
+  @Override
+  public WebSocketConnectOptions putHeader(CharSequence key, Iterable<CharSequence> values) {
+    return (WebSocketConnectOptions) super.putHeader(key, values);
   }
 
   @GenIgnore

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -312,7 +312,7 @@ public class HttpClientImpl implements HttpClient, MetricsProvider, Closeable {
       ar -> {
         if (ar.succeeded()) {
           Http1xClientConnection conn = (Http1xClientConnection) ar.result();
-          conn.toWebSocket(ctx, connectOptions.getURI(), connectOptions.getHeaders(), connectOptions.getVersion(), connectOptions.getSubProtocols(), HttpClientImpl.this.options.getMaxWebSocketFrameSize(), promise);
+          conn.toWebSocket(ctx, connectOptions.getURI(), connectOptions.getHeaders(), connectOptions.getAllowOriginHeader(), connectOptions.getVersion(), connectOptions.getSubProtocols(), HttpClientImpl.this.options.getMaxWebSocketFrameSize(), promise);
         } else {
           promise.fail(ar.cause());
         }


### PR DESCRIPTION
In addition we document how to set a custom origin header value as it can be needed in some situations.

See #4121
