### PR TITLE
Improve the Gradle configuration instructions of Brotli4j in the docs

### DIFF
--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -388,10 +388,12 @@ You need to have Brotli4j on the classpath to decompress Brotli:
 [source,groovy]
 ----
 dependencies {
-  compile 'com.aayushatharva.brotli4j:brotli4j:${brotli4j.version}'
+  implementation 'com.aayushatharva.brotli4j:brotli4j:${brotli4j.version}'
+  runtimeOnly 'com.aayushatharva.brotli4j:native-$system-and-arch:${brotli4j.version}'
 }
 ----
 
+When using Gradle, you need to add the runtime native library manually depending on your OS and architecture. See https://github.com/hyperxpro/Brotli4j#gradle[the Gradle section of Brotli4j] for more details.
 
 By default, decompression is disabled.
 
@@ -786,10 +788,13 @@ Brotli and zstandard libraries need to be added to the classpath.
 [source,groovy]
 ----
 dependencies {
-  compile 'com.aayushatharva.brotli4j:brotli4j:${brotli4j.version}'
-  compile 'com.github.luben:zstd-jni:${zstd-jini.version}'
+  implementation 'com.aayushatharva.brotli4j:brotli4j:${brotli4j.version}'
+  runtimeOnly 'com.aayushatharva.brotli4j:native-$system-and-arch:${brotli4j.version}'
+  implementation 'com.github.luben:zstd-jni:${zstd-jini.version}'
 }
 ----
+
+When using Gradle, you need to add the runtime native library manually depending on your OS and architecture. See https://github.com/hyperxpro/Brotli4j#gradle[the Gradle section of Brotli4j] for more details.
 
 You can configure compressors according to your needs
 


### PR DESCRIPTION
Motivation:

The Gradle configuration instructions of Brotli4j in the docs are incomplete and lead to class initialization errors.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
