### PR TITLE
Support reading PEM file containing EC Private Key

### DIFF
--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -11,24 +11,8 @@
 
 package io.vertx.core.http;
 
-import io.netty.util.internal.PlatformDependent;
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxException;
-import io.vertx.core.VertxOptions;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.net.*;
-import io.vertx.core.net.impl.TrustAllTrustManager;
-import io.vertx.test.core.TestUtils;
-import io.vertx.test.proxy.HAProxy;
-import io.vertx.test.tls.Cert;
-import io.vertx.test.tls.Trust;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.hamcrest.core.StringEndsWith.endsWith;
 
-import javax.net.ssl.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -46,7 +30,39 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import static org.hamcrest.core.StringEndsWith.endsWith;
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.TrustManagerFactorySpi;
+
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import io.netty.util.internal.PlatformDependent;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.JdkSSLEngineOptions;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.KeyCertOptions;
+import io.vertx.core.net.KeyStoreOptions;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.ProxyType;
+import io.vertx.core.net.SelfSignedCertificate;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.TrustOptions;
+import io.vertx.core.net.impl.TrustAllTrustManager;
+import io.vertx.test.core.TestUtils;
+import io.vertx.test.proxy.HAProxy;
+import io.vertx.test.tls.Cert;
+import io.vertx.test.tls.Trust;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -1363,17 +1379,23 @@ public abstract class HttpTLSTest extends HttpTestBase {
         "",
         "-----BEGIN PRIVATE KEY-----",
         "-----BEGIN RSA PRIVATE KEY-----",
+        "-----BEGIN EC PRIVATE KEY-----",
         "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----",
         "-----BEGIN RSA PRIVATE KEY-----\n-----END RSA PRIVATE KEY-----",
+        "-----BEGIN EC PRIVATE KEY-----\n-----END EC PRIVATE KEY-----",
         "-----BEGIN PRIVATE KEY-----\n*\n-----END PRIVATE KEY-----",
-        "-----BEGIN RSA PRIVATE KEY-----\n*\n-----END RSA PRIVATE KEY-----"
+        "-----BEGIN RSA PRIVATE KEY-----\n*\n-----END RSA PRIVATE KEY-----",
+        "-----BEGIN EC PRIVATE KEY-----\n*\n-----END EC PRIVATE KEY-----"
     };
     String[] messages = {
-        "Missing -----BEGIN PRIVATE KEY----- or -----BEGIN RSA PRIVATE KEY----- delimiter",
+        "Missing -----BEGIN PRIVATE KEY----- or -----BEGIN RSA PRIVATE KEY----- or -----BEGIN EC PRIVATE KEY----- delimiter",
         "Missing -----END PRIVATE KEY----- delimiter",
         "Missing -----END RSA PRIVATE KEY----- delimiter",
+        "Missing -----END EC PRIVATE KEY----- delimiter",
         "Empty pem file",
         "Empty pem file",
+        "Empty pem file",
+        "Input byte[] should at least have 2 bytes for base64 bytes",
         "Input byte[] should at least have 2 bytes for base64 bytes",
         "Input byte[] should at least have 2 bytes for base64 bytes"
     };

--- a/src/test/java/io/vertx/test/core/TestUtils.java
+++ b/src/test/java/io/vertx/test/core/TestUtils.java
@@ -11,6 +11,30 @@
 
 package io.vertx.test.core;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.cert.Certificate;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import java.util.zip.GZIPOutputStream;
+
+import javax.security.cert.X509Certificate;
+
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.util.NetUtil;
@@ -19,33 +43,14 @@ import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.Http2Settings;
-import io.vertx.core.net.*;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.KeyCertOptions;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.core.net.PfxOptions;
+import io.vertx.core.net.TrustOptions;
 import io.vertx.core.net.impl.KeyStoreHelper;
 import io.vertx.test.netty.TestLoggerFactory;
-
-import javax.security.cert.X509Certificate;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.RandomAccessFile;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateFactory;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.jar.JarEntry;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-import java.util.zip.GZIPOutputStream;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -511,5 +516,19 @@ public class TestUtils {
       InternalLoggerFactory.setDefaultFactory(prev);
     }
     return factory;
+  }
+
+  /**
+   * Checks if the JVM supports ECC algorithms.
+   *
+   * @return {@code true} if the JVM supports ECC.
+   */
+  public static boolean isECCSupportedByVM() {
+    try {
+      KeyFactory.getInstance("EC");
+      return true;
+    } catch (GeneralSecurityException e) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
vert.x currently does not support reading PEM files that contain a EC private key.
However, ECC based keys are much smaller and easier to process than RSA based keys and therefore
are getting used more and more often, in particular when implementing TLS secured network servers that
need to be accessed by constrained clients (e.g. IoT devices).

The KeyStoreHelper has therefore been extended to support reading EC private keys from PEM files
as described in https://datatracker.ietf.org/doc/html/rfc5915#section-4