### PR TITLE
[ISSUE-4304] clusterPublicPort should be ignored in toJson() result if     it is the default value

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
@@ -173,6 +173,10 @@ public class EventBusOptions extends TCPSSLOptions {
   public JsonObject toJson() {
     JsonObject json = new JsonObject();
     EventBusOptionsConverter.toJson(this, json);
+    final String clusterPublicPortName = "clusterPublicPort";
+    if (json.containsKey(clusterPublicPortName) && json.getInteger(clusterPublicPortName) == DEFAULT_CLUSTER_PUBLIC_PORT) {
+      json.remove(clusterPublicPortName);
+    }
     return json;
   }
 

--- a/src/test/java/io/vertx/core/VertxOptionsTest.java
+++ b/src/test/java/io/vertx/core/VertxOptionsTest.java
@@ -315,6 +315,14 @@ public class VertxOptionsTest extends VertxTestBase {
   }
 
   @Test
+  public void testDefaultJsonVertxOptions() {
+    VertxOptions vertxOptions1 = new VertxOptions();
+    JsonObject json = vertxOptions1.toJson();
+    VertxOptions vertxOptions2 = new VertxOptions(json);
+    assertEquals(json, vertxOptions2.toJson());
+  }
+
+  @Test
   public void testJsonOptions() {
     VertxOptions options = new VertxOptions(new JsonObject());
 


### PR DESCRIPTION
Motivation:

Fixes #4304 

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
