### PR TITLE
Introduce VertxBindException

### DIFF
--- a/src/main/java/io/vertx/core/net/VertxBindException.java
+++ b/src/main/java/io/vertx/core/net/VertxBindException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.net;
+
+import java.net.BindException;
+import java.net.SocketAddress;
+
+/**
+ * An exception that is meant to stand in for {@link BindException} and provide information
+ * about the target which caused the bind exception.
+ */
+public class VertxBindException extends BindException {
+
+  private final SocketAddress bindTarget;
+
+  public VertxBindException(BindException cause, SocketAddress bindTarget) {
+    this.bindTarget = bindTarget;
+    initCause(cause);
+  }
+
+  public SocketAddress getBindTarget() {
+    return bindTarget;
+  }
+}

--- a/src/main/java/io/vertx/core/net/impl/AsyncResolveConnectHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/AsyncResolveConnectHelper.java
@@ -19,8 +19,10 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.VertxBindException;
 import io.vertx.core.net.SocketAddress;
 
+import java.net.BindException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
@@ -46,7 +48,11 @@ public class AsyncResolveConnectHelper {
         if (f.isSuccess()) {
           promise.setSuccess(future.channel());
         } else {
-          promise.setFailure(f.cause());
+          Throwable cause = f.cause();
+          if (cause instanceof BindException) {
+            cause = new VertxBindException((BindException) cause, converted);
+          }
+          promise.setFailure(cause);
         }
       });
     } else {
@@ -60,7 +66,11 @@ public class AsyncResolveConnectHelper {
             if (f.isSuccess()) {
               promise.setSuccess(future.channel());
             } else {
-              promise.setFailure(f.cause());
+              Throwable cause = f.cause();
+              if (cause instanceof BindException) {
+                cause = new VertxBindException((BindException) cause, t);
+              }
+              promise.setFailure(cause);
             }
           });
         } else {


### PR DESCRIPTION
Motivation:

This is useful for Quarkus since it introspects
the BindException in order to figure out which port
caused the conflict.
Without this enhancement, Quarkus resorts to guessing (see [this](https://github.com/quarkusio/quarkus/blob/2.7.0.CR1/core/runtime/src/main/java/io/quarkus/runtime/ApplicationLifecycleManager.java#L158))
and this guess is [not correct](https://github.com/quarkusio/quarkus/issues/22967) when there are various
servers used (like an HTTP server and a GRPC server)
