### PR TITLE
Allow passing throwable in event bus message fail

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/Message.java
+++ b/src/main/java/io/vertx/core/eventbus/Message.java
@@ -141,4 +141,18 @@ public interface Message<T> {
     reply(new ReplyException(ReplyFailure.RECIPIENT_FAILURE, failureCode, message));
   }
 
+  /**
+   * Signal to the sender that processing of this message failed.
+   * <p>
+   * If the message was sent specifying a result handler
+   * the handler will be called with a failure corresponding to the failure code and message specified here.
+   *
+   * @param failureCode A failure code to pass back to the sender
+   * @param message A message to pass back to the sender
+   * @param cause A cause to pass back to the sender
+   */
+  default void fail(int failureCode, String message, Throwable cause) {
+    reply(new ReplyException(ReplyFailure.RECIPIENT_FAILURE, failureCode, message, cause));
+  }
+
 }

--- a/src/main/java/io/vertx/core/eventbus/ReplyException.java
+++ b/src/main/java/io/vertx/core/eventbus/ReplyException.java
@@ -43,6 +43,20 @@ public class ReplyException extends VertxException {
    * Create a ReplyException
    *
    * @param failureType  the failure type
+   * @param failureCode  the failure code
+   * @param message  the failure message
+   * @param cause  the cause
+   */
+  public ReplyException(ReplyFailure failureType, int failureCode, String message, Throwable cause) {
+    super(message, cause);
+    this.failureType = failureType;
+    this.failureCode = failureCode;
+  }
+
+  /**
+   * Create a ReplyException
+   *
+   * @param failureType  the failure type
    * @param message  the failure message
    */
   public ReplyException(ReplyFailure failureType, String message) {


### PR DESCRIPTION
Motivation:

I'm opening this pr mostly as a question with a possible solution.

I would like to be able to pass a `throwable` with the event bus `message.fail` method to preserve some of the context of the failure. Something like:
```
public class MyCustomThrowable extends Throwable {}

vertx.eventBus()
        .consumer("test", message -> message.fail(1, "failure", new MyCustomThrowable()));

vertx.eventBus().request("test", "test")
    .onFailure(h -> {
      if(h.getCause() instanceof MyCustomThrowable) {
        //Custom error handling here.
      }
    });
```
I'm not sure if there is a better way to handle this or if this is a tenable solution? 
