### PR TITLE
Fix flaky timeout

### DIFF
--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -507,7 +507,7 @@ public class MetricsTest extends VertxTestBase {
       latch.countDown();
     });
     awaitLatch(latch);
-    waitUntil(() -> metrics.getReplyFailureAddresses().size() == 1);
+    waitUntil(() -> metrics.getReplyFailureAddresses().size() == 1, 11_000);
     assertEquals(Collections.singletonList(ReplyFailure.TIMEOUT), metrics.getReplyFailures());
   }
 


### PR DESCRIPTION
The send timeout defined execrcized in the test is the same as the default timeout in waitUntil thus causing a race between the tested timeout and the test waitUntil timeout.

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
