### PR TITLE
style: Repair code style issues in io.vertx.core.net.impl.KeyStoreHelper

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
@@ -354,7 +354,7 @@ public class KeyStoreHelper {
         } else {
           String content = pem.substring(beginMatcher.end(), endMatcher.start());
           content = content.replaceAll("\\s", "");
-          if (content.length() == 0) {
+          if (content.isEmpty()) {
             throw new RuntimeException("Empty pem file");
           }
           Collection<P> pemItems = pemFact.apply(endDelimiter, Base64.getDecoder().decode(content));


### PR DESCRIPTION
Motivation:

# Repairing Code Style Issues
## SizeReplaceableByIsEmpty
Checking if a something is empty should be done by `Object#isEmpty` instead of `Object.size==0`
## Changes: 
* Replaced `content.length()` in `content.length() == 0` with `isEmpty()`
<!-- ruleID: "SizeReplaceableByIsEmpty"
filePath: "src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java"
position:
  startLine: 357
  endLine: 0
  startColumn: 15
  endColumn: 0
  charOffset: 13833
  charLength: 21
message: "'content.length() == 0' can be replaced with 'content.isEmpty()'"
messageMarkdown: "`content.length() == 0` can be replaced with 'content.isEmpty()'"
snippet: "          String content = pem.substring(beginMatcher.end(), endMatcher.start());\n\
  \          content = content.replaceAll(\"\\\\s\", \"\");\n          if (content.length()\
  \ == 0) {\n            throw new RuntimeException(\"Empty pem file\");\n       \
  \   }"
analyzer: "Qodana"
 -->
<!-- fingerprint:506809411 -->


Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
