### PR TITLE
Enable using Supplier functions in sequential coordination of Futures

### DIFF
--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -300,9 +300,24 @@ public interface Future<T> extends AsyncResult<T> {
    * of the returned future.
    *
    * @param mapper the function returning the future.
-   * @return the composed future
+   * @return this future
    */
   <U> Future<T> eventually(Function<Void, Future<U>> mapper);
+
+  /**
+   * Compose this future with a {@code supplier} that will be always be called.
+   *
+   * <p>When this future (the one on which {@code eventually} is called) completes, the {@code supplier} will be called
+   * and this supplier returns another future object. This returned future completion will complete the future returned
+   * by this method call with the original result of the future.
+   *
+   * <p>The outcome of the future returned by the {@code supplier} will not influence the nature
+   * of the returned future.
+   *
+   * @param supplier the function returning the future.
+   * @return this future
+   */
+  <U> Future<T> eventually(Supplier<Future<U>> supplier);
 
   /**
    * Apply a {@code mapper} function on this future.<p>

--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -301,7 +301,9 @@ public interface Future<T> extends AsyncResult<T> {
    *
    * @param mapper the function returning the future.
    * @return this future
+   * @deprecated Use {@link #eventually(Supplier)}
    */
+  @Deprecated
   <U> Future<T> eventually(Function<Void, Future<U>> mapper);
 
   /**

--- a/src/main/java/io/vertx/core/impl/future/FutureBase.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureBase.java
@@ -18,6 +18,7 @@ import io.vertx.core.impl.ContextInternal;
 
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Future base implementation.
@@ -81,6 +82,15 @@ abstract class FutureBase<T> implements FutureInternal<T> {
     Objects.requireNonNull(successMapper, "No null success mapper accepted");
     Objects.requireNonNull(failureMapper, "No null failure mapper accepted");
     Composition<T, U> operation = new Composition<>(context, successMapper, failureMapper);
+    addListener(operation);
+    return operation;
+  }
+
+  @Override
+  public <U> Future<U> compose(Supplier<Future<U>> successSupplier, Function<Throwable, Future<U>> failureMapper) {
+    Objects.requireNonNull(successSupplier, "No null success supplier accepted");
+    Objects.requireNonNull(failureMapper, "No null failure mapper accepted");
+    Composition<T, U> operation = new Composition<>(context, unused -> successSupplier.get(), failureMapper);
     addListener(operation);
     return operation;
   }

--- a/src/main/java/io/vertx/core/impl/future/FutureBase.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureBase.java
@@ -112,6 +112,14 @@ abstract class FutureBase<T> implements FutureInternal<T> {
   }
 
   @Override
+  public <U> Future<T> eventually(Supplier<Future<U>> supplier) {
+    Objects.requireNonNull(supplier, "No null supplier accepted");
+    Eventually<T, U> operation = new Eventually<>(context, unused -> supplier.get());
+    addListener(operation);
+    return operation;
+  }
+
+  @Override
   public <U> Future<U> map(Function<T, U> mapper) {
     Objects.requireNonNull(mapper, "No null mapper accepted");
     Mapping<T, U> operation = new Mapping<>(context, mapper);


### PR DESCRIPTION
I sometimes find myself writing code like this:

```java
Future<Void> f = returnSomeVoidFuture();
f.compose(unused -> returnAnotherFuture());
```

The problem here is that when the unary `Function` argument is invoked, `unused` has the value `null`, so programmers must be careful not to reference it. To mitigate this danger, I have been using a naming convention for such unused parameters, but I think a better solution is to allow passing a nullary `Supplier` function instead:

```java
f.compose(() -> returnAnotherFuture());
```

This changeset adds support for that syntax, and similarly for `Future::eventually` (which has the same problem).

P.S. I think it would be nice if `Future::onComplete` and `Future::onSuccess` also supported this syntax, but that change seems much more difficult to implement in a backwards-compatible way.