### PR TITLE
Timers created outside event loop might not fire

### DIFF
--- a/src/main/java/io/vertx/core/impl/AbstractContext.java
+++ b/src/main/java/io/vertx/core/impl/AbstractContext.java
@@ -18,6 +18,7 @@ import io.vertx.core.impl.future.SucceededFuture;
 import io.vertx.core.impl.launcher.VertxCommandLauncher;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A context implementation that does not hold any specific state.
@@ -84,13 +85,13 @@ abstract class AbstractContext implements ContextInternal {
   @Override
   public long setPeriodic(long delay, Handler<Long> handler) {
     VertxImpl owner = (VertxImpl) owner();
-    return owner.scheduleTimeout(this, handler, delay, true);
+    return owner.scheduleTimeout(this, true, delay, TimeUnit.MILLISECONDS, handler);
   }
 
   @Override
   public long setTimer(long delay, Handler<Long> handler) {
     VertxImpl owner = (VertxImpl) owner();
-    return owner.scheduleTimeout(this, handler, delay, false);
+    return owner.scheduleTimeout(this, false, delay, TimeUnit.MILLISECONDS,handler);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -76,6 +76,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -351,7 +352,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   public long setPeriodic(long delay, Handler<Long> handler) {
-    return scheduleTimeout(getOrCreateContext(), handler, delay, true);
+    return scheduleTimeout(getOrCreateContext(), true, delay, TimeUnit.MILLISECONDS, handler);
   }
 
   @Override
@@ -360,7 +361,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   public long setTimer(long delay, Handler<Long> handler) {
-    return scheduleTimeout(getOrCreateContext(), handler, delay, false);
+    return scheduleTimeout(getOrCreateContext(), false, delay, TimeUnit.MILLISECONDS, handler);
   }
 
   @Override
@@ -445,10 +446,9 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   public boolean cancelTimer(long id) {
-    InternalTimerHandler handler = timeouts.remove(id);
+    InternalTimerHandler handler = timeouts.get(id);
     if (handler != null) {
-      handler.cancel();
-      return true;
+      return handler.cancel();
     } else {
       return false;
     }
@@ -504,15 +504,21 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     return new DnsClientImpl(this, options);
   }
 
-  public long scheduleTimeout(ContextInternal context, Handler<Long> handler, long delay, boolean periodic) {
+  public long scheduleTimeout(ContextInternal context, boolean periodic, long delay, TimeUnit timeUnit, Handler<Long> handler) {
     if (delay < 1) {
       throw new IllegalArgumentException("Cannot schedule a timer with delay < 1 ms");
     }
     long timerId = timeoutCounter.getAndIncrement();
-    InternalTimerHandler task = new InternalTimerHandler(timerId, handler, periodic, delay, context);
+    InternalTimerHandler task = new InternalTimerHandler(timerId, handler, periodic, context);
     timeouts.put(timerId, task);
     if (context.isDeployment()) {
       context.addCloseHook(task);
+    }
+    EventLoop el = context.nettyEventLoop();
+    if (periodic) {
+      task.future = el.scheduleAtFixedRate(task, delay, delay, timeUnit);
+    } else {
+      task.future = el.schedule(task, delay, timeUnit);
     }
     return timerId;
   }
@@ -863,19 +869,14 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     private final boolean periodic;
     private final long timerID;
     private final ContextInternal context;
-    private final java.util.concurrent.Future<?> future;
+    private final AtomicBoolean disposed = new AtomicBoolean();
+    private volatile java.util.concurrent.Future<?> future;
 
-    InternalTimerHandler(long timerID, Handler<Long> runnable, boolean periodic, long delay, ContextInternal context) {
+    InternalTimerHandler(long timerID, Handler<Long> runnable, boolean periodic, ContextInternal context) {
       this.context = context;
       this.timerID = timerID;
       this.handler = runnable;
       this.periodic = periodic;
-      EventLoop el = context.nettyEventLoop();
-      if (periodic) {
-        future = el.scheduleAtFixedRate(this, delay, delay, TimeUnit.MILLISECONDS);
-      } else {
-        future = el.schedule(this, delay, TimeUnit.MILLISECONDS);
-      }
     }
 
     @Override
@@ -885,10 +886,11 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
     public void handle(Void v) {
       if (periodic) {
-        if (timeouts.containsKey(timerID)) {
+        if (!disposed.get()) {
           handler.handle(timerID);
         }
-      } else if (timeouts.remove(timerID) != null) {
+      } else if (disposed.compareAndSet(false, true)) {
+        timeouts.remove(timerID);
         try {
           handler.handle(timerID);
         } finally {
@@ -898,18 +900,29 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       }
     }
 
-    private void cancel() {
-      future.cancel(false);
-      if (context.isDeployment()) {
-        context.removeCloseHook(this);
+    private boolean cancel() {
+      boolean cancelled = tryCancel();
+      if (cancelled) {
+        if (context.isDeployment()) {
+          context.removeCloseHook(this);
+        }
+      }
+      return cancelled;
+    }
+
+    private boolean tryCancel() {
+      if  (disposed.compareAndSet(false, true)) {
+        timeouts.remove(timerID);
+        future.cancel(false);
+        return true;
+      } else {
+        return false;
       }
     }
 
     // Called via Context close hook when Verticle is undeployed
     public void close(Promise<Void> completion) {
-      if (timeouts.remove(timerID) != null) {
-        future.cancel(false);
-      }
+      tryCancel();
       completion.complete();
     }
   }
@@ -981,7 +994,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
           throw new IllegalStateException();
         }
         this.handler = handler;
-        id = scheduleTimeout(getOrCreateContext(), this, delay, periodic);
+        id = scheduleTimeout(getOrCreateContext(), periodic, delay, TimeUnit.MILLISECONDS, this);
       } else {
         cancel();
       }


### PR DESCRIPTION
When a timer is created from a non vertx thread, there can be a race with the timer task that executes before the internal timer task is added to the vertx timeout map. When it happens, the timer will not execute since this check is to check whether the task was cancelled by another thread.