### PR TITLE
bugfix: internal NetServer of ClusterEventBus closed too early. fixes #4326

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.eventbus.impl.clustered;
 
+import io.vertx.core.Closeable;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
@@ -96,6 +97,7 @@ public class ClusteredEventBus extends EventBusImpl {
       clusterManager.setNodeInfo(nodeInfo, setPromise);
       return setPromise.future();
     }).onSuccess(v -> {
+      vertx.removeCloseHook((Closeable) server);
       started = true;
       nodeSelector.eventBusStarted();
     }).onComplete(promise);

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -581,14 +581,14 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
         }
         haPromise.future().onComplete(ar2 -> {
           addressResolver.close(ar3 -> {
-            Promise<Void> ebClose = getOrCreateContext().promise();
-            eventBus.close(ebClose);
-            ebClose.future().onComplete(ar4 -> {
-              closeClusterManager(ar5 -> {
-                // Copy set to prevent ConcurrentModificationException
-                deleteCacheDirAndShutdown(completionHandler);
+              closeClusterManager(ar4 -> {
+                Promise<Void> ebClose = getOrCreateContext().promise();
+                eventBus.close(ebClose);
+                ebClose.future().onComplete(ar5 -> {
+                  // Copy set to prevent ConcurrentModificationException
+                  deleteCacheDirAndShutdown(completionHandler);
+                });
               });
-            });
           });
         });
       });


### PR DESCRIPTION

Signed-off-by: Markus Spika <markus.spika@gmail.com>

Motivation:

was looking for this over a year now! finally found it....

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
