### PR TITLE
Implement 103 early hints

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -248,7 +248,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
 
   /**
    * If you send an HTTP request with the header {@code Expect} set to the value {@code 100-continue}
-   * and the server responds with an interim HTTP response with a status code of {@code 100} and a continue handler
+   * and the server responds with an interim HTTP response with a status code of {@code 100} and a Continue handler
    * has been set using this method, then the {@code handler} will be called.
    * <p>
    * You can then continue to write data to the request body and later end it. This is normally used in conjunction with
@@ -258,6 +258,15 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    */
   @Fluent
   HttpClientRequest continueHandler(@Nullable Handler<Void> handler);
+
+  /**
+   * If the server responds with an interim HTTP response with a status code of {@code 103} and a Early Hints handler
+   * has been set using this method, then the {@code handler} will be called.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpClientRequest earlyHintsHandler(@Nullable Handler<MultiMap> handler);
 
   /**
    * Forces the head of the request to be written before {@link #end()} is called on the request or any data is

--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -243,10 +243,12 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
 
   /**
    * Used to write an interim 103 Early Hints response to return some HTTP headers before the final HTTP message.
+   *
+   * @param headers  headers to write
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  HttpServerResponse writeEarlyHints();
+  HttpServerResponse writeEarlyHints(MultiMap headers);
 
   /**
    * Same as {@link #end(Buffer)} but writes a String in UTF-8 encoding before ending the response.

--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -245,10 +245,16 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    * Used to write an interim 103 Early Hints response to return some HTTP headers before the final HTTP message.
    *
    * @param headers  headers to write
-   * @return a reference to this, so the API can be used fluently
+   * @return a future
    */
