### PR TITLE
Added TraceOperationName to HttpClientRequest

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -172,6 +172,21 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   String query();
 
   /**
+   * @return the operation name used for distributed tracing. Defaults to {{@link #getMethod()}} if not explicitly set.
+   */
+  String getTraceOperationName();
+
+  /**
+   * Set the operation name used for distributed tracing which should concisely represent the work done by this request.
+   * A good example of a name is get_account, save_user, etc.
+   *
+   * @param operationName the operation name
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpClientRequest setTraceOperationName(String operationName);
+
+  /**
    * @return The HTTP headers
    */
   @CacheReturn

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -213,7 +213,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
       VertxTracer tracer = context.tracer();
       if (tracer != null) {
         BiConsumer<String, String> headers = (key, val) -> nettyRequest.headers().add(key, val);
-        stream.trace = tracer.sendRequest(stream.context, SpanKind.RPC, options.getTracingPolicy(), request, request.method.name(), headers, HttpUtils.CLIENT_HTTP_REQUEST_TAG_EXTRACTOR);
+        stream.trace = tracer.sendRequest(stream.context, SpanKind.RPC, options.getTracingPolicy(), request, request.getTraceOperationName(), headers, HttpUtils.CLIENT_HTTP_REQUEST_TAG_EXTRACTOR);
       }
     }
     writeToChannel(nettyRequest, handler == null ? null : context.promise(handler));

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -554,7 +554,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
       VertxTracer tracer = context.tracer();
       if (tracer != null) {
         BiConsumer<String, String> headers_ = headers::add;
-        trace = tracer.sendRequest(context, SpanKind.RPC, conn.client.getOptions().getTracingPolicy(), head, headers.method().toString(), headers_, HttpUtils.CLIENT_HTTP_REQUEST_TAG_EXTRACTOR);
+        trace = tracer.sendRequest(context, SpanKind.RPC, conn.client.getOptions().getTracingPolicy(), head, head.getTraceOperationName(), headers_, HttpUtils.CLIENT_HTTP_REQUEST_TAG_EXTRACTOR);
       }
     }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -47,6 +47,7 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   private long currentTimeoutTimerId = -1;
   private long currentTimeoutMs;
   private long lastDataReceived;
+  private String traceOperationName;
 
   HttpClientRequestBase(HttpClientImpl client, HttpClientStream stream, PromiseInternal<HttpClientResponse> responsePromise, boolean ssl, HttpMethod method, SocketAddress server, String host, int port, String uri) {
     this.client = client;
@@ -154,6 +155,18 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
     currentTimeoutMs = timeoutMs;
     currentTimeoutTimerId = context.setTimer(timeoutMs, id -> handleTimeout(timeoutMs));
     return this;
+  }
+
+  @Override
+  public synchronized String getTraceOperationName() {
+    return traceOperationName != null ? traceOperationName : method.name();
+  }
+
+  @Override
+  public synchronized HttpClientRequest setTraceOperationName(String operationName) {
+    Objects.requireNonNull(operationName);
+    this.traceOperationName=operationName;
+    return null;
   }
 
   void handleException(Throwable t) {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -468,7 +468,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
     if (writeHead) {
       HttpMethod method = getMethod();
       String uri = getURI();
-      HttpRequestHead head = new HttpRequestHead(method, uri, headers, authority(), absoluteURI());
+      HttpRequestHead head = new HttpRequestHead(method, uri, headers, authority(), absoluteURI(), getTraceOperationName());
       stream.writeHead(head, chunked, buff, ended, priority, connect, completionHandler);
     } else {
       if (buff == null && !end) {

--- a/src/main/java/io/vertx/core/http/impl/HttpRequestHead.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpRequestHead.java
@@ -27,13 +27,15 @@ public class HttpRequestHead implements HttpRequest {
   public final MultiMap headers;
   public final String authority;
   public final String absoluteURI;
+  public final String traceOperationName;
 
-  public HttpRequestHead(HttpMethod method, String uri, MultiMap headers, String authority, String absoluteURI) {
+  public HttpRequestHead(HttpMethod method, String uri, MultiMap headers, String authority, String absoluteURI, String traceOperationName) {
     this.method = method;
     this.uri = uri;
     this.headers = headers;
     this.authority = authority;
     this.absoluteURI = absoluteURI;
+    this.traceOperationName = traceOperationName;
   }
 
   @Override
@@ -64,5 +66,9 @@ public class HttpRequestHead implements HttpRequest {
   @Override
   public HttpMethod method() {
     return method;
+  }
+
+  public String getTraceOperationName() {
+    return traceOperationName;
   }
 }

--- a/src/test/java/io/vertx/core/http/Http1xClientConnectionTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xClientConnectionTest.java
@@ -69,7 +69,7 @@ public class Http1xClientConnectionTest extends HttpClientConnectionTest {
             stream.reset(cause);
           });
         stream.writeHead(new HttpRequestHead(
-          HttpMethod.GET, "/", MultiMap.caseInsensitiveMultiMap(), "localhost:8080", ""), false, Unpooled.EMPTY_BUFFER, false, new StreamPriority(), false, null);
+          HttpMethod.GET, "/", MultiMap.caseInsensitiveMultiMap(), "localhost:8080", "", "traceOpName"), false, Unpooled.EMPTY_BUFFER, false, new StreamPriority(), false, null);
       }));
     }));
     await();
