### PR TITLE
Allow Http1xServerRequest.toNetSocket work on with HTTP upgrade

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -375,9 +375,6 @@ public class Http1xServerRequest implements HttpServerRequestInternal, io.vertx.
 
   @Override
   public Future<NetSocket> toNetSocket() {
-    if (method() != HttpMethod.CONNECT) {
-      return context.failedFuture("HTTP method must be CONNECT to upgrade the connection to a net socket");
-    }
     return response.netSocket();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -754,9 +754,9 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
     synchronized (conn) {
       if (netSocket == null) {
         if (headWritten) {
-          return context.failedFuture("Response for CONNECT already sent");
+          return context.failedFuture("Response already sent");
         }
-        status = HttpResponseStatus.OK;
+
         prepareHeaders(-1);
         conn.writeToChannel(new AssembledHttpResponse(head, version, status, headers));
         written = true;


### PR DESCRIPTION
Motivation:
  currently, Http1xServerRequest.toNetSocket work on CONNECT method(In other words, just work on forward proxying mode).
  we expect to work on reverse proxying mode just like  [**nginx websocket proxying**](https://nginx.org/en/docs/http/websocket.html) described:
 1. pass Upgrade and Connection header to upstream server.
 2. if the upstream server returned a response with the code 101 (Switching Protocols), setting up a tunnel between client and upstream server.