-  @Fluent
-  HttpServerResponse writeEarlyHints(MultiMap headers);
+  Future<Void> writeEarlyHints(MultiMap headers);
+
+  /**
+   * Same as {@link #writeEarlyHints(MultiMap)} but with an {@code handler} called when the operation completes
+   *
+   * @param headers  headers to write
+   */
+  void writeEarlyHints(MultiMap headers, Handler<AsyncResult<Void>> handler);
 
   /**
    * Same as {@link #end(Buffer)} but writes a String in UTF-8 encoding before ending the response.

--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -242,6 +242,13 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   HttpServerResponse writeContinue();
 
   /**
+   * Used to write an interim 103 Early Hints response to return some HTTP headers before the final HTTP message.
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpServerResponse writeEarlyHints();
+
+  /**
    * Same as {@link #end(Buffer)} but writes a String in UTF-8 encoding before ending the response.
    *
    * @param chunk  the string to write before ending the response

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -383,6 +383,8 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     private Handler<MultiMap> endHandler;
     private Handler<Void> drainHandler;
     private Handler<Void> continueHandler;
+
+    private Handler<MultiMap> earlyHintsHandler;
     private Handler<Throwable> exceptionHandler;
     private Handler<Void> closeHandler;
 
@@ -413,6 +415,11 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     @Override
     public void continueHandler(Handler<Void> handler) {
       continueHandler = handler;
+    }
+
+    @Override
+    public void earlyHintsHandler(Handler<MultiMap> handler) {
+      earlyHintsHandler = handler;
     }
 
     @Override
@@ -616,6 +623,12 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     void handleContinue() {
       if (continueHandler != null) {
         continueHandler.handle(null);
+      }
+    }
+
+    void handleEarlyHints(MultiMap headers) {
+      if (earlyHintsHandler != null) {
+        earlyHintsHandler.handle(headers);
       }
     }
 

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -358,6 +358,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     }
 
     abstract void handleContinue();
+    abstract void handleEarlyHints(MultiMap headers);
     abstract void handleHead(HttpResponseHead response);
     abstract void handleChunk(Buffer buff);
     abstract void handleEnd(LastHttpContent trailer);
@@ -780,8 +781,11 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   }
 
   private void handleResponseBegin(Stream stream, HttpResponseHead response) {
-    if (response.statusCode == 100) {
+    // How can we handle future undefined 1xx informational response codes?
+    if (response.statusCode == HttpResponseStatus.CONTINUE.code()) {
       stream.context.execute(null, v -> stream.handleContinue());
+    } else if (response.statusCode == HttpResponseStatus.EARLY_HINTS.code()) {
+      stream.context.execute(null, v -> stream.handleEarlyHints(response.headers));
     } else {
       HttpRequestHead request;
       synchronized (this) {

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -72,7 +72,6 @@ import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
 public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocketImpl> implements HttpServerConnection {
 
   private static final Logger log = LoggerFactory.getLogger(Http1xServerConnection.class);
-  private static final HttpResponseStatus EARLY_HINTS = HttpResponseStatus.valueOf(103, "Early Hints");
 
   private final String serverOrigin;
   private final Supplier<ContextInternal> streamContextSupplier;
@@ -437,13 +436,13 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
     chctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE));
   }
 
-  void write103EarlyHints(HttpHeaders headers) {
+  void write103EarlyHints(HttpHeaders headers, PromiseInternal<Void> promise) {
     chctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1,
-      EARLY_HINTS,
+      HttpResponseStatus.EARLY_HINTS,
       Unpooled.buffer(0),
       headers,
       EmptyHttpHeaders.INSTANCE
-    ));
+    )).addListener(promise);
   }
 
   protected void handleClosed() {

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -72,6 +72,7 @@ import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
 public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocketImpl> implements HttpServerConnection {
 
   private static final Logger log = LoggerFactory.getLogger(Http1xServerConnection.class);
+  private static final HttpResponseStatus EARLY_HINTS = HttpResponseStatus.valueOf(103, "Early Hints");
 
   private final String serverOrigin;
   private final Supplier<ContextInternal> streamContextSupplier;
@@ -434,6 +435,15 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
 
   void write100Continue() {
     chctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE));
+  }
+
+  void write103EarlyHints(HttpHeaders headers) {
+    chctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1,
+      EARLY_HINTS,
+      Unpooled.buffer(0),
+      headers,
+      EmptyHttpHeaders.INSTANCE
+    ));
   }
 
   protected void handleClosed() {

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -363,6 +363,12 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
+  public HttpServerResponse writeEarlyHints() {
+    conn.write103EarlyHints(headers);
+    return this;
+  }
+
+  @Override
   public Future<Void> end(String chunk) {
     return end(Buffer.buffer(chunk));
   }

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -363,8 +363,16 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public HttpServerResponse writeEarlyHints() {
-    conn.write103EarlyHints(headers);
+  public HttpServerResponse writeEarlyHints(MultiMap headers) {
+    HeadersMultiMap headersMultiMap;
+    if (headers instanceof HeadersMultiMap) {
+      headersMultiMap = (HeadersMultiMap) headers;
+    } else {
+      headersMultiMap = HeadersMultiMap.httpHeaders();
+      headersMultiMap.addAll(headers);
+    }
+    // Write the headers
+    conn.write103EarlyHints(headersMultiMap);
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -315,6 +315,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
           return;
         } else if (status == 103) {
           MultiMap headersMultiMap = HeadersMultiMap.httpHeaders();
+          removeStatusHeaders(headers);
           for (Entry<CharSequence, CharSequence> header : headers) {
             headersMultiMap.add(header.getKey(), header.getValue());
           }
@@ -326,7 +327,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
           status,
           statusMessage,
           new Http2HeadersAdaptor(headers));
-        headers.remove(":status");
+        removeStatusHeaders(headers);
 
         if (conn.metrics != null) {
           conn.metrics.responseBegin(metric, response);
@@ -336,6 +337,10 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
           context.emit(response, headHandler);
         }
       }
+    }
+
+    private void removeStatusHeaders(Http2Headers headers) {
+      headers.remove(":status");
     }
 
     @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -324,6 +324,18 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
+  public HttpServerResponse writeEarlyHints() {
+    synchronized (conn) {
+      checkHeadWritten();
+      DefaultHttp2Headers headers = new DefaultHttp2Headers();
+      headers.add(this.headers);
+      headers.status("103");
+      stream.writeHeaders(headers, false, null);
+      return this;
+    }
+  }
+
+  @Override
   public Future<Void> write(Buffer chunk) {
     ByteBuf buf = chunk.getByteBuf();
     Promise<Void> promise = stream.context.promise();

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -154,6 +154,11 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
     }
 
     @Override
+    public void earlyHintsHandler(Handler<MultiMap> handler) {
+      delegate.earlyHintsHandler(handler);
+    }
+
+    @Override
     public void pushHandler(Handler<HttpClientPush> handler) {
       delegate.pushHandler(handler);
     }
@@ -264,6 +269,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
     private Handler<Throwable> exceptionHandler;
     private Handler<Void> drainHandler;
     private Handler<Void> continueHandler;
+    private Handler<MultiMap> earlyHintsHandler;
     private Handler<HttpClientPush> pushHandler;
     private Handler<HttpFrame> unknownFrameHandler;
     private Handler<Void> closeHandler;
@@ -356,6 +362,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
                 upgradedStream.exceptionHandler(exceptionHandler);
                 upgradedStream.drainHandler(drainHandler);
                 upgradedStream.continueHandler(continueHandler);
+                upgradedStream.earlyHintsHandler(earlyHintsHandler);
                 upgradedStream.pushHandler(pushHandler);
                 upgradedStream.unknownFrameHandler(unknownFrameHandler);
                 upgradedStream.closeHandler(closeHandler);
@@ -366,6 +373,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
                 upgradingStream.exceptionHandler(null);
                 upgradingStream.drainHandler(null);
                 upgradingStream.continueHandler(null);
+                upgradingStream.earlyHintsHandler(null);
                 upgradingStream.pushHandler(null);
                 upgradingStream.unknownFrameHandler(null);
                 upgradingStream.closeHandler(null);
@@ -376,6 +384,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
                 exceptionHandler = null;
                 drainHandler = null;
                 continueHandler = null;
+                earlyHintsHandler = null;
                 pushHandler = null;
                 closeHandler = null;
                 upgradedConnection.current = conn;
@@ -532,6 +541,16 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
       } else {
         upgradingStream.continueHandler(handler);
         continueHandler = handler;
+      }
+    }
+
+    @Override
+    public void earlyHintsHandler(Handler<MultiMap> handler) {
+      if (upgradedStream != null) {
+        upgradedStream.earlyHintsHandler(handler);
+      } else {
+        upgradingStream.earlyHintsHandler(handler);
+        earlyHintsHandler = handler;
       }
     }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -160,6 +160,11 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
+  public HttpClientRequest earlyHintsHandler(@Nullable Handler<MultiMap> handler) {
+    throw new IllegalStateException();
+  }
+
+  @Override
   public Future<Void> sendHead() {
     throw new IllegalStateException();
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -57,6 +57,7 @@ public interface HttpClientStream extends WriteStream<Buffer> {
   void writeFrame(int type, int flags, ByteBuf payload);
 
   void continueHandler(Handler<Void> handler);
+  void earlyHintsHandler(Handler<MultiMap> handler);
   void pushHandler(Handler<HttpClientPush> handler);
   void unknownFrameHandler(Handler<HttpFrame> handler);
 

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -2239,6 +2239,55 @@ public class Http2ServerTest extends Http2TestBase {
   }
 
   @Test
+  public void test103EarlyHints() throws Exception {
+    server.requestHandler(req -> {
+      HttpServerResponse resp = req.response();
+      resp.putHeader("wibble", "wibble-value");
+      resp.writeEarlyHints();
+      req.bodyHandler(body -> {
+        assertEquals("the-body", body.toString());
+        resp.end();
+      });
+    });
+    startServer();
+    TestClient client = new TestClient();
+    ChannelFuture fut = client.connect(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, request -> {
+      int id = request.nextStreamId();
+      request.decoder.frameListener(new Http2EventAdapter() {
+        int count = 0;
+        @Override
+        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) throws Http2Exception {
+          switch (count++) {
+            case 0:
+              vertx.runOnContext(v -> {
+                assertEquals("103", headers.status().toString());
+                assertEquals("wibble-value", headers.get("wibble").toString());
+              });
+              request.encoder.writeData(request.context, id, Buffer.buffer("the-body").getByteBuf(), 0, true, request.context.newPromise());
+              request.context.flush();
+              break;
+            case 1:
+              vertx.runOnContext(v -> {
+                assertEquals("200", headers.status().toString());
+                assertEquals("wibble-value", headers.get("wibble").toString());
+                testComplete();
+              });
+              break;
+            default:
+              vertx.runOnContext(v -> {
+                fail();
+              });
+          }
+        }
+      });
+      request.encoder.writeHeaders(request.context, id, GET("/"), 0, false, request.context.newPromise());
+      request.context.flush();
+    });
+    fut.sync();
+    await();
+  }
+
+  @Test
   public void testNetSocketConnect() throws Exception {
     waitFor(2);
     List<Integer> callbacks = Collections.synchronizedList(new ArrayList<>());

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -58,6 +58,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.impl.Http1xOrH2CHandler;
 import io.vertx.core.http.impl.HttpUtils;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.core.impl.Utils;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
@@ -2242,8 +2243,7 @@ public class Http2ServerTest extends Http2TestBase {
   public void test103EarlyHints() throws Exception {
     server.requestHandler(req -> {
       HttpServerResponse resp = req.response();
-      resp.putHeader("wibble", "wibble-value");
-      resp.writeEarlyHints();
+      resp.writeEarlyHints(HeadersMultiMap.httpHeaders().add("wibble", "wibble-value"));
       req.bodyHandler(body -> {
         assertEquals("the-body", body.toString());
         resp.end();

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -4299,6 +4299,8 @@ public abstract class HttpTest extends HttpTestBase {
       public void write(String chunk, Handler<AsyncResult<Void>> handler) { throw new UnsupportedOperationException(); }
       public void write(String chunk, String enc, Handler<AsyncResult<Void>> handler) { throw new UnsupportedOperationException(); }
       public HttpClientRequest continueHandler(@Nullable Handler<Void> handler) { throw new UnsupportedOperationException(); }
+
+      public HttpClientRequest earlyHintsHandler(@Nullable Handler<MultiMap> handler) { throw new UnsupportedOperationException(); }
       public Future<Void> sendHead() { throw new UnsupportedOperationException(); }
       public HttpClientRequest sendHead(Handler<AsyncResult<Void>> completionHandler) { throw new UnsupportedOperationException(); }
       public Future<HttpClientResponse> connect() { throw new UnsupportedOperationException(); }


### PR DESCRIPTION
Motivation:

Currently it's not possible to send an early-hints response (103 Early Hints (RFC 8297))
