### PR TITLE
Upgrade log4j2 to 2.15.0 for CVE-2021-44228

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
   <properties>
     <slf4j.version>1.7.21</slf4j.version>
-    <log4j2.version>2.13.3</log4j2.version>
+    <log4j2.version>2.15.0</log4j2.version>
     <junit.version>4.13.1</junit.version>
     <assertj.version>3.4.1</assertj.version>
     <apacheds-protocol-dns.version>1.5.7</apacheds-protocol-dns.version>


### PR DESCRIPTION
just to be on the safe side

@vietj shall we do that for all the other maintained branches as well?