### PR TITLE
Fixing small potential bugs: NPE, Resource leak, invalid branch

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientPush.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientPush.java
@@ -34,7 +34,7 @@ public class HttpClientPush implements HttpRequest {
     String rawMethod = headers.method().toString();
     String authority = headers.authority() != null ? headers.authority().toString() : null;
     MultiMap headersMap = new Http2HeadersAdaptor(headers);
-    int pos = authority.indexOf(':');
+    int pos = authority == null ? -1 : authority.indexOf(':');
     if (pos == -1) {
       this.host = authority;
       this.port = 80;

--- a/src/main/java/io/vertx/core/json/impl/JsonUtil.java
+++ b/src/main/java/io/vertx/core/json/impl/JsonUtil.java
@@ -106,14 +106,12 @@ public final class JsonUtil {
       val = val.toString();
     } else if (val instanceof Shareable) {
       // Shareable objects know how to copy themselves, this covers:
-      // JsonObject, JsonArray or any user defined type that can shared across the cluster
+      // JsonObject, JsonArray, Buffer or any user defined type that can shared across the cluster
       val = ((Shareable) val).copy();
     } else if (val instanceof Map) {
       val = (new JsonObject((Map) val)).copy(copier);
     } else if (val instanceof List) {
       val = (new JsonArray((List) val)).copy(copier);
-    } else if (val instanceof Buffer) {
-      val = ((Buffer) val).copy();
     } else if (val instanceof byte[]) {
       // OK
     } else if (val instanceof Instant) {

--- a/src/test/java/io/vertx/core/json/JacksonTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonTest.java
@@ -11,9 +11,13 @@
 
 package io.vertx.core.json;
 
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.jackson.JacksonCodec;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -57,4 +61,12 @@ public class JacksonTest extends VertxTestBase {
       assertTrue(e.getMessage().contains(MyPojo.class.getName()));
     }
   }
+
+  @Test(expected = EncodeException.class)
+  public void encodeToBuffer() {
+    // if other than EncodeException happens here, then
+    // there is probably a leak closing the netty buffer output stream
+    codec.toBuffer(new RuntimeException("Unsupported"));
+  }
+
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

* Fix potential NPE: `HttpClientPush`
* Fix invalid branch `Buffer` is also `Sharable` `JsonUtils`
* ~~Fix potential resource leak if `writeUTF` is called: `JacksonCodec`~~ (Jackson is well-behaved and always closes resources)