### PR TITLE
Expose file locking operations in AsyncFile

### DIFF
--- a/src/main/java/io/vertx/core/file/AsyncFile.java
+++ b/src/main/java/io/vertx/core/file/AsyncFile.java
@@ -12,6 +12,7 @@
 package io.vertx.core.file;
 
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -203,4 +204,48 @@ public interface AsyncFile extends ReadStream<Buffer>, WriteStream<Buffer> {
    * @return the size of the file
    */
   Future<Long> size();
+
+  /**
+   * Try to acquire a non-shared lock on the entire file.
+   *
+   * @return the lock if it can be acquired immediately, otherwise {@code null}
+   */
+  @Nullable AsyncFileLock tryLock();
+
+  /**
+   * Try to acquire a lock on a portion of this file.
+   *
+   * @param position where the region starts
+   * @param size the size of the region
+   * @param shared whether the lock should be shared
+   * @return the lock if it can be acquired immediately, otherwise {@code null}
+   */
+  @Nullable AsyncFileLock tryLock(long position, long size, boolean shared);
+
+  /**
+   * Acquire a non-shared lock on the entire file.
+   *
+   * @return a future indicating the completion of this operation
+   */
+  Future<AsyncFileLock> lock();
+
+  /**
+   * Like {@link #lock()} but the {@code handler} will be called when the operation is complete or if an error occurs.
+   */
+  void lock(Handler<AsyncResult<AsyncFileLock>> handler);
+
+  /**
+   * Acquire a lock on a portion of this file.
+   *
+   * @param position where the region starts
+   * @param size the size of the region
+   * @param shared whether the lock should be shared
+   * @return a future indicating the completion of this operation
+   */
+  Future<AsyncFileLock> lock(long position, long size, boolean shared);
+
+  /**
+   * Like {@link #lock(long, long, boolean)} but the {@code handler} will be called when the operation is complete or if an error occurs.
+   */
+  void lock(long position, long size, boolean shared, Handler<AsyncResult<AsyncFileLock>> handler);
 }

--- a/src/main/java/io/vertx/core/file/AsyncFileLock.java
+++ b/src/main/java/io/vertx/core/file/AsyncFileLock.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.file;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+/**
+ * A lock on a region of an {@link AsyncFile}.
+ */
+@VertxGen
+public interface AsyncFileLock {
+
+  /**
+   * @return the position of the first byte of the locked region
+   */
+  long position();
+
+  /**
+   * @return the size in bytes of the locked region
+   */
+  long size();
+
+  /**
+   * @return {@code true} if this lock is shared, otherwise {@code false}
+   */
+  boolean isShared();
+
+  /**
+   * @return {@code true} if this lock overlaps with the range described by {@code position} and {@code size}, otherwise {@code false}
+   */
+  boolean overlaps(long position, long size);
+
+  /**
+   * Like {@link #isValid()} but blocking.
+   *
+   * @throws FileSystemException if an error occurs
+   */
+  boolean isValidBlocking();
+
+  /**
+   * A lock remains valid until it is released or the file corresponding {@link AsyncFile} is closed.
+   */
+  Future<Boolean> isValid();
+
+  /**
+   * Like {@link #isValid()} but the {@code handler} will be called when the operation completes or if an error occurs.
+   */
+  void isValid(Handler<AsyncResult<Boolean>> handler);
+
+  /**
+   * Like {@link #release()} but blocking.
+   *
+   * @throws FileSystemException if an error occurs
+   */
+  void releaseBlocking();
+
+  /**
+   * Releases this lock;
+   */
+  Future<Void> release();
+
+  /**
+   * Like {@link #release()} but the {@code handler} will be called when the operation completes or if an error occurs.
+   */
+  void release(Handler<AsyncResult<Void>> handler);
+}

--- a/src/main/java/io/vertx/core/file/impl/AsyncFileLockImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/AsyncFileLockImpl.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.file.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.file.AsyncFileLock;
+import io.vertx.core.file.FileSystemException;
+import io.vertx.core.impl.VertxInternal;
+
+import java.io.IOException;
+import java.nio.channels.FileLock;
+import java.util.Objects;
+
+public class AsyncFileLockImpl implements AsyncFileLock {
+
+  private final VertxInternal vertx;
+  private final FileLock fileLock;
+
+  public AsyncFileLockImpl(VertxInternal vertx, FileLock fileLock) {
+    this.vertx = Objects.requireNonNull(vertx, "vertx is null");
+    this.fileLock = Objects.requireNonNull(fileLock, "fileLock is null");
+  }
+
+  @Override
+  public long position() {
+    return fileLock.position();
+  }
+
+  @Override
+  public long size() {
+    return fileLock.size();
+  }
+
+  @Override
+  public boolean isShared() {
+    return fileLock.isShared();
+  }
+
+  @Override
+  public boolean overlaps(long position, long size) {
+    return fileLock.overlaps(position, size);
+  }
+
+  @Override
+  public boolean isValidBlocking() {
+    return fileLock.isValid();
+  }
+
+  @Override
+  public Future<Boolean> isValid() {
+    return vertx.getOrCreateContext().executeBlockingInternal(prom -> {
+      prom.complete(isValidBlocking());
+    });
+  }
+
+  @Override
+  public void isValid(Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> future = isValid();
+    if (handler != null) {
+      future.onComplete(handler);
+    }
+  }
+
+  @Override
+  public void releaseBlocking() {
+    try {
+      fileLock.release();
+    } catch (IOException e) {
+      throw new FileSystemException(e);
+    }
+  }
+
+  @Override
+  public Future<Void> release() {
+    return vertx.getOrCreateContext().executeBlockingInternal(prom -> {
+      try {
+        fileLock.release();
+        prom.complete();
+      } catch (IOException e) {
+        prom.fail(new FileSystemException(e));
+      }
+    });
+  }
+
+  @Override
+  public void release(Handler<AsyncResult<Void>> handler) {
+    Future<Void> future = release();
+    if (handler != null) {
+      future.onComplete(handler);
+    }
+  }
+}


### PR DESCRIPTION
Closes #3856

The underlying AsynchronousFileChannel has methods to acquire file locks.