### PR TITLE
ListenerArray throuhput and allocation improvements

### DIFF
--- a/src/main/java/io/vertx/core/impl/future/FutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureImpl.java
@@ -17,7 +17,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.NoStackTraceThrowable;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -177,12 +177,11 @@ class FutureImpl<T> extends FutureBase<T> {
           ListenerArray<T> listeners;
           if (this.listener instanceof FutureImpl.ListenerArray) {
             listeners = (ListenerArray<T>) this.listener;
+            listeners.add(listener);
           } else {
-            listeners = new ListenerArray<>();
-            listeners.add(this.listener);
+            listeners = new ListenerArray<>(this.listener, listener);
             this.listener = listeners;
           }
-          listeners.add(listener);
         }
         return;
       }
@@ -255,16 +254,37 @@ class FutureImpl<T> extends FutureBase<T> {
     sb.append(value);
   }
 
-  private static class ListenerArray<T> extends ArrayList<Listener<T>> implements Listener<T> {
+  private static class ListenerArray<T> implements Listener<T> {
+
+    Object[] elements;
+    int size; // actual number of listeners in elements array
+
+    ListenerArray(Listener<T> first, Listener<T> second) {
+      elements = new Object[]{first, second, null, null};
+      size = 2;
+    }
+
+    void add(Listener<T> listener) {
+      if (size == elements.length) {
+        elements = Arrays.copyOf(elements, size + (size >> 1));
+      }
+      elements[size++] = listener;
+    }
+
     @Override
+    @SuppressWarnings("unchecked")
     public void onSuccess(T value) {
-      for (Listener<T> handler : this) {
+      for (int i = 0; i < size; i++) {
+        Listener<T> handler = (Listener<T>) elements[i];
         handler.onSuccess(value);
       }
     }
+
     @Override
+    @SuppressWarnings("unchecked")
     public void onFailure(Throwable failure) {
-      for (Listener<T> handler : this) {
+      for (int i = 0; i < size; i++) {
+        Listener<T> handler = (Listener<T>) elements[i];
         handler.onFailure(failure);
       }
     }

--- a/src/test/benchmarks/io/vertx/benchmarks/FutureListenerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/FutureListenerBenchmark.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.benchmarks;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import org.openjdk.jmh.annotations.*;
+
+import static org.openjdk.jmh.annotations.CompilerControl.Mode.DONT_INLINE;
+
+@State(Scope.Thread)
+public class FutureListenerBenchmark extends BenchmarkBase {
+
+  @Param({"2", "4", "6", "8"})
+  int listenerCount;
+
+  @CompilerControl(DONT_INLINE)
+  public static void consume(AsyncResult<Void> ar) {
+  }
+
+  @Benchmark
+  public void addListeners() throws Exception {
+    Promise<Void> promise = Promise.promise();
+    Future<Void> future = promise.future();
+    for (int i = 0; i < listenerCount; i++) {
+      future.onComplete(FutureListenerBenchmark::consume);
+    }
+    promise.complete();
+  }
+}


### PR DESCRIPTION
Use our own elements array with small initial size instead of extending `ArrayList` and using default capacity (10).

Running `FutureListenerBenchmark` before and after this change shows:

* 30% throughput increase and 15% or 12%  memory allocation decrease (per op)
  when adding 2 or 4 listeners
* 6% throughput increase and 6% memory allocation increase (per op) when
  adding 6 listeners
* 1.5% throughput decrease and 24% memory allocation increase (per op)
  when adding 8 listeners

Note that:

* the previous version was tested unchanged, i.e. with `ListenerArray`
  extending `ArrayList` and creating a list with the default capacity (10)
* in many cases, futures get two listeners (`onSuccess`/`onFailure`)
