### PR TITLE
Update log4j to address CVE-2021-45105 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
   <properties>
     <slf4j.version>1.7.21</slf4j.version>
-    <log4j2.version>2.15.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <junit.version>4.13.1</junit.version>
     <assertj.version>3.4.1</assertj.version>
     <apacheds-protocol-dns.version>1.5.7</apacheds-protocol-dns.version>


### PR DESCRIPTION
Motivation:

Update log4j to address: [GHSA-p6xc-xr62-6r2g](https://github.com/advisories/GHSA-p6xc-xr62-6r2g)
Please also refer to https://nvd.nist.gov/vuln/detail/CVE-2021-45105

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
