### PR TITLE
Fix issue 4084 - setTimer should not throw exception for delay < 1ms

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -505,11 +505,9 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   public long scheduleTimeout(ContextInternal context, Handler<Long> handler, long delay, boolean periodic) {
-    if (delay < 1) {
-      throw new IllegalArgumentException("Cannot schedule a timer with delay < 1 ms");
-    }
+    long validDelay = Math.max(delay, 1);
     long timerId = timeoutCounter.getAndIncrement();
-    InternalTimerHandler task = new InternalTimerHandler(timerId, handler, periodic, delay, context);
+    InternalTimerHandler task = new InternalTimerHandler(timerId, handler, periodic, validDelay, context);
     timeouts.put(timerId, task);
     if (context.isDeployment()) {
       context.addCloseHook(task);

--- a/src/test/java/io/vertx/core/TimerTest.java
+++ b/src/test/java/io/vertx/core/TimerTest.java
@@ -33,8 +33,18 @@ public class TimerTest extends VertxTestBase {
   }
 
   @Test
+  public void testInvalidTimer() {
+    timer(0);
+  }
+
+  @Test
   public void testPeriodic() {
     periodic(10);
+  }
+
+  @Test
+  public void testInvalidPeriodic() {
+    periodic(0);
   }
 
   /**


### PR DESCRIPTION
Motivation:
Fixes https://github.com/eclipse-vertx/vert.x/issues/4084

If time set less than 1 ms in `io.vertx.core.Vertx#setTimer` then it throws an exception. Behaviour is changed to use max(delay, 1) to enforce 1ms restriction rather than throwing an exception

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
