### PR TITLE
Make ClusterSerializable extend impl.ClusterSerializable

### DIFF
--- a/src/main/java/io/vertx/core/shareddata/ClusterSerializable.java
+++ b/src/main/java/io/vertx/core/shareddata/ClusterSerializable.java
@@ -19,13 +19,14 @@ import io.vertx.core.buffer.Buffer;
  *
  * @implSpec Implementations must have a public no-argument constructor.
  */
-public interface ClusterSerializable {
+public interface ClusterSerializable extends io.vertx.core.shareddata.impl.ClusterSerializable {
 
   /**
    * Method invoked when serializing this instance.
    *
    * @param buffer the {@link Buffer} where the serialized bytes must be written to
    */
+  @Override
   void writeToBuffer(Buffer buffer);
 
   /**
@@ -35,5 +36,6 @@ public interface ClusterSerializable {
    * @param buffer the {@link Buffer} where the serialized bytes must be read from
    * @return the position after the last serialized byte
    */
+  @Override
   int readFromBuffer(int pos, Buffer buffer);
 }

--- a/src/main/java/io/vertx/core/shareddata/impl/Checker.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/Checker.java
@@ -14,7 +14,6 @@ package io.vertx.core.shareddata.impl;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
-import io.vertx.core.shareddata.ClusterSerializable;
 import io.vertx.core.shareddata.Shareable;
 
 import java.io.*;

--- a/src/main/java/io/vertx/core/shareddata/impl/ClusterSerializable.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/ClusterSerializable.java
@@ -17,11 +17,9 @@ import io.vertx.core.buffer.Buffer;
  * @deprecated as of 4.3, use {@link io.vertx.core.shareddata.ClusterSerializable} instead
  */
 @Deprecated
-public interface ClusterSerializable extends io.vertx.core.shareddata.ClusterSerializable {
+public interface ClusterSerializable {
 
-  @Override
   void writeToBuffer(Buffer buffer);
 
-  @Override
   int readFromBuffer(int pos, Buffer buffer);
 }

--- a/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
@@ -18,7 +18,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.impl.Arguments;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.shareddata.ClusterSerializable;
 import io.vertx.core.shareddata.*;
 import io.vertx.core.spi.cluster.ClusterManager;
 


### PR DESCRIPTION
This allows for smooth upgrades (mixing 4.3 and 4.2 nodes during migration)