### PR TITLE
Add isPaused() method to HttpServerRequest

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -432,6 +432,13 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   boolean isEnded();
 
   /**
+   * Is the request paused?
+   *
+   * @return true if paused
+   */
+  boolean isPaused();
+
+  /**
    * Set a custom frame handler. The handler will get notified when the http stream receives an custom HTTP/2
    * frame. HTTP/2 permits extension of the protocol.
    *

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -493,6 +493,13 @@ public class Http1xServerRequest implements HttpServerRequestInternal, io.vertx.
   }
 
   @Override
+  public boolean isPaused() {
+    synchronized(conn) {
+      return pendingQueue().isPaused();
+    }
+  }
+
+  @Override
   public HttpServerRequest customFrameHandler(Handler<HttpFrame> handler) {
     return this;
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -300,6 +300,13 @@ public class Http2ServerRequest extends Http2ServerStream implements HttpServerR
   }
 
   @Override
+  public boolean isPaused() {
+    synchronized(conn) {
+      return super.isPaused();
+    }
+  }
+
+  @Override
   public HttpServerRequest resume() {
     return fetch(Long.MAX_VALUE);
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -301,7 +301,7 @@ public class Http2ServerRequest extends Http2ServerStream implements HttpServerR
 
   @Override
   public boolean isPaused() {
-    synchronized(conn) {
+    synchronized (conn) {
       return super.isPaused();
     }
   }

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -150,6 +150,10 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
     return bytesRead;
   }
 
+  public boolean isPaused() {
+    return pending.isPaused();
+  }
+
   public void doPause() {
     pending.pause();
   }


### PR DESCRIPTION
Motivation:

Sometimes it is necessary to pause the request before handling it - for example if you intend to make some async calls and then call `toWebSocket()` on it. During that processing, the modules you call may in turn themselves want to pause the request.

In order to write such modules and make them composable, the module must be able to return the request to the state it was previously in (flowing or fetch). That is, you want to be able to do something like:

    boolean wasPaused = request.isPaused();
    request.pause(); // unconditional pause
    ... do stuff with a paused request...
    // restore the state of the request to whatever it was before
    if (!wasPaused) {
        request.resume()
    }

In order to do that you need to know if the request is paused or not. This PR adds an `isPaused()` method to the `HttpServerRequest` for that purpose.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
