### PR TITLE
Support yaml files on the use of "-conf"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,10 @@
       <artifactId>jackson-databind</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
 
     <!-- Loggers -->
     <dependency>


### PR DESCRIPTION
Motivation:

Try to provide support to the use of the flag "-conf" with YAML files

Eg: 
```java -jar target/my-project.jar -conf target/config.yaml```

The approach is similar to the one used on io.vertx.config.yaml.YamlProcessor