### PR TITLE
HTTP connection closed exception

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpClosedException.java
+++ b/src/main/java/io/vertx/core/http/HttpClosedException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.core.VertxException;
+import io.vertx.core.net.impl.ConnectionBase;
+
+/**
+ * Signals a HTTP connection close.
+ */
+public class HttpClosedException extends VertxException {
+
+  private static String formatErrorMessage(GoAway goAway) {
+    if (goAway == null) {
+      return ConnectionBase.CLOSED_EXCEPTION.getMessage();
+    } else {
+      return ConnectionBase.CLOSED_EXCEPTION.getMessage() + " (GOAWAY error code = " + goAway.getErrorCode() + ")";
+    }
+  }
+
+  private final GoAway goAway;
+
+  public HttpClosedException() {
+    super(ConnectionBase.CLOSED_EXCEPTION.getMessage(), true);
+    this.goAway = null;
+  }
+
+  public HttpClosedException(GoAway goAway) {
+    super(formatErrorMessage(goAway), true);
+    this.goAway = goAway;
+  }
+
+  /**
+   * @return the data received when the connection received a {@code GOAWAY} frame prior disconnection (HTTP/2 only)
+   */
+  public GoAway goAway() {
+    return goAway != null ? new GoAway(goAway) : null;
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -619,7 +619,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
 
     @Override
     void handleClosed() {
-      handleException(CLOSED_EXCEPTION);
+      handleException(HttpUtils.CLOSED_EXCEPTION);
       tryClose();
     }
 
@@ -1098,7 +1098,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
       }
       Object trace = stream.trace;
       if (tracer != null && trace != null) {
-        tracer.receiveResponse(stream.context, null, trace, ConnectionBase.CLOSED_EXCEPTION, TagExtractor.empty());
+        tracer.receiveResponse(stream.context, null, trace, HttpUtils.CLOSED_EXCEPTION, TagExtractor.empty());
       }
       stream.context.execute(null, v -> stream.handleClosed());
     }