@@ -93,7 +93,7 @@ public class Http1xClientConnectionTest extends HttpClientConnectionTest {
           complete();
         });
         stream.writeHead(new HttpRequestHead(
-          HttpMethod.GET, "/", MultiMap.caseInsensitiveMultiMap(), "localhost:8080", ""), false, Unpooled.EMPTY_BUFFER, true, new StreamPriority(), false, null);
+          HttpMethod.GET, "/", MultiMap.caseInsensitiveMultiMap(), "localhost:8080", "", "traceOpName"), false, Unpooled.EMPTY_BUFFER, true, new StreamPriority(), false, null);
       }));
     }));
     await();

--- a/src/test/java/io/vertx/core/http/HttpClientConnectionTest.java
+++ b/src/test/java/io/vertx/core/http/HttpClientConnectionTest.java
@@ -51,7 +51,7 @@ public abstract class HttpClientConnectionTest extends HttpTestBase {
     client.connect(testAddress, peerAddress).onComplete(onSuccess(conn -> {
       conn.createStream((ContextInternal) vertx.getOrCreateContext(), onSuccess(stream -> {
         stream.writeHead(new HttpRequestHead(
-          HttpMethod.GET, "/", MultiMap.caseInsensitiveMultiMap(), "localhost:8080", ""), false, Unpooled.EMPTY_BUFFER, true, new StreamPriority(), false, onSuccess(v -> {
+          HttpMethod.GET, "/", MultiMap.caseInsensitiveMultiMap(), "localhost:8080", "", "traceOpName"), false, Unpooled.EMPTY_BUFFER, true, new StreamPriority(), false, onSuccess(v -> {
         }));
         stream.headHandler(resp -> {
           assertEquals(200, resp.statusCode);
@@ -84,7 +84,7 @@ public abstract class HttpClientConnectionTest extends HttpTestBase {
       });
       conn.createStream((ContextInternal) vertx.getOrCreateContext(), onSuccess(stream -> {
         stream.writeHead(new HttpRequestHead(
-          HttpMethod.GET, "/", MultiMap.caseInsensitiveMultiMap(), "localhost:8080", ""), false, Unpooled.EMPTY_BUFFER, true, new StreamPriority(), false, onSuccess(v -> {
+          HttpMethod.GET, "/", MultiMap.caseInsensitiveMultiMap(), "localhost:8080", "", "traceOpName"), false, Unpooled.EMPTY_BUFFER, true, new StreamPriority(), false, onSuccess(v -> {
         }));
         stream.headHandler(resp -> {
           fail();

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -4341,6 +4341,8 @@ public abstract class HttpTest extends HttpTestBase {
       public HttpClientRequest setMethod(HttpMethod method) { throw new UnsupportedOperationException(); }
       public HttpClientRequest response(Handler<AsyncResult<HttpClientResponse>> handler) { throw new UnsupportedOperationException(); }
       public Future<HttpClientResponse> response() { throw new UnsupportedOperationException(); }
+      public String getTraceOperationName() { throw new UnsupportedOperationException();  }
+      public HttpClientRequest setTraceOperationName(String operationName) { throw new UnsupportedOperationException(); }
     }
     HttpClientRequest req = new MockReq();
     class MockResp implements HttpClientResponse {

--- a/src/test/java/io/vertx/core/spi/tracing/HttpTracerTestBase.java
+++ b/src/test/java/io/vertx/core/spi/tracing/HttpTracerTestBase.java
@@ -161,6 +161,7 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
         headers.accept("header-key","header-value");
         assertNotNull(request);
         assertTrue(request instanceof HttpRequest);
+        assertEquals("operation-name", operation);
         return request;
       }
       @Override
@@ -186,6 +187,7 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
       ConcurrentMap<Object, Object> tracerMap = ((ContextInternal) ctx).localContextData();
       tracerMap.put(key, val);
       client.request(HttpMethod.GET, 8080, "localhost", "/", onSuccess(req -> {
+        req.setTraceOperationName("operation-name");
         req.send(onSuccess(resp -> {
           resp.endHandler(v2 -> {
             // Updates are done on the HTTP client context, so we need to run task on this context


### PR DESCRIPTION
Motivation:

Give the user the ability to set the `traceOperationName` for an `HttpClientRequest`. This name will be used by a `Tracer` during distributed tracing for the given HTTP call.

