### PR TITLE
Fix the NPE problem of FileSystemImpl

### DIFF
--- a/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
@@ -1045,11 +1045,16 @@ public class FileSystemImpl implements FileSystem {
             } else {
               files = file.listFiles(fnFilter);
             }
-            List<String> ret = new ArrayList<>(files.length);
-            for (File f : files) {
-              ret.add(f.getCanonicalPath());
+            if (null == files || files.length == 0) {
+              return new ArrayList<>();
+            } else {
+              List<String> ret = new ArrayList<>(files.length);
+              for (File f : files) {
+                ret.add(f.getCanonicalPath());
+              }
+              return ret;
             }
-            return ret;
+
           }
         } catch (IOException e) {
           throw new FileSystemException(getFolderAccessErrorMessage("read", p), e);

--- a/src/test/java/io/vertx/core/file/FileSystemTest.java
+++ b/src/test/java/io/vertx/core/file/FileSystemTest.java
@@ -2336,4 +2336,14 @@ public class FileSystemTest extends VertxTestBase {
     file.close(onSuccess(v -> testComplete()));
     await();
   }
+  
+  @Test
+  public void testWindowsApplicationDataDirs() {
+    Assume.assumeTrue(Utils.isWindows());
+    String file = System.getProperty("user.home") + "/Application Data";
+    Assume.assumeTrue(new File(file).exists());
+    List<String> dirs = vertx.fileSystem().readDirBlocking(file);
+    assertNotNull(dirs);
+    assertEquals(dirs.size(),0);
+  }
 }

--- a/src/test/java/io/vertx/core/file/FileSystemTest.java
+++ b/src/test/java/io/vertx/core/file/FileSystemTest.java
@@ -2344,6 +2344,5 @@ public class FileSystemTest extends VertxTestBase {
     Assume.assumeTrue(new File(file).exists());
     List<String> dirs = vertx.fileSystem().readDirBlocking(file);
     assertNotNull(dirs);
-    assertEquals(dirs.size(),0);
   }
 }


### PR DESCRIPTION
 file.listFiles may return null while using  windows system , this method may occurs  NPE 

test code :
```
        String file = System.getProperty("user.home") + "/Application Data";
        FileSystem fileSystem = Vertx.vertx().fileSystem();
        List<String> list = fileSystem.readDirBlocking(file);
```

System: windows10
JDK: 1.8.0_291

