### PR TITLE
Fix issue 4255 - HTTP header values verifier is laxer than what's advised in the RFCs

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -847,29 +847,38 @@ public final class HttpUtils {
     for (int i = 0;i < value.length();i++) {
       char c = value.charAt(i);
       switch (c) {
-        case 0x1c:
-        case 0x1d:
-        case 0x1e:
-        case 0x1f:
-        case 0x00:
-        case '\t':
-        case '\n':
-        case 0x0b:
-        case '\f':
-        case '\r':
+        // The RFC allows only : "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+        //                       "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+        // Where DIGIT is 0x30-0x39, and ALPHA : 0x41-0x5A and 0x61-0x7A
         case ' ':
+        case '"':
+        case '(':
+        case ')':
         case ',':
+        case '/':
         case ':':
         case ';':
+        case '<':
+        case '>':
         case '=':
+        case '?':
+        case '@':
+        case '[':
+        case ']':
+        case '\\':
+        case '{':
+        case '}':
+        case 0x7f: // DEL
           throw new IllegalArgumentException(
-            "a header name cannot contain the following prohibited characters: =,;: \\t\\r\\n\\v\\f: " +
-              value);
+            "a header name cannot contain some prohibited characters, such as : " + value);
         default:
+          // Check to see if the character is a control character
+          if (c < 0x20) {
+            throw new IllegalArgumentException("a header name cannot contain control characters: " + value);
+          }
           // Check to see if the character is not an ASCII character, or invalid
-          if (c > 127) {
-            throw new IllegalArgumentException("a header name cannot contain non-ASCII character: " +
-              value);
+          if (c > 0x7f) {
+            throw new IllegalArgumentException("a header name cannot contain non-ASCII character: " + value);
           }
       }
     }

--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -793,7 +793,7 @@ public final class HttpUtils {
     }
   }
 
