### PR TITLE
Remove unnecessary semicolon in VertxOptions

### DIFF
--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -52,7 +52,7 @@ public class VertxOptions {
   /**
    * The default value of blocked thread check interval = 1000 ms.
    */
-  public static final long DEFAULT_BLOCKED_THREAD_CHECK_INTERVAL = TimeUnit.SECONDS.toMillis(1);;
+  public static final long DEFAULT_BLOCKED_THREAD_CHECK_INTERVAL = TimeUnit.SECONDS.toMillis(1);
 
   /**
    * The default value of blocked thread check interval unit = {@link TimeUnit#MILLISECONDS}


### PR DESCRIPTION
Motivation:

Just removing an unnecessary semicolon

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
