### PR TITLE
Add a method to verify if a given Context is a duplicated context

### DIFF
--- a/src/main/java/io/vertx/core/impl/ContextInternal.java
+++ b/src/main/java/io/vertx/core/impl/ContextInternal.java
@@ -313,4 +313,13 @@ public interface ContextInternal extends Context {
   default ContextInternal unwrap() {
     return this;
   }
+
+  /**
+   * Returns {@code true} if this context is a duplicated context.
+   *
+   * @return {@code true} if this context is a duplicated context, {@code false} otherwise.
+   */
+  default boolean isDuplicate() {
+    return false;
+  }
 }

--- a/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -187,4 +187,9 @@ class DuplicatedContext extends AbstractContext {
   public ContextInternal unwrap() {
     return delegate;
   }
+
+  @Override
+  public boolean isDuplicate() {
+    return true;
+  }
 }


### PR DESCRIPTION
This method is helpful to know when you can access the context locals without risking a leak.
The method is only added to ContextInternal as it is an advanced use case.

## Motivation:

When using context locals, it's important to know if the current context is a duplicated context or a root context.
Accessing locals from a root context is risky, as it could leak data between unrelated activities.

The current approach to do this check is using:

```java
return !(actual instanceof EventLoopContext || actual instanceof WorkerContext);
```

Using `instanceOf` is fragile in the sense that another Context implementation would break the check
