### PR TITLE
Add forEach method on HeadersMultiMap that avoids object allocation

### DIFF
--- a/src/main/java/io/vertx/core/MultiMap.java
+++ b/src/main/java/io/vertx/core/MultiMap.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /**
@@ -72,6 +74,19 @@ public interface MultiMap extends Iterable<Map.Entry<String, String>> {
   List<String> getAll(CharSequence name);
 
   /**
+   * Allows iterating over the entries in the map
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default void forEach(BiConsumer<String, String> action) {
+    forEach(new Consumer<Map.Entry<String, String>>() {
+      @Override
+      public void accept(Map.Entry<String, String> entry) {
+        action.accept(entry.getKey(), entry.getValue());
+      }
+    });
+  }
+
+  /**
    * Returns all entries in the multi-map.
    *
    * @return A immutable {@link java.util.List} of the name-value entries, which will be
@@ -80,7 +95,7 @@ public interface MultiMap extends Iterable<Map.Entry<String, String>> {
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   default List<Map.Entry<String, String>> entries() {
     List<Map.Entry<String, String>> entries = new ArrayList<>();
-    forEach(entries::add);
+    forEach((Consumer<Map.Entry<String, String>>)entries::add);
     return entries;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/headers/HeadersMultiMap.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/HeadersMultiMap.java
@@ -332,7 +332,16 @@ public final class HeadersMultiMap extends HttpHeaders implements MultiMap {
   public void forEach(Consumer<? super Map.Entry<String, String>> action) {
     HeadersMultiMap.MapEntry e = head.after;
     while (e != head) {
-      action.accept(new AbstractMap.SimpleEntry<>(e.key.toString(), e.value.toString()));
+      action.accept(e.stringEntry());
+      e = e.after;
+    }
+  }
+
+  @Override
+  public void forEach(BiConsumer<String, String> action) {
+    HeadersMultiMap.MapEntry e = head.after;
+    while (e != head) {
+      action.accept(e.getKey().toString(), e.getValue().toString());
       e = e.after;
     }
   }
@@ -570,6 +579,15 @@ public final class HeadersMultiMap extends HttpHeaders implements MultiMap {
     @Override
     public String toString() {
       return getKey() + "=" + getValue();
+    }
+
+    @SuppressWarnings({"rawtypes","unchecked"})
+    private Map.Entry<String, String> stringEntry() {
+      if (key instanceof String && value instanceof String) {
+        return (Map.Entry) this;
+      } else {
+        return new AbstractMap.SimpleEntry<>(key.toString(), value.toString());
+      }
     }
   }
 

--- a/src/test/java/io/vertx/core/http/headers/HeadersTestBase.java
+++ b/src/test/java/io/vertx/core/http/headers/HeadersTestBase.java
@@ -11,12 +11,14 @@
 
 package io.vertx.core.http.headers;
 
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.impl.headers.HeadersAdaptor;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.core.http.impl.headers.Http2HeadersAdaptor;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -27,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -598,17 +602,17 @@ public abstract class HeadersTestBase {
     mmap.set("header", Arrays.asList(HttpHeaders.createOptimized("value1"), HttpHeaders.createOptimized("value2")));
     assertEquals(Arrays.asList("value1", "value2"), mmap.getAll("header"));
   }
-  
+
   @Test
   public void testSetAllOnExistingMapUsingMultiMapHttp1() {
     MultiMap mainMap = new HeadersAdaptor(HeadersMultiMap.httpHeaders());
     mainMap.add("originalKey", "originalValue");
-    
+
     MultiMap setAllMap = newMultiMap();
-    
+
     setAllMap.add("originalKey", "newValue");
     setAllMap.add("anotherKey", "anotherValue");
-    
+
     MultiMap result = mainMap.setAll(setAllMap);
     assertNotNull(result);
     assertFalse(result.isEmpty());
@@ -616,17 +620,17 @@ public abstract class HeadersTestBase {
     assertEquals("newValue",result.get("originalKey"));
     assertEquals("anotherValue",result.get("anotherKey"));
   }
-  
+
   @Test
   public void testSetAllOnExistingMapUsingHashMapHttp1() {
     MultiMap mainMap = new HeadersAdaptor(HeadersMultiMap.httpHeaders());
     mainMap.add("originalKey", "originalValue");
-    
+
     Map<String,String> setAllMap = new HashMap<>();
-    
+
     setAllMap.put("originalKey", "newValue");
     setAllMap.put("anotherKey", "anotherValue");
-    
+
     MultiMap result = mainMap.setAll(setAllMap);
     assertNotNull(result);
     assertFalse(result.isEmpty());
@@ -634,17 +638,17 @@ public abstract class HeadersTestBase {
     assertEquals("newValue",result.get("originalKey"));
     assertEquals("anotherValue",result.get("anotherKey"));
   }
-  
+
   @Test
   public void testSetAllOnExistingMapUsingMultiMapHttp2() {
     MultiMap mainMap = new Http2HeadersAdaptor(new DefaultHttp2Headers());
     mainMap.add("originalKey", "originalValue");
-    
+
     MultiMap setAllMap = newMultiMap();
-    
+
     setAllMap.add("originalKey", "newValue");
     setAllMap.add("anotherKey", "anotherValue");
-    
+
     MultiMap result = mainMap.setAll(setAllMap);
     assertNotNull(result);
     assertFalse(result.isEmpty());
@@ -652,22 +656,35 @@ public abstract class HeadersTestBase {
     assertEquals("newValue",result.get("originalKey"));
     assertEquals("anotherValue",result.get("anotherKey"));
   }
-  
+
   @Test
   public void testSetAllOnExistingMapUsingHashMapHttp2() {
     MultiMap mainMap = new Http2HeadersAdaptor(new DefaultHttp2Headers());
     mainMap.add("originalKey", "originalValue");
-    
+
     Map<String,String> setAllMap = new HashMap<>();
-    
+
     setAllMap.put("originalKey", "newValue");
     setAllMap.put("anotherKey", "anotherValue");
-    
+
     MultiMap result = mainMap.setAll(setAllMap);
     assertNotNull(result);
     assertFalse(result.isEmpty());
     assertEquals(2, result.size());
     assertEquals("newValue",result.get("originalKey"));
     assertEquals("anotherValue",result.get("anotherKey"));
+  }
+
+  @Test
+  public void testForEach() {
+    MultiMap map = newMultiMap();
+
+    map.add(HttpHeaders.ACCEPT, HttpHeaders.TEXT_HTML);
+    map.add(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XML);
+
+    Map<String, String> consumed = new HashMap<>();
+    map.forEach(consumed::put);
+
+    assertThat(consumed).containsOnly(entry("accept", "text/html"), entry("content-type", "application/xml"));
   }
 }


### PR DESCRIPTION
Motivation:

When iterating over the HeadersMultiMap (as vertx-http-proxy) does,
it makes sense to not have to allocate a useless Map.Entry container.
This new method provides that functionality