### PR TITLE
add an event bus system codec for serializable objects

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
@@ -18,6 +18,7 @@ import io.vertx.core.eventbus.impl.codecs.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -44,6 +45,7 @@ public class CodecManager {
   public static final MessageCodec<Character, Character> CHAR_MESSAGE_CODEC = new CharMessageCodec();
   public static final MessageCodec<Byte, Byte> BYTE_MESSAGE_CODEC = new ByteMessageCodec();
   public static final MessageCodec<ReplyException, ReplyException> REPLY_EXCEPTION_MESSAGE_CODEC = new ReplyExceptionMessageCodec();
+  public static final MessageCodec<Serializable, Serializable> SERIALIZABLE_MESSAGE_CODEC = new SerializableMessageCodec(Serializable.class);
 
   private final MessageCodec[] systemCodecs;
   private final ConcurrentMap<String, MessageCodec> userCodecMap = new ConcurrentHashMap<>();
@@ -52,7 +54,7 @@ public class CodecManager {
   public CodecManager() {
     this.systemCodecs = codecs(NULL_MESSAGE_CODEC, PING_MESSAGE_CODEC, STRING_MESSAGE_CODEC, BUFFER_MESSAGE_CODEC, JSON_OBJECT_MESSAGE_CODEC, JSON_ARRAY_MESSAGE_CODEC,
       BYTE_ARRAY_MESSAGE_CODEC, INT_MESSAGE_CODEC, LONG_MESSAGE_CODEC, FLOAT_MESSAGE_CODEC, DOUBLE_MESSAGE_CODEC,
-      BOOLEAN_MESSAGE_CODEC, SHORT_MESSAGE_CODEC, CHAR_MESSAGE_CODEC, BYTE_MESSAGE_CODEC, REPLY_EXCEPTION_MESSAGE_CODEC);
+      BOOLEAN_MESSAGE_CODEC, SHORT_MESSAGE_CODEC, CHAR_MESSAGE_CODEC, BYTE_MESSAGE_CODEC, REPLY_EXCEPTION_MESSAGE_CODEC, SERIALIZABLE_MESSAGE_CODEC);
   }
 
   public MessageCodec lookupCodec(Object body, String codecName) {
@@ -94,6 +96,11 @@ public class CodecManager {
       codec = defaultCodecMap.get(body.getClass());
       if (codec == null) {
         codec = REPLY_EXCEPTION_MESSAGE_CODEC;
+      }
+    } else if (body instanceof Serializable) {
+      codec = defaultCodecMap.get(body.getClass());
+      if (codec == null) {
+        codec = new SerializableMessageCodec(body.getClass());
       }
     } else {
       codec = defaultCodecMap.get(body.getClass());

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/SerializableMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/SerializableMessageCodec.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.eventbus.impl.codecs;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/**
+ * @author <a href="mailto:craigday3@gmail.com">Craig Day</a>
+ */
+public class SerializableMessageCodec<T extends Serializable> implements MessageCodec<T, T> {
+
+  private final Class<T> clazz;
+
+  public SerializableMessageCodec(Class<T> clazz) {
+    this.clazz = clazz;
+  }
+
+  @Override
+  public void encodeToWire(Buffer buffer, Serializable object) {
+    try {
+      ByteArrayOutputStream byteOs = new ByteArrayOutputStream();
+      ObjectOutputStream oos = new ObjectOutputStream(byteOs);
+      oos.writeObject(object);
+      oos.flush();
+      oos.close();
+      byte[] bytes = byteOs.toByteArray();
+      buffer.appendInt(bytes.length);
+      buffer.appendBytes(bytes);
+    } catch (IOException e) {
+      // TODO: what should we do here?
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public T decodeFromWire(int pos, Buffer buffer) {
+    try {
+      int numBytes = buffer.getInt(pos);
+      pos += Integer.BYTES;
+      byte[] bytes = buffer.getBytes(pos, pos + numBytes);
+      ByteArrayInputStream byteIs = new ByteArrayInputStream(bytes);
+      ObjectInputStream ois = new ObjectInputStream(byteIs);
+      T object = clazz.cast(ois.readObject());
+      ois.close();
+      return object;
+    } catch (IOException | ClassNotFoundException e) {
+      // TODO: what should we do here?
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public T transform(T t) {
+    // TODO: This is not very performant, but it allows us to copy an object without reflection
+    Buffer cloneBuf = Buffer.buffer();
+    encodeToWire(cloneBuf, t);
+    return decodeFromWire(0, cloneBuf);
+  }
+
+  @Override
+  public String name() {
+    return "serializable";
+  }
+
+  @Override
+  public byte systemCodecID() {
+    return 16;
+  }
+}


### PR DESCRIPTION
Motivation:

I'm using the event bus in my application to make requests to upstream services, most of which are gRPC services. As it sits right now, I have to register at least 2 codecs for every gRPC call. One for the request protobuf object, and one for the response protobuf object. 

A generic solution could likely come from the outcome of #4120, but I understand that inheritance is a hard problem to solve. In this PR, I've take a step in that direction without trying to solve the entire problem. This adds a system codec that can leverage Java serialization. This specifically solves my case, because the super-class of all protobuf objects is `GeneratedMessageV{version}`, which `implements Serializable`. 

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
