### PR TITLE
[Draft] Ensure inner type when create JsonXxx

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -74,7 +74,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
     if (list == null) {
       throw new NullPointerException();
     }
-    this.list = list;
+    this.list = new ArrayList(list);
   }
 
   /**

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -70,7 +70,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
     if (map == null) {
       throw new NullPointerException();
     }
-    this.map = map;
+    this.map = new LinkedHashMap(map);
   }
 
   /**


### PR DESCRIPTION
Motivation:

When I work with https://github.com/eclipse-vertx/vert.x/pull/4401 and do some research and test, I found problem when I create JsonObject and JsonArray with `ImmutableCollections`.

Take  the below example:

```
  @Test
  void testMapOf(Vertx vertx, VertxTestContext testContext) {
    Map<String, Object> map = Map.of("x", 1);
    JsonObject obj = new JsonObject(map);
    logger.info("Run testMapOf with JsonObject " + obj);

    try {
      obj.put("y", "222");
      testContext.failNow("Should not reach here");
      return;
    } catch (Throwable t) {
      logger.info("Run testMapOf with JsonObject updating error" + t);
    }

    testContext.completeNow();
  }
```

When I create JsonObject with a map created by Map.of, a immutable map, the JsonObject instance I created cannot updated again, this feels strange.

This pull request is a draft and look forward to further discussion for a correct solution if this is a problem, and I will make a reasonable change after that.
If this is expected, I will close it.