### PR TITLE
Fix issue 4232 - Validate header names in RequestOptions

### DIFF
--- a/src/main/java/io/vertx/core/http/RequestOptions.java
+++ b/src/main/java/io/vertx/core/http/RequestOptions.java
@@ -526,7 +526,7 @@ public class RequestOptions {
 
   private void checkHeaders() {
     if (headers == null) {
-      headers = MultiMap.caseInsensitiveMultiMap();
+      headers = HttpHeaders.headers();
     }
   }
 

--- a/src/test/java/io/vertx/core/http/RequestOptionsTest.java
+++ b/src/test/java/io/vertx/core/http/RequestOptionsTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class RequestOptionsTest {
@@ -94,5 +95,15 @@ public class RequestOptionsTest {
     assertEquals(headers.toString(), 2, headers.size());
     assertEquals(Collections.singletonList("value"), headers.getAll("key"));
     assertEquals(Arrays.asList("bar", "baz"), headers.getAll("foo"));
+  }
+
+  @Test
+  public void testHeaderNameValidation() {
+    assertThrows(IllegalArgumentException.class, () -> new RequestOptions().addHeader("=", "invalid header name"));
+  }
+
+  @Test
+  public void testHeaderValueValidation() {
+    assertThrows(IllegalArgumentException.class, () -> new RequestOptions().addHeader("invalid-header-value", "\r"));
   }
 }


### PR DESCRIPTION
See https://github.com/eclipse-vertx/vert.x/issues/4232

Signed-off-by: Nils Renaud <renaud.nils@gmail.com>