### PR TITLE
fix(VertxOptions): QuickWin https://github.com/eclipse-vertx/vert.x/i…

### DIFF
--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -412,7 +412,7 @@ public class VertxOptions {
    * @return a reference to this, so the API can be used fluently
    */
   public VertxOptions setQuorumSize(int quorumSize) {
-    if (quorumSize < 1) {
+    if (quorumSize <= 0) {
       throw new IllegalArgumentException("quorumSize should be >= 1");
     }
     this.quorumSize = quorumSize;


### PR DESCRIPTION
…ssues/4431#issue-1297779421

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

VertOptions has been incorrect exception messages for Quorum Size

Following the inputs:

Current 

public VertxOptions setQuorumSize(int quorumSize) {
    if (quorumSize < 1) {
      throw new IllegalArgumentException("quorumSize should be >= 1");
    }
    this.quorumSize = quorumSize;
    return this;
  }

setQuorumSize :
condition to throw exception: quorum < 1
message part of exception: workerPoolSize muse be >= 1

Proposed  condition  

public VertxOptions setQuorumSize(int quorumSize) {
    if (quorumSize <=0 ) {
      throw new IllegalArgumentException("quorumSize should be >= 1");
    }
    this.quorumSize = quorumSize;
    return this;
  }

Vertx version: Latest version

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
