### PR TITLE
Do not log before being LoggerFactory is fully initialized

### DIFF
--- a/src/main/java/io/vertx/core/logging/Log4j2LogDelegateFactory.java
+++ b/src/main/java/io/vertx/core/logging/Log4j2LogDelegateFactory.java
@@ -13,25 +13,22 @@ package io.vertx.core.logging;
 
 import io.vertx.core.spi.logging.LogDelegate;
 import io.vertx.core.spi.logging.LogDelegateFactory;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * A {@link LogDelegateFactory} which creates {@link Log4j2LogDelegate} instances.
  *
  * @author Clement Escoffier - clement@apache.org
- *
- *
  */
-public class Log4j2LogDelegateFactory implements LogDelegateFactory
-{
+public class Log4j2LogDelegateFactory implements LogDelegateFactory {
 
   @Override
   public boolean isAvailable() {
-    return true;
+    return LogManager.getLogger(Log4j2LogDelegateFactory.class) != null;
   }
 
-  public LogDelegate createDelegate(final String name)
-   {
-      return new Log4j2LogDelegate(name);
-   }
+  public LogDelegate createDelegate(final String name) {
+    return new Log4j2LogDelegate(name);
+  }
 
 }

--- a/src/main/java/io/vertx/core/logging/LoggerFactory.java
+++ b/src/main/java/io/vertx/core/logging/LoggerFactory.java
@@ -32,6 +32,9 @@ public class LoggerFactory {
 
   static {
     initialise();
+    // Do not log before being fully initialized (a logger extension may use Vert.x classes)
+    LogDelegate log = delegateFactory.createDelegate(LoggerFactory.class.getName());
+    log.debug("Using " + delegateFactory.getClass().getName());
   }
 
   public static synchronized void initialise() {
@@ -56,14 +59,12 @@ public class LoggerFactory {
   }
 
   private static boolean configureWith(String name, boolean shortName, ClassLoader loader) {
-    String loggerName = LoggerFactory.class.getName();
     try {
       Class<?> clazz = Class.forName(shortName ? "io.vertx.core.logging." + name + "LogDelegateFactory" : name, true, loader);
       LogDelegateFactory factory = (LogDelegateFactory) clazz.newInstance();
       if (!factory.isAvailable()) {
         return false;
       }
-      factory.createDelegate(loggerName).debug("Using " + factory.getClass().getName());
       delegateFactory = factory;
       return true;
     } catch (Throwable ignore) {

--- a/src/test/java/io/vertx/core/impl/logging/NoExceptionInInitializerErrorTest.java
+++ b/src/test/java/io/vertx/core/impl/logging/NoExceptionInInitializerErrorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.impl.logging;
+
+import io.vertx.core.Vertx;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.pattern.ConverterKeys;
+import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
+import org.apache.logging.log4j.core.pattern.PatternConverter;
+import org.junit.After;
+import org.junit.Test;
+
+import static io.vertx.core.logging.LoggerFactory.LOGGER_DELEGATE_FACTORY_CLASS_NAME;
+
+
+/**
+ * Must be separated from {@link LoggingBackendSelectionTest}.
+ * Otherwise, the Vert.x instance might be fully initialized before our test runs.
+ *
+ * @author Thomas Segismont
+ */
+public class NoExceptionInInitializerErrorTest {
+
+  @After
+  public void tearDown() {
+    System.clearProperty(LOGGER_DELEGATE_FACTORY_CLASS_NAME);
+  }
+
+  @Test
+  public void doTest() throws Exception {
+    System.setProperty(LOGGER_DELEGATE_FACTORY_CLASS_NAME, "io.vertx.core.logging.Log4j2LogDelegateFactory");
+    // Will fail if:
+    //  - the logging impl uses Vertx static methods (e.g. currentContext in a converter)
+    //  - io.vertx.core.logging.LoggerFactory logs something before being fully initialized
+    Vertx.vertx();
+  }
+
+  @Plugin(name = "VertxContextConverter", category = PatternConverter.CATEGORY)
+  @ConverterKeys("vsc")
+  public static class VertxContextConverter extends LogEventPatternConverter {
+
+    private VertxContextConverter(String[] options) {
+      super("vsc", "vsc");
+    }
+
+    @Override
+    public void format(LogEvent event, StringBuilder toAppendTo) {
+      // We simply want to make sure we can only get an initialized Vert.x instance
+      toAppendTo.append(Vertx.currentContext());
+    }
+
+    public static VertxContextConverter newInstance(final String[] options) {
+      return new VertxContextConverter(options);
+    }
+  }
+}

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -21,7 +21,7 @@ appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.follow = true
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%t] %p %c %C{1}.%M:%L - %m%n
+appender.console.layout.pattern = [%t] %p %c %C{1}.%M:%L %vsc - %m%n
 appender.console.target = SYSTEM_ERR
 
 rootLogger.level = trace


### PR DESCRIPTION
Fixes reactiverse/reactiverse-contextual-logging#52

Otherwise, a logger extension might use Vert.x classes before they are fully initialized.