### PR TITLE
Improve fairness of SimpleConnectionPool by yielding its combiner executor

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/pool/CombinerExecutor.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/CombinerExecutor.java
@@ -12,61 +12,149 @@ package io.vertx.core.net.impl.pool;
 
 import io.netty.util.internal.PlatformDependent;
 
+import java.time.Duration;
+import java.util.Objects;
 import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongSupplier;
 
 /**
  * Lock free executor.
- *
+ * <p>
  * When a thread submits an action, it will enqueue the action to execute and then try to acquire
  * a lock. When the lock is acquired it will execute all the tasks in the queue until empty and then
  * release the lock.
  */
 public class CombinerExecutor<S> implements Executor<S> {
+  @FunctionalInterface
+  interface YieldCondition {
+    boolean yield(long actions);
+
+    static YieldCondition withMaxDuration(final Duration duration) {
+      return withMaxDuration(duration, System::nanoTime);
+    }
+
+    static YieldCondition withMaxDuration(final Duration duration, final LongSupplier nanoTimeSupplier) {
+      return new YieldCondition() {
+        private final long durationInNs = Objects.requireNonNull(duration).toNanos();
+        private long start;
+
+        @Override
+        public boolean yield(long actions) {
+          assert actions >= 0;
+          if (actions == 0) {
+            start = nanoTimeSupplier.getAsLong();
+            return false;
+          }
+          final long elapsed = nanoTimeSupplier.getAsLong() - start;
+          assert elapsed >= 0;
+          return elapsed >= durationInNs;
+        }
+      };
+    }
+
+    static YieldCondition withMaxCount(final int maxActions) {
+      if (maxActions < 0) {
+        throw new IllegalArgumentException("maxActions must be >= 1");
+      }
+      return count -> count >= maxActions;
+    }
+  }
 
   private final Queue<Action<S>> q = PlatformDependent.newMpscQueue();
   private final AtomicInteger s = new AtomicInteger();
   private final S state;
 
-  public CombinerExecutor(S state) {
+  private final YieldCondition yieldCondition;
+
+  private final Continuation resume;
+
+  private final AtomicBoolean inflightContinuation = new AtomicBoolean();
+
+  public CombinerExecutor(final S state) {
+    this(state, null);
+  }
+
+  public CombinerExecutor(final S state, final YieldCondition yieldCondition) {
     this.state = state;
+    this.resume = () -> {
+      if (!inflightContinuation.compareAndSet(true, false)) {
+        throw new IllegalStateException("Continuation cannot be resumed twice or without a prior yield");
+      }
+      return pollAndExecute();
+    };
+    this.yieldCondition = yieldCondition;
+  }
+  public int actions() {
+    return q.size();
   }
 
   @Override
-  public void submit(Action<S> action) {
+  public Continuation submitAndContinue(final Action<S> action) {
+    Objects.requireNonNull(action);
     q.add(action);
-    if (s.get() != 0 || !s.compareAndSet(0, 1)) {
-      return;
-    }
-    Task head = null;
-    do {
-      try {
-        head = pollAndExecute(head);
-      } finally {
-        s.set(0);
-      }
-    } while (!q.isEmpty() && s.compareAndSet(0, 1));
-    while (head != null) {
-      head.run();
-      head = head.next;
-    }
+    return pollAndExecute();
   }
 
-  private Task pollAndExecute(Task head) {
-    Action<S> a;
-    while ((a = q.poll()) != null) {
-      Task action = a.execute(state);
-      if (action != null) {
-        if (head == null) {
-          head = action;
-          head.prev = head;
-        } else {
-          action.prev = head.prev;
-          head.prev.next = action;
-          head.prev = action;
-        }
-      }
+  private Continuation pollAndExecute() {
+    if (s.get() != 0 || !s.compareAndSet(0, 1)) {
+      return null;
     }
-    return head;
+    final YieldCondition condition = this.yieldCondition;
+    Task head = null;
+    Task tail = null;
+    Continuation resume = null;
+    long actions = 0;
+    do {
+      // single threaded
+      boolean requiresResume = false;
+      try {
+        while (true) {
+          final Action<S> a = q.poll();
+          if (a == null) {
+            break;
+          }
+          if (condition != null && actions == 0) {
+            // we can ignore the value here
+            condition.yield(0);
+          }
+          Task task = a.execute(state);
+          if (task != null) {
+            if (head == null) {
+              assert tail == null;
+              tail = task;
+              head = task;
+            } else {
+              tail = tail.next(task);
+            }
+          }
+          actions++;
+          if (condition != null && condition.yield(actions)) {
+            requiresResume = true;
+            break;
+          }
+        }
+      } finally {
+        s.set(0);
+        // no longer single threaded
+      }
+      // requiresResume == true doesn't mean 100% chances to resume: if others has already picked up
+      // the action backlog or there wasn't any new actions already, there's no need to resume
+      if (q.isEmpty()) {
+        break;
+      }
+      if (requiresResume) {
+        if (inflightContinuation.compareAndSet(false, true)) {
+          resume = this.resume;
+        }
+        break;
+      }
+    } while (s.compareAndSet(0, 1));
+    if (head != null) {
+      head.runNextTasks();
+    }
+    return resume;
   }
+
 }

--- a/src/main/java/io/vertx/core/net/impl/pool/ConnectionPool.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/ConnectionPool.java
@@ -42,11 +42,24 @@ public interface ConnectionPool<C> {
   };
 
   static <C> ConnectionPool<C> pool(PoolConnector<C> connector, int[] maxSizes) {
-    return new SimpleConnectionPool<>(connector, maxSizes);
+    return new SimpleConnectionPool<>(connector, maxSizes, null);
+  }
+
+  static <C> ConnectionPool<C> pool(PoolConnector<C> connector, int[] maxSizes, java.util.concurrent.Executor resumeExecutor) {
+    return new SimpleConnectionPool<>(connector, maxSizes, resumeExecutor);
   }
 
   static <C> ConnectionPool<C> pool(PoolConnector<C> connector, int[] maxSizes, int maxWaiters) {
-    return new SimpleConnectionPool<>(connector, maxSizes, maxWaiters);
+    return new SimpleConnectionPool<>(connector, maxSizes, maxWaiters, null, null);
+  }
+
+  static <C> ConnectionPool<C> pool(PoolConnector<C> connector, int[] maxSizes, int maxWaiters, java.util.concurrent.Executor resumeExecutor) {
+    return new SimpleConnectionPool<>(connector, maxSizes, maxWaiters, resumeExecutor, null);
+  }
+
+  static <C> ConnectionPool<C> pool(PoolConnector<C> connector, int[] maxSizes, int maxWaiters,
+                                    java.util.concurrent.Executor resumeExecutor, CombinerExecutor.YieldCondition yieldCondition) {
+    return new SimpleConnectionPool<>(connector, maxSizes, maxWaiters, resumeExecutor, yieldCondition);
   }
 
   /**

--- a/src/main/java/io/vertx/core/net/impl/pool/SemaphoreExecutor.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/SemaphoreExecutor.java
@@ -23,7 +23,7 @@ public class SemaphoreExecutor<S> implements Executor<S> {
   }
 
   @Override
-  public void submit(Action<S> action) {
+  public Continuation submitAndContinue(Action<S> action) {
     lock.lock();
     Task post = null;
     try {
@@ -34,5 +34,6 @@ public class SemaphoreExecutor<S> implements Executor<S> {
         post.run();
       }
     }
+    return null;
   }
 }

--- a/src/main/java/io/vertx/core/net/impl/pool/Task.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/Task.java
@@ -12,8 +12,23 @@ package io.vertx.core.net.impl.pool;
 
 public abstract class Task {
 
-  Task prev;
-  Task next;
+  private Task next;
+
+  public Task next(Task next) {
+    this.next = next;
+    return next;
+  }
+
+  public void runNextTasks() {
+    Task task = this;
+    while (task != null) {
+      task.run();
+      final Task next = task.next;
+      // help GC :P
+      task.next = null;
+      task = next;
+    }
+  }
 
   public abstract void run();
 }

--- a/src/test/benchmarks/io/vertx/benchmarks/CombinerExecutorBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/CombinerExecutorBenchmark.java
@@ -35,7 +35,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 @State(Scope.Benchmark)
 @Warmup(iterations = 20, time = 200, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 200, timeUnit = MILLISECONDS)
-@Threads(2)
+@Threads(8)
 public class CombinerExecutorBenchmark extends BenchmarkBase {
 
   private Executor<Object> exec;

--- a/src/test/java/io/vertx/core/net/impl/pool/CombinerExecutorContinuationTest.java
+++ b/src/test/java/io/vertx/core/net/impl/pool/CombinerExecutorContinuationTest.java
@@ -1,0 +1,292 @@
+package io.vertx.core.net.impl.pool;
+
+import io.vertx.test.core.AsyncTestBase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+
+import static java.lang.Boolean.TRUE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+public class CombinerExecutorContinuationTest extends AsyncTestBase {
+
+  @Rule
+  public ErrorCollector errors = new ErrorCollector() {
+    @Override
+    public synchronized void addError(Throwable error) {
+      super.addError(error);
+    }
+
+    @Override
+    protected synchronized void verify() throws Throwable {
+      super.verify();
+    }
+  };
+
+  @FunctionalInterface
+  private interface ExRunnable {
+
+    void run() throws Exception;
+  }
+
+  private static Callable<Boolean> asCallable(ExRunnable runnable) {
+    return () -> {
+      runnable.run();
+      return TRUE;
+    };
+  }
+
+  @Test
+  public void yieldWithMaxCountDeadlineControlExecutionDuration() throws InterruptedException, ExecutionException {
+    CombinerExecutor<Object> sync = new CombinerExecutor<>(new Object(), CombinerExecutor.YieldCondition.withMaxCount(1));
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    final int TEST_ITERATION = 10000;
+    try {
+      for (int t = 0; t < TEST_ITERATION; t++) {
+        final CountDownLatch submissionsWithoutContinuation = new CountDownLatch(1);
+        final CountDownLatch winnerExecuting = new CountDownLatch(1);
+        CompletableFuture<Executor.Continuation> continuationResult = new CompletableFuture<>();
+        executorService.execute(() -> {
+          AtomicReference<Thread> executed = new AtomicReference<>();
+          Executor.Continuation continuation = sync.submitAndContinue(state -> {
+            executed.set(Thread.currentThread());
+            winnerExecuting.countDown();
+            if (errors.checkSucceeds(asCallable(submissionsWithoutContinuation::await)) != TRUE) {
+              return null;
+            }
+            errors.checkThat("pending actions doesn't match expected ones", sync.actions(), is(2));
+            return null;
+          });
+          errors.checkThat("The current thread hasn't win the race to execute this action",
+            executed.get(), is(Thread.currentThread()));
+          errors.checkThat("Continuation isn't supposed to be null", continuation, notNullValue());
+          continuationResult.complete(continuation);
+        });
+        executorService.submit(() -> {
+          if (errors.checkSucceeds(asCallable(winnerExecuting::await)) != TRUE) {
+            return;
+          }
+          AtomicReference<Thread> executed = new AtomicReference<>();
+          for (int i = 0; i < 2; i++) {
+            final Executor.Continuation continuation = sync.submitAndContinue(state -> {
+              Thread existing = executed.getAndSet(Thread.currentThread());
+              if (existing != null) {
+                errors.checkThat("This action isn't supposed to be executed twice by different threads",
+                  existing, is(Thread.currentThread()));
+              }
+              return null;
+            });
+            errors.checkThat("Continuation is supposed to be null", continuation, nullValue());
+          }
+          submissionsWithoutContinuation.countDown();
+          errors.checkThat("Action isn't supposed to be executed", executed.get(), nullValue());
+          errors.checkThat("expecting one action still left to happen", sync.actions(), is(2));
+          final Executor.Continuation winnerContinuation = errors.checkSucceeds(continuationResult::get);
+          if (winnerContinuation == null) {
+            return;
+          }
+          final Executor.Continuation lastContinuation = winnerContinuation.resume();
+          errors.checkThat("Expecting another continuation", lastContinuation, notNullValue());
+          errors.checkThat("There should be just another action left", sync.actions(), is(1));
+          errors.checkThat("The current thread hasn't win the race to resume its pending action", executed.get(), is(Thread.currentThread()));
+          errors.checkThat("Further continuation isn't supposed to be needed", lastContinuation.resume(), nullValue());
+          errors.checkThat("There shouldn't be any action left", sync.actions(), is(0));
+          errors.checkThat("The current thread hasn't win the race to resume its pending action", executed.get(), is(Thread.currentThread()));
+        }).get();
+      }
+    } finally {
+      executorService.shutdown();
+    }
+  }
+
+  private static class TimeMachine implements LongSupplier {
+
+    private final AtomicLong currentTime = new AtomicLong(0);
+
+    @Override
+    public long getAsLong() {
+      return currentTime.get();
+    }
+
+    public long moveForward(Duration time) {
+      return currentTime.addAndGet(time.toNanos());
+    }
+
+    public long rewind(Duration time) {
+      return currentTime.addAndGet(-time.toNanos());
+    }
+
+    public void rewind() {
+      currentTime.set(0);
+    }
+  }
+
+  @Test
+  public void cannotResumeTwiceContinuationIfNotSuspended() throws InterruptedException {
+    final CombinerExecutor<Object> sync = new CombinerExecutor<>(new Object(), actions -> true);
+    final CountDownLatch executing = new CountDownLatch(1);
+    final CountDownLatch accumulated = new CountDownLatch(1);
+    Thread executor = new Thread(() -> {
+      final Executor.Continuation continuation = sync.submitAndContinue(state -> {
+        executing.countDown();
+        if (errors.checkSucceeds(asCallable(accumulated::await)) != TRUE) {
+          return null;
+        }
+        errors.checkThat("pending actions doesn't match expected ones", sync.actions(), is(1));
+        return null;
+      });
+      errors.checkThat("continuation is supposed to not be null", continuation, notNullValue());
+      errors.checkThat("continuation is supposed to be null: no actions left to execute", continuation.resume(), nullValue());
+      // cannot resume it again!
+      errors.checkThrows(IllegalStateException.class, continuation::resume);
+    });
+    executor.start();
+    Thread accumulator = new Thread(() -> {
+      if (errors.checkSucceeds(asCallable(executing::await)) != TRUE) {
+        return;
+      }
+      sync.submitAndContinue(state -> null);
+      accumulated.countDown();
+    });
+    accumulator.start();
+    accumulator.join();
+    executor.join();
+  }
+
+  @Test
+  public void notEmitContinuationIfAlreadySuspended() throws InterruptedException, ExecutionException {
+    final CombinerExecutor<Object> sync = new CombinerExecutor<>(new Object(), actions -> true);
+    final CountDownLatch executing = new CountDownLatch(1);
+    final CountDownLatch accumulated = new CountDownLatch(1);
+    final CompletableFuture<Executor.Continuation> resume = new CompletableFuture<>();
+    Thread executor = new Thread(() -> {
+      final Executor.Continuation continuation = sync.submitAndContinue(state -> {
+        executing.countDown();
+        if (errors.checkSucceeds(asCallable(accumulated::await)) != TRUE) {
+          return null;
+        }
+        errors.checkThat("pending actions doesn't match expected ones", sync.actions(), is(2));
+        return null;
+      });
+      errors.checkThat("continuation is supposed to not be null", continuation, notNullValue());
+      resume.complete(continuation);
+    });
+    executor.start();
+    Thread accumulator = new Thread(() -> {
+      if (errors.checkSucceeds(asCallable(executing::await)) != TRUE) {
+        return;
+      }
+      class Executed {
+        int value = 0;
+      }
+      Executed executed = new Executed();
+      for (int i = 0; i < 2; i++) {
+        sync.submitAndContinue(state -> {
+          executed.value++;
+          return null;
+        });
+      }
+      accumulated.countDown();
+      // this is going to await the concurrent submission to complete
+      Executor.Continuation continuation = errors.checkSucceeds(resume::get);
+      errors.checkThat("continuation is supposed to be null; no resume has happened yet", sync.submitAndContinue(state -> {
+        executed.value++;
+        return null;
+      }), nullValue());
+      errors.checkThat("pending actions doesn't match expected ones", sync.actions(), is(2));
+      errors.checkThat(executed.value, is(1));
+      continuation = continuation.resume();
+      errors.checkThat(continuation, notNullValue());
+      errors.checkThat("pending actions doesn't match expected ones", sync.actions(), is(1));
+      errors.checkThat(executed.value, is(2));
+      errors.checkThat(continuation.resume(), nullValue());
+      errors.checkThat("pending actions doesn't match expected ones", sync.actions(), is(0));
+      errors.checkThat(executed.value, is(3));
+    });
+    accumulator.start();
+    accumulator.join();
+    executor.join();
+  }
+
+  @Test
+  public void yieldWithTimeDeadlineControlExecutionDuration() throws InterruptedException, ExecutionException {
+    final TimeMachine timeMachine = new TimeMachine();
+    final Duration TIMEOUT_EXE = Duration.ofMillis(100);
+    final Duration MORE_THEN_TIMEOUT_EXE = TIMEOUT_EXE.plusNanos(1);
+    final CombinerExecutor<Object> sync = new CombinerExecutor<>(new Object(), CombinerExecutor.YieldCondition.withMaxDuration(TIMEOUT_EXE, timeMachine));
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    final int TEST_ITERATION = 10000;
+    try {
+      for (int t = 0; t < TEST_ITERATION; t++) {
+        timeMachine.rewind();
+        final CountDownLatch submissionsWithoutContinuation = new CountDownLatch(1);
+        final CountDownLatch winnerExecuting = new CountDownLatch(1);
+        CompletableFuture<Executor.Continuation> continuationResult = new CompletableFuture<>();
+        executorService.execute(() -> {
+          AtomicReference<Thread> executed = new AtomicReference<>();
+          Executor.Continuation continuation = sync.submitAndContinue(state -> {
+            timeMachine.moveForward(MORE_THEN_TIMEOUT_EXE);
+            executed.set(Thread.currentThread());
+            winnerExecuting.countDown();
+            if (errors.checkSucceeds(asCallable(submissionsWithoutContinuation::await)) != TRUE) {
+              return null;
+            }
+            errors.checkThat("pending actions doesn't match expected ones", sync.actions(), is(2));
+            return null;
+          });
+          errors.checkThat("The current thread hasn't win the race to execute this action",
+            executed.get(), is(Thread.currentThread()));
+          errors.checkThat("Continuation isn't supposed to be null", continuation, notNullValue());
+          continuationResult.complete(continuation);
+        });
+        executorService.submit(() -> {
+          if (errors.checkSucceeds(asCallable(winnerExecuting::await)) != TRUE) {
+            return;
+          }
+          AtomicReference<Thread> executed = new AtomicReference<>();
+          for (int i = 0; i < 2; i++) {
+            final Executor.Continuation continuation = sync.submitAndContinue(state -> {
+              timeMachine.moveForward(MORE_THEN_TIMEOUT_EXE);
+              Thread existing = executed.getAndSet(Thread.currentThread());
+              if (existing != null) {
+                errors.checkThat("This action isn't supposed to be executed twice by different threads",
+                  existing, is(Thread.currentThread()));
+              }
+              return null;
+            });
+            errors.checkThat("Continuation is supposed to be null", continuation, nullValue());
+          }
+          submissionsWithoutContinuation.countDown();
+          errors.checkThat("Action isn't supposed to be executed", executed.get(), nullValue());
+          errors.checkThat("expecting one action still left to happen", sync.actions(), is(2));
+          final Executor.Continuation winnerContinuation = errors.checkSucceeds(continuationResult::get);
+          if (winnerContinuation == null) {
+            return;
+          }
+          final Executor.Continuation lastContinuation = winnerContinuation.resume();
+          errors.checkThat("Expecting another continuation", lastContinuation, notNullValue());
+          errors.checkThat("There should be just another action left", sync.actions(), is(1));
+          errors.checkThat("The current thread hasn't win the race to resume its pending action", executed.get(), is(Thread.currentThread()));
+          errors.checkThat("Further continuation isn't supposed to be needed", lastContinuation.resume(), nullValue());
+          errors.checkThat("There shouldn't be any action left", sync.actions(), is(0));
+          errors.checkThat("The current thread hasn't win the race to resume its pending action", executed.get(), is(Thread.currentThread()));
+        }).get();
+      }
+    } finally {
+      executorService.shutdown();
+    }
+  }
+}


### PR DESCRIPTION
Motivation: 

`SimpleConnectionPool` is backed by a `CombinerExecutor` that can be caught in a tight (potentially endless) loop while consuming (and executing) actions, occupying its current running event loop for too long.

This PR add both duration-based and max action count based yield strategies with some opportunistic action resume ie
if a resume continuation is emitted, any concurrent "lucky" resume/submit can still consume the existing actions backlog.
