### PR TITLE
HTPP client ignores direct H2C preface errors

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -610,8 +610,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
     ClientMetrics metrics,
     EventLoopContext context,
     boolean upgrade,
-    Object socketMetric,
-    Handler<Http2ClientConnection> c) {
+    Object socketMetric) {
     HttpClientOptions options = client.options();
     HttpClientMetrics met = client.metrics();
     VertxHttp2ConnectionHandler<Http2ClientConnection> handler = new VertxHttp2ConnectionHandlerBuilder<Http2ClientConnection>()
@@ -638,7 +637,6 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
           met.endpointConnected(metrics);
         }
       }
-      c.handle(conn);
     });
     handler.removeHandler(conn -> {
       if (metrics != null) {

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -21,6 +21,8 @@ import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.Http2Stream;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -179,28 +181,26 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
     if (headers != null) {
       headers.forEach(header -> headers_.add(header.getKey(), header.getValue()));
     }
-    handler.writePushPromise(streamId, headers_, new Handler<AsyncResult<Integer>>() {
-      @Override
-      public void handle(AsyncResult<Integer> ar) {
-        if (ar.succeeded()) {
-          synchronized (Http2ServerConnection.this) {
-            int promisedStreamId = ar.result();
-            String contentEncoding = determineContentEncoding(headers_);
-            Http2Stream promisedStream = handler.connection().stream(promisedStreamId);
-            Push push = new Push(context, contentEncoding, method, path, promise);
-            push.priority(streamPriority);
-            push.init(promisedStream);
-            int maxConcurrentStreams = handler.maxConcurrentStreams();
-            if (concurrentStreams < maxConcurrentStreams) {
-              concurrentStreams++;
-              push.complete();
-            } else {
-              pendingPushes.add(push);
-            }
+    Future<Integer> fut = handler.writePushPromise(streamId, headers_);
+    fut.addListener((FutureListener<Integer>) future -> {
+      if (future.isSuccess()) {
+        synchronized (Http2ServerConnection.this) {
+          int promisedStreamId = future.getNow();
+          String contentEncoding = determineContentEncoding(headers_);
+          Http2Stream promisedStream = handler.connection().stream(promisedStreamId);
+          Push push = new Push(context, contentEncoding, method, path, promise);
+          push.priority(streamPriority);
+          push.init(promisedStream);
+          int maxConcurrentStreams = handler.maxConcurrentStreams();
+          if (concurrentStreams < maxConcurrentStreams) {
+            concurrentStreams++;
+            push.complete();
+          } else {
+            pendingPushes.add(push);
           }
-        } else {
-          promise.fail(ar.cause());
         }
+      } else {
+        promise.fail(future.cause());
       }
     });
   }

--- a/src/test/java/io/vertx/core/http/Http2ClientTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientTest.java
@@ -1708,6 +1708,27 @@ public class Http2ClientTest extends Http2TestBase {
   }
 
   @Test
+  public void testRejectClearTextDirect() throws Exception {
+    System.setProperty("vertx.disableH2c", "true");
+    try {
+      server.close();
+      server = vertx.createHttpServer(serverOptions.setUseAlpn(false).setSsl(false));
+      server.requestHandler(req -> {
+        fail();
+      });
+      startServer(testAddress);
+      client.close();
+      client = vertx.createHttpClient(clientOptions.setUseAlpn(false).setSsl(false).setHttp2ClearTextUpgrade(false));
+      client.request(requestOptions).onComplete(onFailure(err -> {
+        testComplete();
+      }));
+      await();
+    } finally {
+      System.clearProperty("vertx.disableH2c");
+    }
+  }
+
+  @Test
   public void testIdleTimeout() throws Exception {
     testIdleTimeout(serverOptions, clientOptions.setDefaultPort(DEFAULT_HTTPS_PORT));
   }


### PR DESCRIPTION
The HttpClient assumes that after a directH2C connection (without HTTP upgrade) has been established with the server, it will always be successfully interacting with an H2 server.

When a server sends invalid data (from the client perspective), e.g a plain HTTP server, the client should handle this case and fail the connection result.

A connect future is added to VertxHttp2ConnectionHandler that is completed when the preface has been read and failed when a connection error happens before the settings have been read. When the client receives a corrupted settings frame, the connection error is triggered and the future is failed.

The connector now interacts with a promise of connection instead of the previous handler, removing the assumption the connection will always be established.

fixes #4367 #4254
