### PR TITLE
Allow loading PKCS#11 keystores (HSM)

### DIFF
--- a/src/main/java/io/vertx/core/net/KeyStoreOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/KeyStoreOptionsBase.java
@@ -177,11 +177,12 @@ public abstract class KeyStoreOptionsBase implements KeyCertOptions, TrustOption
     if (helper == null) {
       Supplier<Buffer> value;
       if (this.path != null) {
-        value = () -> vertx.fileSystem().readFileBlocking(((VertxInternal) vertx).resolveFile(path).getAbsolutePath());
+        value = () -> vertx.fileSystem().readFileBlocking(path);
       } else if (this.value != null) {
         value = this::getValue;
       } else {
-        return null;
+        // Keystore input can be "null", for example PKCS#11
+        value = () -> null;
       }
       helper = new KeyStoreHelper(KeyStoreHelper.loadKeyStore(type, provider, password, value, getAlias()), password, getAliasPassword());
     }

--- a/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
@@ -208,8 +208,13 @@ public class KeyStoreHelper {
   public static KeyStore loadKeyStore(String type, String provider, String password, Supplier<Buffer> value, String alias) throws Exception {
     Objects.requireNonNull(type);
     KeyStore ks = provider == null ? KeyStore.getInstance(type) : KeyStore.getInstance(type, provider);
-    try (InputStream in = new ByteArrayInputStream(value.get().getBytes())) {
-      ks.load(in, password != null ? password.toCharArray() : null);
+    Buffer keystoreBuffer = value.get();
+    if (keystoreBuffer == null) {
+      ks.load(null, password != null ? password.toCharArray() : null);
+    } else {
+      try (InputStream in = new ByteArrayInputStream(value.get().getBytes())) {
+        ks.load(in, password != null ? password.toCharArray() : null);
+      }
     }
     if (alias != null) {
       if (!ks.containsAlias(alias)) {


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

PKCS#11 (Hardware Smart Cards) do not provide a keystore file path or buffer, instead they are expected to be loaded with a `null` inputstream.

Vert.x core on the other hand, assumed that `null` wasn't a valid value.

This PR attempts to fix this by allowing `null` to be used.
