### PR TITLE
Default invalid request handler enhancements.

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -55,8 +55,7 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
    *   starts with <i>An HTTP line is larger than</i> the {@code REQUEST_URI_TOO_LONG} status is sent </li>
    *   <li>Otherwise when the cause is an instance of {@code io.netty.handler.codec.TooLongFrameException} and the error message
    *   starts with <i>HTTP header is larger than</i> the {@code REQUEST_HEADER_FIELDS_TOO_LARGE} status is sent</li>
-   *   <li>Otherwise when the request is a {@link HttpVersion#HTTP_1_0} {@code GET} {@code /bad-request} then {@code BAD_REQUEST} status is sent</li>
-   *   <li>Otherwise the connection is closed</li>
+   *   <li>Otherwise then {@code BAD_REQUEST} status is sent</li>
    * </ul>
    */
   @GenIgnore
@@ -72,16 +71,12 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
         status = HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE;
       }
     }
-    if (status == null && HttpMethod.GET == request.method() &&
-      HttpVersion.HTTP_1_0 == request.version() && "/bad-request".equals(request.uri())) {
-      // Matches Netty's specific HttpRequest for invalid messages
+    if (status == null) {
       status = HttpResponseStatus.BAD_REQUEST;
     }
-    if (status != null) {
-      request.response().setStatusCode(status.code()).end();
-    } else {
-      request.connection().close();
-    }
+    HttpServerResponse response = request.response();
+    response.setStatusCode(status.code()).end();
+    response.close();
   };
 
   @Override

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -4761,6 +4761,32 @@ public class Http1xTest extends HttpTest {
   }
 
   @Test
+  public void testInvalidHttpRequestHeaderResponse() throws Exception {
+    server.requestHandler(req -> {
+      fail();
+    });
+    startServer(testAddress);
+    NetClient client = vertx.createNetClient();
+    try {
+      CountDownLatch latch = new CountDownLatch(1);
+      Buffer response = Buffer.buffer();
+      client.connect(testAddress, onSuccess(so -> {
+        so.write("GET /some/path HTTP/1.1\r\n" +
+          "Host: vertx.io\r\n" +
+          "\uD83D\uDE31: val\r\n" +
+          "\r\n");
+        so.handler(response::appendBuffer);
+        so.closeHandler(v -> {
+          latch.countDown();
+        });
+      }));
+      awaitLatch(latch);
+      assertTrue(response.toString().startsWith("HTTP/1.1 400 Bad Request\r\n"));
+    } finally {
+      client.close();
+    }
+  }
+  @Test
   public void testChunkedServerResponse() {
     server.requestHandler(req -> {
       HttpServerResponse resp = req.response();


### PR DESCRIPTION
The implementation of the default invalid request handler only send a 400 response (bad_request) in some situation otherwise it will simply close the connection without sending a response message.

It should instead always send a response message (400 when nothing more specific can be sent) and then close the connection since the Netty decoder is in an un-recoverable state.

This commit changes the default invalid request handler to senda 400 response when no specific status code can be sent and then close the response.