### PR TITLE
Allow NetClient to propagate an externally supplied SSLContext to the…

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -44,6 +44,7 @@ import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.metrics.TCPMetrics;
 
+import javax.net.ssl.SSLContext;
 import java.io.FileNotFoundException;
 import java.net.ConnectException;
 import java.util.Objects;
@@ -174,6 +175,13 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
   @Override
   public boolean isMetricsEnabled() {
     return metrics != null;
+  }
+
+  /**
+   * Must be called before calling connect().
+   */
+  public void setSuppliedSSLContext(SSLContext suppliedSSLContext) {
+    sslHelper.setSuppliedSslContext(suppliedSSLContext);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -122,6 +122,7 @@ public class SSLHelper {
     new ConcurrentHashMap<>(), new ConcurrentHashMap<>()
   };
   private boolean openSslSessionCacheEnabled = true;
+  private volatile SSLContext suppliedSslContext;
 
   private SSLHelper(TCPSSLOptions options, KeyCertOptions keyCertOptions, TrustOptions trustOptions) {
     SSLEngineOptions sslEngineOptions = resolveEngineOptions(options);
@@ -183,6 +184,7 @@ public class SSLHelper {
     this.enabledProtocols = that.enabledProtocols;
     this.endpointIdentificationAlgorithm = that.endpointIdentificationAlgorithm;
     this.openSslSessionCacheEnabled = that.openSslSessionCacheEnabled;
+    this.suppliedSslContext = that.suppliedSslContext;
   }
 
   public boolean isUseAlpn() {
@@ -221,6 +223,17 @@ public class SSLHelper {
   public SSLHelper setApplicationProtocols(List<String> applicationProtocols) {
     this.applicationProtocols = applicationProtocols;
     return this;
+  }
+
+  /**
+   * Must be called before createEngine()
+   */
+  public void setSuppliedSslContext(SSLContext suppliedSslContext) {
+    if (this.suppliedSslContext != null) {
+      throw new IllegalArgumentException("suppliedSslContext already set");
+    }
+    Objects.requireNonNull(suppliedSslContext, "suppliedSslContext should not be null");
+    this.suppliedSslContext = suppliedSslContext;
   }
 
   /*
@@ -502,15 +515,34 @@ public class SSLHelper {
   }
 
   public SSLEngine createEngine(VertxInternal vertx, SocketAddress socketAddress, String serverName, boolean useAlpn) {
-    SslContext context = getContext(vertx, null, useAlpn);
-    SSLEngine engine;
-    if (socketAddress.isDomainSocket()) {
-      engine = context.newEngine(ByteBufAllocator.DEFAULT);
+    if (suppliedSslContext == null) {
+      SslContext context = getContext(vertx, null, useAlpn);
+      SSLEngine engine;
+      if (socketAddress.isDomainSocket()) {
+        engine = context.newEngine(ByteBufAllocator.DEFAULT);
+      } else {
+        engine = context.newEngine(ByteBufAllocator.DEFAULT, socketAddress.host(), socketAddress.port());
+      }
+      configureEngine(engine, serverName);
+      return engine;
     } else {
-      engine = context.newEngine(ByteBufAllocator.DEFAULT, socketAddress.host(), socketAddress.port());
+      if (useAlpn) {
+        throw new IllegalStateException("Can not use useAlpn=true together with a supplied SSLContext");
+      }
+      if (!client) {
+        throw new IllegalStateException("Can only use a supplied SSLContext with clients");
+      }
+      SSLEngine engine;
+      if (socketAddress.isDomainSocket()) {
+        engine = suppliedSslContext.createSSLEngine();
+      } else {
+        engine = suppliedSslContext.createSSLEngine(socketAddress.host(), socketAddress.port());
+      }
+
+      configureEngine(engine, serverName);
+      return engine;
+
     }
-    configureEngine(engine, serverName);
-    return engine;
   }
 
   public SSLEngine createEngine(VertxInternal vertx, String host, int port, boolean forceSNI) {


### PR DESCRIPTION
… SSLHelper

If an external SSLContext is passed to the SSLHelper, it will be used
to create the SSLEngine. In other words the SSLContext will take
precendence over the parts of NetClientOptions traditionally used to
create the SSLEngine.

Motivation:

As discussed with @vietj we need to be able to pass in an SSLContext when running the clients in WildFly. If one is passed in, that takes over creation of the SSLEngine. Currently Vert.x creates the SSLEngine from a specified truststore etc.

Conformance:
I've signed the agreement (and adjusted to sign the commits after opening the initial PR)
