### PR TITLE
Fix issue 4208 - Add more information on timed out connections

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -404,6 +404,7 @@ public abstract class ConnectionBase {
    * perform extra work when the idle event happens.
    */
   protected void handleIdle(IdleStateEvent event) {
+    log.debug("The connection will be closed due to timeout");
     chctx.close();
   }
 


### PR DESCRIPTION
See https://github.com/eclipse-vertx/vert.x/issues/4208

Signed-off-by: Nils Renaud <renaud.nils@gmail.com>

Motivation:

Using the Vert.x HTTP client, when a connection takes too long and reaches its time out, we get this exception : `io.vertx.core.VertxException: Connection was closed`
This does not help in understanding the connection timeout has been reached.

I would rather have a dedicated exception or a dedicated message in the `VertxException` but as Julien Viet stated [here](https://github.com/eclipse-vertx/vert.x/issues/4208#issuecomment-1003970313) : we can start with a debug log explaining the closure reason.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
