### PR TITLE
FileSystemExamples: close file after piping

### DIFF
--- a/src/main/java/examples/FileSystemExamples.java
+++ b/src/main/java/examples/FileSystemExamples.java
@@ -142,6 +142,7 @@ public class FileSystemExamples {
         AsyncFile file = result.result();
         file.pipeTo(output)
           .onComplete(v -> {
+            file.close();
             System.out.println("Copy done");
           });
       } else {


### PR DESCRIPTION
Otherwise, a file handle is kept open.