### PR TITLE
fix: ensure `DeliveryOptions.headers` are properly cloned

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/DeliveryOptions.java
+++ b/src/main/java/io/vertx/core/eventbus/DeliveryOptions.java
@@ -67,7 +67,9 @@ public class DeliveryOptions {
   public DeliveryOptions(DeliveryOptions other) {
     this.timeout = other.getSendTimeout();
     this.codecName = other.getCodecName();
-    this.headers = other.getHeaders();
+    if (other.getHeaders() != null) {
+      this.headers = MultiMap.caseInsensitiveMultiMap().addAll(other.getHeaders());
+    }
     this.localOnly = other.localOnly;
     this.tracingPolicy = other.tracingPolicy;
   }

--- a/src/test/java/io/vertx/core/eventbus/DeliveryOptionsTest.java
+++ b/src/test/java/io/vertx/core/eventbus/DeliveryOptionsTest.java
@@ -48,4 +48,18 @@ public class DeliveryOptionsTest {
 
     assertEquals(fullJson, new DeliveryOptions(fullJson).toJson());
   }
+
+  @Test
+  public void ensureClonedHeaders() {
+    DeliveryOptions original = new DeliveryOptions();
+    original.addHeader("foo", "bar");
+    assertEquals(1, original.getHeaders().size());
+
+    DeliveryOptions cloned = new DeliveryOptions(original);
+    assertEquals(1, cloned.getHeaders().size());
+    cloned.addHeader("bar", "foo");
+    assertEquals(2, cloned.getHeaders().size());
+
+    assertEquals(1, original.getHeaders().size());
+  }
 }


### PR DESCRIPTION
Motivation:

I've run into situations where using re-using a  `*VertxEBProxy` (produced by vertx-service-proxy) sends messages to the wrong consumer because the `DeliveryOptions.headers` contains multiple `action` values.

This ensures the `DeliveryOptions.headers` are properly cloned. 
