### PR TITLE
WebSocket handshake completion timeout

### DIFF
--- a/src/main/java/io/vertx/core/http/WebSocketConnectOptions.java
+++ b/src/main/java/io/vertx/core/http/WebSocketConnectOptions.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.http;
 
+import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.MultiMap;
@@ -178,6 +179,18 @@ public class WebSocketConnectOptions extends RequestOptions {
   @Override
   public WebSocketConnectOptions setURI(String uri) {
     return (WebSocketConnectOptions) super.setURI(uri);
+  }
+
+  /**
+   * Sets the amount of time after which if the WebSocket handshake does not happen within the timeout period an
+   * {@link WebSocketHandshakeException} will be passed to the exception handler and the connection will be closed.
+   *
+   * @param timeout the amount of time in milliseconds.
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Override
+  public WebSocketConnectOptions setTimeout(long timeout) {
+    return (WebSocketConnectOptions) super.setTimeout(timeout);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -339,7 +339,15 @@ public class HttpClientImpl implements HttpClient, MetricsProvider, Closeable {
       ar -> {
         if (ar.succeeded()) {
           Http1xClientConnection conn = (Http1xClientConnection) ar.result();
-          conn.toWebSocket(ctx, connectOptions.getURI(), connectOptions.getHeaders(), connectOptions.getAllowOriginHeader(), connectOptions.getVersion(), connectOptions.getSubProtocols(), HttpClientImpl.this.options.getMaxWebSocketFrameSize(), promise);
+          conn.toWebSocket(ctx,
+            connectOptions.getURI(),
+            connectOptions.getHeaders(),
+            connectOptions.getAllowOriginHeader(),
+            connectOptions.getVersion(),
+            connectOptions.getSubProtocols(),
+            connectOptions.getTimeout(),
+            HttpClientImpl.this.options.getMaxWebSocketFrameSize(),
+            promise);
         } else {
           promise.fail(ar.cause());
         }


### PR DESCRIPTION
The HttpClient does not have a timeout for handshake completion. After the connection has been established with the server, we can set a timeout to fire if the server has not responded with the handshake response timely.

See #4323