### PR TITLE
[ISSUE-4487] NPE when NetSocket.upgradeToSsl() is called if no TLS configuration in NetClientOptions

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -18,6 +18,7 @@ import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SniHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.SslProvider;
 import io.netty.util.Mapping;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -39,6 +40,7 @@ import io.vertx.core.net.SSLEngineOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.TCPSSLOptions;
 import io.vertx.core.net.TrustOptions;
+import io.vertx.core.spi.tls.DefaultSslContextFactory;
 import io.vertx.core.spi.tls.SslContextFactory;
 
 import javax.net.ssl.*;
@@ -222,7 +224,7 @@ public class SSLHelper {
           p.complete(sslProvider);
         })).onComplete(promise);
       } else {
-        fut = Future.succeededFuture();
+        fut = Future.succeededFuture(() -> new DefaultSslContextFactory(SslProvider.JDK, false));
       }
       sslProvider = fut;
     }

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -3293,6 +3293,23 @@ public class NetTest extends VertxTestBase {
     await();
   }
 
+  /**
+   * Test that NetSocket.upgradeToSsl() should fail the handler if no TLS configuration was set.
+   */
+  @Test
+  public void testUpgradeToSSLIncorrectClientOptions() {
+    server.close();
+    server = vertx.createNetServer(new NetServerOptions().setSsl(true).setPort(4043)
+      .setKeyCertOptions(Cert.SERVER_JKS_ROOT_CA.get()));
+    NetClient client = vertx.createNetClient();
+    server.connectHandler(ns -> {}).listen(onSuccess(v -> {
+      client.connect(4043, "127.0.0.1", onSuccess(ns -> {
+        ns.upgradeToSsl(onFailure(err -> client.close(onSuccess(s -> testComplete()))));
+      }));
+    }));
+    await();
+  }
+
   @Test
   public void testClientLocalAddress() {
     String expectedAddress = TestUtils.loopbackAddress();


### PR DESCRIPTION
Motivation:

Fixes: #4487 

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines


This PR proposes to specify a default SslContextFactory (SslProvider.JDK) when there is no TLS configuration set