### PR TITLE
Project Loom: Update thread factory code to accept virtual threads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,7 @@
         </configuration>
         <executions>
           <execution>
+            <?m2e ignore ?>
             <id>generate-sources</id>
             <goals>
               <goal>process</goal>

--- a/src/main/java/io/vertx/core/Context.java
+++ b/src/main/java/io/vertx/core/Context.java
@@ -15,7 +15,7 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
-import io.vertx.core.impl.VertxThread;
+import io.vertx.core.VertxThread;
 import io.vertx.core.json.JsonObject;
 
 import java.util.List;

--- a/src/main/java/io/vertx/core/VertxThread.java
+++ b/src/main/java/io/vertx/core/VertxThread.java
@@ -1,0 +1,32 @@
+package io.vertx.core;
+
+import io.vertx.core.impl.BlockedThreadChecker;
+import io.vertx.core.impl.ContextInternal;
+
+public interface VertxThread extends BlockedThreadChecker.Task {
+
+	/**
+	 * @return the current context of this thread, this method must be called from
+	 *         the current thread
+	 */
+	ContextInternal context();
+
+	boolean isWorker();
+
+	StackTraceElement[] getStackTrace();
+
+	void setDaemon(boolean b);
+
+	/**
+	 * Check whether the thread execution time can be tracked.
+	 * @return
+	 */
+	boolean isTrackable();
+
+	/**
+	 * Return the actual {@link Thread} that corresponds to the {@link VertxThread}.
+	 * @return
+	 */
+	Thread getThread();
+
+}

--- a/src/main/java/io/vertx/core/VertxThread.java
+++ b/src/main/java/io/vertx/core/VertxThread.java
@@ -27,6 +27,6 @@ public interface VertxThread extends BlockedThreadChecker.Task {
 	 * Return the actual {@link Thread} that corresponds to the {@link VertxThread}.
 	 * @return
 	 */
-	Thread getThread();
+	Thread unwrap();
 
 }

--- a/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
+++ b/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
@@ -12,6 +12,7 @@
 package io.vertx.core.impl;
 
 import io.vertx.core.VertxException;
