### PR TITLE
Adding full details on what are the requirements for the SPI

### DIFF
--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -11,9 +11,7 @@
 
 package io.vertx.core.json;
 
-import io.vertx.core.ServiceHelper;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.jackson.JacksonFactory;
 import io.vertx.core.spi.JsonFactory;
 import io.vertx.core.spi.json.JsonCodec;
 

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -533,7 +533,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
    * @return the string encoding
    */
   public String encode() {
-    return Json.CODEC.toString(this, false);
+    return Json.CODEC.toString(this.list, false);
   }
 
   /**
@@ -542,7 +542,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
    * @return the buffer encoding.
    */
   public Buffer toBuffer() {
-    return Json.CODEC.toBuffer(this, false);
+    return Json.CODEC.toBuffer(this.list, false);
   }
 
   /**
@@ -551,7 +551,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
    * @return the string encoding
    */
   public String encodePrettily() {
-    return Json.CODEC.toString(this, true);
+    return Json.CODEC.toString(this.list, true);
   }
 
   /**

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -725,7 +725,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
    * @return the string encoding.
    */
   public String encode() {
-    return Json.CODEC.toString(this, false);
+    return Json.CODEC.toString(this.map, false);
   }
 
   /**
@@ -735,7 +735,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
    * @return the pretty string encoding.
    */
   public String encodePrettily() {
-    return Json.CODEC.toString(this, true);
+    return Json.CODEC.toString(this.map, true);
   }
 
   /**
@@ -744,7 +744,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
    * @return the buffer encoding.
    */
   public Buffer toBuffer() {
-    return Json.CODEC.toBuffer(this, false);
+    return Json.CODEC.toBuffer(this.map, false);
   }
 
   /**

--- a/src/main/java/io/vertx/core/json/jackson/VertxModule.java
+++ b/src/main/java/io/vertx/core/json/jackson/VertxModule.java
@@ -33,7 +33,7 @@ public class VertxModule extends SimpleModule {
     // custom types
     addSerializer(JsonObject.class, new JsonObjectSerializer());
     addSerializer(JsonArray.class, new JsonArraySerializer());
-    // he have 2 extensions: RFC-7493
+    // we have 2 extensions: RFC-7493
     addSerializer(Instant.class, new InstantSerializer());
     addDeserializer(Instant.class, new InstantDeserializer());
     addSerializer(byte[].class, new ByteArraySerializer());

--- a/src/main/java/io/vertx/core/spi/json/JsonCodec.java
+++ b/src/main/java/io/vertx/core/spi/json/JsonCodec.java
@@ -24,7 +24,7 @@ import io.vertx.core.json.JsonArray;
  * The SPI consists of 3 main features:
  *
  * <ol>
- *   <li>{@link #fromString(String, Class)}, {@link #fromBuffer(Buffer, Class)} - Parse a given test or binary input and
+ *   <li>{@link #fromString(String, Class)}, {@link #fromBuffer(Buffer, Class)} - Parse a given text or binary input and
  *   return a object representation of the input for the given {@link Class} type</li>
  *   <li>{@link #fromValue(Object, Class)} - Given an object, use the mapping features if available to convert to the desired target POJO of {@link Class}</li>
  *   <li>{@link #toString(Object)}, {@link #toBuffer(Object)} - Encodes a given object to either a textual or binary representation.</li>


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Users trying to implement a custom JsonCodec face application failures because the expectations of the SPI are not well documented. For example, nothing is stated over how to encode `JsonObject/JsonArray` or the RFCs vert.x implements.

This PR is mostly a documentation update explaining the expectations so users can write working codecs.
