### PR TITLE
Return failed future when executeBlocking task is rejected

### DIFF
--- a/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -176,7 +176,7 @@ abstract class ContextImpl extends AbstractContext {
       if (metrics != null) {
         metrics.rejected(queueMetric);
       }
-      throw e;
+      promise.fail(e);
     }
     return fut;
   }


### PR DESCRIPTION
Fixes #4209

When Vert.x is closed, there's a small timeframe which allows tasks to be submitted on worker pool but they will never get executed because the pool is closed.

Instead of throwing the runtime exception, we can return a failed future and give the user a chance to deal with it.