### PR TITLE
ConnectionBase discards incoming message when it has been proactively closed

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -149,14 +149,10 @@ public abstract class ConnectionBase {
    */
   final void read(Object msg) {
     read = true;
-    if (!closed) {
-      if (METRICS_ENABLED) {
-        reportBytesRead(msg);
-      }
-      handleMessage(msg);
-    } else {
-      ReferenceCountUtil.release(msg);
+    if (METRICS_ENABLED) {
+      reportBytesRead(msg);
     }
+    handleMessage(msg);
   }
 
   /**

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -3619,7 +3619,6 @@ public abstract class HttpTest extends HttpTestBase {
       conn.closeHandler(v -> complete());
     });
     server.requestHandler(req -> {
-      fail();
     });
     startServer(testAddress, serverCtx, server);
     client.connectionHandler(conn -> {


### PR DESCRIPTION
The ConnectionBase discards incoming message when the connection has been marked as closed, we should always accept such messages otherwise we might lose messages when a connection is closed proactively when a message read is in progress.

see #4285