-  private static final int HIGHEST_INVALID_VALUE_CHAR_MASK = ~15;
+  private static final int HIGHEST_INVALID_VALUE_CHAR_MASK = ~0x1F;
 
   private static int validateValueChar(CharSequence seq, int state, char character) {
     /*
@@ -802,15 +802,15 @@ public final class HttpUtils {
      * 1: The previous character was CR
      * 2: The previous character was LF
      */
-    if ((character & HIGHEST_INVALID_VALUE_CHAR_MASK) == 0) {
-      // Check the absolutely prohibited characters.
+    if ((character & HIGHEST_INVALID_VALUE_CHAR_MASK) == 0 || character == 0x7F) { // 0x7F is "DEL".
+      // The only characters allowed in the range 0x00-0x1F are : HTAB, LF and CR
       switch (character) {
-        case 0x0: // NULL
-          throw new IllegalArgumentException("a header value contains a prohibited character '\0': " + seq);
-        case 0x0b: // Vertical tab
-          throw new IllegalArgumentException("a header value contains a prohibited character '\\v': " + seq);
-        case '\f':
-          throw new IllegalArgumentException("a header value contains a prohibited character '\\f': " + seq);
+        case 0x09: // Horizontal tab - HTAB
+        case 0x0a: // Line feed - LF
+        case 0x0d: // Carriage return - CR
+          break;
+        default:
+          throw new IllegalArgumentException("a header value contains a prohibited character '" + (int) character + "': " + seq);
       }
     }
 

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -4713,7 +4713,14 @@ public class Http1xTest extends HttpTest {
 
   @Test
   public void testHeaderValueValidation() {
-    List<String> invalid = Arrays.asList("\f", "\0", "\u000b", "\r\n3", "\r3", "\n3", "\n\r");
+    List<String> invalid = Arrays.asList(
+      "\u0000", "\u0001", "\u0002", "\u0003", "\u0004", "\u0005", "\u0006", "\u0007", "\u0008", /* HTAB */ /* LF */
+      "\u000b", "\u000c", /* CR  */ "\u000e", "\u000f", "\u0010", "\u0011", "\u0012", "\u0013", "\u0014", "\u0015",
+      "\u0016", "\u0017", "\u0018", "\u0019", "\u001a", "\u001b", "\u001c", "\u001d", "\u001e", "\u001f", /* SP */
+      /* u0021-u007e */
+      "\u007F",
+      /* u0080-u00FF obsolete but still accepted */
+      "\r\n3", "\r3", "\n3", "\n\r");
     for (String test : invalid) {
       try {
         HttpUtils.validateHeaderValue(test);

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -4711,16 +4711,21 @@ public class Http1xTest extends HttpTest {
     }
   }
 
-  @Test
-  public void testHeaderValueValidation() {
-    List<String> invalid = Arrays.asList(
+  private static List<String> invalidCharsForHeaders() {
+    return Arrays.asList(
       "\u0000", "\u0001", "\u0002", "\u0003", "\u0004", "\u0005", "\u0006", "\u0007", "\u0008", /* HTAB */ /* LF */
       "\u000b", "\u000c", /* CR  */ "\u000e", "\u000f", "\u0010", "\u0011", "\u0012", "\u0013", "\u0014", "\u0015",
       "\u0016", "\u0017", "\u0018", "\u0019", "\u001a", "\u001b", "\u001c", "\u001d", "\u001e", "\u001f", /* SP */
       /* u0021-u007e */
-      "\u007F",
-      /* u0080-u00FF obsolete but still accepted */
-      "\r\n3", "\r3", "\n3", "\n\r");
+      "\u007f"
+      /* u0080-u00FF obsolete but still accepted for header value */
+    );
+  }
+
+  @Test
+  public void testHeaderValueValidation() {
+    List<String> invalid = new ArrayList<>(invalidCharsForHeaders());
+    invalid.addAll(Arrays.asList("\r\n3", "\r3", "\n3", "\n\r"));
     for (String test : invalid) {
       try {
         HttpUtils.validateHeaderValue(test);
@@ -4748,10 +4753,18 @@ public class Http1xTest extends HttpTest {
     startServer(testAddress);
     NetClient client = vertx.createNetClient();
     try {
-      char[] chars = { 0x1c, 0x1d, 0x1e, 0x1f, 0x0c };
+      List<String> chars = new ArrayList<>(invalidCharsForHeaders());
+      chars.addAll(Arrays.asList(
+        // Forbidden chars in a header name part
+        // Note : '\t' and ' ' are forbidden too, but still used in the obsolete line folding syntax
+        // Note : '\n', '\r' and ':' are forbidden too, but they are used as header boundaries, so it will never fail.
+        "\"", "(", ")", ",", "/", ";", "<", ">", "=", "?", "@", "[", "]", "\\", "{", "}",
+        // Outside the ASCII range
+        "\u0080", "\u0090", "\u00a0", "\u00b0", "\u00c0", "\u00d0", "\u00e0", "\u00f0", "\u00ff"));
       boolean[] positions = { true, false };
       for (boolean position : positions) {
-        for (char invalid : chars) {
+        for (String invalid : chars) {
+          System.out.println("char : " + invalid.codePointAt(0) + " - position : " + position);
           int current = invalidRequests.get();
           CountDownLatch latch = new CountDownLatch(1);
           client.connect(testAddress, onSuccess(so -> {
@@ -5243,7 +5256,7 @@ public class Http1xTest extends HttpTest {
         if (payload != null) {
           assertEquals(payload, body);
         }
-        req.response().headers().set("HTTP/1.1", "101 Upgrade");
+        req.response().setStatusCode(101);
         req.toNetSocket().onComplete(onSuccess(so -> {
           so.handler(buff -> {
             assertEquals("ping", buff.toString());

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -13,6 +13,7 @@ package io.vertx.core.http;
 
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.handler.codec.compression.DecompressionException;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.vertx.codegen.annotations.Nullable;
@@ -939,9 +940,9 @@ public abstract class HttpTest extends HttpTestBase {
   @Test
   public void testRequestHeadersWithCharSequence() {
     HashMap<CharSequence, String> expectedHeaders = new HashMap<>();
-    expectedHeaders.put(HttpHeaders.TEXT_HTML, "text/html");
-    expectedHeaders.put(HttpHeaders.USER_AGENT, "User-Agent");
-    expectedHeaders.put(HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED, "application/x-www-form-urlencoded");
+    expectedHeaders.put(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=utf-8");
+    expectedHeaders.put(HttpHeaderNames.CONTENT_ENCODING, "gzip");
+    expectedHeaders.put(HttpHeaderNames.USER_AGENT, "Mozilla/5.0");
 
     server.requestHandler(req -> {
 
@@ -1052,9 +1053,9 @@ public abstract class HttpTest extends HttpTestBase {
   @Test
   public void testResponseHeadersWithCharSequence() {
     HashMap<CharSequence, String> headers = new HashMap<>();
-    headers.put(HttpHeaders.TEXT_HTML, "text/html");
-    headers.put(HttpHeaders.USER_AGENT, "User-Agent");
-    headers.put(HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED, "application/x-www-form-urlencoded");
+    headers.put(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=utf-8");
+    headers.put(HttpHeaderNames.CONTENT_ENCODING, "gzip");
+    headers.put(HttpHeaderNames.USER_AGENT, "Mozilla/5.0");
 
     server.requestHandler(req -> {
       headers.forEach((k, v) -> req.response().headers().add(k, v));
@@ -5217,7 +5218,7 @@ public abstract class HttpTest extends HttpTestBase {
     waitFor(2);
 
     server.requestHandler(req -> {
-      req.response().headers().set("HTTP/1.1", "101 Upgrade");
+      req.response().setStatusCode(101);
       req.toNetSocket().onComplete(onSuccess(serverHandler::handle));
     });
 


### PR DESCRIPTION

According to :
- https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
- https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
- https://datatracker.ietf.org/doc/html/rfc7540#section-10.3

For both HTTP/1.1 and HTTP/2.0 versions, bytes allowed for header value are : CR (0x0D), LF (0x0A), SP (0x20), HTAB (0x09) and ranges 0x21 to 0x7E and 0x80 to 0xFF (although the last range is considered as obsolete)

For more information, see the related issue : https://github.com/eclipse-vertx/vert.x/issues/4255

Signed-off-by: Nils Renaud <renaud.nils@gmail.com>