### PR TITLE
refactor: fix code style issues

### DIFF
--- a/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
@@ -1065,8 +1065,7 @@ public class FileSystemImpl implements FileSystem {
         try {
           Path target = vertx.resolveFile(path).toPath();
           byte[] bytes = Files.readAllBytes(target);
-          Buffer buff = Buffer.buffer(bytes);
-          return buff;
+          return Buffer.buffer(bytes);
         } catch (IOException e) {
           throw new FileSystemException(getFileAccessErrorMessage("read", path), e);
         }
@@ -1158,7 +1157,7 @@ public class FileSystemImpl implements FileSystem {
 
     protected final ContextInternal context;
 
-    public BlockingAction() {
+    protected BlockingAction() {
       this.context = vertx.getOrCreateContext();
     }
 


### PR DESCRIPTION
# Changelog
The following bad smells are refactored:
## Non-Protected-Constructor-in-Abstract-Class
A non-protected constructor in an abstract class is not needed because only subclasses can be instantiated
## UnnecessaryLocalVariable
A local variable is declared and in the next line returned. This can be replaced by an instant return.

## The following has changed in the code:
### Non-Protected-Constructor-in-Abstract-Class
- Constructor `io.vertx.core.file.impl.FileSystemImpl$BlockingAction()` is now protected instead of public
### UnnecessaryLocalVariable
- Inlined return statement return `io.vertx.core.buffer.Buffer.buffer(bytes)`

Motivation:

I fixed some easy code style problems an IDE like JetBrains IntelliJ finds. This does not alter any functionality and only increases the code quality.
