### PR TITLE
Fix the cookie comparator to consider user-agent cookies correctly

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/CookieImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/CookieImpl.java
@@ -26,17 +26,26 @@ import io.vertx.core.http.CookieSameSite;
 public class CookieImpl implements ServerCookie {
 
   private final io.netty.handler.codec.http.cookie.Cookie nettyCookie;
+  // denotes if a cookie has been created from an HTTP request (true) or during the
+  // application/response life cycle (false)
+  private final boolean fromUserAgent;
+
   private boolean changed;
-  private boolean fromUserAgent;
-  // extension features
+  // extension feature(s)
   private CookieSameSite sameSite;
 
   public CookieImpl(String name, String value) {
     this.nettyCookie = new DefaultCookie(name, value);
+    fromUserAgent = false;
     this.changed = true;
   }
 
-  public CookieImpl(io.netty.handler.codec.http.cookie.Cookie nettyCookie) {
+  /**
+   * Internal constructor, only used by the CookieJar.
+   *
+   * @param nettyCookie the underlying cookie object
+   */
+  CookieImpl(io.netty.handler.codec.http.cookie.Cookie nettyCookie) {
     this.nettyCookie = nettyCookie;
     fromUserAgent = true;
   }

--- a/src/main/java/io/vertx/core/http/impl/CookieJar.java
+++ b/src/main/java/io/vertx/core/http/impl/CookieJar.java
@@ -147,6 +147,11 @@ public class CookieJar extends AbstractSet<ServerCookie> {
       return v;
     }
 
+    if (cookie.isFromUserAgent()) {
+      // user-agent cookies never include a path or domain, so we must assume equality
+      return 0;
+    }
+
     if (cookie.getPath() == null) {
       if (path != null) {
         return -1;

--- a/src/main/java/io/vertx/core/http/impl/CookieJar.java
+++ b/src/main/java/io/vertx/core/http/impl/CookieJar.java
@@ -143,40 +143,47 @@ public class CookieJar extends AbstractSet<ServerCookie> {
     Objects.requireNonNull(name);
 
     int v = cookie.getName().compareTo(name);
-    if (v != 0) {
-      return v;
-    }
 
     if (cookie.isFromUserAgent()) {
       // user-agent cookies never include a path or domain, so we must assume equality
-      return 0;
-    }
-
-    if (cookie.getPath() == null) {
-      if (path != null) {
-        return -1;
-      }
-    } else if (path == null) {
-      return 1;
+      // just by comparing the name
+      return v;
     } else {
-      v = cookie.getPath().compareTo(path);
+      // perform the tuple check:
+
+      // 1. name comparison (on equals check the next parameter)
       if (v != 0) {
         return v;
       }
-    }
 
-    if (cookie.getDomain() == null) {
-      if (domain != null) {
-        return -1;
+      // 2. path comparison (on equals check the next parameter)
+      if (cookie.getPath() == null) {
+        if (path != null) {
+          return -1;
+        }
+      } else if (path == null) {
+        return 1;
+      } else {
+        v = cookie.getPath().compareTo(path);
+        if (v != 0) {
+          return v;
+        }
       }
-    } else if (domain == null) {
-      return 1;
-    } else {
-      v = cookie.getDomain().compareToIgnoreCase(domain);
-      return v;
-    }
 
-    return 0;
+      // 3. domain comparison (on equals terminate with 0)
+      if (cookie.getDomain() == null) {
+        if (domain != null) {
+          return -1;
+        }
+      } else if (domain == null) {
+        return 1;
+      } else {
+        v = cookie.getDomain().compareToIgnoreCase(domain);
+        return v;
+      }
+
+      return 0;
+    }
   }
 
 


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fix #4187 

The problem:

Cookies can have 2 different representations:

1. A full server cookie with many attributes including `name`, `path`, `domain` and `value`
2. A user agent cookie just with `name` and `value`

When adding cookies to the cookie jar a comparator function will run over the cookies and match according to the spec. However one case wasn't taken in consideration. The case when a Cookie is populated from the user agent (the request includes a cookie) and the application adds a server cookie **with the same name** and other attributes.

In this case, as the attributes would not match, the 2 cookies would be counted as different. The example:

```
user-agent: XSRF-TOKEN=c359b44aef83415
server: XSRF-TOKEN=88533580000c314; Path=/
```

Should be considered "same" identifier as user-agent cookies never include `Path` or `Domain` as the user agent will only send them if the target path or domain is correct.

The fix is to short the comparision if the current list of cookies element to compare is of type `user-agent` just to the name, otherwise fallback to the full check.

This should only affect the legacy (deprecated) API but is needed to ensure proper RFC compliance and backwards compatibility.