### PR TITLE
Add Netty optional native dependencies for macos dns and unix-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,16 @@
       <artifactId>netty-transport-native-kqueue</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-unix-common</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver-dns-native-macos</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <!-- Jackson -->
     <dependency>


### PR DESCRIPTION
Motivation:

allows adding
```
<dependency>
  <groupId>io.netty</groupId>
  <artifactId>netty-resolver-dns-native-macos</artifactId>
  <classifier>osx-${os.detected.arch}</classifier>
</dependency>
```
to prevent `DnsServerAddressStreamProviders - Can not find io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider in the classpath, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS.`

as well as
```
<dependency>
  <groupId>io.netty</groupId>
  <artifactId>netty-transport-native-unix-common</artifactId>
  <classifier>${os.detected.name}-${os.detected.arch}</classifier>
</dependency>
```