@@ -1150,7 +1150,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
       if (stream != null) {
         stream.promise.future().onComplete(handler);
       } else {
-        handler.handle(Future.failedFuture(CLOSED_EXCEPTION));
+        handler.handle(Future.failedFuture(HttpUtils.CLOSED_EXCEPTION));
       }
     } else {
       eventLoop.execute(() -> {

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -447,12 +447,12 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
     }
     if (requestInProgress != null) {
       requestInProgress.context.execute(v -> {
-        requestInProgress.handleException(CLOSED_EXCEPTION);
+        requestInProgress.handleException(HttpUtils.CLOSED_EXCEPTION);
       });
     }
     if (responseInProgress != null && responseInProgress != requestInProgress) {
       responseInProgress.context.execute(v -> {
-        responseInProgress.handleException(CLOSED_EXCEPTION);
+        responseInProgress.handleException(HttpUtils.CLOSED_EXCEPTION);
       });
     }
     if (ws != null) {

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -14,9 +14,6 @@ package io.vertx.core.http.impl;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
@@ -33,6 +30,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.Cookie;
+import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
@@ -43,7 +41,6 @@ import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.NetSocket;
-import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.observability.HttpResponse;
 
@@ -635,7 +632,7 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   void handleException(Throwable t) {
-    if (t == Http1xServerConnection.CLOSED_EXCEPTION) {
+    if (t instanceof HttpClosedException) {
       handleClosed();
     } else {
       Handler<Throwable> handler;
@@ -663,7 +660,7 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
       closedHandler = this.closeHandler;
     }
     if (exceptionHandler != null) {
-      context.dispatch(ConnectionBase.CLOSED_EXCEPTION, exceptionHandler);
+      context.dispatch(HttpUtils.CLOSED_EXCEPTION, exceptionHandler);
     }
     if (endHandler != null) {
       context.dispatch(null, endHandler);

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -220,8 +220,8 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
     }
 
     @Override
-    void handleClose() {
-      super.handleClose();
+    void handleClose(HttpClosedException ex) {
+      super.handleClose(ex);
       if (pendingPushes.remove(this)) {
         promise.fail("Push reset by client");
       } else {
@@ -232,7 +232,7 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
           concurrentStreams++;
           push.complete();
         }
-        response.handleClose();
+        response.handleClose(ex);
       }
     }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -29,6 +29,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.AsyncFile;
 import io.vertx.core.http.Cookie;
+import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
@@ -36,7 +37,6 @@ import io.vertx.core.http.StreamPriority;
 import io.vertx.core.http.StreamResetException;
 import io.vertx.core.http.impl.headers.Http2HeadersAdaptor;
 import io.vertx.core.net.NetSocket;
-import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.spi.observability.HttpResponse;
 import io.vertx.core.streams.ReadStream;
 
@@ -105,7 +105,7 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
     }
   }
 
-  void handleClose() {
+  void handleClose(HttpClosedException ex) {
     Handler<Throwable> exceptionHandler;
     Handler<Void> endHandler;
     Handler<Void> closeHandler;
@@ -117,7 +117,7 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
       closeHandler = this.closeHandler;
     }
     if (exceptionHandler != null) {
-      stream.context.emit(ConnectionBase.CLOSED_EXCEPTION, exceptionHandler);
+      stream.context.emit(ex, exceptionHandler);
     }
     if (endHandler != null) {
       stream.context.emit(null, endHandler);

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
@@ -16,6 +16,7 @@ import io.netty.handler.codec.http2.Http2Headers;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.StreamPriority;
@@ -129,8 +130,8 @@ abstract class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection>
   }
 
   @Override
-  void handleClose() {
-    super.handleClose();
+  void handleClose(HttpClosedException ex) {
+    super.handleClose(ex);
     if (METRICS_ENABLED) {
       HttpServerMetrics metrics = conn.metrics();
       if (metrics != null) {

--- a/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
@@ -17,16 +17,14 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
-import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.AsyncFile;
-import io.vertx.core.http.StreamResetException;
+import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.ConnectionBase;
-import io.vertx.core.streams.Pipe;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 
@@ -86,7 +84,7 @@ class HttpNetSocket implements NetSocket {
   }
 
   private void handleException(Throwable cause) {
-    if (cause == ConnectionBase.CLOSED_EXCEPTION || cause.getClass() == ClosedChannelException.class) {
+    if (cause instanceof HttpClosedException || cause.getClass() == ClosedChannelException.class) {
       Handler<Void> endHandler = endHandler();
       if (endHandler != null) {
         endHandler.handle(null);

--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -29,6 +29,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.AsyncFile;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.OpenOptions;
+import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.StreamPriority;
@@ -60,6 +61,7 @@ import static io.vertx.core.http.Http2Settings.*;
  */
 public final class HttpUtils {
 
+  static final HttpClosedException CLOSED_EXCEPTION = new HttpClosedException();
   static final int SC_SWITCHING_PROTOCOLS = 101;
   static final int SC_BAD_GATEWAY = 502;
 

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
@@ -24,6 +24,8 @@ import io.netty.util.concurrent.FutureListener;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.GoAway;
 
 import java.util.function.Function;
 
@@ -187,12 +189,12 @@ class VertxHttp2ConnectionHandler<C extends Http2ConnectionBase> extends Http2Co
 
   @Override
   public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
-    connection.onGoAwaySent(lastStreamId, errorCode, debugData);
+    connection.onGoAwaySent(new GoAway().setErrorCode(errorCode).setLastStreamId(lastStreamId).setDebugData(Buffer.buffer(debugData)));
   }
 
   @Override
   public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
-    connection.onGoAwayReceived(lastStreamId, errorCode, debugData);
+    connection.onGoAwayReceived(new GoAway().setErrorCode(errorCode).setLastStreamId(lastStreamId).setDebugData(Buffer.buffer(debugData)));
   }
 
   //

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -22,6 +22,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.HttpFrame;
 import io.vertx.core.http.StreamPriority;
 import io.vertx.core.http.impl.headers.Http2HeadersAdaptor;
@@ -80,9 +81,9 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
     stream.setProperty(conn.streamKey, this);
   }
 
-  void onClose() {
+  void onClose(HttpClosedException ex) {
     conn.flushBytesWritten();
-    context.execute(v -> this.handleClose());
+    context.execute(ex, this::handleClose);
   }
 
   void onError(Throwable cause) {
@@ -256,7 +257,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
   void handleException(Throwable cause) {
   }
 
-  void handleClose() {
+  void handleClose(HttpClosedException ex) {
   }
 
   synchronized void priority(StreamPriority streamPriority) {

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -39,7 +39,6 @@ import io.vertx.core.http.impl.ws.WebSocketFrameInternal;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.streams.impl.InboundBuffer;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -512,7 +511,7 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
       textConsumer.unregister();
     }
     if (exceptionHandler != null && !graceful) {
-      context.dispatch(ConnectionBase.CLOSED_EXCEPTION, exceptionHandler);
+      context.dispatch(HttpUtils.CLOSED_EXCEPTION, exceptionHandler);
     }
     if (closeHandler != null) {
       context.dispatch(null, closeHandler);

--- a/src/test/java/io/vertx/core/http/Http2ClientTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientTest.java
@@ -1037,7 +1037,11 @@ public class Http2ClientTest extends Http2TestBase {
       });
     });
     client.request(requestOptions).onComplete(onSuccess(req -> {
-      req.send(onFailure(err -> complete()));
+      req.send(onFailure(err -> {
+        assertEquals(HttpClosedException.class, err.getClass());
+        assertEquals(0, ((HttpClosedException)err).goAway().getErrorCode());
+        complete();
+      }));
     }));
     await();
   }

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -1614,6 +1614,8 @@ public class Http2ServerTest extends Http2TestBase {
           closed.incrementAndGet();
         });
         req.response().exceptionHandler(err -> {
+          assertEquals(HttpClosedException.class, err.getClass());
+          assertEquals(0, ((HttpClosedException)err).goAway().getErrorCode());
           closed.incrementAndGet();
         });
         HttpConnection conn = req.connection();


### PR DESCRIPTION
Introduce an `HttpClosedException` that denotes when an HTTP connection has been closed that provides the HTTP go away status when an HTTP/2 connection has been closed intentionally by the remote endpoint. This is useful for the developer that can use it to determine if the remote endpoint was closed intentionally.
