### PR TITLE
[Issue-4389] FileResolverImpl tries to unpack resources from bundle URL on each call for same file resolving

### DIFF
--- a/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
@@ -83,6 +83,10 @@ public class FileResolverImpl implements FileResolver {
     return null;
   }
 
+  FileCache getFileCache() {
+    return this.cache;
+  }
+
   /**
    * Close this file resolver, this is a blocking operation.
    */
@@ -238,7 +242,7 @@ public class FileResolverImpl implements FileResolver {
       case "jrt": // java run-time (JEP 220)
       case "resource":  // substratevm (graal native image)
       case "vfs":  // jboss-vfs
-        return unpackFromBundleURL(url, isDir);
+        return unpackFromBundleURL(url, fileName, isDir);
       default:
         throw new IllegalStateException("Invalid url protocol: " + prot);
     }
@@ -344,23 +348,23 @@ public class FileResolverImpl implements FileResolver {
    * reading it from the url.
    *
    * @param url the url
+   * @param  fileName the file name used to cache the content
    * @return the extracted file
    */
-  private File unpackFromBundleURL(URL url, boolean isDir) {
-    String file = url.getHost() + File.separator + url.getFile();
+  private File unpackFromBundleURL(URL url, String fileName, boolean isDir) {
     try {
       if ((getClassLoader() != null && isBundleUrlDirectory(url)) || isDir) {
         // Directory
-        cache.cacheDir(file);
+        cache.cacheDir(fileName);
       } else {
         try (InputStream is = url.openStream()) {
-          cache.cacheFile(file, is, !enableCaching);
+          cache.cacheFile(fileName, is, !enableCaching);
         }
       }
     } catch (IOException e) {
       throw new VertxException(FileSystemImpl.getFileAccessErrorMessage("unpack", url.toString()), e);
     }
-    return cache.getFile(file);
+    return cache.getFile(fileName);
   }
 
 

--- a/src/test/java/io/vertx/core/file/impl/URLBundleFileResolverTest.java
+++ b/src/test/java/io/vertx/core/file/impl/URLBundleFileResolverTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.file.impl;
+
+import io.vertx.core.file.JarFileResolverTest;
+import org.junit.Test;
+
+import java.io.File;
+
+/**
+ * Tests on file resolving in case of FileResolverImpl#unpackFromBundleURL(URL, String, boolean) is needed.
+ *
+ * The following test(testResolveURLBundle) works on both JDK8 (jar:) and JDK11(jrt:)
+ *
+ * @author <a href="mailto: aoingl@gmail.com">Lin Gao</a>
+ */
+public class URLBundleFileResolverTest extends JarFileResolverTest {
+
+  @Test
+  public void testResolveURLBundle() {
+    String fileName = "java/lang/Object.class";
+    assertFalse(resolver.getFileCache().getFile(fileName).exists());
+    File file = resolver.resolveFile(fileName);
+    assertTrue(file.exists());
+    // cache.getFile should return the cached file.
+    assertTrue(resolver.getFileCache().getFile(fileName).exists());
+    // resolve again
+    file = resolver.resolveFile(fileName);
+    assertTrue(file.exists());
+    assertTrue(resolver.getFileCache().getFile(fileName).exists());
+  }
+
+}


### PR DESCRIPTION
Motivation:

Fixes: https://github.com/eclipse-vertx/vert.x/issues/4389

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
