### PR TITLE
Bump log4j to 2.17.0 - 3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
         <slf4j.version>1.7.21</slf4j.version>
 
-        <log4j2.version>2.15.0</log4j2.version>
+        <log4j2.version>2.17.0</log4j2.version>
 
         <junit.version>4.13.1</junit.version>
 


### PR DESCRIPTION
Motivation:

log4j provides an additional release that disables JNDI by default to deal better with CVE-2021-44228 and completely remove support for Message Lookups.

* https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.0

Target: 3.9