### PR TITLE
The pool implementation does not correctly check a waiter is enqueued…

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/pool/PoolWaiter.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/PoolWaiter.java
@@ -53,6 +53,7 @@ public class PoolWaiter<C> {
   PoolWaiter<C> prev;
   PoolWaiter<C> next;
   boolean disposed;
+  boolean queued;
 
   PoolWaiter(PoolWaiter.Listener<C> listener, ContextInternal context, final int capacity, Handler<AsyncResult<Lease<C>>> handler) {
     this.listener = listener;

--- a/src/test/java/io/vertx/core/net/impl/pool/ConnectionPoolTest.java
+++ b/src/test/java/io/vertx/core/net/impl/pool/ConnectionPoolTest.java
@@ -632,10 +632,15 @@ public class ConnectionPoolTest extends VertxTestBase {
         w.complete(waiter);
       }
     }, 0, ar -> fail());
-    w.get(10, TimeUnit.SECONDS);
-    pool.cancel(w.get(10, TimeUnit.SECONDS), onSuccess(removed -> {
-      assertTrue(removed);
-      testComplete();
+    PoolWaiter<Connection> waiter = w.get(10, TimeUnit.SECONDS);
+    pool.cancel(waiter, onSuccess(removed1 -> {
+      assertTrue(removed1);
+      assertEquals(0, pool.waiters());
+      pool.cancel(waiter, onSuccess(removed2 -> {
+        assertFalse(removed2);
+        assertEquals(0, pool.waiters());
+        testComplete();
+      }));
     }));
     await();
   }


### PR DESCRIPTION
… in the waiter list before removing it leading to an incorrect waiter list size computation. In addition the size is used before a poll and instead a poll operation could be used and then check the polled nullity.

fixes #4224
