### PR TITLE
Introduce support for pcap traffic capturing of network traffic

### DIFF
--- a/src/main/generated/io/vertx/core/dns/DnsClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/dns/DnsClientOptionsConverter.java
@@ -20,6 +20,11 @@ public class DnsClientOptionsConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DnsClientOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "activityLogFormat":
+          if (member.getValue() instanceof String) {
+            obj.setActivityLogFormat(io.netty.handler.logging.ByteBufFormat.valueOf((String)member.getValue()));
+          }
+          break;
         case "host":
           if (member.getValue() instanceof String) {
             obj.setHost((String)member.getValue());
@@ -54,6 +59,9 @@ public class DnsClientOptionsConverter {
   }
 
   public static void toJson(DnsClientOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getActivityLogFormat() != null) {
+      json.put("activityLogFormat", obj.getActivityLogFormat().name());
+    }
     if (obj.getHost() != null) {
       json.put("host", obj.getHost());
     }

--- a/src/main/generated/io/vertx/core/eventbus/EventBusOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/eventbus/EventBusOptionsConverter.java
@@ -25,6 +25,11 @@ public class EventBusOptionsConverter {
             obj.setAcceptBacklog(((Number)member.getValue()).intValue());
           }
           break;
+        case "activityLogDataFormat":
+          if (member.getValue() instanceof String) {
+            obj.setActivityLogDataFormat(io.netty.handler.logging.ByteBufFormat.valueOf((String)member.getValue()));
+          }
+          break;
         case "clientAuth":
           if (member.getValue() instanceof String) {
             obj.setClientAuth(io.vertx.core.http.ClientAuth.valueOf((String)member.getValue()));
@@ -127,6 +132,11 @@ public class EventBusOptionsConverter {
         case "openSslEngineOptions":
           if (member.getValue() instanceof JsonObject) {
             obj.setOpenSslEngineOptions(new io.vertx.core.net.OpenSSLEngineOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+        case "pcapCaptureFile":
+          if (member.getValue() instanceof String) {
+            obj.setPcapCaptureFile((String)member.getValue());
           }
           break;
         case "pemKeyCertOptions":
@@ -269,6 +279,9 @@ public class EventBusOptionsConverter {
 
    static void toJson(EventBusOptions obj, java.util.Map<String, Object> json) {
     json.put("acceptBacklog", obj.getAcceptBacklog());
+    if (obj.getActivityLogDataFormat() != null) {
+      json.put("activityLogDataFormat", obj.getActivityLogDataFormat().name());
+    }
     if (obj.getClientAuth() != null) {
       json.put("clientAuth", obj.getClientAuth().name());
     }
@@ -318,6 +331,9 @@ public class EventBusOptionsConverter {
     json.put("logActivity", obj.getLogActivity());
     if (obj.getOpenSslEngineOptions() != null) {
       json.put("openSslEngineOptions", obj.getOpenSslEngineOptions().toJson());
+    }
+    if (obj.getPcapCaptureFile() != null) {
+      json.put("pcapCaptureFile", obj.getPcapCaptureFile());
     }
     if (obj.getPemKeyCertOptions() != null) {
       json.put("pemKeyCertOptions", obj.getPemKeyCertOptions().toJson());

--- a/src/main/generated/io/vertx/core/net/NetworkOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/net/NetworkOptionsConverter.java
@@ -20,9 +20,19 @@ public class NetworkOptionsConverter {
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, NetworkOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "activityLogDataFormat":
+          if (member.getValue() instanceof String) {
+            obj.setActivityLogDataFormat(io.netty.handler.logging.ByteBufFormat.valueOf((String)member.getValue()));
+          }
+          break;
         case "logActivity":
           if (member.getValue() instanceof Boolean) {
             obj.setLogActivity((Boolean)member.getValue());
+          }
+          break;
+        case "pcapCaptureFile":
+          if (member.getValue() instanceof String) {
+            obj.setPcapCaptureFile((String)member.getValue());
           }
           break;
         case "receiveBufferSize":
@@ -59,7 +69,13 @@ public class NetworkOptionsConverter {
   }
 
    static void toJson(NetworkOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getActivityLogDataFormat() != null) {
+      json.put("activityLogDataFormat", obj.getActivityLogDataFormat().name());
+    }
     json.put("logActivity", obj.getLogActivity());
+    if (obj.getPcapCaptureFile() != null) {
+      json.put("pcapCaptureFile", obj.getPcapCaptureFile());
+    }
     json.put("receiveBufferSize", obj.getReceiveBufferSize());
     json.put("reuseAddress", obj.isReuseAddress());
     json.put("reusePort", obj.isReusePort());

--- a/src/main/java/io/vertx/core/datagram/DatagramSocketOptions.java
+++ b/src/main/java/io/vertx/core/datagram/DatagramSocketOptions.java
@@ -137,6 +137,11 @@ public class DatagramSocketOptions extends NetworkOptions {
   }
 
   @Override
+  public DatagramSocketOptions setPcapCaptureFile(String pcapCaptureFile) {
+    return (DatagramSocketOptions) super.setPcapCaptureFile(pcapCaptureFile);
+  }
+
+  @Override
   public int getTrafficClass() {
     return super.getTrafficClass();
   }

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
@@ -28,6 +28,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.datagram.DatagramSocketOptions;
+import io.vertx.core.http.impl.VertxPcapWriteHandler;
 import io.vertx.core.impl.AddressResolver;
 import io.vertx.core.impl.Arguments;
 import io.vertx.core.impl.ContextInternal;
@@ -77,6 +78,9 @@ public class DatagramSocketImpl implements DatagramSocket, MetricsProvider {
     context.nettyEventLoop().register(channel);
     if (options.getLogActivity()) {
       channel.pipeline().addLast("logging", new LoggingHandler(options.getActivityLogDataFormat()));
+    }
+    if ((options.getPcapCaptureFile() != null) && !options.getPcapCaptureFile().isEmpty()) {
+      channel.pipeline().addLast("pcapCapturing", new VertxPcapWriteHandler(options.getPcapCaptureFile()));
     }
     VertxMetrics metrics = vertx.metricsSPI();
     this.metrics = metrics != null ? metrics.createDatagramSocketMetrics(options) : null;

--- a/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
@@ -441,6 +441,12 @@ public class EventBusOptions extends TCPSSLOptions {
   }
 
   @Override
+  public EventBusOptions setPcapCaptureFile(String pcapCaptureFile) {
+    super.setPcapCaptureFile(pcapCaptureFile);
+    return this;
+  }
+
+  @Override
   public EventBusOptions setSendBufferSize(int sendBufferSize) {
     super.setSendBufferSize(sendBufferSize);
     return this;

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -414,6 +414,12 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public HttpClientOptions setPcapCaptureFile(String pcapCaptureFile) {
+    super.setPcapCaptureFile(pcapCaptureFile);
+    return this;
+  }
+
+  @Override
   public HttpClientOptions setTrafficClass(int trafficClass) {
     super.setTrafficClass(trafficClass);
     return this;

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -285,6 +285,12 @@ public class HttpServerOptions extends NetServerOptions {
   }
 
   @Override
+  public HttpServerOptions setPcapCaptureFile(String pcapCaptureFile) {
+    super.setPcapCaptureFile(pcapCaptureFile);
+    return this;
+  }
+
+  @Override
   public HttpServerOptions setTrafficClass(int trafficClass) {
     super.setTrafficClass(trafficClass);
     return this;

--- a/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
@@ -57,6 +57,7 @@ public class HttpChannelConnector {
   private final HttpVersion version;
   private final SocketAddress peerAddress;
   private final SocketAddress server;
+  private final boolean enablePcapCapture;
 
   public HttpChannelConnector(HttpClientImpl client,
                               NetClientImpl netClient,
@@ -77,6 +78,7 @@ public class HttpChannelConnector {
     this.version = version;
     this.peerAddress = peerAddress;
     this.server = server;
+    this.enablePcapCapture = (options.getPcapCaptureFile() != null) && !options.getPcapCaptureFile().isEmpty();
   }
 
   public SocketAddress server() {
@@ -163,6 +165,9 @@ public class HttpChannelConnector {
     }
     if (options.getLogActivity()) {
       pipeline.addLast("logging", new LoggingHandler(options.getActivityLogDataFormat()));
+    }
+    if (enablePcapCapture) {
+      pipeline.addLast("pcapCapturing", new VertxPcapWriteHandler(options.getPcapCaptureFile()));
     }
     pipeline.addLast("codec", new HttpClientCodec(
       options.getMaxInitialLineLength(),

--- a/src/main/java/io/vertx/core/http/impl/HttpServerWorker.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerWorker.java
@@ -35,6 +35,10 @@ import io.vertx.core.net.impl.VertxHandler;
 import io.vertx.core.net.impl.HAProxyMessageCompletionHandler;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 
@@ -55,6 +59,7 @@ public class HttpServerWorker implements Handler<Channel> {
   private final String serverOrigin;
   private final boolean logEnabled;
   private final boolean disableH2C;
+  private final boolean enablePcapCapture;
   final Handler<HttpServerConnection> connectionHandler;
   private final Handler<Throwable> exceptionHandler;
 
@@ -77,6 +82,7 @@ public class HttpServerWorker implements Handler<Channel> {
     this.serverOrigin = serverOrigin;
     this.logEnabled = options.getLogActivity();
     this.disableH2C = disableH2C;
+    this.enablePcapCapture = (options.getPcapCaptureFile() != null) && !options.getPcapCaptureFile().isEmpty();
     this.connectionHandler = connectionHandler;
     this.exceptionHandler = exceptionHandler;
   }
@@ -251,6 +257,9 @@ public class HttpServerWorker implements Handler<Channel> {
   private void configureHttp1OrH2C(ChannelPipeline pipeline) {
     if (logEnabled) {
       pipeline.addLast("logging", new LoggingHandler(options.getActivityLogDataFormat()));
+    }
+    if (enablePcapCapture) {
+      pipeline.addLast("pcapCapturing", new VertxPcapWriteHandler(options.getPcapCaptureFile()));
     }
     if (HttpServerImpl.USE_FLASH_POLICY_HANDLER) {
       pipeline.addLast("flashpolicy", new FlashPolicyHandler());

--- a/src/main/java/io/vertx/core/http/impl/VertxPcapWriteHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxPcapWriteHandler.java
@@ -1,0 +1,119 @@
+package io.vertx.core.http.impl;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.pcap.PcapWriteHandler;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import java.io.Closeable;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A handler that simply delegates to the built in {@link PcapWriteHandler}.
+ * Vert.x needs this because the handler might not have been added to the processing pipeline
+ * when the {@code channelRead} method is invoked, and thus the necessary setup is performed
+ * in the {@code channelRegistered} method.
+ * Furthermore, we want to support capturing the output of multiple Netty pipelines into a single file,
+ * so for example both the output of an HTTP server and an HTTP Client can be inspected via the same file.
+ */
+public class VertxPcapWriteHandler extends ChannelDuplexHandler implements Closeable {
+
+  private static final Logger log = LoggerFactory.getLogger(VertxPcapWriteHandler.class);
+
+  /**
+   * The idea of this map is to control the usage of each throughout the entire Vert.x application.
+   * When the same file is configured for multiple pipelines, we want each pipeline to write to the same
+   * OutputStream, but we only want to close it when the last pipeline has been closed.
+   */
+  private static final ConcurrentMap<String, Metadata> fileToMetadata = new ConcurrentHashMap<>();
+
+  private final PcapWriteHandler delegate;
+  private final String pcapCaptureFile;
+
+  public VertxPcapWriteHandler(String pcapCaptureFile) {
+    this.pcapCaptureFile = pcapCaptureFile;
+    Metadata metadata = fileToMetadata.computeIfAbsent(pcapCaptureFile, Metadata::new);
+    // pcap contains a global header section that should only be written by the first handler
+    int openedCount = metadata.openedCount.getAndIncrement();
+    this.delegate = new PcapWriteHandler(metadata.outputStream, false, openedCount == 0);
+  }
+
+  @Override
+  public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+    delegate.channelActive(ctx);
+  }
+
+  @Override
+  public void channelActive(ChannelHandlerContext ctx) throws Exception {
+    delegate.channelActive(ctx);
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+    delegate.channelRead(ctx, msg);
+  }
+
+  @Override
+  public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    delegate.write(ctx, msg, promise);
+  }
+
+  @Override
+  public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+    int openedCount = fileToMetadata.get(pcapCaptureFile).openedCount.decrementAndGet();
+    if (openedCount == 0) {
+      delegate.handlerRemoved(ctx);
+    }
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    delegate.exceptionCaught(ctx, cause);
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+
+  private static class Metadata {
+
+    final AtomicInteger openedCount;
+    final OutputStream outputStream;
+
+    Metadata(String pcapFile) {
+      openedCount = new AtomicInteger(0);
+      outputStream = getOutputStream(pcapFile);
+    }
+
+    private OutputStream getOutputStream(String pcapFile) {
+      try {
+        return new FileOutputStream(pcapFile);
+      } catch (FileNotFoundException e) {
+        log.warn("Unable to open capture file for writing, so no capture information will be recorded.", e);
+        return NullOutputStream.INSTANCE;
+      }
+    }
+
+    private static class NullOutputStream extends OutputStream {
+
+      static final NullOutputStream INSTANCE = new NullOutputStream();
+
+      private NullOutputStream() {
+      }
+
+      @Override
+      public void write(int b) throws IOException {
+
+      }
+    }
+  }
+
+}

--- a/src/main/java/io/vertx/core/net/ClientOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/ClientOptionsBase.java
@@ -367,6 +367,11 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
   }
 
   @Override
+  public ClientOptionsBase setPcapCaptureFile(String pcapCaptureFile) {
+    return (ClientOptionsBase) super.setPcapCaptureFile(pcapCaptureFile);
+  }
+
+  @Override
   public ClientOptionsBase setTrafficClass(int trafficClass) {
     return (ClientOptionsBase) super.setTrafficClass(trafficClass);
   }

--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -45,11 +45,17 @@ public class NetClientOptions extends ClientOptionsBase {
    */
   public static final String DEFAULT_HOSTNAME_VERIFICATION_ALGORITHM = "";
 
+  /**
+   * Default pcap file name where capturing of HTTP traffic is recorded. When no file is set, capturing is disabled.
+   */
+  public static final String DEFAULT_PCAP_CAPTURE_FILE = "";
+
 
   private int reconnectAttempts;
   private long reconnectInterval;
   private String hostnameVerificationAlgorithm;
   private List<String> applicationLayerProtocols;
+  private String pcapCaptureFile;
 
     /**
    * The default constructor
@@ -70,6 +76,7 @@ public class NetClientOptions extends ClientOptionsBase {
     this.reconnectInterval = other.getReconnectInterval();
     this.hostnameVerificationAlgorithm = other.getHostnameVerificationAlgorithm();
     this.applicationLayerProtocols = other.applicationLayerProtocols != null ? new ArrayList<>(other.applicationLayerProtocols) : null;
+    this.pcapCaptureFile = other.pcapCaptureFile;
   }
 
   /**
@@ -96,6 +103,7 @@ public class NetClientOptions extends ClientOptionsBase {
     this.reconnectAttempts = DEFAULT_RECONNECT_ATTEMPTS;
     this.reconnectInterval = DEFAULT_RECONNECT_INTERVAL;
     this.hostnameVerificationAlgorithm = DEFAULT_HOSTNAME_VERIFICATION_ALGORITHM;
+    this.pcapCaptureFile = DEFAULT_PCAP_CAPTURE_FILE;
   }
 
   @Override
@@ -119,6 +127,12 @@ public class NetClientOptions extends ClientOptionsBase {
   @Override
   public NetClientOptions setReusePort(boolean reusePort) {
     super.setReusePort(reusePort);
+    return this;
+  }
+
+  @Override
+  public NetClientOptions setPcapCaptureFile(String pcapCaptureFile) {
+    super.setPcapCaptureFile(pcapCaptureFile);
     return this;
   }
 

--- a/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -153,6 +153,12 @@ public class NetServerOptions extends TCPSSLOptions {
   }
 
   @Override
+  public NetServerOptions setPcapCaptureFile(String pcapCaptureFile) {
+    super.setPcapCaptureFile(pcapCaptureFile);
+    return this;
+  }
+
+  @Override
   public NetServerOptions setTrafficClass(int trafficClass) {
     super.setTrafficClass(trafficClass);
     return this;

--- a/src/main/java/io/vertx/core/net/NetworkOptions.java
+++ b/src/main/java/io/vertx/core/net/NetworkOptions.java
@@ -58,6 +58,11 @@ public abstract class NetworkOptions {
    */
   public static final ByteBufFormat DEFAULT_LOG_ACTIVITY_FORMAT = ByteBufFormat.HEX_DUMP;
 
+  /**
+   * Default pcap file name where capturing of HTTP traffic is recorded. When no file is set, capturing is disabled.
+   */
+  public static final String DEFAULT_PCAP_CAPTURE_FILE = "";
+
   private int sendBufferSize;
   private int receiveBufferSize;
   private int trafficClass;
@@ -65,6 +70,7 @@ public abstract class NetworkOptions {
   private boolean logActivity;
   private ByteBufFormat activityLogDataFormat;
   private boolean reusePort;
+  private String pcapCaptureFile;
 
   /**
    * Default constructor
@@ -77,6 +83,7 @@ public abstract class NetworkOptions {
     logActivity = DEFAULT_LOG_ENABLED;
     activityLogDataFormat = DEFAULT_LOG_ACTIVITY_FORMAT;
     reusePort = DEFAULT_REUSE_PORT;
+    pcapCaptureFile = DEFAULT_PCAP_CAPTURE_FILE;
   }
 
   /**
@@ -92,6 +99,7 @@ public abstract class NetworkOptions {
     this.trafficClass = other.getTrafficClass();
     this.logActivity = other.logActivity;
     this.activityLogDataFormat = other.activityLogDataFormat;
+    this.pcapCaptureFile = other.pcapCaptureFile;
   }
 
   /**
@@ -246,6 +254,18 @@ public abstract class NetworkOptions {
    */
   public NetworkOptions setReusePort(boolean reusePort) {
     this.reusePort = reusePort;
+    return this;
+  }
+
+  /**
+   * @return the name of the PCAP file where the HTTP traffic will be written to.
+   */
+  public String getPcapCaptureFile() {
+    return pcapCaptureFile;
+  }
+
+  public NetworkOptions setPcapCaptureFile(String pcapCaptureFile) {
+    this.pcapCaptureFile = pcapCaptureFile;
     return this;
   }
 }

--- a/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -819,4 +819,8 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     return (TCPSSLOptions) super.setReusePort(reusePort);
   }
 
+  @Override
+  public TCPSSLOptions setPcapCaptureFile(String pcapCaptureFile) {
+    return (TCPSSLOptions) super.setPcapCaptureFile(pcapCaptureFile);
+  }
 }

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -29,6 +29,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.impl.PartialPooledByteBufAllocator;
+import io.vertx.core.http.impl.VertxPcapWriteHandler;
 import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.future.PromiseInternal;
@@ -64,6 +65,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
   protected final int writeIdleTimeout;
   private final TimeUnit idleTimeoutUnit;
   protected final boolean logEnabled;
+  private final boolean enablePcapCapture;
 
   private final VertxInternal vertx;
   private final NetClientOptions options;
@@ -90,6 +92,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
     this.idleTimeoutUnit = options.getIdleTimeoutUnit();
     this.closeFuture = closeFuture;
     this.proxyFilter = options.getNonProxyHosts() != null ? ProxyFilter.nonProxyHosts(options.getNonProxyHosts()) : ProxyFilter.DEFAULT_PROXY_FILTER;
+    this.enablePcapCapture = (options.getPcapCaptureFile() != null) && !options.getPcapCaptureFile().isEmpty();
 
     sslHelper.validate(vertx);
   }
@@ -97,6 +100,9 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
   protected void initChannel(ChannelPipeline pipeline) {
     if (logEnabled) {
       pipeline.addLast("logging", new LoggingHandler(options.getActivityLogDataFormat()));
+    }
+    if (enablePcapCapture) {
+      pipeline.addLast("pcapCapturing", new VertxPcapWriteHandler(options.getPcapCaptureFile()));
     }
     if (options.isSsl()) {
       // only add ChunkedWriteHandler when SSL is enabled otherwise it is not needed as FileRegion is used.


### PR DESCRIPTION
**Motivation**:

The idea here is to allow users to analyze HTTP traffic consumed and produced via Vert.x using Wireshark.
This capabity relies on Netty's `io.netty.handler.pcap.PcapWriteHandler` and has also been mentioned in https://github.com/vert-x3/issues/issues/566.


P.S. I tested this by also patching Quarkus to use this change and tried an application that uses RESTEasy Reactive and the Reactive REST Client.
Here is what the Wireshark screenshot looks like:
![Screenshot from 2022-01-28 16-51-38](https://user-images.githubusercontent.com/4374975/151568188-a3973682-0b2c-4ce2-bc18-a35d33501bcd.png)


