### PR TITLE
feat: Support for java time types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
       <artifactId>jackson-databind</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <!-- Loggers -->
     <dependency>

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -17,6 +17,7 @@ import io.vertx.core.shareddata.impl.ClusterSerializable;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
 import java.util.function.Function;
@@ -25,6 +26,7 @@ import java.util.stream.Stream;
 import static io.vertx.core.json.impl.JsonUtil.*;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
 /**
@@ -115,6 +117,8 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
       return ISO_LOCAL_TIME.format((LocalTime) val);
     } else if (val instanceof LocalDate) {
       return ISO_LOCAL_DATE.format((LocalDate) val);
+    } else if (val instanceof LocalDateTime) {
+      return ISO_LOCAL_DATE_TIME.format((LocalDateTime) val);
     } else if (val instanceof byte[]) {
       return BASE64_ENCODER.encodeToString((byte[]) val);
     } else if (val instanceof Buffer) {
@@ -369,7 +373,6 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
     return LocalTime.from(ISO_LOCAL_TIME.parse(encoded));
   }
 
-
   /**
    * Get the LocalDate at position {@code pos} in the array.
    *
@@ -378,7 +381,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
    * mentioned before. The method will then decode and return a local date value.
    *
    * @param pos the position in the array
-   * @return the LocalTime, or null if a null value present
+   * @return the LocalDate, or null if a null value present
    * @throws java.lang.ClassCastException            if the value cannot be converted to String
    * @throws java.time.format.DateTimeParseException if the String value is not a legal ISO 8601 encoded value
    */
@@ -396,6 +399,34 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
     String encoded = (String) val;
     // parse to proper type
     return LocalDate.from(ISO_LOCAL_DATE.parse(encoded));
+  }
+
+  /**
+   * Get the LocalDateTime at position {@code pos} in the array.
+   *
+   * JSON itself has no notion of a temporal types, this extension allows ISO 8601 string formatted local date
+   * time without offset or timezone information. This extension complies to the RFC-7493 with all the restrictions
+   * mentioned before. The method will then decode and return a local date value.
+   *
+   * @param pos the position in the array
+   * @return the LocalDateTime, or null if a null value present
+   * @throws java.lang.ClassCastException            if the value cannot be converted to String
+   * @throws java.time.format.DateTimeParseException if the String value is not a legal ISO 8601 encoded value
+   */
+  public LocalDateTime getLocalDateTime(int pos) {
+    Object val = list.get(pos);
+    // no-op
+    if (val == null) {
+      return null;
+    }
+    // no-op if value is already correct type
+    if (val instanceof LocalDateTime) {
+      return (LocalDateTime) val;
+    }
+    // assume that the value is in String format as per RFC
+    String encoded = (String) val;
+    // parse to proper type
+    return LocalDateTime.from(ISO_LOCAL_DATE_TIME.parse(encoded));
   }
 
   /**

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -16,6 +16,7 @@ import io.vertx.core.shareddata.Shareable;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.*;
 import java.util.function.Function;
@@ -23,6 +24,7 @@ import java.util.stream.Stream;
 
 import static io.vertx.core.json.impl.JsonUtil.*;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
 /**
@@ -111,6 +113,8 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
       return ISO_INSTANT.format((Instant) val);
     } else if (val instanceof LocalTime) {
       return ISO_LOCAL_TIME.format((LocalTime) val);
+    } else if (val instanceof LocalDate) {
+      return ISO_LOCAL_DATE.format((LocalDate) val);
     } else if (val instanceof byte[]) {
       return BASE64_ENCODER.encodeToString((byte[]) val);
     } else if (val instanceof Buffer) {
@@ -342,7 +346,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
    *
    * JSON itself has no notion of a temporal types, this extension allows ISO 8601 string formatted local time
    * without offset or timezone information. This extension complies to the RFC-7493 with all the restrictions
-   * mentioned before. The method will then decode and return an instant value.
+   * mentioned before. The method will then decode and return a local time value.
    *
    * @param pos the position in the array
    * @return the LocalTime, or null if a null value present
@@ -363,6 +367,35 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
     String encoded = (String) val;
     // parse to proper type
     return LocalTime.from(ISO_LOCAL_TIME.parse(encoded));
+  }
+
+
+  /**
+   * Get the LocalDate at position {@code pos} in the array.
+   *
+   * JSON itself has no notion of a temporal types, this extension allows ISO 8601 string formatted local date
+   * without offset or timezone information. This extension complies to the RFC-7493 with all the restrictions
+   * mentioned before. The method will then decode and return a local date value.
+   *
+   * @param pos the position in the array
+   * @return the LocalTime, or null if a null value present
+   * @throws java.lang.ClassCastException            if the value cannot be converted to String
+   * @throws java.time.format.DateTimeParseException if the String value is not a legal ISO 8601 encoded value
+   */
+  public LocalDate getLocalDate(int pos) {
+    Object val = list.get(pos);
+    // no-op
+    if (val == null) {
+      return null;
+    }
+    // no-op if value is already correct type
+    if (val instanceof LocalDate) {
+      return (LocalDate) val;
+    }
+    // assume that the value is in String format as per RFC
+    String encoded = (String) val;
+    // parse to proper type
+    return LocalDate.from(ISO_LOCAL_DATE.parse(encoded));
   }
 
   /**

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -16,12 +16,14 @@ import io.vertx.core.shareddata.Shareable;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 
 import java.time.Instant;
+import java.time.LocalTime;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static io.vertx.core.json.impl.JsonUtil.*;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
 /**
  * A representation of a <a href="http://json.org/">JSON</a> array in Java.
@@ -107,6 +109,8 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
 
     if (val instanceof Instant) {
       return ISO_INSTANT.format((Instant) val);
+    } else if (val instanceof LocalTime) {
+      return ISO_LOCAL_TIME.format((LocalTime) val);
     } else if (val instanceof byte[]) {
       return BASE64_ENCODER.encodeToString((byte[]) val);
     } else if (val instanceof Buffer) {
@@ -331,6 +335,34 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
     String encoded = (String) val;
     // parse to proper type
     return Instant.from(ISO_INSTANT.parse(encoded));
+  }
+
+  /**
+   * Get the LocalTime at position {@code pos} in the array.
+   *
+   * JSON itself has no notion of a temporal types, this extension allows ISO 8601 string formatted local time
+   * without offset or timezone information. This extension complies to the RFC-7493 with all the restrictions
+   * mentioned before. The method will then decode and return an instant value.
+   *
+   * @param pos the position in the array
+   * @return the LocalTime, or null if a null value present
+   * @throws java.lang.ClassCastException            if the value cannot be converted to String
+   * @throws java.time.format.DateTimeParseException if the String value is not a legal ISO 8601 encoded value
+   */
+  public LocalTime getLocalTime(int pos) {
+    Object val = list.get(pos);
+    // no-op
+    if (val == null) {
+      return null;
+    }
+    // no-op if value is already correct type
+    if (val instanceof LocalTime) {
+      return (LocalTime) val;
+    }
+    // assume that the value is in String format as per RFC
+    String encoded = (String) val;
+    // parse to proper type
+    return LocalTime.from(ISO_LOCAL_TIME.parse(encoded));
   }
 
   /**

--- a/src/main/java/io/vertx/core/json/impl/JsonUtil.java
+++ b/src/main/java/io/vertx/core/json/impl/JsonUtil.java
@@ -12,6 +12,7 @@ package io.vertx.core.json.impl;
 
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
@@ -19,6 +20,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.Shareable;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
@@ -39,6 +41,8 @@ public final class JsonUtil {
 
   private static final DateTimeFormatter LOCAL_TIME_FORMATTER =
       DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSSSS");
+  private static final DateTimeFormatter LOCAL_DATE_TIME_FORMATTER =
+    DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS");
 
   static {
     /*
@@ -86,6 +90,8 @@ public final class JsonUtil {
       val = LOCAL_TIME_FORMATTER.format((LocalTime) val);
     } else if (val instanceof LocalDate) {
       val = ISO_LOCAL_DATE.format(((LocalDate) val));
+    } else if (val instanceof LocalDateTime) {
+      val = LOCAL_DATE_TIME_FORMATTER.format(((LocalDateTime) val));
     } else if (val instanceof byte[]) {
       val = BASE64_ENCODER.encodeToString((byte[]) val);
     } else if (val instanceof Buffer) {
@@ -131,6 +137,8 @@ public final class JsonUtil {
     } else if (val instanceof LocalTime) {
       // OK
     } else if (val instanceof LocalDate) {
+      // OK
+    } else if (val instanceof LocalDateTime) {
       // OK
     } else if (val instanceof Enum) {
       // OK

--- a/src/main/java/io/vertx/core/json/impl/JsonUtil.java
+++ b/src/main/java/io/vertx/core/json/impl/JsonUtil.java
@@ -16,6 +16,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.Shareable;
 
 import java.time.Instant;
+import java.time.LocalTime;
 import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
 /**
  * Implementation utilities (details) affecting the way JSON objects are wrapped.
@@ -74,6 +76,8 @@ public final class JsonUtil {
       val = new JsonArray((List) val);
     } else if (val instanceof Instant) {
       val = ISO_INSTANT.format((Instant) val);
+    } else if (val instanceof LocalTime) {
+      val = ISO_LOCAL_TIME.format((LocalTime) val);
     } else if (val instanceof byte[]) {
       val = BASE64_ENCODER.encodeToString((byte[]) val);
     } else if (val instanceof Buffer) {
@@ -115,6 +119,8 @@ public final class JsonUtil {
     } else if (val instanceof byte[]) {
       // OK
     } else if (val instanceof Instant) {
+      // OK
+    } else if (val instanceof LocalTime) {
       // OK
     } else if (val instanceof Enum) {
       // OK

--- a/src/main/java/io/vertx/core/json/impl/JsonUtil.java
+++ b/src/main/java/io/vertx/core/json/impl/JsonUtil.java
@@ -13,6 +13,7 @@ package io.vertx.core.json.impl;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
@@ -22,6 +23,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.Iterator;
@@ -43,6 +45,8 @@ public final class JsonUtil {
       DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSSSS");
   private static final DateTimeFormatter LOCAL_DATE_TIME_FORMATTER =
     DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS");
+  private static final DateTimeFormatter OFFSET_DATE_TIME_FORMATTER =
+    DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSSXXX");
 
   static {
     /*
@@ -67,6 +71,8 @@ public final class JsonUtil {
    *   <li>{@code Instant} will be converted to iso date {@code String}</li>
    *   <li>{@code LocalTime} will be converted to iso time {@code String}</li>
    *   <li>{@code LocalDate} will be converted to iso date {@code String}</li>
+   *   <li>{@code LocalDateTime} will be converted to iso date time {@code String}</li>
+   *   <li>{@code OffsetDateTime} will be converted to iso date time {@code String}</li>
    *   <li>{@code byte[]} will be converted to base64 {@code String}</li>
    *   <li>{@code Enum} will be converted to enum name {@code String}</li>
    * </ul>
@@ -92,6 +98,8 @@ public final class JsonUtil {
       val = ISO_LOCAL_DATE.format(((LocalDate) val));
     } else if (val instanceof LocalDateTime) {
       val = LOCAL_DATE_TIME_FORMATTER.format(((LocalDateTime) val));
+    } else if (val instanceof OffsetDateTime) {
+      val = OFFSET_DATE_TIME_FORMATTER.format(((OffsetDateTime) val));
     } else if (val instanceof byte[]) {
       val = BASE64_ENCODER.encodeToString((byte[]) val);
     } else if (val instanceof Buffer) {
@@ -139,6 +147,8 @@ public final class JsonUtil {
     } else if (val instanceof LocalDate) {
       // OK
     } else if (val instanceof LocalDateTime) {
+      // OK
+    } else if (val instanceof OffsetDateTime) {
       // OK
     } else if (val instanceof Enum) {
       // OK

--- a/src/main/java/io/vertx/core/json/impl/JsonUtil.java
+++ b/src/main/java/io/vertx/core/json/impl/JsonUtil.java
@@ -10,13 +10,17 @@
  */
 package io.vertx.core.json.impl;
 
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.Shareable;
-
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
@@ -25,9 +29,6 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static java.time.format.DateTimeFormatter.ISO_INSTANT;
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
-
 /**
  * Implementation utilities (details) affecting the way JSON objects are wrapped.
  */
