### PR TITLE
Bump log4j to 2.17.0 - master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
   <properties>
     <slf4j.version>1.7.21</slf4j.version>
-    <log4j2.version>2.15.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <junit.version>4.13.1</junit.version>
     <assertj.version>3.4.1</assertj.version>
     <apacheds-protocol-dns.version>1.5.7</apacheds-protocol-dns.version>


### PR DESCRIPTION
Motivation:

log4j provides an additional release that disables JNDI by default to deal better with CVE-2021-44228 and completely remove support for Message Lookups.

* https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.0

Target: master