### PR TITLE
Fix hashCode in EndpointKey

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/EndpointKey.java
+++ b/src/main/java/io/vertx/core/http/impl/EndpointKey.java
@@ -71,8 +71,7 @@ final class EndpointKey {
     if (options.getUsername() != null && options.getPassword() != null) {
       return Objects.hash(options.getHost(), options.getPort(), options.getType(), options.getUsername(), options.getPassword());
     } else {
-      Objects.hash(options.getHost(), options.getPort(), options.getType());
+      return Objects.hash(options.getHost(), options.getPort(), options.getType());
     }
-    return 0;
   }
 }

--- a/src/test/java/io/vertx/core/http/impl/EndPointKeyTest.java
+++ b/src/test/java/io/vertx/core/http/impl/EndPointKeyTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.SocketAddress;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
+ */
+public class EndPointKeyTest {
+
+  @Test
+  public void testEndPointKey() {
+    final SocketAddress addr = SocketAddress.inetSocketAddress(8080, "localhost");
+    EndpointKey key1 = new EndpointKey(false, new ProxyOptions(), addr, addr);
+    EndpointKey key2 = new EndpointKey(false, new ProxyOptions(), addr, addr);
+    assertEquals(key1, key2);
+    assertEquals(key1.hashCode(), key2.hashCode());
+    EndpointKey key3 = new EndpointKey(false, new ProxyOptions().setUsername("foo").setPassword("bar"), addr, addr);
+    EndpointKey key4 = new EndpointKey(false, new ProxyOptions().setUsername("foo").setPassword("bar"), addr, addr);
+    assertEquals(key3, key4);
+    assertEquals(key3.hashCode(), key4.hashCode());
+    EndpointKey key5 = new EndpointKey(false, new ProxyOptions().setHost("localhost"), addr, addr);
+    EndpointKey key6 = new EndpointKey(false, new ProxyOptions().setHost("127.0.0.1"), addr, addr);
+    assertNotEquals(key5, key6);
+    assertNotEquals(key5.hashCode(), key6.hashCode());
+    assertNotEquals(key1.hashCode(), key6.hashCode());
+  }
+
+}


### PR DESCRIPTION
Motivation:

When I read the changes in EndPointKey:

https://github.com/eclipse-vertx/vert.x/blob/0e3b061c463ebc357f8f18a377218729218fa497/src/main/java/io/vertx/core/http/impl/EndpointKey.java#L71-L74

I think it is a typo, it should return here.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
