### PR TITLE
Support customizing BlockedThreadChecker

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -30,6 +30,7 @@ import io.vertx.core.eventbus.impl.EventBusImpl;
 import io.vertx.core.eventbus.impl.EventBusInternal;
 import io.vertx.core.eventbus.impl.clustered.ClusteredEventBus;
 import io.vertx.core.file.FileSystem;
+import io.vertx.core.impl.btc.BlockedThreadChecker;
 import io.vertx.core.spi.file.FileResolver;
 import io.vertx.core.file.impl.FileSystemImpl;
 import io.vertx.core.file.impl.WindowsFileSystem;

--- a/src/main/java/io/vertx/core/impl/VertxInternal.java
+++ b/src/main/java/io/vertx/core/impl/VertxInternal.java
@@ -19,6 +19,7 @@ import io.vertx.core.*;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.impl.HttpServerImpl;
+import io.vertx.core.impl.btc.BlockedThreadChecker;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;

--- a/src/main/java/io/vertx/core/impl/VertxThread.java
+++ b/src/main/java/io/vertx/core/impl/VertxThread.java
@@ -12,6 +12,7 @@
 package io.vertx.core.impl;
 
 import io.netty.util.concurrent.FastThreadLocalThread;
+import io.vertx.core.impl.btc.BlockedThreadChecker;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/io/vertx/core/impl/btc/BlockedThreadEvent.java
+++ b/src/main/java/io/vertx/core/impl/btc/BlockedThreadEvent.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.impl.btc;
+
+/**
+ * A class containing status details about how long a particular thread has been blocked,
+ * and how long it is allowed to be blocked before warnings start getting logged. All times
+ * and durations are in nanoseconds.
+ */
+public class BlockedThreadEvent {
+  private final Thread thread;
+  private final long maxExecTime;
+  private final long duration;
+  private final long warningExceptionTime;
+
+  /**
+   * Create an instance of BlockedThreadEvent
+   *
+   * @param thread The thread being checked
+   * @param duration The duration the thread has been blocked, in nanoseconds
+   * @param maxExecTime The max execution time the thread is allowed, in nanoseconds
+   * @param warningExceptionTime The max time a thread can be blocked before stack traces get logged, in nanoseconds
+   */
+  public BlockedThreadEvent(Thread thread, long duration, long maxExecTime, long warningExceptionTime) {
+    this.thread = thread;
+    this.duration = duration;
+    this.maxExecTime = maxExecTime;
+    this.warningExceptionTime = warningExceptionTime;
+  }
+
+  public Thread thread() {
+    return thread;
+  }
+
+  public long maxExecTime() {
+    return maxExecTime;
+  }
+
+  public long duration() {
+    return duration;
+  }
+
+  public long warningExceptionTime() {
+    return warningExceptionTime;
+  }
+}

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -13,6 +13,7 @@ package io.vertx.core;
 
 import io.netty.channel.EventLoop;
 import io.vertx.core.impl.*;
+import io.vertx.core.impl.btc.BlockedThreadChecker;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;

--- a/src/test/java/io/vertx/test/core/BlockedThreadWarning.java
+++ b/src/test/java/io/vertx/test/core/BlockedThreadWarning.java
@@ -11,7 +11,7 @@
 
 package io.vertx.test.core;
 
-import io.vertx.core.impl.BlockedThreadChecker;
+import io.vertx.core.impl.btc.BlockedThreadChecker;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;


### PR DESCRIPTION
Signed-off-by: Dan O'Reilly <oreilldf@gmail.com>

Adds support for customizing the implementation of BlockedThreadChecker, exposing an API that allows users to pass a callback that will be executed whenever a thread is blocked for longer than the allowed duration. To use the API, users have to call the `blockedThreadChecker()` getter on `VertxInternal`.

**Motivation:**
In my application, I want to be able to restart the JVM if thread stay blocked for an extended period of time, so that my application can potentially self-heal if something goes very wrong and a thread ends up stuck forever. It's currently not possible to do this (at least as far as I can tell). Adding this new API makes it possible.
