### PR TITLE
Serializer may throw ConcurrentModificationException when used from worker verticle

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/Serializer.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,13 +11,10 @@
 
 package io.vertx.core.eventbus.impl.clustered;
 
-import io.netty.channel.EventLoop;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.VertxInternal;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -29,16 +26,22 @@ import java.util.function.BiConsumer;
 /**
  * @author Thomas Segismont
  */
-public class Serializer {
+public class Serializer implements Closeable {
 
-  private final ContextInternal context;
+  private final ContextInternal ctx;
   private final Map<String, SerializerQueue> queues;
 
   private Serializer(ContextInternal context) {
-    this.context = context;
+    ContextInternal unwrapped = context.unwrap();
+    if (unwrapped.isEventLoopContext()) {
+      ctx = unwrapped;
+    } else {
+      VertxInternal vertx = unwrapped.owner();
+      ctx = vertx.createEventLoopContext(unwrapped.nettyEventLoop(), unwrapped.workerPool(), unwrapped.classLoader());
+    }
     queues = new HashMap<>();
-    if (context.isDeployment()) {
-      context.addCloseHook(this::close);
+    if (unwrapped.isDeployment()) {
+      unwrapped.addCloseHook(this);
     }
   }
 
@@ -58,19 +61,21 @@ public class Serializer {
   }
 
   public <T> void queue(Message<?> message, BiConsumer<Message<?>, Promise<T>> selectHandler, Promise<T> promise) {
-    EventLoop eventLoop = context.nettyEventLoop();
-    if (eventLoop.inEventLoop()) {
+    ctx.emit(v -> {
       String address = message.address();
       SerializerQueue queue = queues.computeIfAbsent(address, SerializerQueue::new);
       queue.add(message, selectHandler, promise);
-    } else {
-      eventLoop.execute(() -> queue(message, selectHandler, promise));
-    }
+    });
   }
 
-  private void close(Promise<Void> promise) {
-    queues.forEach((address, queue) -> queue.close());
-    promise.complete();
+  @Override
+  public void close(Promise<Void> completion) {
+    ctx.emit(v -> {
+      for (SerializerQueue queue : queues.values()) {
+        queue.close();
+      }
+      completion.complete();
+    });
   }
 
   private class SerializerQueue {
@@ -106,7 +111,7 @@ public class Serializer {
     }
 
     <U> void add(Message<?> msg, BiConsumer<Message<?>, Promise<U>> selectHandler, Promise<U> promise) {
-      SerializedTask<U> serializedTask = new SerializedTask<>(context, msg, selectHandler);
+      SerializedTask<U> serializedTask = new SerializedTask<>(ctx, msg, selectHandler);
       Future<U> fut = serializedTask.internalPromise.future();
       fut.onComplete(promise);
       fut.onComplete(serializedTask);

--- a/src/test/java/io/vertx/core/eventbus/MessageQueueOnWorkerThreadTest.java
+++ b/src/test/java/io/vertx/core/eventbus/MessageQueueOnWorkerThreadTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.eventbus;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.impl.clustered.Serializer;
+import io.vertx.core.impl.VertxBuilder;
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.core.spi.cluster.NodeSelector;
+import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * This test verifies the {@link Serializer} mechanism works when used from a worker context or execute blocking.
+ * <p>
+ * See <a href="https://github.com/eclipse-vertx/vert.x/issues/4128">issue on GitHub</a>
+ */
+public class MessageQueueOnWorkerThreadTest extends VertxTestBase {
+
+  private Vertx vertx;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    CustomNodeSelector selector = new CustomNodeSelector();
+    VertxBuilder factory = new VertxBuilder().init().clusterNodeSelector(selector);
+    Promise<Vertx> promise = Promise.promise();
+    factory.clusteredVertx(promise);
+    vertx = promise.future().toCompletionStage().toCompletableFuture().get();
+  }
+
+  @Test
+  public void testWorkerContext() throws Exception {
+    test(true);
+  }
+
+  @Test
+  public void testExecuteBlocking() throws Exception {
+    test(false);
+  }
+
+  private void test(boolean worker) throws Exception {
+    int senderInstances = 20, messagesToSend = 100, expected = senderInstances * messagesToSend;
+    waitFor(expected);
+    vertx.eventBus().consumer("foo", msg -> complete()).completionHandler(onSuccess(registered -> {
+      DeploymentOptions options = new DeploymentOptions().setWorker(worker).setInstances(senderInstances);
+      vertx.deployVerticle(() -> new SenderVerticle(worker, messagesToSend), options);
+    }));
+    await(5, SECONDS);
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    try {
+      if (vertx != null) {
+        closeClustered(Collections.singletonList(vertx));
+      }
+    } finally {
+      super.tearDown();
+    }
+  }
+
+  private static class CustomNodeSelector implements NodeSelector {
+    ClusterManager clusterManager;
+    String nodeId;
+
+    @Override
+    public void init(Vertx vertx, ClusterManager clusterManager) {
+      this.clusterManager = clusterManager;
+    }
+
+    @Override
+    public void eventBusStarted() {
+      nodeId = this.clusterManager.getNodeId();
+    }
+
+    @Override
+    public void selectForSend(Message<?> message, Promise<String> promise) {
+      try {
+        NANOSECONDS.sleep(150);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      promise.tryComplete(nodeId);
+    }
+
+    @Override
+    public void selectForPublish(Message<?> message, Promise<Iterable<String>> promise) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void registrationsUpdated(RegistrationUpdateEvent event) {
+    }
+
+    @Override
+    public void registrationsLost() {
+    }
+  }
+
+  private static class SenderVerticle extends AbstractVerticle {
+
+    final boolean worker;
+    int count;
+
+    SenderVerticle(boolean worker, int count) {
+      this.worker = worker;
+      this.count = count;
+    }
+
+    @Override
+    public void start() throws Exception {
+      sendMessage();
+    }
+
+    void sendMessage() {
+      if (worker) {
+        vertx.executeBlocking(prom -> {
+          if (count > 0) {
+            vertx.eventBus().send("foo", "bar");
+            count--;
+            prom.complete();
+          }
+        }, ar -> vertx.runOnContext(v -> sendMessage()));
+      } else {
+        if (count > 0) {
+          vertx.eventBus().send("foo", "bar");
+          count--;
+          vertx.runOnContext(v -> sendMessage());
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #4128

When invoked from a worker verticle, `Serializer` queues messages on the event loop of the worker context.
But when the serialized task completes, it executes on the worker context, ie the worker thread.
Therefore, the queues map can be modified concurrently.

With this change, we make sure the `Serializer` code is only invoked from an event loop.