### PR TITLE
[Issue-4246] Support vfs protocol in the default FileResolver implementation

### DIFF
--- a/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
@@ -237,6 +237,7 @@ public class FileResolverImpl implements FileResolver {
       case "bundleresource": // Equinox
       case "jrt": // java run-time (JEP 220)
       case "resource":  // substratevm (graal native image)
+      case "vfs":  // jboss-vfs
         return unpackFromBundleURL(url, isDir);
       default:
         throw new IllegalStateException("Invalid url protocol: " + prot);


### PR DESCRIPTION
Motivation:

Fixes #4246 

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