@@ -35,6 +36,9 @@ public final class JsonUtil {
 
   public static final Base64.Encoder BASE64_ENCODER;
   public static final Base64.Decoder BASE64_DECODER;
+
+  private static final DateTimeFormatter LOCAL_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSSSSS");
 
   static {
     /*
@@ -57,6 +61,8 @@ public final class JsonUtil {
    *   <li>{@code Map} will be wrapped to {@code JsonObject}</li>
    *   <li>{@code List} will be wrapped to {@code JsonArray}</li>
    *   <li>{@code Instant} will be converted to iso date {@code String}</li>
+   *   <li>{@code LocalTime} will be converted to iso time {@code String}</li>
+   *   <li>{@code LocalDate} will be converted to iso date {@code String}</li>
    *   <li>{@code byte[]} will be converted to base64 {@code String}</li>
    *   <li>{@code Enum} will be converted to enum name {@code String}</li>
    * </ul>
@@ -77,7 +83,9 @@ public final class JsonUtil {
     } else if (val instanceof Instant) {
       val = ISO_INSTANT.format((Instant) val);
     } else if (val instanceof LocalTime) {
-      val = ISO_LOCAL_TIME.format((LocalTime) val);
+      val = LOCAL_TIME_FORMATTER.format((LocalTime) val);
+    } else if (val instanceof LocalDate) {
+      val = ISO_LOCAL_DATE.format(((LocalDate) val));
     } else if (val instanceof byte[]) {
       val = BASE64_ENCODER.encodeToString((byte[]) val);
     } else if (val instanceof Buffer) {
@@ -121,6 +129,8 @@ public final class JsonUtil {
     } else if (val instanceof Instant) {
       // OK
     } else if (val instanceof LocalTime) {
+      // OK
+    } else if (val instanceof LocalDate) {
       // OK
     } else if (val instanceof Enum) {
       // OK

--- a/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.netty.buffer.ByteBufInputStream;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
@@ -26,7 +25,6 @@ import io.vertx.core.json.JsonObject;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -77,6 +75,7 @@ public class DatabindCodec extends JacksonCodec {
     return value;
   }
 
+  @Override
   public <T> T fromValue(Object json, TypeReference<T> type) {
     T value = DatabindCodec.mapper.convertValue(json, type);
     if (type.getType() == Object.class) {
@@ -90,6 +89,7 @@ public class DatabindCodec extends JacksonCodec {
     return fromParser(createParser(str), clazz);
   }
 
+  @Override
   public <T> T fromString(String str, TypeReference<T> typeRef) throws DecodeException {
     return fromParser(createParser(str), typeRef);
   }
@@ -99,6 +99,7 @@ public class DatabindCodec extends JacksonCodec {
     return fromParser(createParser(buf), clazz);
   }
 
+  @Override
   public <T> T fromBuffer(Buffer buf, TypeReference<T> typeRef) throws DecodeException {
     return fromParser(createParser(buf), typeRef);
   }

--- a/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -26,6 +26,7 @@ import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.EncodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.spi.json.JsonCodec;
 
 import java.io.Closeable;
@@ -327,6 +328,9 @@ public class JacksonCodec implements JsonCodec {
       } else if (json instanceof LocalTime) {
         // RFC-7493
         generator.writeString((ISO_LOCAL_TIME.format((LocalTime)json)));
+      } else if (json instanceof LocalDate) {
+        // RFC-7493
+        generator.writeString(ISO_LOCAL_DATE.format((LocalDate)json));
       } else if (json instanceof byte[]) {
         // RFC-7493
         generator.writeString(BASE64_ENCODER.encodeToString((byte[]) json));
@@ -386,6 +390,8 @@ public class JacksonCodec implements JsonCodec {
         o = Instant.from(ISO_INSTANT.parse(str));
       } else if (clazz == LocalTime.class) {
         o = LocalTime.from(ISO_LOCAL_TIME.parse(str));
+      } else if (clazz == LocalDate.class) {
+        o = LocalDate.from(ISO_LOCAL_DATE.parse(str));
       } else if (!clazz.isAssignableFrom(String.class)) {
         throw new DecodeException("Failed to decode");
       }

--- a/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -331,6 +331,9 @@ public class JacksonCodec implements JsonCodec {
       } else if (json instanceof LocalDate) {
         // RFC-7493
         generator.writeString(ISO_LOCAL_DATE.format((LocalDate)json));
+      } else if (json instanceof LocalDateTime) {
+        // RFC-7493
+        generator.writeString(ISO_LOCAL_DATE_TIME.format((LocalDateTime)json));
       } else if (json instanceof byte[]) {
         // RFC-7493
         generator.writeString(BASE64_ENCODER.encodeToString((byte[]) json));
@@ -392,6 +395,8 @@ public class JacksonCodec implements JsonCodec {
         o = LocalTime.from(ISO_LOCAL_TIME.parse(str));
       } else if (clazz == LocalDate.class) {
         o = LocalDate.from(ISO_LOCAL_DATE.parse(str));
+      } else if (clazz == LocalDateTime.class) {
+        o = LocalDateTime.from(ISO_LOCAL_DATE_TIME.parse(str));
       } else if (!clazz.isAssignableFrom(String.class)) {
         throw new DecodeException("Failed to decode");
       }

--- a/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -39,6 +39,11 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -47,6 +52,11 @@ import java.util.Map;
 import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static io.vertx.core.json.impl.JsonUtil.BASE64_DECODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -314,6 +324,9 @@ public class JacksonCodec implements JsonCodec {
       } else if (json instanceof Instant) {
         // RFC-7493
         generator.writeString((ISO_INSTANT.format((Instant)json)));
+      } else if (json instanceof LocalTime) {
+        // RFC-7493
+        generator.writeString((ISO_LOCAL_TIME.format((LocalTime)json)));
       } else if (json instanceof byte[]) {
         // RFC-7493
         generator.writeString(BASE64_ENCODER.encodeToString((byte[]) json));
@@ -371,6 +384,8 @@ public class JacksonCodec implements JsonCodec {
         o = Buffer.buffer(BASE64_DECODER.decode(str));
       } else if (clazz == Instant.class) {
         o = Instant.from(ISO_INSTANT.parse(str));
+      } else if (clazz == LocalTime.class) {
+        o = LocalTime.from(ISO_LOCAL_TIME.parse(str));
       } else if (!clazz.isAssignableFrom(String.class)) {
         throw new DecodeException("Failed to decode");
       }

--- a/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -334,6 +334,9 @@ public class JacksonCodec implements JsonCodec {
       } else if (json instanceof LocalDateTime) {
         // RFC-7493
         generator.writeString(ISO_LOCAL_DATE_TIME.format((LocalDateTime)json));
+      } else if (json instanceof OffsetDateTime) {
+        // RFC-7493
+        generator.writeString(ISO_OFFSET_DATE_TIME.format((OffsetDateTime)json));
       } else if (json instanceof byte[]) {
         // RFC-7493
         generator.writeString(BASE64_ENCODER.encodeToString((byte[]) json));
@@ -397,6 +400,8 @@ public class JacksonCodec implements JsonCodec {
         o = LocalDate.from(ISO_LOCAL_DATE.parse(str));
       } else if (clazz == LocalDateTime.class) {
         o = LocalDateTime.from(ISO_LOCAL_DATE_TIME.parse(str));
+      } else if (clazz == OffsetDateTime.class) {
+        o = OffsetDateTime.from(ISO_OFFSET_DATE_TIME.parse(str));
       } else if (!clazz.isAssignableFrom(String.class)) {
         throw new DecodeException("Failed to decode");
       }

--- a/src/main/java/io/vertx/core/json/jackson/LocalDateDeserializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/LocalDateDeserializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.json.jackson;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import java.io.IOException;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+
+class LocalDateDeserializer extends JsonDeserializer<LocalDate> {
+  @Override
+  public LocalDate deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    String text = p.getText();
+    try {
+      return LocalDate.from(ISO_LOCAL_DATE.parse(text));
+    } catch (DateTimeException e) {
+      throw new InvalidFormatException(p, "Expected an ISO 8601 formatted date", text, LocalDate.class);
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/json/jackson/LocalDateSerializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/LocalDateSerializer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.json.jackson;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.LocalDate;
+
+class LocalDateSerializer extends JsonSerializer<LocalDate> {
+
+  @Override
+  public void serialize(LocalDate value, JsonGenerator jgen, SerializerProvider provider)
+      throws IOException {
+    jgen.writeString(ISO_LOCAL_DATE.format(value));
+  }
+}

--- a/src/main/java/io/vertx/core/json/jackson/LocalDateTimeDeserializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/LocalDateTimeDeserializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.json.jackson;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import java.io.IOException;
+import java.time.DateTimeException;
+import java.time.LocalDateTime;
+
+class LocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+  @Override
+  public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    String text = p.getText();
+    try {
+      return LocalDateTime.from(ISO_LOCAL_DATE_TIME.parse(text));
+    } catch (DateTimeException e) {
+      throw new InvalidFormatException(
+          p, "Expected an ISO 8601 formatted datetime", text, LocalDateTime.class);
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/json/jackson/LocalDateTimeSerializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/LocalDateTimeSerializer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.json.jackson;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+class LocalDateTimeSerializer extends JsonSerializer<LocalDateTime> {
+
+  @Override
+  public void serialize(LocalDateTime value, JsonGenerator jgen, SerializerProvider provider)
+      throws IOException {
+    jgen.writeString(ISO_LOCAL_DATE_TIME.format(value));
+  }
+}

--- a/src/main/java/io/vertx/core/json/jackson/LocalTimeDeserializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/LocalTimeDeserializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.json.jackson;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import java.io.IOException;
+import java.time.DateTimeException;
+import java.time.LocalTime;
+
+class LocalTimeDeserializer extends JsonDeserializer<LocalTime> {
+  @Override
+  public LocalTime deserialize(JsonParser p, DeserializationContext c) throws IOException {
+    String text = p.getText();
+    try {
+      return LocalTime.from(ISO_LOCAL_TIME.parse(text));
+    } catch (DateTimeException e) {
+      throw new InvalidFormatException(p, "Expected an ISO 8601 formatted local time", text, LocalTime.class);
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/json/jackson/LocalTimeSerializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/LocalTimeSerializer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.json.jackson;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.LocalTime;
+
+class LocalTimeSerializer extends JsonSerializer<LocalTime> {
+  @Override
+  public void serialize(LocalTime value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+    jgen.writeString(ISO_LOCAL_TIME.format(value));
+  }
+}

--- a/src/main/java/io/vertx/core/json/jackson/OffsetDateTimeDeserializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/OffsetDateTimeDeserializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.json.jackson;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import java.io.IOException;
+import java.time.DateTimeException;
+import java.time.OffsetDateTime;
+
+class OffsetDateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
+  @Override
+  public OffsetDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    String text = p.getText();
+    try {
+      return OffsetDateTime.from(ISO_OFFSET_DATE_TIME.parse(text));
+    } catch (DateTimeException e) {
+      throw new InvalidFormatException(
+          p, "Expected an ISO 8601 formatted datetime", text, OffsetDateTime.class);
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/json/jackson/OffsetDateTimeSerializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/OffsetDateTimeSerializer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.json.jackson;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+
+class OffsetDateTimeSerializer extends JsonSerializer<OffsetDateTime> {
+
+  @Override
+  public void serialize(OffsetDateTime value, JsonGenerator jgen, SerializerProvider provider)
+      throws IOException {
+    jgen.writeString(ISO_OFFSET_DATE_TIME.format(value));
+  }
+}

--- a/src/main/java/io/vertx/core/json/jackson/VertxModule.java
+++ b/src/main/java/io/vertx/core/json/jackson/VertxModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 /**
@@ -26,6 +27,8 @@ import java.time.LocalTime;
  *   <li>{@code JsonArraySerializer} of {@code JsonArray}</li>
  *   <li>{@code InstantSerializer} and {@code InstantDeserializer} of {@code Instant}</li>
  *   <li>{@code LocalTimeSerializer} and {@code LocalTimeDeserializer} of {@code LocalTime}</li>
+ *   <li>{@code LocalDateSerializer} and {@code LocalDateDeserializer} of {@code LocalDate}</li>
+ *   <li>{@code LocalDateTimeSerializer} and {@code LocalDateTimeDeserializer} of {@code LocalDateTime}</li>
  *   <li>{@code ByteArraySerializer} and {@code ByteArrayDeserializer} of {@code byte[]}</li>
  *   <li>{@code BufferSerializer} and {@code BufferDeserializer} of {@code Buffer}</li>
  * </ul>
@@ -43,6 +46,8 @@ public class VertxModule extends SimpleModule {
     addDeserializer(LocalTime.class, new LocalTimeDeserializer());
     addSerializer(LocalDate.class, new LocalDateSerializer());
     addDeserializer(LocalDate.class, new LocalDateDeserializer());
+    addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
+    addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer());
     addSerializer(byte[].class, new ByteArraySerializer());
     addDeserializer(byte[].class, new ByteArrayDeserializer());
     addSerializer(Buffer.class, new BufferSerializer());

--- a/src/main/java/io/vertx/core/json/jackson/VertxModule.java
+++ b/src/main/java/io/vertx/core/json/jackson/VertxModule.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 
 /**
  * A Jackson {@code Module} to provide following Vert.x Serializers and Deserializers
@@ -29,6 +30,7 @@ import java.time.LocalTime;
  *   <li>{@code LocalTimeSerializer} and {@code LocalTimeDeserializer} of {@code LocalTime}</li>
  *   <li>{@code LocalDateSerializer} and {@code LocalDateDeserializer} of {@code LocalDate}</li>
  *   <li>{@code LocalDateTimeSerializer} and {@code LocalDateTimeDeserializer} of {@code LocalDateTime}</li>
+ *   <li>{@code OffsetDateTimeSerializer} and {@code OffsetDateTimeDeserializer} of {@code OffsetDateTime}</li>
  *   <li>{@code ByteArraySerializer} and {@code ByteArrayDeserializer} of {@code byte[]}</li>
  *   <li>{@code BufferSerializer} and {@code BufferDeserializer} of {@code Buffer}</li>
  * </ul>
@@ -48,6 +50,8 @@ public class VertxModule extends SimpleModule {
     addDeserializer(LocalDate.class, new LocalDateDeserializer());
     addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
     addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer());
+    addSerializer(OffsetDateTime.class, new OffsetDateTimeSerializer());
+    addDeserializer(OffsetDateTime.class, new OffsetDateTimeDeserializer());
     addSerializer(byte[].class, new ByteArraySerializer());
     addDeserializer(byte[].class, new ByteArrayDeserializer());
     addSerializer(Buffer.class, new BufferSerializer());

--- a/src/main/java/io/vertx/core/json/jackson/VertxModule.java
+++ b/src/main/java/io/vertx/core/json/jackson/VertxModule.java
@@ -15,16 +15,18 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.time.Instant;
+import java.time.LocalTime;
 
 /**
- * A Jackson {@code Module} to provide following VertX Serializers and Deserializers
- * that can be reused for building custom mappers :
+ * A Jackson {@code Module} to provide following Vert.x Serializers and Deserializers
+ * that can be reused for building custom mappers:
  * <ul>
  *   <li>{@code JsonObjectSerializer} of {@code JsonObject} </li>
  *   <li>{@code JsonArraySerializer} of {@code JsonArray}</li>
  *   <li>{@code InstantSerializer} and {@code InstantDeserializer} of {@code Instant}</li>
- *   <li>{@code ByteArraySerializer} and {@code ByteArraySerializer} of {@code byte[]}</li>
- *   <li>{@code BufferSerializer} and {@code BufferSerializer} of {@code Buffer}</li>
+ *   <li>{@code LocalTimeSerializer} and {@code LocalTimeDeserializer} of {@code LocalTime}</li>
+ *   <li>{@code ByteArraySerializer} and {@code ByteArrayDeserializer} of {@code byte[]}</li>
+ *   <li>{@code BufferSerializer} and {@code BufferDeserializer} of {@code Buffer}</li>
  * </ul>
  */
 public class VertxModule extends SimpleModule {
@@ -33,9 +35,11 @@ public class VertxModule extends SimpleModule {
     // custom types
     addSerializer(JsonObject.class, new JsonObjectSerializer());
     addSerializer(JsonArray.class, new JsonArraySerializer());
-    // he have 2 extensions: RFC-7493
+    // Extensions to RFC-7493
     addSerializer(Instant.class, new InstantSerializer());
     addDeserializer(Instant.class, new InstantDeserializer());
+    addSerializer(LocalTime.class, new LocalTimeSerializer());
+    addDeserializer(LocalTime.class, new LocalTimeDeserializer());
     addSerializer(byte[].class, new ByteArraySerializer());
     addDeserializer(byte[].class, new ByteArrayDeserializer());
     addSerializer(Buffer.class, new BufferSerializer());

--- a/src/main/java/io/vertx/core/json/jackson/VertxModule.java
+++ b/src/main/java/io/vertx/core/json/jackson/VertxModule.java
@@ -15,6 +15,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 /**
@@ -40,6 +41,8 @@ public class VertxModule extends SimpleModule {
     addDeserializer(Instant.class, new InstantDeserializer());
     addSerializer(LocalTime.class, new LocalTimeSerializer());
     addDeserializer(LocalTime.class, new LocalTimeDeserializer());
+    addSerializer(LocalDate.class, new LocalDateSerializer());
+    addDeserializer(LocalDate.class, new LocalDateDeserializer());
     addSerializer(byte[].class, new ByteArraySerializer());
     addDeserializer(byte[].class, new ByteArrayDeserializer());
     addSerializer(Buffer.class, new BufferSerializer());

--- a/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
@@ -19,6 +19,7 @@ import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.core.json.jackson.JacksonCodec;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
+import java.time.LocalTime;
 import org.junit.Test;
 
 import java.time.Instant;
@@ -26,6 +27,7 @@ import java.util.*;
 
 import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -83,6 +85,21 @@ public class JacksonDatabindTest extends VertxTestBase {
   }
 
   @Test
+  public void testLocalTimeDecoding() {
+    Pojo original = new Pojo();
+    original.localTime = LocalTime.from(ISO_LOCAL_TIME.parse("07:25:38.397"));
+    Pojo decoded = Json.decodeValue("{\"localTime\":\"07:25:38.397\"}", Pojo.class);
+    assertEquals(original.localTime, decoded.localTime);
+  }
+
+  @Test
+  public void testNullLocalTimeDecoding() {
+    Pojo original = new Pojo();
+    Pojo decoded = Json.decodeValue("{\"localTime\":null}", Pojo.class);
+    assertEquals(original.localTime, decoded.localTime);
+  }
+
+  @Test
   public void testBytesDecoding() {
     Pojo original = new Pojo();
     original.bytes = TestUtils.randomByteArray(12);
@@ -104,5 +121,7 @@ public class JacksonDatabindTest extends VertxTestBase {
     Instant instant;
     @JsonProperty
     byte[] bytes;
+    @JsonProperty
+    LocalTime localTime;
   }
 }

--- a/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
@@ -20,6 +20,7 @@ import io.vertx.core.json.jackson.JacksonCodec;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import org.junit.Test;
 
@@ -29,6 +30,7 @@ import java.util.*;
 import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
 /**
@@ -117,6 +119,21 @@ public class JacksonDatabindTest extends VertxTestBase {
   }
 
   @Test
+  public void testLocalDateTimeDecoding() {
+    Pojo original = new Pojo();
+    original.localDateTime = LocalDateTime.from(ISO_LOCAL_DATE_TIME.parse("2022-02-22T01:02:03.123456789"));
+    Pojo decoded = Json.decodeValue("{\"localDateTime\":\"2022-02-22T01:02:03.123456789\"}", Pojo.class);
+    assertEquals(original.localDateTime, decoded.localDateTime);
+  }
+
+  @Test
+  public void testNullLocalDateTimeDecoding() {
+    Pojo original = new Pojo();
+    Pojo decoded = Json.decodeValue("{\"localDateTime\":null}", Pojo.class);
+    assertEquals(original.localDateTime, decoded.localDateTime);
+  }
+
+  @Test
   public void testBytesDecoding() {
     Pojo original = new Pojo();
     original.bytes = TestUtils.randomByteArray(12);
@@ -142,5 +159,7 @@ public class JacksonDatabindTest extends VertxTestBase {
     LocalTime localTime;
     @JsonProperty
     LocalDate localDate;
+    @JsonProperty
+    LocalDateTime localDateTime;
   }
 }

--- a/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
@@ -19,6 +19,7 @@ import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.core.json.jackson.JacksonCodec;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import org.junit.Test;
 
@@ -27,6 +28,7 @@ import java.util.*;
 
 import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
 /**
@@ -100,6 +102,21 @@ public class JacksonDatabindTest extends VertxTestBase {
   }
 
   @Test
+  public void testLocalDateDecoding() {
+    Pojo original = new Pojo();
+    original.localDate = LocalDate.from(ISO_LOCAL_DATE.parse("2022-02-22"));
+    Pojo decoded = Json.decodeValue("{\"localDate\":\"2022-02-22\"}", Pojo.class);
+    assertEquals(original.localDate, decoded.localDate);
+  }
+
+  @Test
+  public void testNullLocalDateDecoding() {
+    Pojo original = new Pojo();
+    Pojo decoded = Json.decodeValue("{\"localDate\":null}", Pojo.class);
+    assertEquals(original.localDate, decoded.localDate);
+  }
+
+  @Test
   public void testBytesDecoding() {
     Pojo original = new Pojo();
     original.bytes = TestUtils.randomByteArray(12);
@@ -123,5 +140,7 @@ public class JacksonDatabindTest extends VertxTestBase {
     byte[] bytes;
     @JsonProperty
     LocalTime localTime;
+    @JsonProperty
+    LocalDate localDate;
   }
 }

--- a/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
@@ -22,6 +22,7 @@ import io.vertx.test.core.VertxTestBase;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import org.junit.Test;
 
 import java.time.Instant;
@@ -32,6 +33,7 @@ import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -134,6 +136,21 @@ public class JacksonDatabindTest extends VertxTestBase {
   }
 
   @Test
+  public void testOffsetDateTimeDecoding() {
+    Pojo original = new Pojo();
+    original.offsetDateTime = OffsetDateTime.from(ISO_OFFSET_DATE_TIME.parse("2022-02-22T01:02:03.123456789+02:00"));
+    Pojo decoded = Json.decodeValue("{\"offsetDateTime\":\"2022-02-22T01:02:03.123456789+02:00\"}", Pojo.class);
+    assertEquals(original.offsetDateTime, decoded.offsetDateTime);
+  }
+
+  @Test
+  public void testNullOffsetDateTimeDecoding() {
+    Pojo original = new Pojo();
+    Pojo decoded = Json.decodeValue("{\"offsetDateTime\":null}", Pojo.class);
+    assertEquals(original.offsetDateTime, decoded.offsetDateTime);
+  }
+
+  @Test
   public void testBytesDecoding() {
     Pojo original = new Pojo();
     original.bytes = TestUtils.randomByteArray(12);
@@ -161,5 +178,7 @@ public class JacksonDatabindTest extends VertxTestBase {
     LocalDate localDate;
     @JsonProperty
     LocalDateTime localDateTime;
+    @JsonProperty
+    OffsetDateTime offsetDateTime;
   }
 }

--- a/src/test/java/io/vertx/core/json/JsonArrayTest.java
+++ b/src/test/java/io/vertx/core/json/JsonArrayTest.java
@@ -442,12 +442,12 @@ public class JsonArrayTest {
     }
     LocalTime localTime = LocalTime.now();
     jsonArray.add(localTime);
-    assertEquals(localTime, jsonArray.getLocalTime(13));
-    assertEquals(localTime.toString(), jsonArray.getValue(13));
+    assertEquals(localTime, jsonArray.getLocalTime(12));
+    assertEquals(localTime.toString(), jsonArray.getValue(12));
     LocalDate localDate = LocalDate.now();
     jsonArray.add(localDate);
-    assertEquals(localDate, jsonArray.getLocalDate(14));
-    assertEquals(localDate.toString(), jsonArray.getValue(14));
+    assertEquals(localDate, jsonArray.getLocalDate(13));
+    assertEquals(localDate.toString(), jsonArray.getValue(13));
     // JsonObject with inner Map
     List<Object> list = new ArrayList<>();
     Map<String, Object> innerMap = new HashMap<>();

--- a/src/test/java/io/vertx/core/json/JsonArrayTest.java
+++ b/src/test/java/io/vertx/core/json/JsonArrayTest.java
@@ -17,6 +17,7 @@ import io.vertx.test.core.TestUtils;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,6 +35,7 @@ import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static org.junit.Assert.*;
 
 /**
@@ -457,6 +459,11 @@ public class JsonArrayTest {
     assertEquals(localDateTime, jsonArray.getLocalDateTime(14));
     assertEquals(localDateTime.toString(), jsonArray.getValue(14));
 
+    OffsetDateTime offsetDateTime = OffsetDateTime.now();
+    jsonArray.add(offsetDateTime);
+    assertEquals(offsetDateTime, jsonArray.getOffsetDateTime(15));
+    assertEquals(offsetDateTime.toString(), jsonArray.getValue(15));
+
     // JsonObject with inner Map
     List<Object> list = new ArrayList<>();
     Map<String, Object> innerMap = new HashMap<>();
@@ -627,6 +634,17 @@ public class JsonArrayTest {
   }
 
   @Test
+  public void testAddOffsetDateTime() {
+    OffsetDateTime now = OffsetDateTime.now();
+    assertSame(jsonArray, jsonArray.add(now));
+    assertEquals(now, jsonArray.getOffsetDateTime(0));
+    assertEquals(now.toString(), jsonArray.getValue(0));
+    jsonArray.add(null);
+    assertNull(jsonArray.getValue(1));
+    assertEquals(2, jsonArray.size());
+  }
+
+  @Test
   public void testAddObject() {
     jsonArray.add((Object)"bar");
     jsonArray.add((Object)(Integer.valueOf(123)));
@@ -648,6 +666,8 @@ public class JsonArrayTest {
     jsonArray.add(localDate);
     LocalDateTime localDateTime = LocalDateTime.now();
     jsonArray.add(localDateTime);
+    OffsetDateTime offsetDateTime = OffsetDateTime.now();
+    jsonArray.add(offsetDateTime);
 
     assertEquals("bar", jsonArray.getString(0));
     assertEquals(Integer.valueOf(123), jsonArray.getInteger(1));
@@ -667,6 +687,8 @@ public class JsonArrayTest {
     assertEquals(localDate.toString(), jsonArray.getValue(11));
     assertEquals(localDateTime, jsonArray.getLocalDateTime(12));
     assertEquals(localDateTime.toString(), jsonArray.getValue(12));
+    assertEquals(offsetDateTime, jsonArray.getOffsetDateTime(13));
+    assertEquals(offsetDateTime.toString(), jsonArray.getValue(13));
 
     try {
       jsonArray.add(new SomeClass());
@@ -1329,6 +1351,21 @@ public class JsonArrayTest {
   }
 
   @Test
+  public void testSetOffsetDateTime() {
+    OffsetDateTime now = OffsetDateTime.now();
+    try {
+      jsonArray.set(0, now);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    jsonArray.add("bar");
+    assertSame(jsonArray, jsonArray.set(0, now));
+    assertEquals(now.toString(), jsonArray.getValue(0));
+    assertEquals(1, jsonArray.size());
+  }
+
+  @Test
   public void testSetObject() {
     jsonArray.add("bar");
     try {
@@ -1647,6 +1684,49 @@ public class JsonArrayTest {
     }
     jsonArray.addNull();
     assertNull(jsonArray.getLocalDateTime(2));
+    assertNull(jsonArray.getValue(2));
+  }
+
+  @Test
+  public void testGetOffsetDateTime() {
+    OffsetDateTime now = OffsetDateTime.now();
+    jsonArray.add(now);
+    assertEquals(now, jsonArray.getOffsetDateTime(0));
+    assertEquals(now.toString(), jsonArray.getValue(0));
+    assertEquals(now, OffsetDateTime.from(ISO_OFFSET_DATE_TIME.parse(jsonArray.getString(0))));
+    try {
+      jsonArray.getOffsetDateTime(-1);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    try {
+      jsonArray.getValue(-1);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    try {
+      jsonArray.getOffsetDateTime(1);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    try {
+      jsonArray.getValue(1);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    jsonArray.add(123);
+    try {
+      jsonArray.getOffsetDateTime(1);
+      fail();
+    } catch (ClassCastException e) {
+      // OK
+    }
+    jsonArray.addNull();
+    assertNull(jsonArray.getOffsetDateTime(2));
     assertNull(jsonArray.getValue(2));
   }
 }

--- a/src/test/java/io/vertx/core/json/JsonArrayTest.java
+++ b/src/test/java/io/vertx/core/json/JsonArrayTest.java
@@ -15,6 +15,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.Shareable;
 import io.vertx.test.core.TestUtils;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +32,7 @@ import static io.vertx.core.json.impl.JsonUtil.BASE64_DECODER;
 import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 import static org.junit.Assert.*;
 
@@ -444,10 +446,17 @@ public class JsonArrayTest {
     jsonArray.add(localTime);
     assertEquals(localTime, jsonArray.getLocalTime(12));
     assertEquals(localTime.toString(), jsonArray.getValue(12));
+
     LocalDate localDate = LocalDate.now();
     jsonArray.add(localDate);
     assertEquals(localDate, jsonArray.getLocalDate(13));
     assertEquals(localDate.toString(), jsonArray.getValue(13));
+
+    LocalDateTime localDateTime = LocalDateTime.now();
+    jsonArray.add(localDateTime);
+    assertEquals(localDateTime, jsonArray.getLocalDateTime(14));
+    assertEquals(localDateTime.toString(), jsonArray.getValue(14));
+
     // JsonObject with inner Map
     List<Object> list = new ArrayList<>();
     Map<String, Object> innerMap = new HashMap<>();
@@ -607,6 +616,17 @@ public class JsonArrayTest {
   }
 
   @Test
+  public void testAddLocalDateTime() {
+    LocalDateTime now = LocalDateTime.now();
+    assertSame(jsonArray, jsonArray.add(now));
+    assertEquals(now, jsonArray.getLocalDateTime(0));
+    assertEquals(now.toString(), jsonArray.getValue(0));
+    jsonArray.add(null);
+    assertNull(jsonArray.getValue(1));
+    assertEquals(2, jsonArray.size());
+  }
+
+  @Test
   public void testAddObject() {
     jsonArray.add((Object)"bar");
     jsonArray.add((Object)(Integer.valueOf(123)));
@@ -626,6 +646,9 @@ public class JsonArrayTest {
     jsonArray.add(localTime);
     LocalDate localDate = LocalDate.now();
     jsonArray.add(localDate);
+    LocalDateTime localDateTime = LocalDateTime.now();
+    jsonArray.add(localDateTime);
+
     assertEquals("bar", jsonArray.getString(0));
     assertEquals(Integer.valueOf(123), jsonArray.getInteger(1));
     assertEquals(Long.valueOf(123l), jsonArray.getLong(2));
@@ -642,6 +665,9 @@ public class JsonArrayTest {
     assertEquals(localTime.toString(), jsonArray.getValue(10));
     assertEquals(localDate, jsonArray.getLocalDate(11));
     assertEquals(localDate.toString(), jsonArray.getValue(11));
+    assertEquals(localDateTime, jsonArray.getLocalDateTime(12));
+    assertEquals(localDateTime.toString(), jsonArray.getValue(12));
+
     try {
       jsonArray.add(new SomeClass());
       // OK (we can put anything, yet it should fail to encode if a codec is missing)
@@ -1288,6 +1314,21 @@ public class JsonArrayTest {
   }
 
   @Test
+  public void testSetLocalDateTime() {
+    LocalDateTime now = LocalDateTime.now();
+    try {
+      jsonArray.set(0, now);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    jsonArray.add("bar");
+    assertSame(jsonArray, jsonArray.set(0, now));
+    assertEquals(now.toString(), jsonArray.getValue(0));
+    assertEquals(1, jsonArray.size());
+  }
+
+  @Test
   public void testSetObject() {
     jsonArray.add("bar");
     try {
@@ -1563,6 +1604,49 @@ public class JsonArrayTest {
     }
     jsonArray.addNull();
     assertNull(jsonArray.getLocalDate(2));
+    assertNull(jsonArray.getValue(2));
+  }
+
+  @Test
+  public void testGetLocalDateTime() {
+    LocalDateTime now = LocalDateTime.now();
+    jsonArray.add(now);
+    assertEquals(now, jsonArray.getLocalDateTime(0));
+    assertEquals(now.toString(), jsonArray.getValue(0));
+    assertEquals(now, LocalDateTime.from(ISO_LOCAL_DATE_TIME.parse(jsonArray.getString(0))));
+    try {
+      jsonArray.getLocalDateTime(-1);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    try {
+      jsonArray.getValue(-1);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    try {
+      jsonArray.getLocalDateTime(1);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    try {
+      jsonArray.getValue(1);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    jsonArray.add(123);
+    try {
+      jsonArray.getLocalDateTime(1);
+      fail();
+    } catch (ClassCastException e) {
+      // OK
+    }
+    jsonArray.addNull();
+    assertNull(jsonArray.getLocalDateTime(2));
     assertNull(jsonArray.getValue(2));
   }
 }

--- a/src/test/java/io/vertx/core/json/JsonArrayTest.java
+++ b/src/test/java/io/vertx/core/json/JsonArrayTest.java
@@ -14,6 +14,7 @@ package io.vertx.core.json;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.Shareable;
 import io.vertx.test.core.TestUtils;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
 import static io.vertx.core.json.impl.JsonUtil.BASE64_DECODER;
 import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 import static org.junit.Assert.*;
 
@@ -438,6 +440,14 @@ public class JsonArrayTest {
     } catch (IndexOutOfBoundsException e) {
       // OK
     }
+    LocalTime localTime = LocalTime.now();
+    jsonArray.add(localTime);
+    assertEquals(localTime, jsonArray.getLocalTime(13));
+    assertEquals(localTime.toString(), jsonArray.getValue(13));
+    LocalDate localDate = LocalDate.now();
+    jsonArray.add(localDate);
+    assertEquals(localDate, jsonArray.getLocalDate(14));
+    assertEquals(localDate.toString(), jsonArray.getValue(14));
     // JsonObject with inner Map
     List<Object> list = new ArrayList<>();
     Map<String, Object> innerMap = new HashMap<>();
@@ -586,6 +596,17 @@ public class JsonArrayTest {
   }
 
   @Test
+  public void testAddLocalDate() {
+    LocalDate now = LocalDate.now();
+    assertSame(jsonArray, jsonArray.add(now));
+    assertEquals(now, jsonArray.getLocalDate(0));
+    assertEquals(now.toString(), jsonArray.getValue(0));
+    jsonArray.add(null);
+    assertNull(jsonArray.getValue(1));
+    assertEquals(2, jsonArray.size());
+  }
+
+  @Test
   public void testAddObject() {
     jsonArray.add((Object)"bar");
     jsonArray.add((Object)(Integer.valueOf(123)));
@@ -603,6 +624,8 @@ public class JsonArrayTest {
     jsonArray.add((Object)arr);
     LocalTime localTime = LocalTime.now();
     jsonArray.add(localTime);
+    LocalDate localDate = LocalDate.now();
+    jsonArray.add(localDate);
     assertEquals("bar", jsonArray.getString(0));
     assertEquals(Integer.valueOf(123), jsonArray.getInteger(1));
     assertEquals(Long.valueOf(123l), jsonArray.getLong(2));
@@ -617,6 +640,8 @@ public class JsonArrayTest {
     assertEquals(arr, jsonArray.getJsonArray(9));
     assertEquals(localTime, jsonArray.getLocalTime(10));
     assertEquals(localTime.toString(), jsonArray.getValue(10));
+    assertEquals(localDate, jsonArray.getLocalDate(11));
+    assertEquals(localDate.toString(), jsonArray.getValue(11));
     try {
       jsonArray.add(new SomeClass());
       // OK (we can put anything, yet it should fail to encode if a codec is missing)
@@ -1248,6 +1273,21 @@ public class JsonArrayTest {
   }
 
   @Test
+  public void testSetLocalDate() {
+    LocalDate now = LocalDate.now();
+    try {
+      jsonArray.set(0, now);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    jsonArray.add("bar");
+    assertSame(jsonArray, jsonArray.set(0, now));
+    assertEquals(now.toString(), jsonArray.getValue(0));
+    assertEquals(1, jsonArray.size());
+  }
+
+  @Test
   public void testSetObject() {
     jsonArray.add("bar");
     try {
@@ -1483,5 +1523,46 @@ public class JsonArrayTest {
     assertNull(jsonArray.getValue(2));
   }
 
-
+  @Test
+  public void testGetLocalDate() {
+    LocalDate now = LocalDate.now();
+    jsonArray.add(now);
+    assertEquals(now, jsonArray.getLocalDate(0));
+    assertEquals(now.toString(), jsonArray.getValue(0));
+    assertEquals(now, LocalDate.from(ISO_LOCAL_DATE.parse(jsonArray.getString(0))));
+    try {
+      jsonArray.getLocalDate(-1);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    try {
+      jsonArray.getValue(-1);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    try {
+      jsonArray.getLocalDate(1);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    try {
+      jsonArray.getValue(1);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // OK
+    }
+    jsonArray.add(123);
+    try {
+      jsonArray.getLocalDate(1);
+      fail();
+    } catch (ClassCastException e) {
+      // OK
+    }
+    jsonArray.addNull();
+    assertNull(jsonArray.getLocalDate(2));
+    assertNull(jsonArray.getValue(2));
+  }
 }

--- a/src/test/java/io/vertx/core/json/JsonCodecTest.java
+++ b/src/test/java/io/vertx/core/json/JsonCodecTest.java
@@ -21,6 +21,8 @@ import io.vertx.test.core.TestUtils;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import org.assertj.core.data.Offset;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -45,6 +47,7 @@ import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -99,6 +102,8 @@ public class JsonCodecTest {
     jsonObject.put("mylocaldate", localDate);
     LocalDateTime localDateTime = LocalDateTime.now();
     jsonObject.put("mylocaldatetime", localDateTime);
+    OffsetDateTime offsetDateTime = OffsetDateTime.now();
+    jsonObject.put("myoffsetdatetime", offsetDateTime);
     jsonObject.putNull("mynull");
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
@@ -117,6 +122,7 @@ public class JsonCodecTest {
       + "\"mylocaltime\":\"" + ISO_LOCAL_TIME.format(localTime) + "\","
       + "\"mylocaldate\":\"" + ISO_LOCAL_DATE.format(localDate) + "\","
       + "\"mylocaldatetime\":\"" + ISO_LOCAL_DATE_TIME.format(localDateTime) + "\","
+      + "\"myoffsetdatetime\":\"" + ISO_OFFSET_DATE_TIME.format(offsetDateTime) + "\","
       + "\"mynull\":null,"
       + "\"myobj\":{\"foo\":\"bar\"},"
       + "\"myarr\":[\"foo\",123]"
@@ -144,6 +150,7 @@ public class JsonCodecTest {
     jsonArray.add(LocalTime.NOON);
     jsonArray.add(LocalDate.parse("2022-02-22"));
     jsonArray.add(LocalDateTime.parse("2022-02-22T01:02:03.123456"));
+    jsonArray.add(OffsetDateTime.parse("2022-02-22T01:02:03.123456+02:00"));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
 
     String expected = "["
@@ -160,7 +167,8 @@ public class JsonCodecTest {
       + "[\"foo\",123],"
       + "\"12:00:00\","
       + "\"2022-02-22\","
-      + "\"2022-02-22T01:02:03.123456\""
+      + "\"2022-02-22T01:02:03.123456\","
+      + "\"2022-02-22T01:02:03.123456+02:00\""
       + "]";
     String json = mapper.toString(jsonArray);
     assertEquals(expected, json);
@@ -186,6 +194,8 @@ public class JsonCodecTest {
     jsonObject.put("mylocaldate", localDate);
     LocalDateTime localDateTime = LocalDateTime.now();
     jsonObject.put("mylocaldatetime", localDateTime);
+    OffsetDateTime offsetDateTime = OffsetDateTime.now();
+    jsonObject.put("myoffsetdatetime", offsetDateTime);
     jsonObject.putNull("mynull");
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
@@ -204,6 +214,7 @@ public class JsonCodecTest {
       + "\"mylocaltime\":\"" + ISO_LOCAL_TIME.format(localTime) + "\","
       + "\"mylocaldate\":\"" + ISO_LOCAL_DATE.format(localDate) + "\","
       + "\"mylocaldatetime\":\"" + ISO_LOCAL_DATE_TIME.format(localDateTime) + "\","
+      + "\"myoffsetdatetime\":\"" + ISO_OFFSET_DATE_TIME.format(offsetDateTime) + "\","
       + "\"mynull\":null,"
       + "\"myobj\":{\"foo\":\"bar\"},"
       + "\"myarr\":[\"foo\",123]"
@@ -231,8 +242,16 @@ public class JsonCodecTest {
     jsonArray.add(LocalTime.parse("12:34:56.123"));
     jsonArray.add(LocalDate.parse("2022-02-22"));
     jsonArray.add(LocalDateTime.parse("2022-02-22T01:02:03.1234567"));
+    jsonArray.add(OffsetDateTime.parse("2022-02-22T01:02:03.1234567+02:00"));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
-    Buffer expected = Buffer.buffer("[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123],\"12:34:56.123\",\"2022-02-22\",\"2022-02-22T01:02:03.1234567\"]", "UTF-8");
+    Buffer expected =
+        Buffer.buffer(
+            "[\"foo\",123,1234,1.23,2.34,true,\""
+                + strBytes
+                + "\",\""
+                + strBytes
+                + "\",null,{\"foo\":\"bar\"},[\"foo\",123],\"12:34:56.123\",\"2022-02-22\",\"2022-02-22T01:02:03.1234567\",\"2022-02-22T01:02:03.1234567+02:00\"]",
+            "UTF-8");
     Buffer json = mapper.toBuffer(jsonArray);
     assertArrayEquals(expected.getBytes(), json.getBytes());
   }
@@ -254,6 +273,7 @@ public class JsonCodecTest {
     jsonObject.put("mylocaltime", LocalTime.parse("12:34:56.123"));
     jsonObject.put("mylocaldate", LocalDate.parse("2022-02-22"));
     jsonObject.put("mylocaldatetime", LocalDateTime.parse("2022-02-22T01:02:03.123456123"));
+    jsonObject.put("myoffsetdatetime", OffsetDateTime.parse("2022-02-22T01:02:03.123456123+02:00"));
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
@@ -271,6 +291,7 @@ public class JsonCodecTest {
       "  \"mylocaltime\" : \"12:34:56.123\"," + Utils.LINE_SEPARATOR +
       "  \"mylocaldate\" : \"2022-02-22\"," + Utils.LINE_SEPARATOR +
       "  \"mylocaldatetime\" : \"2022-02-22T01:02:03.123456123\"," + Utils.LINE_SEPARATOR +
+      "  \"myoffsetdatetime\" : \"2022-02-22T01:02:03.123456123+02:00\"," + Utils.LINE_SEPARATOR +
       "  \"myobj\" : {" + Utils.LINE_SEPARATOR +
       "    \"foo\" : \"bar\"" + Utils.LINE_SEPARATOR +
       "  }," + Utils.LINE_SEPARATOR +
@@ -298,10 +319,18 @@ public class JsonCodecTest {
     jsonArray.add(LocalTime.parse("12:34:56.123"));
     jsonArray.add(LocalDate.parse("2022-02-22"));
     jsonArray.add(LocalDateTime.parse("2022-02-22T01:02:03.123456001"));
+    jsonArray.add(OffsetDateTime.parse("2022-02-22T01:02:03.123456001+02:00"));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
-    String expected = "[ \"foo\", 123, 1234, 1.23, 2.34, true, \"" + strBytes + "\", \"" + strBytes + "\", null, {" + Utils.LINE_SEPARATOR +
-      "  \"foo\" : \"bar\"" + Utils.LINE_SEPARATOR +
-      "}, [ \"foo\", 123 ], \"12:34:56.123\", \"2022-02-22\", \"2022-02-22T01:02:03.123456001\" ]";
+    String expected =
+        "[ \"foo\", 123, 1234, 1.23, 2.34, true, \""
+            + strBytes
+            + "\", \""
+            + strBytes
+            + "\", null, {"
+            + Utils.LINE_SEPARATOR
+            + "  \"foo\" : \"bar\""
+            + Utils.LINE_SEPARATOR
+            + "}, [ \"foo\", 123 ], \"12:34:56.123\", \"2022-02-22\", \"2022-02-22T01:02:03.123456001\", \"2022-02-22T01:02:03.123456001+02:00\" ]";
     String json = mapper.toString(jsonArray, true);
     assertEquals(expected, json);
   }
@@ -325,6 +354,7 @@ public class JsonCodecTest {
       + "\"mylocaltime\":\"12:34:56.123\","
       + "\"mylocaldate\":\"2022-02-22\","
       + "\"mylocaldatetime\":\"2022-02-22T01:02:03.123456780\","
+      + "\"myoffsetdatetime\":\"2022-02-22T01:02:03.123456780+02:00\","
       + "\"mynull\":null,"
       + "\"myobj\":{\"foo\":\"bar\"},"
       + "\"myarr\":[\"foo\",123]}";
@@ -352,6 +382,9 @@ public class JsonCodecTest {
     LocalDateTime localDateTime = LocalDateTime.parse("2022-02-22T01:02:03.12345678");
     assertEquals(localDateTime, obj.getLocalDateTime("mylocaldatetime"));
     assertEquals(localDateTime.toString(), obj.getValue("mylocaldatetime"));
+    OffsetDateTime offsetDateTime = OffsetDateTime.parse("2022-02-22T01:02:03.12345678+02:00");
+    assertEquals(offsetDateTime, obj.getOffsetDateTime("myoffsetdatetime"));
+    assertEquals(offsetDateTime.toString(), obj.getValue("myoffsetdatetime"));
     assertTrue(obj.containsKey("mynull"));
     JsonObject nestedObj = obj.getJsonObject("myobj");
     assertEquals("bar", nestedObj.getString("foo"));
@@ -366,22 +399,30 @@ public class JsonCodecTest {
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
     Instant now = Instant.now();
     String strInstant = ISO_INSTANT.format(now);
-    String json = "[\"foo\","
-      + "123,"
-      + "1234,"
-      + "1.23,"
-      + "2.34,"
-      + "true,"
-      + "124,"
-      + "\"" + strBytes + "\","
-      + "\"" + strBytes + "\","
-      + "\"" + strInstant + "\","
-      + "null,"
-      + "{\"foo\":\"bar\"},"
-      + "[\"foo\",123],"
-      + "\"12:34:56.123\","
-      + "\"2022-02-22\","
-      + "\"2022-02-22T01:02:03.123456789\"]";
+    String json =
+        "[\"foo\","
+            + "123,"
+            + "1234,"
+            + "1.23,"
+            + "2.34,"
+            + "true,"
+            + "124,"
+            + "\""
+            + strBytes
+            + "\","
+            + "\""
+            + strBytes
+            + "\","
+            + "\""
+            + strInstant
+            + "\","
+            + "null,"
+            + "{\"foo\":\"bar\"},"
+            + "[\"foo\",123],"
+            + "\"12:34:56.123\","
+            + "\"2022-02-22\","
+            + "\"2022-02-22T01:02:03.123456789\","
+            + "\"2022-02-22T01:02:03.123456789+02:00\"]";
     JsonArray arr = new JsonArray(mapper.fromString(json, List.class));
     assertEquals("foo", arr.getString(0));
     assertEquals(Integer.valueOf(123), arr.getInteger(1));
@@ -411,6 +452,9 @@ public class JsonCodecTest {
     LocalDateTime localDateTime = LocalDateTime.parse("2022-02-22T01:02:03.123456789");
     assertEquals(localDateTime, arr.getLocalDateTime(15));
     assertEquals(localDateTime.toString(), arr.getValue(15));
+    OffsetDateTime offsetDateTime = OffsetDateTime.parse("2022-02-22T01:02:03.123456789+02:00");
+    assertEquals(offsetDateTime, arr.getOffsetDateTime(16));
+    assertEquals(offsetDateTime.toString(), arr.getValue(16));
   }
 
   // Strict JSON doesn't allow comments but we do so users can add comments to config files etc
@@ -556,6 +600,24 @@ public class JsonCodecTest {
     LocalDateTime now = LocalDateTime.now();
     String json = '"' + ISO_LOCAL_DATE_TIME.format(now) + '"';
     LocalDateTime decoded = mapper.fromString(json, LocalDateTime.class);
+    assertEquals(now, decoded);
+  }
+
+  @Test
+  public void encodeCustomTypeOffsetDateTime() {
+    OffsetDateTime now = OffsetDateTime.now();
+    String json = mapper.toString(now);
+    assertNotNull(json);
+    // the RFC is one way only
+    OffsetDateTime decoded = OffsetDateTime.from(ISO_OFFSET_DATE_TIME.parse(json.substring(1, json.length() - 1)));
+    assertEquals(now, decoded);
+  }
+
+  @Test
+  public void decodeCustomTypeOffsetDateTime() {
+    OffsetDateTime now = OffsetDateTime.now();
+    String json = '"' + ISO_OFFSET_DATE_TIME.format(now) + '"';
+    OffsetDateTime decoded = mapper.fromString(json, OffsetDateTime.class);
     assertEquals(now, decoded);
   }
 
@@ -706,6 +768,9 @@ public class JsonCodecTest {
     LocalDateTime localDateTime = LocalDateTime.parse("2022-02-22T01:02:03.123456");
     assertEquals("{\"key\":\"2022-02-22T01:02:03.123456\"}", checkMap(localDateTime));
     assertEquals("[\"2022-02-22T01:02:03.123456\"]", checkList(localDateTime));
+    OffsetDateTime offsetDateTime = OffsetDateTime.parse("2022-02-22T01:02:03.123456+02:00");
+    assertEquals("{\"key\":\"2022-02-22T01:02:03.123456+02:00\"}", checkMap(offsetDateTime));
+    assertEquals("[\"2022-02-22T01:02:03.123456+02:00\"]", checkList(offsetDateTime));
     assertEquals("{\"key\":\"MICROSECONDS\"}", checkMap(TimeUnit.MICROSECONDS));
     assertEquals("[\"MICROSECONDS\"]", checkList(TimeUnit.MICROSECONDS));
     BigInteger bigInt = new BigInteger("123456789");

--- a/src/test/java/io/vertx/core/json/JsonCodecTest.java
+++ b/src/test/java/io/vertx/core/json/JsonCodecTest.java
@@ -19,6 +19,7 @@ import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.core.json.jackson.JacksonCodec;
 import io.vertx.test.core.TestUtils;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -95,6 +97,8 @@ public class JsonCodecTest {
     jsonObject.put("mylocaltime", localTime);
     LocalDate localDate = LocalDate.now();
     jsonObject.put("mylocaldate", localDate);
+    LocalDateTime localDateTime = LocalDateTime.now();
+    jsonObject.put("mylocaldatetime", localDateTime);
     jsonObject.putNull("mynull");
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
@@ -112,6 +116,7 @@ public class JsonCodecTest {
       + "\"myinstant\":\"" + ISO_INSTANT.format(now) + "\","
       + "\"mylocaltime\":\"" + ISO_LOCAL_TIME.format(localTime) + "\","
       + "\"mylocaldate\":\"" + ISO_LOCAL_DATE.format(localDate) + "\","
+      + "\"mylocaldatetime\":\"" + ISO_LOCAL_DATE_TIME.format(localDateTime) + "\","
       + "\"mynull\":null,"
       + "\"myobj\":{\"foo\":\"bar\"},"
       + "\"myarr\":[\"foo\",123]"
@@ -138,6 +143,7 @@ public class JsonCodecTest {
     jsonArray.add(new JsonArray().add("foo").add(123));
     jsonArray.add(LocalTime.NOON);
     jsonArray.add(LocalDate.parse("2022-02-22"));
+    jsonArray.add(LocalDateTime.parse("2022-02-22T01:02:03.123456"));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
 
     String expected = "["
@@ -153,7 +159,8 @@ public class JsonCodecTest {
       + "{\"foo\":\"bar\"},"
       + "[\"foo\",123],"
       + "\"12:00:00\","
-      + "\"2022-02-22\""
+      + "\"2022-02-22\","
+      + "\"2022-02-22T01:02:03.123456\""
       + "]";
     String json = mapper.toString(jsonArray);
     assertEquals(expected, json);
@@ -177,6 +184,8 @@ public class JsonCodecTest {
     jsonObject.put("mylocaltime", localTime);
     LocalDate localDate = LocalDate.now();
     jsonObject.put("mylocaldate", localDate);
+    LocalDateTime localDateTime = LocalDateTime.now();
+    jsonObject.put("mylocaldatetime", localDateTime);
     jsonObject.putNull("mynull");
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
@@ -194,6 +203,7 @@ public class JsonCodecTest {
       + "\"myinstant\":\"" + ISO_INSTANT.format(now) + "\","
       + "\"mylocaltime\":\"" + ISO_LOCAL_TIME.format(localTime) + "\","
       + "\"mylocaldate\":\"" + ISO_LOCAL_DATE.format(localDate) + "\","
+      + "\"mylocaldatetime\":\"" + ISO_LOCAL_DATE_TIME.format(localDateTime) + "\","
       + "\"mynull\":null,"
       + "\"myobj\":{\"foo\":\"bar\"},"
       + "\"myarr\":[\"foo\",123]"
@@ -220,12 +230,12 @@ public class JsonCodecTest {
     jsonArray.add(new JsonArray().add("foo").add(123));
     jsonArray.add(LocalTime.parse("12:34:56.123"));
     jsonArray.add(LocalDate.parse("2022-02-22"));
+    jsonArray.add(LocalDateTime.parse("2022-02-22T01:02:03.1234567"));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
-    Buffer expected = Buffer.buffer("[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123],\"12:34:56.123\",\"2022-02-22\"]", "UTF-8");
+    Buffer expected = Buffer.buffer("[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123],\"12:34:56.123\",\"2022-02-22\",\"2022-02-22T01:02:03.1234567\"]", "UTF-8");
     Buffer json = mapper.toBuffer(jsonArray);
     assertArrayEquals(expected.getBytes(), json.getBytes());
   }
-
 
   @Test
   public void testEncodeJsonObjectPrettily() {
@@ -243,6 +253,7 @@ public class JsonCodecTest {
     jsonObject.put("myinstant", now);
     jsonObject.put("mylocaltime", LocalTime.parse("12:34:56.123"));
     jsonObject.put("mylocaldate", LocalDate.parse("2022-02-22"));
+    jsonObject.put("mylocaldatetime", LocalDateTime.parse("2022-02-22T01:02:03.123456123"));
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
@@ -259,6 +270,7 @@ public class JsonCodecTest {
       "  \"myinstant\" : \"" + strInstant + "\"," + Utils.LINE_SEPARATOR +
       "  \"mylocaltime\" : \"12:34:56.123\"," + Utils.LINE_SEPARATOR +
       "  \"mylocaldate\" : \"2022-02-22\"," + Utils.LINE_SEPARATOR +
+      "  \"mylocaldatetime\" : \"2022-02-22T01:02:03.123456123\"," + Utils.LINE_SEPARATOR +
       "  \"myobj\" : {" + Utils.LINE_SEPARATOR +
       "    \"foo\" : \"bar\"" + Utils.LINE_SEPARATOR +
       "  }," + Utils.LINE_SEPARATOR +
@@ -285,10 +297,11 @@ public class JsonCodecTest {
     jsonArray.add(new JsonArray().add("foo").add(123));
     jsonArray.add(LocalTime.parse("12:34:56.123"));
     jsonArray.add(LocalDate.parse("2022-02-22"));
+    jsonArray.add(LocalDateTime.parse("2022-02-22T01:02:03.123456001"));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
     String expected = "[ \"foo\", 123, 1234, 1.23, 2.34, true, \"" + strBytes + "\", \"" + strBytes + "\", null, {" + Utils.LINE_SEPARATOR +
       "  \"foo\" : \"bar\"" + Utils.LINE_SEPARATOR +
-      "}, [ \"foo\", 123 ], \"12:34:56.123\", \"2022-02-22\" ]";
+      "}, [ \"foo\", 123 ], \"12:34:56.123\", \"2022-02-22\", \"2022-02-22T01:02:03.123456001\" ]";
     String json = mapper.toString(jsonArray, true);
     assertEquals(expected, json);
   }
@@ -311,6 +324,7 @@ public class JsonCodecTest {
       + "\"myinstant\":\"" + strInstant + "\","
       + "\"mylocaltime\":\"12:34:56.123\","
       + "\"mylocaldate\":\"2022-02-22\","
+      + "\"mylocaldatetime\":\"2022-02-22T01:02:03.123456780\","
       + "\"mynull\":null,"
       + "\"myobj\":{\"foo\":\"bar\"},"
       + "\"myarr\":[\"foo\",123]}";
@@ -335,6 +349,9 @@ public class JsonCodecTest {
     LocalDate localDate = LocalDate.parse("2022-02-22");
     assertEquals(localDate, obj.getLocalDate("mylocaldate"));
     assertEquals(localDate.toString(), obj.getValue("mylocaldate"));
+    LocalDateTime localDateTime = LocalDateTime.parse("2022-02-22T01:02:03.12345678");
+    assertEquals(localDateTime, obj.getLocalDateTime("mylocaldatetime"));
+    assertEquals(localDateTime.toString(), obj.getValue("mylocaldatetime"));
     assertTrue(obj.containsKey("mynull"));
     JsonObject nestedObj = obj.getJsonObject("myobj");
     assertEquals("bar", nestedObj.getString("foo"));
@@ -363,7 +380,8 @@ public class JsonCodecTest {
       + "{\"foo\":\"bar\"},"
       + "[\"foo\",123],"
       + "\"12:34:56.123\","
-      + "\"2022-02-22\"]";
+      + "\"2022-02-22\","
+      + "\"2022-02-22T01:02:03.123456789\"]";
     JsonArray arr = new JsonArray(mapper.fromString(json, List.class));
     assertEquals("foo", arr.getString(0));
     assertEquals(Integer.valueOf(123), arr.getInteger(1));
@@ -390,6 +408,9 @@ public class JsonCodecTest {
     LocalDate localDate = LocalDate.parse("2022-02-22");
     assertEquals(localDate, arr.getLocalDate(14));
     assertEquals(localDate.toString(), arr.getValue(14));
+    LocalDateTime localDateTime = LocalDateTime.parse("2022-02-22T01:02:03.123456789");
+    assertEquals(localDateTime, arr.getLocalDateTime(15));
+    assertEquals(localDateTime.toString(), arr.getValue(15));
   }
 
   // Strict JSON doesn't allow comments but we do so users can add comments to config files etc
@@ -517,6 +538,24 @@ public class JsonCodecTest {
     LocalDate now = LocalDate.now();
     String json = '"' + ISO_LOCAL_DATE.format(now) + '"';
     LocalDate decoded = mapper.fromString(json, LocalDate.class);
+    assertEquals(now, decoded);
+  }
+
+  @Test
+  public void encodeCustomTypeLocalDateTime() {
+    LocalDateTime now = LocalDateTime.now();
+    String json = mapper.toString(now);
+    assertNotNull(json);
+    // the RFC is one way only
+    LocalDateTime decoded = LocalDateTime.from(ISO_LOCAL_DATE_TIME.parse(json.substring(1, json.length() - 1)));
+    assertEquals(now, decoded);
+  }
+
+  @Test
+  public void decodeCustomTypeLocalDateTime() {
+    LocalDateTime now = LocalDateTime.now();
+    String json = '"' + ISO_LOCAL_DATE_TIME.format(now) + '"';
+    LocalDateTime decoded = mapper.fromString(json, LocalDateTime.class);
     assertEquals(now, decoded);
   }
 
@@ -664,6 +703,9 @@ public class JsonCodecTest {
     LocalDate localDate = LocalDate.parse("2022-02-22");
     assertEquals("{\"key\":\"2022-02-22\"}", checkMap(localDate));
     assertEquals("[\"2022-02-22\"]", checkList(localDate));
+    LocalDateTime localDateTime = LocalDateTime.parse("2022-02-22T01:02:03.123456");
+    assertEquals("{\"key\":\"2022-02-22T01:02:03.123456\"}", checkMap(localDateTime));
+    assertEquals("[\"2022-02-22T01:02:03.123456\"]", checkList(localDateTime));
     assertEquals("{\"key\":\"MICROSECONDS\"}", checkMap(TimeUnit.MICROSECONDS));
     assertEquals("[\"MICROSECONDS\"]", checkList(TimeUnit.MICROSECONDS));
     BigInteger bigInt = new BigInteger("123456789");

--- a/src/test/java/io/vertx/core/json/JsonCodecTest.java
+++ b/src/test/java/io/vertx/core/json/JsonCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,7 +22,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
-import org.assertj.core.data.Offset;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/io/vertx/core/json/JsonCodecTest.java
+++ b/src/test/java/io/vertx/core/json/JsonCodecTest.java
@@ -18,6 +18,7 @@ import io.vertx.core.impl.Utils;
 import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.core.json.jackson.JacksonCodec;
 import io.vertx.test.core.TestUtils;
+import java.time.LocalTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -39,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -87,12 +89,28 @@ public class JsonCodecTest {
     jsonObject.put("mybuffer", Buffer.buffer(bytes));
     Instant now = Instant.now();
     jsonObject.put("myinstant", now);
+    LocalTime localTime = LocalTime.now();
+    jsonObject.put("mylocaltime", localTime);
     jsonObject.putNull("mynull");
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
-    String expected = "{\"mystr\":\"foo\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
-      "myboolean\":true,\"mybyte\":255,\"mybinary\":\"" + strBytes + "\",\"mybuffer\":\"" + strBytes + "\",\"myinstant\":\"" + ISO_INSTANT.format(now) + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}";
+    String expected = "{"
+      + "\"mystr\":\"foo\","
+      + "\"myint\":123,"
+      + "\"mylong\":1234,"
+      + "\"myfloat\":1.23,"
+      + "\"mydouble\":2.34,"
+      + "\"myboolean\":true,"
+      + "\"mybyte\":255,"
+      + "\"mybinary\":\"" + strBytes + "\","
+      + "\"mybuffer\":\"" + strBytes + "\","
+      + "\"myinstant\":\"" + ISO_INSTANT.format(now) + "\","
+      + "\"mylocaltime\":\"" + ISO_LOCAL_TIME.format(localTime) + "\","
+      + "\"mynull\":null,"
+      + "\"myobj\":{\"foo\":\"bar\"},"
+      + "\"myarr\":[\"foo\",123]"
+      + "}";
     String json = mapper.toString(jsonObject);
     assertEquals(expected, json);
   }
@@ -113,8 +131,23 @@ public class JsonCodecTest {
     jsonArray.addNull();
     jsonArray.add(new JsonObject().put("foo", "bar"));
     jsonArray.add(new JsonArray().add("foo").add(123));
+    jsonArray.add(LocalTime.NOON);
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
-    String expected = "[\"foo\",123,1234,1.23,2.34,true,124,\"" + strBytes + "\",\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123]]";
+
+    String expected = "["
+      + "\"foo\","
+      + "123,1234,"
+      + "1.23,"
+      + "2.34,"
+      + "true,"
+      + "124,"
+      + "\"" + strBytes + "\","
+      + "\"" + strBytes + "\","
+      + "null,"
+      + "{\"foo\":\"bar\"},"
+      + "[\"foo\",123],"
+      + "\"12:00:00\""
+      + "]";
     String json = mapper.toString(jsonArray);
     assertEquals(expected, json);
   }
@@ -133,13 +166,28 @@ public class JsonCodecTest {
     jsonObject.put("mybuffer", Buffer.buffer(bytes));
     Instant now = Instant.now();
     jsonObject.put("myinstant", now);
+    LocalTime localTime = LocalTime.now();
+    jsonObject.put("mylocaltime", localTime);
     jsonObject.putNull("mynull");
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
 
-    Buffer expected = Buffer.buffer("{\"mystr\":\"foo\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
-      "myboolean\":true,\"mybinary\":\"" + strBytes + "\",\"mybuffer\":\"" + strBytes + "\",\"myinstant\":\"" + ISO_INSTANT.format(now) + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}", "UTF-8");
+    Buffer expected = Buffer.buffer("{"
+      + "\"mystr\":\"foo\","
+      + "\"myint\":123,"
+      + "\"mylong\":1234,"
+      + "\"myfloat\":1.23,"
+      + "\"mydouble\":2.34,"
+      + "\"myboolean\":true,"
+      + "\"mybinary\":\"" + strBytes + "\","
+      + "\"mybuffer\":\"" + strBytes + "\","
+      + "\"myinstant\":\"" + ISO_INSTANT.format(now) + "\","
+      + "\"mylocaltime\":\"" + ISO_LOCAL_TIME.format(localTime) + "\","
+      + "\"mynull\":null,"
+      + "\"myobj\":{\"foo\":\"bar\"},"
+      + "\"myarr\":[\"foo\",123]"
+      + "}", "UTF-8");
 
     Buffer json = mapper.toBuffer(jsonObject);
     assertArrayEquals(expected.getBytes(), json.getBytes());
@@ -160,8 +208,9 @@ public class JsonCodecTest {
     jsonArray.addNull();
     jsonArray.add(new JsonObject().put("foo", "bar"));
     jsonArray.add(new JsonArray().add("foo").add(123));
+    jsonArray.add(LocalTime.parse("12:34:56.123"));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
-    Buffer expected = Buffer.buffer("[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123]]", "UTF-8");
+    Buffer expected = Buffer.buffer("[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123],\"12:34:56.123\"]", "UTF-8");
     Buffer json = mapper.toBuffer(jsonArray);
     assertArrayEquals(expected.getBytes(), json.getBytes());
   }
@@ -181,6 +230,7 @@ public class JsonCodecTest {
     jsonObject.put("mybuffer", Buffer.buffer(bytes));
     Instant now = Instant.now();
     jsonObject.put("myinstant", now);
+    jsonObject.put("mylocaltime", LocalTime.parse("12:34:56.123"));
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
@@ -195,6 +245,7 @@ public class JsonCodecTest {
       "  \"mybinary\" : \"" + strBytes + "\"," + Utils.LINE_SEPARATOR +
       "  \"mybuffer\" : \"" + strBytes + "\"," + Utils.LINE_SEPARATOR +
       "  \"myinstant\" : \"" + strInstant + "\"," + Utils.LINE_SEPARATOR +
+      "  \"mylocaltime\" : \"12:34:56.123\"," + Utils.LINE_SEPARATOR +
       "  \"myobj\" : {" + Utils.LINE_SEPARATOR +
       "    \"foo\" : \"bar\"" + Utils.LINE_SEPARATOR +
       "  }," + Utils.LINE_SEPARATOR +
@@ -219,10 +270,11 @@ public class JsonCodecTest {
     jsonArray.addNull();
     jsonArray.add(new JsonObject().put("foo", "bar"));
     jsonArray.add(new JsonArray().add("foo").add(123));
+    jsonArray.add(LocalTime.parse("12:34:56.123"));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
     String expected = "[ \"foo\", 123, 1234, 1.23, 2.34, true, \"" + strBytes + "\", \"" + strBytes + "\", null, {" + Utils.LINE_SEPARATOR +
       "  \"foo\" : \"bar\"" + Utils.LINE_SEPARATOR +
-      "}, [ \"foo\", 123 ] ]";
+      "}, [ \"foo\", 123 ], \"12:34:56.123\" ]";
     String json = mapper.toString(jsonArray, true);
     assertEquals(expected, json);
   }
@@ -233,8 +285,20 @@ public class JsonCodecTest {
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
     Instant now = Instant.now();
     String strInstant = ISO_INSTANT.format(now);
-    String json = "{\"mystr\":\"foo\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
-      "myboolean\":true,\"mybyte\":124,\"mybinary\":\"" + strBytes + "\",\"mybuffer\":\"" + strBytes + "\",\"myinstant\":\"" + strInstant + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}";
+    String json = "{\"mystr\":\"foo\","
+      + "\"myint\":123,"
+      + "\"mylong\":1234,"
+      + "\"myfloat\":1.23,"
+      + "\"mydouble\":2.34,"
+      + "\"myboolean\":true,"
+      + "\"mybyte\":124,"
+      + "\"mybinary\":\"" + strBytes + "\","
+      + "\"mybuffer\":\"" + strBytes + "\","
+      + "\"myinstant\":\"" + strInstant + "\","
+      + "\"mylocaltime\":\"12:34:56.123\","
+      + "\"mynull\":null,"
+      + "\"myobj\":{\"foo\":\"bar\"},"
+      + "\"myarr\":[\"foo\",123]}";
     JsonObject obj = new JsonObject(mapper.fromString(json, Map.class));
     assertEquals(json, mapper.toString(obj));
     assertEquals("foo", obj.getString("mystr"));
@@ -250,6 +314,9 @@ public class JsonCodecTest {
     assertEquals(BASE64_ENCODER.encodeToString(bytes), obj.getValue("mybuffer"));
     assertEquals(now, obj.getInstant("myinstant"));
     assertEquals(now.toString(), obj.getValue("myinstant"));
+    LocalTime localTime = LocalTime.parse("12:34:56.123");
+    assertEquals(localTime, obj.getLocalTime("mylocaltime"));
+    assertEquals(localTime.toString(), obj.getValue("mylocaltime"));
     assertTrue(obj.containsKey("mynull"));
     JsonObject nestedObj = obj.getJsonObject("myobj");
     assertEquals("bar", nestedObj.getString("foo"));
@@ -264,7 +331,20 @@ public class JsonCodecTest {
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
     Instant now = Instant.now();
     String strInstant = ISO_INSTANT.format(now);
-    String json = "[\"foo\",123,1234,1.23,2.34,true,124,\"" + strBytes + "\",\"" + strBytes + "\",\"" + strInstant + "\",null,{\"foo\":\"bar\"},[\"foo\",123]]";
+    String json = "[\"foo\","
+      + "123,"
+      + "1234,"
+      + "1.23,"
+      + "2.34,"
+      + "true,"
+      + "124,"
+      + "\"" + strBytes + "\","
+      + "\"" + strBytes + "\","
+      + "\"" + strInstant + "\","
+      + "null,"
+      + "{\"foo\":\"bar\"},"
+      + "[\"foo\",123],"
+      + "\"12:34:56.123\"]";
     JsonArray arr = new JsonArray(mapper.fromString(json, List.class));
     assertEquals("foo", arr.getString(0));
     assertEquals(Integer.valueOf(123), arr.getInteger(1));
@@ -285,6 +365,9 @@ public class JsonCodecTest {
     JsonArray arr2 = arr.getJsonArray(12);
     assertEquals("foo", arr2.getString(0));
     assertEquals(Integer.valueOf(123), arr2.getInteger(1));
+    LocalTime localTime = LocalTime.parse("12:34:56.123");
+    assertEquals(localTime, arr.getLocalTime(13));
+    assertEquals(localTime.toString(), arr.getValue(13));
   }
 
   // Strict JSON doesn't allow comments but we do so users can add comments to config files etc
@@ -376,6 +459,24 @@ public class JsonCodecTest {
     Instant now = Instant.now();
     String json = '"' + ISO_INSTANT.format(now) + '"';
     Instant decoded = mapper.fromString(json, Instant.class);
+    assertEquals(now, decoded);
+  }
+
+  @Test
+  public void encodeCustomTypeLocalTime() {
+    LocalTime now = LocalTime.now();
+    String json = mapper.toString(now);
+    assertNotNull(json);
+    // the RFC is one way only
+    LocalTime decoded = LocalTime.from(ISO_LOCAL_TIME.parse(json.substring(1, json.length() - 1)));
+    assertEquals(now, decoded);
+  }
+
+  @Test
+  public void decodeCustomTypeLocalTime() {
+    LocalTime now = LocalTime.now();
+    String json = '"' + ISO_LOCAL_TIME.format(now) + '"';
+    LocalTime decoded = mapper.fromString(json, LocalTime.class);
     assertEquals(now, decoded);
   }
 
@@ -517,6 +618,9 @@ public class JsonCodecTest {
     Instant instant = Instant.ofEpochMilli(0);
     assertEquals("{\"key\":\"1970-01-01T00:00:00Z\"}", checkMap(instant));
     assertEquals("[\"1970-01-01T00:00:00Z\"]", checkList(instant));
+    LocalTime localTime = LocalTime.NOON;
+    assertEquals("{\"key\":\"12:00:00\"}", checkMap(localTime));
+    assertEquals("[\"12:00:00\"]", checkList(localTime));
     assertEquals("{\"key\":\"MICROSECONDS\"}", checkMap(TimeUnit.MICROSECONDS));
     assertEquals("[\"MICROSECONDS\"]", checkList(TimeUnit.MICROSECONDS));
     BigInteger bigInt = new BigInteger("123456789");

--- a/src/test/java/io/vertx/core/json/JsonCodecTest.java
+++ b/src/test/java/io/vertx/core/json/JsonCodecTest.java
@@ -18,6 +18,7 @@ import io.vertx.core.impl.Utils;
 import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.core.json.jackson.JacksonCodec;
 import io.vertx.test.core.TestUtils;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -91,6 +93,8 @@ public class JsonCodecTest {
     jsonObject.put("myinstant", now);
     LocalTime localTime = LocalTime.now();
     jsonObject.put("mylocaltime", localTime);
+    LocalDate localDate = LocalDate.now();
+    jsonObject.put("mylocaldate", localDate);
     jsonObject.putNull("mynull");
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
@@ -107,6 +111,7 @@ public class JsonCodecTest {
       + "\"mybuffer\":\"" + strBytes + "\","
       + "\"myinstant\":\"" + ISO_INSTANT.format(now) + "\","
       + "\"mylocaltime\":\"" + ISO_LOCAL_TIME.format(localTime) + "\","
+      + "\"mylocaldate\":\"" + ISO_LOCAL_DATE.format(localDate) + "\","
       + "\"mynull\":null,"
       + "\"myobj\":{\"foo\":\"bar\"},"
       + "\"myarr\":[\"foo\",123]"
@@ -132,6 +137,7 @@ public class JsonCodecTest {
     jsonArray.add(new JsonObject().put("foo", "bar"));
     jsonArray.add(new JsonArray().add("foo").add(123));
     jsonArray.add(LocalTime.NOON);
+    jsonArray.add(LocalDate.parse("2022-02-22"));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
 
     String expected = "["
@@ -146,7 +152,8 @@ public class JsonCodecTest {
       + "null,"
       + "{\"foo\":\"bar\"},"
       + "[\"foo\",123],"
-      + "\"12:00:00\""
+      + "\"12:00:00\","
+      + "\"2022-02-22\""
       + "]";
     String json = mapper.toString(jsonArray);
     assertEquals(expected, json);
@@ -168,6 +175,8 @@ public class JsonCodecTest {
     jsonObject.put("myinstant", now);
     LocalTime localTime = LocalTime.now();
     jsonObject.put("mylocaltime", localTime);
+    LocalDate localDate = LocalDate.now();
+    jsonObject.put("mylocaldate", localDate);
     jsonObject.putNull("mynull");
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
@@ -184,6 +193,7 @@ public class JsonCodecTest {
       + "\"mybuffer\":\"" + strBytes + "\","
       + "\"myinstant\":\"" + ISO_INSTANT.format(now) + "\","
       + "\"mylocaltime\":\"" + ISO_LOCAL_TIME.format(localTime) + "\","
+      + "\"mylocaldate\":\"" + ISO_LOCAL_DATE.format(localDate) + "\","
       + "\"mynull\":null,"
       + "\"myobj\":{\"foo\":\"bar\"},"
       + "\"myarr\":[\"foo\",123]"
@@ -209,8 +219,9 @@ public class JsonCodecTest {
     jsonArray.add(new JsonObject().put("foo", "bar"));
     jsonArray.add(new JsonArray().add("foo").add(123));
     jsonArray.add(LocalTime.parse("12:34:56.123"));
+    jsonArray.add(LocalDate.parse("2022-02-22"));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
-    Buffer expected = Buffer.buffer("[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123],\"12:34:56.123\"]", "UTF-8");
+    Buffer expected = Buffer.buffer("[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123],\"12:34:56.123\",\"2022-02-22\"]", "UTF-8");
     Buffer json = mapper.toBuffer(jsonArray);
     assertArrayEquals(expected.getBytes(), json.getBytes());
   }
@@ -231,6 +242,7 @@ public class JsonCodecTest {
     Instant now = Instant.now();
     jsonObject.put("myinstant", now);
     jsonObject.put("mylocaltime", LocalTime.parse("12:34:56.123"));
+    jsonObject.put("mylocaldate", LocalDate.parse("2022-0-22"));
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
@@ -246,6 +258,7 @@ public class JsonCodecTest {
       "  \"mybuffer\" : \"" + strBytes + "\"," + Utils.LINE_SEPARATOR +
       "  \"myinstant\" : \"" + strInstant + "\"," + Utils.LINE_SEPARATOR +
       "  \"mylocaltime\" : \"12:34:56.123\"," + Utils.LINE_SEPARATOR +
+      "  \"mylocaldate\" : \"2022-02-22\"," + Utils.LINE_SEPARATOR +
       "  \"myobj\" : {" + Utils.LINE_SEPARATOR +
       "    \"foo\" : \"bar\"" + Utils.LINE_SEPARATOR +
       "  }," + Utils.LINE_SEPARATOR +
@@ -271,10 +284,11 @@ public class JsonCodecTest {
     jsonArray.add(new JsonObject().put("foo", "bar"));
     jsonArray.add(new JsonArray().add("foo").add(123));
     jsonArray.add(LocalTime.parse("12:34:56.123"));
+    jsonArray.add(LocalDate.parse("2022-02-22"));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);
     String expected = "[ \"foo\", 123, 1234, 1.23, 2.34, true, \"" + strBytes + "\", \"" + strBytes + "\", null, {" + Utils.LINE_SEPARATOR +
       "  \"foo\" : \"bar\"" + Utils.LINE_SEPARATOR +
-      "}, [ \"foo\", 123 ], \"12:34:56.123\" ]";
+      "}, [ \"foo\", 123 ], \"12:34:56.123\", \"2022-02-22\" ]";
     String json = mapper.toString(jsonArray, true);
     assertEquals(expected, json);
   }
@@ -296,6 +310,7 @@ public class JsonCodecTest {
       + "\"mybuffer\":\"" + strBytes + "\","
       + "\"myinstant\":\"" + strInstant + "\","
       + "\"mylocaltime\":\"12:34:56.123\","
+      + "\"mylocaldate\":\"2022-02-22\","
       + "\"mynull\":null,"
       + "\"myobj\":{\"foo\":\"bar\"},"
       + "\"myarr\":[\"foo\",123]}";
@@ -317,6 +332,9 @@ public class JsonCodecTest {
     LocalTime localTime = LocalTime.parse("12:34:56.123");
     assertEquals(localTime, obj.getLocalTime("mylocaltime"));
     assertEquals(localTime.toString(), obj.getValue("mylocaltime"));
+    LocalDate localDate = LocalDate.parse("2022-02-22");
+    assertEquals(localDate, obj.getLocalDate("mylocaldate"));
+    assertEquals(localDate.toString(), obj.getValue("mylocaldate"));
     assertTrue(obj.containsKey("mynull"));
     JsonObject nestedObj = obj.getJsonObject("myobj");
     assertEquals("bar", nestedObj.getString("foo"));
@@ -344,7 +362,8 @@ public class JsonCodecTest {
       + "null,"
       + "{\"foo\":\"bar\"},"
       + "[\"foo\",123],"
-      + "\"12:34:56.123\"]";
+      + "\"12:34:56.123\","
+      + "\"2022-02-22\"]";
     JsonArray arr = new JsonArray(mapper.fromString(json, List.class));
     assertEquals("foo", arr.getString(0));
     assertEquals(Integer.valueOf(123), arr.getInteger(1));
@@ -368,6 +387,9 @@ public class JsonCodecTest {
     LocalTime localTime = LocalTime.parse("12:34:56.123");
     assertEquals(localTime, arr.getLocalTime(13));
     assertEquals(localTime.toString(), arr.getValue(13));
+    LocalDate localDate = LocalDate.parse("2022-02-22");
+    assertEquals(localDate, arr.getLocalDate(14));
+    assertEquals(localDate.toString(), arr.getValue(14));
   }
 
   // Strict JSON doesn't allow comments but we do so users can add comments to config files etc
@@ -477,6 +499,24 @@ public class JsonCodecTest {
     LocalTime now = LocalTime.now();
     String json = '"' + ISO_LOCAL_TIME.format(now) + '"';
     LocalTime decoded = mapper.fromString(json, LocalTime.class);
+    assertEquals(now, decoded);
+  }
+
+  @Test
+  public void encodeCustomTypeLocalDate() {
+    LocalDate now = LocalDate.now();
+    String json = mapper.toString(now);
+    assertNotNull(json);
+    // the RFC is one way only
+    LocalDate decoded = LocalDate.from(ISO_LOCAL_DATE.parse(json.substring(1, json.length() - 1)));
+    assertEquals(now, decoded);
+  }
+
+  @Test
+  public void decodeCustomTypeLocalDate() {
+    LocalDate now = LocalDate.now();
+    String json = '"' + ISO_LOCAL_DATE.format(now) + '"';
+    LocalDate decoded = mapper.fromString(json, LocalDate.class);
     assertEquals(now, decoded);
   }
 
@@ -621,6 +661,9 @@ public class JsonCodecTest {
     LocalTime localTime = LocalTime.NOON;
     assertEquals("{\"key\":\"12:00:00\"}", checkMap(localTime));
     assertEquals("[\"12:00:00\"]", checkList(localTime));
+    LocalDate localDate = LocalDate.parse("2022-02-22");
+    assertEquals("{\"key\":\"2022-02-22\"}", checkMap(localDate));
+    assertEquals("[\"2022-02-22\"]", checkList(localDate));
     assertEquals("{\"key\":\"MICROSECONDS\"}", checkMap(TimeUnit.MICROSECONDS));
     assertEquals("[\"MICROSECONDS\"]", checkList(TimeUnit.MICROSECONDS));
     BigInteger bigInt = new BigInteger("123456789");

--- a/src/test/java/io/vertx/core/json/JsonCodecTest.java
+++ b/src/test/java/io/vertx/core/json/JsonCodecTest.java
@@ -242,7 +242,7 @@ public class JsonCodecTest {
     Instant now = Instant.now();
     jsonObject.put("myinstant", now);
     jsonObject.put("mylocaltime", LocalTime.parse("12:34:56.123"));
-    jsonObject.put("mylocaldate", LocalDate.parse("2022-0-22"));
+    jsonObject.put("mylocaldate", LocalDate.parse("2022-02-22"));
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
     String strBytes = BASE64_ENCODER.encodeToString(bytes);

--- a/src/test/java/io/vertx/core/json/JsonObjectTest.java
+++ b/src/test/java/io/vertx/core/json/JsonObjectTest.java
@@ -17,6 +17,7 @@ import io.vertx.test.core.TestUtils;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,6 +37,7 @@ import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static org.junit.Assert.*;
 
 /**
@@ -1744,6 +1746,7 @@ public class JsonObjectTest {
     obj.put("mylocaltime", LocalTime.now());
     obj.put("mylocaldate", LocalDate.now());
     obj.put("mylocaldatetime", LocalDateTime.now());
+    obj.put("myoffsetdatetime", OffsetDateTime.now());
     return obj;
   }
 
@@ -1803,6 +1806,10 @@ public class JsonObjectTest {
     json.getMap().put("localDateTime", localDateTime);
     assertEquals(localDateTime, json.getLocalDateTime("localDateTime"));
     assertSame(localDateTime, json.getLocalDateTime("localDateTime"));
+    OffsetDateTime offsetDateTime = OffsetDateTime.now();
+    json.getMap().put("offsetDateTime", offsetDateTime);
+    assertEquals(offsetDateTime, json.getOffsetDateTime("offsetDateTime"));
+    assertSame(offsetDateTime, json.getOffsetDateTime("offsetDateTime"));
   }
 
   @Test
@@ -2349,6 +2356,138 @@ public class JsonObjectTest {
   @Test
   public void testPutLocalDateTimeAsObject() {
     Object localDateTime = LocalDateTime.now();
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.put("foo", localDateTime);
+    // assert data is stored as String
+    assertTrue(jsonObject.getValue("foo") instanceof String);
+  }
+
+  @Test
+  public void testGetOffsetDateTime() {
+    OffsetDateTime now = OffsetDateTime.now();
+    jsonObject.put("foo", now);
+    assertEquals(now, jsonObject.getOffsetDateTime("foo"));
+    assertEquals(now.toString(), jsonObject.getValue("foo"));
+
+    // Can also get as string:
+    String val = jsonObject.getString("foo");
+    assertNotNull(val);
+    OffsetDateTime retrieved = OffsetDateTime.from(ISO_OFFSET_DATE_TIME.parse(val));
+    assertEquals(now, retrieved);
+
+    jsonObject.put("foo", 123);
+    try {
+      jsonObject.getOffsetDateTime("foo");
+      fail();
+    } catch (ClassCastException e) {
+      // Ok
+    }
+
+    jsonObject.putNull("foo");
+    assertNull(jsonObject.getOffsetDateTime("foo"));
+    assertNull(jsonObject.getValue("foo"));
+    assertNull(jsonObject.getOffsetDateTime("absent"));
+    assertNull(jsonObject.getValue("absent"));
+    try {
+      jsonObject.getOffsetDateTime(null);
+      fail();
+    } catch (NullPointerException e) {
+      // OK
+    }
+    try {
+      jsonObject.getValue(null);
+      fail();
+    } catch (NullPointerException e) {
+      // OK
+    }
+    try {
+      jsonObject.getOffsetDateTime(null, null);
+      fail();
+    } catch (NullPointerException e) {
+      // OK
+    }
+    try {
+      jsonObject.getValue(null, null);
+      fail();
+    } catch (NullPointerException e) {
+      // OK
+    }
+  }
+
+  @Test
+  public void testGetOffsetDateTimeDefault() {
+    OffsetDateTime now = OffsetDateTime.now();
+    OffsetDateTime later = now.plus(1, ChronoUnit.DAYS);
+    jsonObject.put("foo", now);
+    assertEquals(now, jsonObject.getOffsetDateTime("foo", later));
+    assertEquals(now.toString(), jsonObject.getValue("foo", later));
+    assertEquals(now, jsonObject.getOffsetDateTime("foo", null));
+    assertEquals(now.toString(), jsonObject.getValue("foo", null));
+
+    jsonObject.put("foo", 123);
+    try {
+      jsonObject.getOffsetDateTime("foo", later);
+      fail();
+    } catch (ClassCastException e) {
+      // Ok
+    }
+
+    jsonObject.putNull("foo");
+    assertNull(jsonObject.getOffsetDateTime("foo", later));
+    assertEquals(later, jsonObject.getOffsetDateTime("absent", later));
+    assertEquals(later, jsonObject.getValue("absent", later));
+    assertNull(jsonObject.getOffsetDateTime("foo", null));
+    assertNull(jsonObject.getValue("foo", null));
+    assertNull(jsonObject.getOffsetDateTime("absent", null));
+    assertNull(jsonObject.getValue("absent", null));
+    try {
+      jsonObject.getOffsetDateTime(null, null);
+      fail();
+    } catch (NullPointerException e) {
+      // OK
+    }
+    try {
+      jsonObject.getValue(null, null);
+      fail();
+    } catch (NullPointerException e) {
+      // OK
+    }
+  }
+
+  @Test
+  public void testPutOffsetDateTime() {
+    OffsetDateTime day1 = OffsetDateTime.now();
+    OffsetDateTime day2 = day1.plus(1, ChronoUnit.DAYS);
+    OffsetDateTime day3 = day2.plus(1, ChronoUnit.DAYS);
+
+    assertSame(jsonObject, jsonObject.put("foo", day1));
+    assertEquals(day1, jsonObject.getOffsetDateTime("foo"));
+    assertEquals(day1.toString(), jsonObject.getValue("foo"));
+
+    jsonObject.put("fum", day2);
+    assertEquals(day2, jsonObject.getOffsetDateTime("fum"));
+    assertEquals(day2.toString(), jsonObject.getValue("fum"));
+    assertEquals(day1, jsonObject.getOffsetDateTime("foo"));
+    assertEquals(day1.toString(), jsonObject.getValue("foo"));
+
+    jsonObject.put("foo", day3);
+    assertEquals(day3, jsonObject.getOffsetDateTime("foo"));
+    assertEquals(day3.toString(), jsonObject.getValue("foo"));
+
+    jsonObject.put("foo", null);
+    assertTrue(jsonObject.containsKey("foo"));
+
+    try {
+      jsonObject.put(null, day1);
+      fail();
+    } catch (NullPointerException e) {
+      // OK
+    }
+  }
+
+  @Test
+  public void testPutOffsetDateTimeAsObject() {
+    Object localDateTime = OffsetDateTime.now();
     JsonObject jsonObject = new JsonObject();
     jsonObject.put("foo", localDateTime);
     // assert data is stored as String

--- a/src/test/java/io/vertx/core/json/JsonObjectTest.java
+++ b/src/test/java/io/vertx/core/json/JsonObjectTest.java
@@ -18,6 +18,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -2487,9 +2489,9 @@ public class JsonObjectTest {
 
   @Test
   public void testPutOffsetDateTimeAsObject() {
-    Object localDateTime = OffsetDateTime.now();
+    Object offsetDateTime = OffsetDateTime.now();
     JsonObject jsonObject = new JsonObject();
-    jsonObject.put("foo", localDateTime);
+    jsonObject.put("foo", offsetDateTime);
     // assert data is stored as String
     assertTrue(jsonObject.getValue("foo") instanceof String);
   }

--- a/src/test/java/io/vertx/core/json/JsonObjectTest.java
+++ b/src/test/java/io/vertx/core/json/JsonObjectTest.java
@@ -796,8 +796,9 @@ public class JsonObjectTest {
     jsonObject = new JsonObject(map);
     arr = (JsonArray)jsonObject.getValue("foo");
     assertEquals("blah", arr.getString(0));
-    jsonObject.put("foo", LocalTime.NOON);
-    assertEquals("12:00:00", jsonObject.getValue("foo"));
+    LocalTime now = LocalTime.now();
+    jsonObject.put("foo", now);
+    assertEquals(now.toString(), jsonObject.getValue("foo"));
   }
 
   @Test
@@ -840,9 +841,10 @@ public class JsonObjectTest {
     assertNull(jsonObject.getValue("foo", null));
     assertEquals("blah", jsonObject.getValue("absent", "blah"));
     assertNull(jsonObject.getValue("absent", null));
-    jsonObject.put("foo", LocalTime.NOON);
-    assertEquals("12:00:00", jsonObject.getValue("foo", "blah"));
-    assertEquals("12:00:00", jsonObject.getValue("foo", null));
+    LocalTime now = LocalTime.now();
+    jsonObject.put("foo", now);
+    assertEquals(now.toString(), jsonObject.getValue("foo", "blah"));
+    assertEquals(now.toString(), jsonObject.getValue("foo", null));
   }
 
   @Test

--- a/src/test/java/io/vertx/core/json/JsonPOJOMapperTest.java
+++ b/src/test/java/io/vertx/core/json/JsonPOJOMapperTest.java
@@ -14,6 +14,7 @@ package io.vertx.core.json;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import io.vertx.core.buffer.Buffer;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
@@ -153,26 +154,32 @@ public class JsonPOJOMapperTest {
     JavaTimeTypes j = new JsonObject()
       .put("localTime", LocalTime.NOON)
       .put("localDate", LocalDate.parse("2022-02-22"))
+      .put("localDateTime", LocalDateTime.parse("2022-02-22T01:02:03.123456000"))
       .mapTo(JavaTimeTypes.class);
     assertEquals(LocalTime.NOON, j.localTime);
     assertEquals(LocalDate.parse("2022-02-22"), j.localDate);
+    assertEquals(LocalDateTime.parse("2022-02-22T01:02:03.123456000"), j.localDateTime);
   }
 
   @Test
   public void testJavaTimesFromObjectMapping() {
     JsonObject json = JsonObject.mapFrom(new JavaTimeTypes());
     assertEquals(LocalTime.NOON, json.getLocalTime("localTime"));
+    assertEquals(LocalDate.parse("2022-02-22"), json.getLocalDate("localDate"));
+    assertEquals(LocalDateTime.parse("2022-02-22T01:02:03.123456000"), json.getLocalDateTime("localDateTime"));
   }
 
   @Test
   public void testInvalidJavaTimeTypes() {
     testInvalidValueToPOJO("localTime", JavaTimeTypes.class);
     testInvalidValueToPOJO("localDate", JavaTimeTypes.class);
+    testInvalidValueToPOJO("localDateTime", JavaTimeTypes.class);
   }
 
   public static class JavaTimeTypes {
     public LocalTime localTime = LocalTime.NOON;
     public LocalDate localDate = LocalDate.parse("2022-02-22");
+    public LocalDateTime localDateTime = LocalDateTime.parse("2022-02-22T01:02:03.123456000");
   }
 
   private void testInvalidValueToPOJO(String key) {

--- a/src/test/java/io/vertx/core/json/JsonPOJOMapperTest.java
+++ b/src/test/java/io/vertx/core/json/JsonPOJOMapperTest.java
@@ -13,6 +13,8 @@ package io.vertx.core.json;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import io.vertx.core.buffer.Buffer;
+import java.time.LocalTime;
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
 import java.time.Instant;
@@ -87,6 +89,7 @@ public class JsonPOJOMapperTest {
 
   public static class MyType2 {
     public Instant isodate = Instant.now();
+    public LocalTime localTime = LocalTime.NOON;
     public byte[] base64 = "Hello World!".getBytes();
   }
 
@@ -145,7 +148,7 @@ public class JsonPOJOMapperTest {
       new JsonObject().put(key, "1").mapTo(MyType2.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e.getCause(), is(instanceOf(InvalidFormatException.class)));
+      MatcherAssert.assertThat(e.getCause(), instanceOf(InvalidFormatException.class));
       InvalidFormatException ife = (InvalidFormatException) e.getCause();
       assertEquals("1", ife.getValue());
     }
@@ -156,4 +159,24 @@ public class JsonPOJOMapperTest {
     assertNull(JsonObject.mapFrom(null));
   }
 
+  @Test
+  public void testJavaTimesToObjectMapping() {
+    JavaTimeTypes j = new JsonObject().put("localTime", LocalTime.NOON).mapTo(JavaTimeTypes.class);
+    assertEquals(LocalTime.NOON, j.localTime);
+  }
+
+  @Test
+  public void testJavaTimesFromObjectMapping() {
+    JsonObject json = JsonObject.mapFrom(new JavaTimeTypes());
+    assertEquals(LocalTime.NOON, json.getLocalTime("localTime"));
+  }
+
+  @Test
+  public void testInvalidLocalTime() {
+    testInvalidValueToPOJO("localTime");
+  }
+
+  public static class JavaTimeTypes {
+    public LocalTime localTime = LocalTime.NOON;
+  }
 }

--- a/src/test/java/io/vertx/core/json/JsonPOJOMapperTest.java
+++ b/src/test/java/io/vertx/core/json/JsonPOJOMapperTest.java
@@ -16,6 +16,7 @@ import io.vertx.core.buffer.Buffer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
@@ -155,10 +156,12 @@ public class JsonPOJOMapperTest {
       .put("localTime", LocalTime.NOON)
       .put("localDate", LocalDate.parse("2022-02-22"))
       .put("localDateTime", LocalDateTime.parse("2022-02-22T01:02:03.123456000"))
+      .put("offsetDateTime", OffsetDateTime.parse("2022-02-22T01:02:03.123456000+02:00"))
       .mapTo(JavaTimeTypes.class);
     assertEquals(LocalTime.NOON, j.localTime);
     assertEquals(LocalDate.parse("2022-02-22"), j.localDate);
     assertEquals(LocalDateTime.parse("2022-02-22T01:02:03.123456000"), j.localDateTime);
+    assertEquals(OffsetDateTime.parse("2022-02-22T01:02:03.123456000+02:00"), j.offsetDateTime);
   }
 
   @Test
@@ -167,6 +170,7 @@ public class JsonPOJOMapperTest {
     assertEquals(LocalTime.NOON, json.getLocalTime("localTime"));
     assertEquals(LocalDate.parse("2022-02-22"), json.getLocalDate("localDate"));
     assertEquals(LocalDateTime.parse("2022-02-22T01:02:03.123456000"), json.getLocalDateTime("localDateTime"));
+    assertEquals(OffsetDateTime.parse("2022-02-22T01:02:03.123456000+02:00"), json.getOffsetDateTime("offsetDateTime"));
   }
 
   @Test
@@ -174,12 +178,14 @@ public class JsonPOJOMapperTest {
     testInvalidValueToPOJO("localTime", JavaTimeTypes.class);
     testInvalidValueToPOJO("localDate", JavaTimeTypes.class);
     testInvalidValueToPOJO("localDateTime", JavaTimeTypes.class);
+    testInvalidValueToPOJO("offsetDateTime", JavaTimeTypes.class);
   }
 
   public static class JavaTimeTypes {
     public LocalTime localTime = LocalTime.NOON;
     public LocalDate localDate = LocalDate.parse("2022-02-22");
     public LocalDateTime localDateTime = LocalDateTime.parse("2022-02-22T01:02:03.123456000");
+    public OffsetDateTime offsetDateTime = OffsetDateTime.parse("2022-02-22T01:02:03.123456000+02:00");
   }
 
   private void testInvalidValueToPOJO(String key) {


### PR DESCRIPTION
Motivation:

The `@DataObject` when used together with e.g. PostgreSQL have trouble mapping `TIMESTAMPTZ` column directly to JsonObject. This PR adds direct support for some common java.time types:
* LocalTime
* LocalDate
* LocalDateTime
* OffsetDateTime

Relates to [thced:feat/support-more-java-time-types#344](https://github.com/eclipse-vertx/vertx-codegen/pull/344)