+import io.vertx.core.VertxThread;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 
@@ -37,7 +38,7 @@ public class BlockedThreadChecker {
 
   private static final Logger log = LoggerFactory.getLogger(BlockedThreadChecker.class);
 
-  private final Map<Thread, Task> threads = new WeakHashMap<>();
+  private final Map<VertxThread, Task> threads = new WeakHashMap<>();
   private final Timer timer; // Need to use our own timer - can't use event loop for this
 
   BlockedThreadChecker(long interval, TimeUnit intervalUnit, long warningExceptionTime, TimeUnit warningExceptionTimeUnit) {
@@ -47,7 +48,7 @@ public class BlockedThreadChecker {
       public void run() {
         synchronized (BlockedThreadChecker.this) {
           long now = System.nanoTime();
-          for (Map.Entry<Thread, Task> entry : threads.entrySet()) {
+          for (Map.Entry<VertxThread, Task> entry : threads.entrySet()) {
             long execStart = entry.getValue().startTime();
             long dur = now - execStart;
             final long timeLimit = entry.getValue().maxExecTime();
@@ -69,7 +70,7 @@ public class BlockedThreadChecker {
     }, intervalUnit.toMillis(interval), intervalUnit.toMillis(interval));
   }
 
-  synchronized void registerThread(Thread thread, Task checked) {
+  synchronized void registerThread(VertxThread thread, Task checked) {
     threads.put(thread, checked);
   }
 

--- a/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -19,6 +19,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
 
+import static io.vertx.core.impl.jvm.JavaCompatUtil.isVirtual;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -37,8 +39,12 @@ abstract class ContextImpl extends AbstractContext {
    */
   static void executeIsolated(Handler<Void> task) {
     Thread currentThread = Thread.currentThread();
-    if (currentThread instanceof VertxThread) {
-      VertxThread vertxThread = (VertxThread) currentThread;
+    if (isVirtual(currentThread)) {
+      // TODO Handle usage of virtual threads
+      return;
+    }
+    if (currentThread instanceof VertxThreadImpl) {
+      VertxThreadImpl vertxThread = (VertxThreadImpl) currentThread;
       ContextInternal prev = vertxThread.beginEmission(null);
       try {
         task.handle(null);

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -1149,11 +1149,13 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     AtomicInteger threadCount = new AtomicInteger(0);
     return runnable -> {
       VertxThread thread = threadFactory.newVertxThread(runnable, prefix + threadCount.getAndIncrement(), worker, maxExecuteTime, maxExecuteTimeUnit);
-      checker.registerThread(thread, thread);
+      if (thread.isTrackable()) {
+        checker.registerThread(thread, thread);
+      }
       // Vert.x threads are NOT daemons - we want them to prevent JVM exit so embedded user doesn't
       // have to explicitly prevent JVM from exiting.
       thread.setDaemon(false);
-      return thread;
+      return thread.getThread();
     };
   }
 

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -1155,7 +1155,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       // Vert.x threads are NOT daemons - we want them to prevent JVM exit so embedded user doesn't
       // have to explicitly prevent JVM from exiting.
       thread.setDaemon(false);
-      return thread.getThread();
+      return thread.unwrap();
     };
   }
 

--- a/src/main/java/io/vertx/core/impl/VertxThreadImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxThreadImpl.java
@@ -12,13 +12,14 @@
 package io.vertx.core.impl;
 
 import io.netty.util.concurrent.FastThreadLocalThread;
+import io.vertx.core.VertxThread;
 
 import java.util.concurrent.TimeUnit;
 
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-public class VertxThread extends FastThreadLocalThread implements BlockedThreadChecker.Task {
+public class VertxThreadImpl extends FastThreadLocalThread implements VertxThread {
 
   private final boolean worker;
   private final long maxExecTime;
@@ -27,17 +28,15 @@ public class VertxThread extends FastThreadLocalThread implements BlockedThreadC
   private ContextInternal context;
   private ClassLoader topLevelTCCL;
 
-  public VertxThread(Runnable target, String name, boolean worker, long maxExecTime, TimeUnit maxExecTimeUnit) {
+  public VertxThreadImpl(Runnable target, String name, boolean worker, long maxExecTime, TimeUnit maxExecTimeUnit) {
     super(target, name);
     this.worker = worker;
     this.maxExecTime = maxExecTime;
     this.maxExecTimeUnit = maxExecTimeUnit;
   }
 
-  /**
-   * @return the current context of this thread, this method must be called from the current thread
-   */
-  ContextInternal context() {
+  @Override
+  public ContextInternal context() {
     return context;
   }
 
@@ -57,6 +56,7 @@ public class VertxThread extends FastThreadLocalThread implements BlockedThreadC
     return execStart;
   }
 
+  @Override
   public boolean isWorker() {
     return worker;
   }
@@ -69,6 +69,16 @@ public class VertxThread extends FastThreadLocalThread implements BlockedThreadC
   @Override
   public TimeUnit maxExecTimeUnit() {
     return maxExecTimeUnit;
+  }
+
+  @Override
+  public boolean isTrackable() {
+    return true;
+  }
+
+  @Override
+  public Thread getThread() {
+    return this;
   }
 
   /**

--- a/src/main/java/io/vertx/core/impl/VertxThreadImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxThreadImpl.java
@@ -77,7 +77,7 @@ public class VertxThreadImpl extends FastThreadLocalThread implements VertxThrea
   }
 
   @Override
-  public Thread getThread() {
+  public Thread unwrap() {
     return this;
   }
 

--- a/src/main/java/io/vertx/core/impl/jvm/JavaCompatUtil.java
+++ b/src/main/java/io/vertx/core/impl/jvm/JavaCompatUtil.java
@@ -15,9 +15,7 @@ public final class JavaCompatUtil {
    * 
    * @param thread
    * @return true if the provided thread is a virtual one.
-   * @deprecated Use Thread#isVirtual instead
    */
-  @Deprecated
   public static boolean isVirtual(Thread thread) {
     if (thread == null) {
       return false;

--- a/src/main/java/io/vertx/core/impl/jvm/JavaCompatUtil.java
+++ b/src/main/java/io/vertx/core/impl/jvm/JavaCompatUtil.java
@@ -1,0 +1,28 @@
+package io.vertx.core.impl.jvm;
+
+/**
+ * Utility class which provides JDK backport and utility methods.
+ */
+public final class JavaCompatUtil {
+
+  private static final String VIRTUAL_THREAD_CLASSNAME = "java.lang.VirtualThread";
+
+  private JavaCompatUtil() {
+  }
+
+  /**
+   * Check whether the provided thread is a project loom virtual thread.
+   * 
+   * @param thread
+   * @return true if the provided thread is a virtual one.
+   * @deprecated Use Thread#isVirtual instead
+   */
+  @Deprecated
+  public static boolean isVirtual(Thread thread) {
+    if (thread == null) {
+      return false;
+    }
+    return VIRTUAL_THREAD_CLASSNAME.equals(thread.getClass().getName());
+  }
+
+}

--- a/src/main/java/io/vertx/core/spi/VertxThreadFactory.java
+++ b/src/main/java/io/vertx/core/spi/VertxThreadFactory.java
@@ -12,7 +12,8 @@
 package io.vertx.core.spi;
 
 import io.vertx.core.impl.VertxBuilder;
-import io.vertx.core.impl.VertxThread;
+import io.vertx.core.VertxThread;
+import io.vertx.core.impl.VertxThreadImpl;
 
 import java.util.concurrent.TimeUnit;
 
@@ -32,6 +33,6 @@ public interface VertxThreadFactory extends VertxServiceProvider {
   }
 
   default VertxThread newVertxThread(Runnable target, String name, boolean worker, long maxExecTime, TimeUnit maxExecTimeUnit) {
-    return new VertxThread(target, name, worker, maxExecTime, maxExecTimeUnit);
+    return new VertxThreadImpl(target, name, worker, maxExecTime, maxExecTimeUnit);
   }
 }

--- a/src/main/java/io/vertx/core/streams/impl/InboundBuffer.java
+++ b/src/main/java/io/vertx/core/streams/impl/InboundBuffer.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.streams.impl;
 
+import static io.vertx.core.impl.jvm.JavaCompatUtil.isVirtual;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
@@ -100,6 +101,10 @@ public class InboundBuffer<E> {
 
   private void checkThread() {
     Thread thread = Thread.currentThread();
+    if (isVirtual(thread)) {
+      // TODO Check impact of potentially lacking FastThreadLocalThread support
+      return;
+    }
     if (!(thread instanceof FastThreadLocalThread)) {
       throw new IllegalStateException("This operation must be called from a Vert.x thread");
     }

--- a/src/test/benchmarks/io/vertx/core/impl/VertxExecutorService.java
+++ b/src/test/benchmarks/io/vertx/core/impl/VertxExecutorService.java
@@ -26,6 +26,7 @@ public class VertxExecutorService extends ThreadPoolExecutor {
     super(maxThreads, maxThreads,
       0L, TimeUnit.MILLISECONDS,
       new LinkedBlockingQueue<>(),
-      r -> VertxThreadFactory.INSTANCE.newVertxThread(r, prefix, false, 10000, TimeUnit.NANOSECONDS));
+      // TODO Add type check of find a better way to expose wrapped thread
+      r -> (Thread)VertxThreadFactory.INSTANCE.newVertxThread(r, prefix, false, 10000, TimeUnit.NANOSECONDS));
   }
 }

--- a/src/test/java/io/vertx/core/ContextTaskTest.java
+++ b/src/test/java/io/vertx/core/ContextTaskTest.java
@@ -12,7 +12,7 @@ package io.vertx.core;
 
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.impl.VertxThread;
+import io.vertx.core.impl.VertxThreadImpl;
 import io.vertx.core.impl.WorkerPool;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
@@ -46,7 +46,7 @@ public class ContextTaskTest extends VertxTestBase {
 
   @Override
   public void setUp() throws Exception {
-    workerExecutor = Executors.newFixedThreadPool(2, r -> new VertxThread(r, "vert.x-worker-thread", true, 10, TimeUnit.SECONDS));
+    workerExecutor = Executors.newFixedThreadPool(2, r -> new VertxThreadImpl(r, "vert.x-worker-thread", true, 10, TimeUnit.SECONDS));
     super.setUp();
   }
 

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -45,7 +45,7 @@ public class ContextTest extends VertxTestBase {
 
   @Override
   public void setUp() throws Exception {
-    workerExecutor = Executors.newFixedThreadPool(2, r -> new VertxThread(r, "vert.x-worker-thread", true, 10, TimeUnit.SECONDS));
+    workerExecutor = Executors.newFixedThreadPool(2, r -> new VertxThreadImpl(r, "vert.x-worker-thread", true, 10, TimeUnit.SECONDS));
     super.setUp();
   }
 

--- a/src/test/java/io/vertx/core/NamedWorkerPoolTest.java
+++ b/src/test/java/io/vertx/core/NamedWorkerPoolTest.java
@@ -11,7 +11,6 @@
 
 package io.vertx.core;
 
-import io.vertx.core.impl.VertxThread;
 import io.vertx.test.core.BlockedThreadWarning;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;

--- a/src/test/java/io/vertx/it/CustomVertxThread.java
+++ b/src/test/java/io/vertx/it/CustomVertxThread.java
@@ -1,10 +1,10 @@
 package io.vertx.it;
 
-import io.vertx.core.impl.VertxThread;
+import io.vertx.core.impl.VertxThreadImpl;
 
 import java.util.concurrent.TimeUnit;
 
-public class CustomVertxThread extends VertxThread  {
+public class CustomVertxThread extends VertxThreadImpl  {
   public CustomVertxThread(Runnable target, String name, boolean worker, long maxExecTime, TimeUnit maxExecTimeUnit) {
     super(target, name, worker, maxExecTime, maxExecTimeUnit);
   }

--- a/src/test/java/io/vertx/it/CustomVertxThreadFactory.java
+++ b/src/test/java/io/vertx/it/CustomVertxThreadFactory.java
@@ -1,6 +1,6 @@
 package io.vertx.it;
 
-import io.vertx.core.impl.VertxThread;
+import io.vertx.core.VertxThread;
 import io.vertx.core.spi.VertxThreadFactory;
 
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
This PR contains a collection of patches which I used to experiment with [Project Loom](https://openjdk.java.net/projects/loom/) support in Vert.x.

The patches prepare Vert.x so that it can accept a custom thread factory which can provide virtual threads.
I did use the SPI mechanism for `VertxThreadFactory` to provide a custom JDK 18 based factory.
The code for this factory and corresponding tests can be found in my [vertx-loom](https://github.com/Jotschi/vertx-loom) project.

# Changes

* I had to create a wrapper since Virtual Threads can't be extended any more. Thus I needed to create the `VertxThread` interface.
* In some places it was needed to identify virtual threads. In order to keep the codebase JRE 8 friendly I created the `JavaCompatUtil` utility which helps to identify virtual threads.

# Caveat

* `VirtualVertxThreadImpl` objects can no longer be fetched via `Thread.currentThread()` when virtual threads are used. This poses a problem when handling dispatch calls (see `AbstractContext`). This issue most likely also renders the `BlockedThreadChecker` inoperable.
* Using Virtual Threads may also affect classloader handling / hierarchy. I have not investigated this at the moment.
* Large thread pool sizes for the eventloop (400+) can cause Netty to stall during request processing due to pinned carrier threads. The usage of `Select#select()` requires synchronization and this makes use of a monitor lock. [Details on loom-dev mailinglist](https://mail.openjdk.java.net/pipermail/loom-dev/2021-October/003000.html) - A warning on this has been added to the VertxVirtualThreadFactory.
* `ContextImpl#executeIsolated` is still lacking a virtual thread friendly implementation. Maybe the given task could just be executed in a dedicated virtual thread.
