### PR TITLE
Introduced abstraction layer to base64 encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <assertj.version>3.4.1</assertj.version>
     <apacheds-protocol-dns.version>1.5.7</apacheds-protocol-dns.version>
     <generated.dir>${project.basedir}/src/main/generated</generated.dir>
-    <stack.version>4.3.2-SNAPSHOT</stack.version>
+    <stack.version>4.3.1</stack.version>
     <jmh.version>1.19</jmh.version>
     <vertx.testNativeTransport>false</vertx.testNativeTransport>
     <vertx.testDomainSockets>false</vertx.testDomainSockets>
@@ -133,6 +133,12 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
     </dependency>
 
     <!-- Loggers -->

--- a/src/main/java/io/vertx/core/VertxBase64.java
+++ b/src/main/java/io/vertx/core/VertxBase64.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+
+/**
+ * Abstracts base64 encoding within vert.x, delegates to {@link Base64} or {@link org.apache.commons.codec.binary.Base64}
+ * depending on the configuration, see {@link io.vertx.core.json.impl.JsonUtil}
+ */
+public class VertxBase64 {
+
+  public static class Encoder {
+
+    private final Base64.Encoder encoder;
+
+    public Encoder(boolean legacyMode) {
+      if (legacyMode) {
+        encoder = Base64.getEncoder();
+      } else {
+        encoder = Base64.getUrlEncoder().withoutPadding();
+      }
+    }
+
+    public String encodeToString(byte[] src) {
+      return encoder.encodeToString(src);
+    }
+
+    public byte[] encode(byte[] src) {
+      return encoder.encode(src);
+    }
+
+    public int encode(byte[] src, byte[] dst) {
+      return encoder.encode(src, dst);
+    }
+
+    public ByteBuffer encode(ByteBuffer buffer) {
+      return encoder.encode(buffer);
+    }
+
+  }
+
+  public static class Decoder {
+
+    private final VertxBase64Decoder decoder;
+
+    public Decoder(boolean legacyMode, boolean useApacheImplementation) {
+      if (useApacheImplementation) {
+        // supports both modes
+        decoder = new VertxBase64DecoderApacheImpl();
+      } else {
+        decoder = new VertxBase64DecoderJdkImpl(legacyMode);
+      }
+    }
+
+    public byte[] decode(String src) {
+      return decoder.decode(src);
+    }
+  }
+
+  private interface VertxBase64Decoder {
+    byte[] decode(String src);
+  }
+
+  private static class VertxBase64DecoderJdkImpl implements VertxBase64Decoder {
+
+    private final Base64.Decoder decoder;
+
+    public VertxBase64DecoderJdkImpl(boolean legacyMode) {
+      if (legacyMode) {
+        decoder = Base64.getDecoder();
+      } else {
+        decoder = Base64.getUrlDecoder();
+      }
+    }
+
+    @Override
+    public byte[] decode(String src) {
+      return decoder.decode(src);
+    }
+  }
+
+  private static class VertxBase64DecoderApacheImpl implements VertxBase64Decoder {
+
+    org.apache.commons.codec.binary.Base64 decoder = new org.apache.commons.codec.binary.Base64();
+
+    @Override
+    public byte[] decode(String src) {
+      return decoder.decode(src);
+    }
+  }
+
+
+}

