### PR TITLE
Update BareCommand to support argument processor on cli

### DIFF
--- a/src/main/java/io/vertx/core/spi/cli/CliJsonProcessor.java
+++ b/src/main/java/io/vertx/core/spi/cli/CliJsonProcessor.java
@@ -1,0 +1,11 @@
+package io.vertx.core.spi.cli;
+
+import io.vertx.core.json.JsonObject;
+
+public interface CliJsonProcessor {
+
+  String name();
+
+  JsonObject process(String content);
+
+}

--- a/src/main/java/io/vertx/core/spi/cli/CliJsonProcessors.java
+++ b/src/main/java/io/vertx/core/spi/cli/CliJsonProcessors.java
@@ -1,0 +1,29 @@
+package io.vertx.core.spi.cli;
+
+import java.util.Collection;
+import java.util.HashMap;
+
+import io.vertx.core.ServiceHelper;
+
+public class CliJsonProcessors {
+
+  private static final HashMap<String, CliJsonProcessor> CLI_JSON_PROCESSORS = new HashMap<>();
+
+  public CliJsonProcessors() {
+  }
+
+  static {
+    synchronized (CliJsonProcessors.class) {
+      Collection<CliJsonProcessor> cliJsonProcessors = ServiceHelper.loadFactories(CliJsonProcessor.class);
+      cliJsonProcessors.forEach(c -> CLI_JSON_PROCESSORS.put(c.name(), c));
+    }
+  }
+
+  public static CliJsonProcessor get(String format) {
+    synchronized (CliJsonProcessors.class) {
+      return CLI_JSON_PROCESSORS.get(format);
+    }
+  }
+
+
+}

--- a/src/main/java/io/vertx/core/spi/cli/DefaultCliJsonProcessor.java
+++ b/src/main/java/io/vertx/core/spi/cli/DefaultCliJsonProcessor.java
@@ -1,0 +1,16 @@
+package io.vertx.core.spi.cli;
+
+import io.vertx.core.json.JsonObject;
+
+public class DefaultCliJsonProcessor implements CliJsonProcessor {
+
+  @Override
+  public String name() {
+    return "json";
+  }
+
+  @Override
+  public JsonObject process(String content) {
+    return new JsonObject(content);
+  }
+}

--- a/src/main/resources/META-INF/services/io.vertx.core.spi.cli.CliJsonProcessor
+++ b/src/main/resources/META-INF/services/io.vertx.core.spi.cli.CliJsonProcessor
@@ -1,0 +1,10 @@
+# Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+io.vertx.core.spi.cli.DefaultCliJsonProcessor


### PR DESCRIPTION
New PR base from https://github.com/eclipse-vertx/vert.x/pull/4340

This will allow to each vertx-conf-{extension} to define another CliJsonProcessor(if is needed) to allow for example work with YAML files
