### PR TITLE
Feature: setPeriodic add argument initialDelay parameter

### DIFF
--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -292,7 +292,7 @@ public interface Vertx extends Measured {
    * Set a periodic timer to fire every {@code delay} milliseconds with initial delay, at which point {@code handler} will be called with
    * the id of the timer.
    *
-   * @param initialDelay the initial delay， the default initial delay is {@code delay}
+   * @param initialDelay the initial delay in milliseconds
    * @param delay  the delay in milliseconds, after which the timer will fire
    * @param handler  the handler that will be called with the timer ID when the timer fires
    * @return the unique ID of the timer
@@ -312,7 +312,7 @@ public interface Vertx extends Measured {
    * Returns a periodic timer as a read stream. The timer will be fired every {@code delay} milliseconds after
    * the {@link ReadStream#handler} has been called.
    *
-   * @param initialDelay the initial delay， the default initial delay is {@code delay}
+   * @param initialDelay the initial delay in milliseconds
    * @param delay  the delay in milliseconds, after which the timer will fire
    * @return the periodic stream
    */

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -293,7 +293,7 @@ public interface Vertx extends Measured {
    * the id of the timer.
    *
    * @param delay  the delay in milliseconds, after which the timer will fire
-   * @param initialDelay the initial delay
+   * @param initialDelay the initial delay， the default initial delay is {@code delay}
    * @param handler  the handler that will be called with the timer ID when the timer fires
    * @return the unique ID of the timer
    */

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -292,12 +292,12 @@ public interface Vertx extends Measured {
    * Set a periodic timer to fire every {@code delay} milliseconds with initial delay, at which point {@code handler} will be called with
    * the id of the timer.
    *
-   * @param delay  the delay in milliseconds, after which the timer will fire
    * @param initialDelay the initial delay， the default initial delay is {@code delay}
+   * @param delay  the delay in milliseconds, after which the timer will fire
    * @param handler  the handler that will be called with the timer ID when the timer fires
    * @return the unique ID of the timer
    */
-  long setPeriodic(long delay, long initialDelay, Handler<Long> handler);
+  long setPeriodic(long initialDelay, long delay, Handler<Long> handler);
 
   /**
    * Returns a periodic timer as a read stream. The timer will be fired every {@code delay} milliseconds after
@@ -307,6 +307,16 @@ public interface Vertx extends Measured {
    * @return the periodic stream
    */
   TimeoutStream periodicStream(long delay);
+
+  /**
+   * Returns a periodic timer as a read stream. The timer will be fired every {@code delay} milliseconds after
+   * the {@link ReadStream#handler} has been called.
+   *
+   * @param initialDelay the initial delay， the default initial delay is {@code delay}
+   * @param delay  the delay in milliseconds, after which the timer will fire
+   * @return the periodic stream
+   */
+  TimeoutStream periodicStream(long initialDelay, long delay);
 
   /**
    * Cancels the timer with the specified {@code id}.

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -282,12 +282,22 @@ public interface Vertx extends Measured {
    * Set a periodic timer to fire every {@code delay} milliseconds, at which point {@code handler} will be called with
    * the id of the timer.
    *
-   *
    * @param delay  the delay in milliseconds, after which the timer will fire
    * @param handler  the handler that will be called with the timer ID when the timer fires
    * @return the unique ID of the timer
    */
   long setPeriodic(long delay, Handler<Long> handler);
+
+  /**
+   * Set a periodic timer to fire every {@code delay} milliseconds with initial delay, at which point {@code handler} will be called with
+   * the id of the timer.
+   *
+   * @param delay  the delay in milliseconds, after which the timer will fire
+   * @param initialDelay the initial delay
+   * @param handler  the handler that will be called with the timer ID when the timer fires
+   * @return the unique ID of the timer
+   */
+  long setPeriodic(long delay, long initialDelay, Handler<Long> handler);
 
   /**
    * Returns a periodic timer as a read stream. The timer will be fired every {@code delay} milliseconds after

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -557,7 +557,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
                                               TimeUnit timeUnit,
                                               boolean addCloseHook,
                                               Handler<Long> handler) {
-    return scheduleTimeout(context, periodic, delay,0, timeUnit, addCloseHook, handler);
+    return scheduleTimeout(context, periodic, delay, delay, timeUnit, addCloseHook, handler);
   }
 
   public ContextInternal getContext() {

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -361,7 +361,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   public long setPeriodic(long delay, Handler<Long> handler) {
     return setPeriodic(delay, delay, handler);
   }
-  }
 
   @Override
   public long setPeriodic(long initialDelay, long delay, Handler<Long> handler) {

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -359,7 +359,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public long setPeriodic(long delay, Handler<Long> handler) {
-    return setPeriodic(delay, 0, handler);
+    return setPeriodic(delay, delay, handler);
   }
 
   @Override
@@ -544,7 +544,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     }
     EventLoop el = context.nettyEventLoop();
     if (periodic) {
-      task.future = el.scheduleAtFixedRate(task, initialDelay + delay, delay, timeUnit);
+      task.future = el.scheduleAtFixedRate(task, initialDelay, delay, timeUnit);
     } else {
       task.future = el.schedule(task, delay, timeUnit);
     }

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -1048,7 +1048,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
         }
         ContextInternal ctx = getOrCreateContext();
         this.handler = handler;
-        this.id = scheduleTimeout(ctx, periodic, delay, initialDelay, TimeUnit.MILLISECONDS, ctx.isDeployment(), this);
+        this.id = scheduleTimeout(ctx, periodic, initialDelay, delay, TimeUnit.MILLISECONDS, ctx.isDeployment(), this);
       } else {
         cancel();
       }

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -359,8 +359,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public long setPeriodic(long delay, Handler<Long> handler) {
-    ContextInternal ctx = getOrCreateContext();
-    return scheduleTimeout(ctx, true, delay, delay, TimeUnit.MILLISECONDS, ctx.isDeployment(), handler);
+    return setPeriodic(delay, delay, handler);
   }
   }
 
@@ -992,10 +991,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     private long demand;
 
     public TimeoutStreamImpl(long delay, boolean periodic) {
-      this.initialDelay = delay;
-      this.delay = delay;
-      this.periodic = periodic;
-      this.demand = Long.MAX_VALUE;
+      this(delay, delay, periodic);
     }
 
     public TimeoutStreamImpl(long initialDelay, long delay, boolean periodic) {

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -369,7 +369,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   @Override
-  publish TimeoutStream periodicStream(long initialDelay, long delay) {
+  public TimeoutStream periodicStream(long initialDelay, long delay) {
     return new TimeoutStreamImpl(initialDelay, delay, true);
   }
 

--- a/src/test/java/io/vertx/core/TimerTest.java
+++ b/src/test/java/io/vertx/core/TimerTest.java
@@ -292,6 +292,31 @@ public class TimerTest extends VertxTestBase {
   }
 
   @Test
+  public void testPeriodicStreamHandlerWithInitialDelay() {
+    TimeoutStream timer = vertx.periodicStream(10, 20);
+    AtomicInteger count = new AtomicInteger();
+    timer.handler(l -> {
+      int value = count.incrementAndGet();
+      switch (value) {
+        case 0:
+          break;
+        case 1:
+          throw new RuntimeException();
+        case 2:
+          timer.cancel();
+          testComplete();
+          break;
+        default:
+          fail();
+      }
+    });
+    timer.endHandler(v -> {
+      fail();
+    });
+    await();
+  }
+
+  @Test
   public void testPeriodicSetHandlerTwice() {
     vertx.runOnContext(v -> {
       ReadStream<Long> timer = vertx.periodicStream(200);

--- a/src/test/java/io/vertx/core/TimerTest.java
+++ b/src/test/java/io/vertx/core/TimerTest.java
@@ -40,6 +40,11 @@ public class TimerTest extends VertxTestBase {
     periodic(10);
   }
 
+  @Test
+  public void testPeriodicWithInitialDelay() {
+    periodic(10, 20);
+  }
+
   /**
    * Test the timers fire with approximately the correct delay
    */
@@ -77,6 +82,12 @@ public class TimerTest extends VertxTestBase {
             testComplete();
           }
         });
+        vertx.setPeriodic(3, 4, id -> {
+          assertSame(thr, Thread.currentThread());
+          if (cnt.incrementAndGet() == 5) {
+            testComplete();
+          }
+        });
       }
     }
     MyVerticle verticle = new MyVerticle();
@@ -88,6 +99,27 @@ public class TimerTest extends VertxTestBase {
     final int numFires = 10;
     final AtomicLong id = new AtomicLong(-1);
     id.set(vertx.setPeriodic(delay, new Handler<Long>() {
+      int count;
+
+      public void handle(Long timerID) {
+        assertEquals(id.get(), timerID.longValue());
+        count++;
+        if (count == numFires) {
+          vertx.cancelTimer(timerID);
+          setEndTimer();
+        }
+        if (count > numFires) {
+          fail("Fired too many times");
+        }
+      }
+    }));
+    await();
+  }
+
+  private void periodic(long initialDelay, long delay) {
+    final int numFires = 10;
+    final AtomicLong id = new AtomicLong(-1);
+    id.set(vertx.setPeriodic(initialDelay, delay, new Handler<Long>() {
       int count;
 
       public void handle(Long timerID) {


### PR DESCRIPTION
Motivation:

add a new parameter `initialDelay` in `setPeriodic` method of `Vertx` https://github.com/eclipse-vertx/vert.x/issues/4436