--- a/src/main/java/io/vertx/core/impl/ConversionHelper.java
+++ b/src/main/java/io/vertx/core/impl/ConversionHelper.java
@@ -18,7 +18,7 @@ import io.vertx.core.json.JsonObject;
 import java.time.Instant;
 import java.util.*;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
 /**
@@ -47,7 +47,7 @@ public class ConversionHelper {
     } else if (obj instanceof CharSequence) {
       return obj.toString();
     } else if (obj instanceof Buffer) {
-      return BASE64_ENCODER.encodeToString(((Buffer) obj).getBytes());
+      return VERTX_BASE64_ENCODER.encodeToString(((Buffer) obj).getBytes());
     }
     return obj;
   }
@@ -81,7 +81,7 @@ public class ConversionHelper {
     } else if (obj instanceof Instant) {
       return (T) ISO_INSTANT.format((Instant) obj);
     } else if (obj instanceof byte[]) {
-      return (T) BASE64_ENCODER.encodeToString((byte[]) obj);
+      return (T) VERTX_BASE64_ENCODER.encodeToString((byte[]) obj);
     } else if (obj instanceof Enum) {
       return (T) ((Enum) obj).name();
     }

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -108,9 +108,9 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
     if (val instanceof Instant) {
       return ISO_INSTANT.format((Instant) val);
     } else if (val instanceof byte[]) {
-      return BASE64_ENCODER.encodeToString((byte[]) val);
+      return VERTX_BASE64_ENCODER.encodeToString((byte[]) val);
     } else if (val instanceof Buffer) {
-      return BASE64_ENCODER.encodeToString(((Buffer) val).getBytes());
+      return VERTX_BASE64_ENCODER.encodeToString(((Buffer) val).getBytes());
     } else if (val instanceof Enum) {
       return ((Enum) val).name();
     } else {
@@ -270,7 +270,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
     // assume that the value is in String format as per RFC
     String encoded = (String) val;
     // parse to proper type
-    return BASE64_DECODER.decode(encoded);
+    return VERTX_BASE64_DECODER.decode(encoded);
   }
 
   /**
@@ -301,7 +301,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
     // assume that the value is in String format as per RFC
     String encoded = (String) val;
     // parse to proper type
-    return Buffer.buffer(BASE64_DECODER.decode(encoded));
+    return Buffer.buffer(VERTX_BASE64_DECODER.decode(encoded));
   }
 
   /**

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -134,9 +134,9 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
     if (val instanceof Instant) {
       return ISO_INSTANT.format((Instant) val);
     } else if (val instanceof byte[]) {
-      return BASE64_ENCODER.encodeToString((byte[]) val);
+      return VERTX_BASE64_ENCODER.encodeToString((byte[]) val);
     } else if (val instanceof Buffer) {
-      return BASE64_ENCODER.encodeToString(((Buffer) val).getBytes());
+      return VERTX_BASE64_ENCODER.encodeToString(((Buffer) val).getBytes());
     } else if (val instanceof Enum) {
       return ((Enum) val).name();
     } else {
@@ -305,7 +305,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
     // assume that the value is in String format as per RFC
     String encoded = (String) val;
     // parse to proper type
-    return BASE64_DECODER.decode(encoded);
+    return VERTX_BASE64_DECODER.decode(encoded);
   }
 
   /**
@@ -339,7 +339,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
     // assume that the value is in String format as per RFC
     String encoded = (String) val;
     // parse to proper type
-    return Buffer.buffer(BASE64_DECODER.decode(encoded));
+    return Buffer.buffer(VERTX_BASE64_DECODER.decode(encoded));
   }
 
   /**

--- a/src/main/java/io/vertx/core/json/jackson/BufferDeserializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/BufferDeserializer.java
@@ -20,7 +20,8 @@ import io.vertx.core.buffer.Buffer;
 import java.io.IOException;
 import java.time.Instant;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_DECODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_DECODER;
+
 
 class BufferDeserializer extends JsonDeserializer<Buffer> {
 
@@ -28,7 +29,7 @@ class BufferDeserializer extends JsonDeserializer<Buffer> {
   public Buffer deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
     String text = p.getText();
     try {
-      return Buffer.buffer(BASE64_DECODER.decode(text));
+      return Buffer.buffer(VERTX_BASE64_DECODER.decode(text));
     } catch (IllegalArgumentException e) {
       throw new InvalidFormatException(p, "Expected a base64 encoded byte array", text, Instant.class);
     }

--- a/src/main/java/io/vertx/core/json/jackson/BufferSerializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/BufferSerializer.java
@@ -17,12 +17,12 @@ import io.vertx.core.buffer.Buffer;
 
 import java.io.IOException;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_ENCODER;
 
 class BufferSerializer extends JsonSerializer<Buffer> {
 
   @Override
   public void serialize(Buffer value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-    jgen.writeString(BASE64_ENCODER.encodeToString(value.getBytes()));
+    jgen.writeString(VERTX_BASE64_ENCODER.encodeToString(value.getBytes()));
   }
 }

--- a/src/main/java/io/vertx/core/json/jackson/ByteArrayDeserializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/ByteArrayDeserializer.java
@@ -19,7 +19,8 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import java.io.IOException;
 import java.time.Instant;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_DECODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_DECODER;
+
 
 class ByteArrayDeserializer extends JsonDeserializer<byte[]> {
 
@@ -27,7 +28,7 @@ class ByteArrayDeserializer extends JsonDeserializer<byte[]> {
   public byte[] deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
     String text = p.getText();
     try {
-      return BASE64_DECODER.decode(text);
+      return VERTX_BASE64_DECODER.decode(text);
     } catch (IllegalArgumentException e) {
       throw new InvalidFormatException(p, "Expected a base64 encoded byte array", text, Instant.class);
     }

--- a/src/main/java/io/vertx/core/json/jackson/ByteArraySerializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/ByteArraySerializer.java
@@ -16,12 +16,12 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_ENCODER;
 
 class ByteArraySerializer extends JsonSerializer<byte[]> {
 
   @Override
   public void serialize(byte[] value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-    jgen.writeString(BASE64_ENCODER.encodeToString(value));
+    jgen.writeString(VERTX_BASE64_ENCODER.encodeToString(value));
   }
 }

--- a/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -44,8 +44,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
-import static io.vertx.core.json.impl.JsonUtil.BASE64_DECODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_DECODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
 /**
@@ -316,10 +316,10 @@ public class JacksonCodec implements JsonCodec {
         generator.writeString((ISO_INSTANT.format((Instant)json)));
       } else if (json instanceof byte[]) {
         // RFC-7493
-        generator.writeString(BASE64_ENCODER.encodeToString((byte[]) json));
+        generator.writeString(VERTX_BASE64_ENCODER.encodeToString((byte[]) json));
       } else if (json instanceof Buffer) {
         // RFC-7493
-        generator.writeString(BASE64_ENCODER.encodeToString(((Buffer) json).getBytes()));
+        generator.writeString(VERTX_BASE64_ENCODER.encodeToString(((Buffer) json).getBytes()));
       } else if (json instanceof Enum) {
         // vert.x extra (non standard but allowed conversion)
         generator.writeString(((Enum<?>) json).name());
@@ -366,9 +366,9 @@ public class JacksonCodec implements JsonCodec {
       if (clazz.isEnum()) {
         o = Enum.valueOf((Class<Enum>) clazz, str);
       } else if (clazz == byte[].class) {
-        o = BASE64_DECODER.decode(str);
+        o = VERTX_BASE64_DECODER.decode(str);
       } else if (clazz == Buffer.class) {
-        o = Buffer.buffer(BASE64_DECODER.decode(str));
+        o = Buffer.buffer(VERTX_BASE64_DECODER.decode(str));
       } else if (clazz == Instant.class) {
         o = Instant.from(ISO_INSTANT.parse(str));
       } else if (!clazz.isAssignableFrom(String.class)) {

--- a/src/main/java/io/vertx/core/parsetools/impl/JsonEventImpl.java
+++ b/src/main/java/io/vertx/core/parsetools/impl/JsonEventImpl.java
@@ -23,7 +23,7 @@ import io.vertx.core.parsetools.JsonEventType;
 
 import java.time.Instant;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_DECODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_DECODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
 /**
@@ -174,7 +174,7 @@ public class JsonEventImpl implements JsonEvent {
 
   @Override
   public Buffer binaryValue() {
-    return value != null ? Buffer.buffer(BASE64_DECODER.decode((String) value)) : null;
+    return value != null ? Buffer.buffer(VERTX_BASE64_DECODER.decode((String) value)) : null;
   }
 
   @Override

--- a/src/test/java/io/vertx/core/ConversionHelperTest.java
+++ b/src/test/java/io/vertx/core/ConversionHelperTest.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_DECODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_DECODER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -106,7 +106,7 @@ public class ConversionHelperTest {
     assertEquals("the_string", map.get("string"));
     assertEquals(4, map.get("integer"));
     assertEquals(true, map.get("boolean"));
-    assertEquals("hello", new String(BASE64_DECODER.decode((String)map.get("binary"))));
+    assertEquals("hello", new String(VERTX_BASE64_DECODER.decode((String)map.get("binary"))));
     assertEquals(Collections.singletonMap("nested", 4), map.get("object"));
     assertEquals(Arrays.asList(1, 2, 3), map.get("array"));
   }
@@ -125,7 +125,7 @@ public class ConversionHelperTest {
     assertEquals("the_string", map.get(0));
     assertEquals(4, map.get(1));
     assertEquals(true, map.get(2));
-    assertEquals("hello", new String(BASE64_DECODER.decode((String)map.get(3))));
+    assertEquals("hello", new String(VERTX_BASE64_DECODER.decode((String)map.get(3))));
     assertEquals(Collections.singletonMap("nested", 4), map.get(4));
     assertEquals(Arrays.asList(1, 2, 3), map.get(5));
   }

--- a/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import java.time.Instant;
 import java.util.*;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
 /**
@@ -86,7 +86,7 @@ public class JacksonDatabindTest extends VertxTestBase {
   public void testBytesDecoding() {
     Pojo original = new Pojo();
     original.bytes = TestUtils.randomByteArray(12);
-    Pojo decoded = Json.decodeValue("{\"bytes\":\"" + BASE64_ENCODER.encodeToString(original.bytes) + "\"}", Pojo.class);
+    Pojo decoded = Json.decodeValue("{\"bytes\":\"" + VERTX_BASE64_ENCODER.encodeToString(original.bytes) + "\"}", Pojo.class);
     assertArrayEquals(original.bytes, decoded.bytes);
   }
 

--- a/src/test/java/io/vertx/core/json/JsonArrayTest.java
+++ b/src/test/java/io/vertx/core/json/JsonArrayTest.java
@@ -25,8 +25,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_DECODER;
-import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_DECODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static org.junit.Assert.*;
 
@@ -239,8 +239,8 @@ public class JsonArrayTest {
     byte[] bytes = TestUtils.randomByteArray(10);
     jsonArray.add(bytes);
     assertArrayEquals(bytes, jsonArray.getBinary(0));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), jsonArray.getValue(0));
-    assertArrayEquals(bytes, BASE64_DECODER.decode(jsonArray.getString(0)));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), jsonArray.getValue(0));
+    assertArrayEquals(bytes, VERTX_BASE64_DECODER.decode(jsonArray.getString(0)));
     try {
       jsonArray.getBinary(-1);
       fail();
@@ -269,8 +269,8 @@ public class JsonArrayTest {
     Buffer bytes = TestUtils.randomBuffer(10);
     jsonArray.add(bytes);
     assertEquals(bytes, jsonArray.getBuffer(0));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes.getBytes()), jsonArray.getValue(0));
-    assertEquals(bytes, Buffer.buffer(BASE64_DECODER.decode(jsonArray.getString(0))));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes.getBytes()), jsonArray.getValue(0));
+    assertEquals(bytes, Buffer.buffer(VERTX_BASE64_DECODER.decode(jsonArray.getString(0))));
     try {
       jsonArray.getBuffer(-1);
       fail();
@@ -417,7 +417,7 @@ public class JsonArrayTest {
     assertEquals(arr, jsonArray.getValue(8));
     byte[] bytes = TestUtils.randomByteArray(100);
     jsonArray.add(bytes);
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), jsonArray.getValue(9));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), jsonArray.getValue(9));
     Instant now = Instant.now();
     jsonArray.add(now);
     assertEquals(now, jsonArray.getInstant(10));
@@ -555,7 +555,7 @@ public class JsonArrayTest {
     byte[] bytes = TestUtils.randomByteArray(10);
     assertSame(jsonArray, jsonArray.add(bytes));
     assertArrayEquals(bytes, jsonArray.getBinary(0));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), jsonArray.getValue(0));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), jsonArray.getValue(0));
     jsonArray.add((byte[])null);
     assertNull(jsonArray.getValue(1));
     assertEquals(2, jsonArray.size());
@@ -595,7 +595,7 @@ public class JsonArrayTest {
     assertEquals(Double.valueOf(1.23d), jsonArray.getDouble(4));
     assertEquals(true, jsonArray.getBoolean(5));
     assertArrayEquals(bytes, jsonArray.getBinary(6));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), jsonArray.getValue(6));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), jsonArray.getValue(6));
     assertEquals(now, jsonArray.getInstant(7));
     assertEquals(now.toString(), jsonArray.getValue(7));
     assertEquals(obj, jsonArray.getJsonObject(8));
@@ -1196,7 +1196,7 @@ public class JsonArrayTest {
     }
     jsonArray.add("bar");
     assertSame(jsonArray, jsonArray.set(0, bytes));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), jsonArray.getValue(0));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), jsonArray.getValue(0));
     assertEquals(1, jsonArray.size());
   }
 

--- a/src/test/java/io/vertx/core/json/JsonCodecTest.java
+++ b/src/test/java/io/vertx/core/json/JsonCodecTest.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -90,7 +90,7 @@ public class JsonCodecTest {
     jsonObject.putNull("mynull");
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
-    String strBytes = BASE64_ENCODER.encodeToString(bytes);
+    String strBytes = VERTX_BASE64_ENCODER.encodeToString(bytes);
     String expected = "{\"mystr\":\"foo\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
       "myboolean\":true,\"mybyte\":255,\"mybinary\":\"" + strBytes + "\",\"mybuffer\":\"" + strBytes + "\",\"myinstant\":\"" + ISO_INSTANT.format(now) + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}";
     String json = mapper.toString(jsonObject);
@@ -113,7 +113,7 @@ public class JsonCodecTest {
     jsonArray.addNull();
     jsonArray.add(new JsonObject().put("foo", "bar"));
     jsonArray.add(new JsonArray().add("foo").add(123));
-    String strBytes = BASE64_ENCODER.encodeToString(bytes);
+    String strBytes = VERTX_BASE64_ENCODER.encodeToString(bytes);
     String expected = "[\"foo\",123,1234,1.23,2.34,true,124,\"" + strBytes + "\",\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123]]";
     String json = mapper.toString(jsonArray);
     assertEquals(expected, json);
@@ -136,7 +136,7 @@ public class JsonCodecTest {
     jsonObject.putNull("mynull");
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
-    String strBytes = BASE64_ENCODER.encodeToString(bytes);
+    String strBytes = VERTX_BASE64_ENCODER.encodeToString(bytes);
 
     Buffer expected = Buffer.buffer("{\"mystr\":\"foo\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
       "myboolean\":true,\"mybinary\":\"" + strBytes + "\",\"mybuffer\":\"" + strBytes + "\",\"myinstant\":\"" + ISO_INSTANT.format(now) + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}", "UTF-8");
@@ -160,7 +160,7 @@ public class JsonCodecTest {
     jsonArray.addNull();
     jsonArray.add(new JsonObject().put("foo", "bar"));
     jsonArray.add(new JsonArray().add("foo").add(123));
-    String strBytes = BASE64_ENCODER.encodeToString(bytes);
+    String strBytes = VERTX_BASE64_ENCODER.encodeToString(bytes);
     Buffer expected = Buffer.buffer("[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123]]", "UTF-8");
     Buffer json = mapper.toBuffer(jsonArray);
     assertArrayEquals(expected.getBytes(), json.getBytes());
@@ -183,7 +183,7 @@ public class JsonCodecTest {
     jsonObject.put("myinstant", now);
     jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
     jsonObject.put("myarr", new JsonArray().add("foo").add(123));
-    String strBytes = BASE64_ENCODER.encodeToString(bytes);
+    String strBytes = VERTX_BASE64_ENCODER.encodeToString(bytes);
     String strInstant = ISO_INSTANT.format(now);
     String expected = "{" + Utils.LINE_SEPARATOR +
       "  \"mystr\" : \"foo\"," + Utils.LINE_SEPARATOR +
@@ -219,7 +219,7 @@ public class JsonCodecTest {
     jsonArray.addNull();
     jsonArray.add(new JsonObject().put("foo", "bar"));
     jsonArray.add(new JsonArray().add("foo").add(123));
-    String strBytes = BASE64_ENCODER.encodeToString(bytes);
+    String strBytes = VERTX_BASE64_ENCODER.encodeToString(bytes);
     String expected = "[ \"foo\", 123, 1234, 1.23, 2.34, true, \"" + strBytes + "\", \"" + strBytes + "\", null, {" + Utils.LINE_SEPARATOR +
       "  \"foo\" : \"bar\"" + Utils.LINE_SEPARATOR +
       "}, [ \"foo\", 123 ] ]";
@@ -230,7 +230,7 @@ public class JsonCodecTest {
   @Test
   public void testDecodeJsonObject() {
     byte[] bytes = TestUtils.randomByteArray(10);
-    String strBytes = BASE64_ENCODER.encodeToString(bytes);
+    String strBytes = VERTX_BASE64_ENCODER.encodeToString(bytes);
     Instant now = Instant.now();
     String strInstant = ISO_INSTANT.format(now);
     String json = "{\"mystr\":\"foo\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
@@ -246,8 +246,8 @@ public class JsonCodecTest {
     assertEquals(124, obj.getValue("mybyte"));
     assertArrayEquals(bytes, obj.getBinary("mybinary"));
     assertEquals(Buffer.buffer(bytes), obj.getBuffer("mybuffer"));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), obj.getValue("mybinary"));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), obj.getValue("mybuffer"));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), obj.getValue("mybinary"));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), obj.getValue("mybuffer"));
     assertEquals(now, obj.getInstant("myinstant"));
     assertEquals(now.toString(), obj.getValue("myinstant"));
     assertTrue(obj.containsKey("mynull"));
@@ -261,7 +261,7 @@ public class JsonCodecTest {
   @Test
   public void testDecodeJsonArray() {
     byte[] bytes = TestUtils.randomByteArray(10);
-    String strBytes = BASE64_ENCODER.encodeToString(bytes);
+    String strBytes = VERTX_BASE64_ENCODER.encodeToString(bytes);
     Instant now = Instant.now();
     String strInstant = ISO_INSTANT.format(now);
     String json = "[\"foo\",123,1234,1.23,2.34,true,124,\"" + strBytes + "\",\"" + strBytes + "\",\"" + strInstant + "\",null,{\"foo\":\"bar\"},[\"foo\",123]]";
@@ -274,9 +274,9 @@ public class JsonCodecTest {
     assertEquals(true, arr.getBoolean(5));
     assertEquals(124, arr.getValue(6));
     assertArrayEquals(bytes, arr.getBinary(7));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), arr.getValue(7));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), arr.getValue(7));
     assertEquals(Buffer.buffer(bytes), arr.getBuffer(8));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), arr.getValue(8));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), arr.getValue(8));
     assertEquals(now, arr.getInstant(9));
     assertEquals(now.toString(), arr.getValue(9));
     assertTrue(arr.hasNull(10));

--- a/src/test/java/io/vertx/core/json/JsonObjectTest.java
+++ b/src/test/java/io/vertx/core/json/JsonObjectTest.java
@@ -27,8 +27,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_DECODER;
-import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_DECODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static org.junit.Assert.*;
 
@@ -442,12 +442,12 @@ public class JsonObjectTest {
     byte[] bytes = TestUtils.randomByteArray(100);
     jsonObject.put("foo", bytes);
     assertArrayEquals(bytes, jsonObject.getBinary("foo"));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), jsonObject.getValue("foo"));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), jsonObject.getValue("foo"));
 
     // Can also get as string:
     String val = jsonObject.getString("foo");
     assertNotNull(val);
-    byte[] retrieved = BASE64_DECODER.decode(val);
+    byte[] retrieved = VERTX_BASE64_DECODER.decode(val);
     assertTrue(TestUtils.byteArraysEqual(bytes, retrieved));
 
     jsonObject.put("foo", 123);
@@ -482,12 +482,12 @@ public class JsonObjectTest {
     Buffer bytes = TestUtils.randomBuffer(100);
     jsonObject.put("foo", bytes);
     assertEquals(bytes, jsonObject.getBuffer("foo"));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes.getBytes()), jsonObject.getValue("foo"));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes.getBytes()), jsonObject.getValue("foo"));
 
     // Can also get as string:
     String val = jsonObject.getString("foo");
     assertNotNull(val);
-    byte[] retrieved = BASE64_DECODER.decode(val);
+    byte[] retrieved = VERTX_BASE64_DECODER.decode(val);
     assertTrue(TestUtils.byteArraysEqual(bytes.getBytes(), retrieved));
 
     jsonObject.put("foo", 123);
@@ -575,9 +575,9 @@ public class JsonObjectTest {
     byte[] defBytes = TestUtils.randomByteArray(100);
     jsonObject.put("foo", bytes);
     assertArrayEquals(bytes, jsonObject.getBinary("foo", defBytes));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), jsonObject.getValue("foo", BASE64_ENCODER.encode(defBytes)));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), jsonObject.getValue("foo", VERTX_BASE64_ENCODER.encode(defBytes)));
     assertArrayEquals(bytes, jsonObject.getBinary("foo", null));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), jsonObject.getValue("foo", null));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), jsonObject.getValue("foo", null));
 
     jsonObject.put("foo", 123);
     try {
@@ -772,7 +772,7 @@ public class JsonObjectTest {
     assertEquals(arr, jsonObject.getValue("foo"));
     byte[] bytes = TestUtils.randomByteArray(100);
     jsonObject.put("foo", bytes);
-    assertTrue(TestUtils.byteArraysEqual(bytes, BASE64_DECODER.decode((String) jsonObject.getValue("foo"))));
+    assertTrue(TestUtils.byteArraysEqual(bytes, VERTX_BASE64_DECODER.decode((String) jsonObject.getValue("foo"))));
     jsonObject.putNull("foo");
     assertNull(jsonObject.getValue("foo"));
     assertNull(jsonObject.getValue("absent"));
@@ -827,8 +827,8 @@ public class JsonObjectTest {
     assertEquals(arr, jsonObject.getValue("foo", null));
     byte[] bytes = TestUtils.randomByteArray(100);
     jsonObject.put("foo", bytes);
-    assertTrue(TestUtils.byteArraysEqual(bytes, BASE64_DECODER.decode((String) jsonObject.getValue("foo", "blah"))));
-    assertTrue(TestUtils.byteArraysEqual(bytes, BASE64_DECODER.decode((String)jsonObject.getValue("foo", null))));
+    assertTrue(TestUtils.byteArraysEqual(bytes, VERTX_BASE64_DECODER.decode((String) jsonObject.getValue("foo", "blah"))));
+    assertTrue(TestUtils.byteArraysEqual(bytes, VERTX_BASE64_DECODER.decode((String)jsonObject.getValue("foo", null))));
     jsonObject.putNull("foo");
     assertNull(jsonObject.getValue("foo", "blah"));
     assertNull(jsonObject.getValue("foo", null));
@@ -1084,15 +1084,15 @@ public class JsonObjectTest {
 
     assertSame(jsonObject, jsonObject.put("foo", bin1));
     assertArrayEquals(bin1, jsonObject.getBinary("foo"));
-    assertEquals(BASE64_ENCODER.encodeToString(bin1), jsonObject.getValue("foo"));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bin1), jsonObject.getValue("foo"));
     jsonObject.put("quux", bin2);
     assertArrayEquals(bin2, jsonObject.getBinary("quux"));
-    assertEquals(BASE64_ENCODER.encodeToString(bin2), jsonObject.getValue("quux"));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bin2), jsonObject.getValue("quux"));
     assertArrayEquals(bin1, jsonObject.getBinary("foo"));
-    assertEquals(BASE64_ENCODER.encodeToString(bin1), jsonObject.getValue("foo"));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bin1), jsonObject.getValue("foo"));
     jsonObject.put("foo", bin3);
     assertArrayEquals(bin3, jsonObject.getBinary("foo"));
-    assertEquals(BASE64_ENCODER.encodeToString(bin3), jsonObject.getValue("foo"));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bin3), jsonObject.getValue("foo"));
 
     jsonObject.put("foo", (byte[]) null);
     assertTrue(jsonObject.containsKey("foo"));
@@ -1170,7 +1170,7 @@ public class JsonObjectTest {
     assertEquals(Float.valueOf(1.23f), jsonObject.getFloat("float"));
     assertEquals(Double.valueOf(1.23d), jsonObject.getDouble("double"));
     assertArrayEquals(bytes, jsonObject.getBinary("binary"));
-    assertEquals(BASE64_ENCODER.encodeToString(bytes), jsonObject.getValue("binary"));
+    assertEquals(VERTX_BASE64_ENCODER.encodeToString(bytes), jsonObject.getValue("binary"));
     assertEquals(now, jsonObject.getInstant("instant"));
     assertEquals(now.toString(), jsonObject.getValue("instant"));
     assertEquals(obj, jsonObject.getJsonObject("obj"));

--- a/src/test/java/io/vertx/core/parsetools/JsonParserTest.java
+++ b/src/test/java/io/vertx/core/parsetools/JsonParserTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
+import static io.vertx.core.json.impl.JsonUtil.VERTX_BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.*;
@@ -240,7 +240,7 @@ public class JsonParserTest {
   @Test
   public void testBinaryValue() {
     byte[] value = TestUtils.randomByteArray(10);
-    String encoded = BASE64_ENCODER.encodeToString(value);
+    String encoded = VERTX_BASE64_ENCODER.encodeToString(value);
     testValue('"' + encoded + '"', event -> {
       assertEquals(encoded, event.value());
       assertFalse(event.isArray());


### PR DESCRIPTION
Motivation:

Refer to the discussion in

https://github.com/eclipse-vertx/vert.x/pull/3123

The purpose of this PR is to get feedback on the idea to use 

org.apache.commons.codec.binary.Base64

to decode. The advantage is that it supports both, the "legacy" and "new" mode and thus makes transition to the "new" mode possible in certain scenarios.

The usage of the commons Base64 decoder is optional and can be configured through a system property. 

I realize that https://github.com/eclipse-vertx/vertx-codegen and a number of other projects will need to be adapted to make this work. I'm happy do so and hope to be able to figure out how to actually achieve this.

Note that I wasn't able to run the tests in my environment, yet to find out if the build will pass on the build server.


