### PR TITLE
Abstract http server request internal

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -61,7 +61,7 @@ import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class Http1xServerRequest implements HttpServerRequestInternal, io.vertx.core.spi.observability.HttpRequest {
+public class Http1xServerRequest extends HttpServerRequestInternal implements io.vertx.core.spi.observability.HttpRequest {
 
   private static final Logger log = LoggerFactory.getLogger(Http1xServerRequest.class);
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -134,13 +134,15 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
     return null;
   }
 
-  private Http2ServerRequest createRequest(int streamId, Http2Headers headers, boolean streamEnded) {
+  private Http2ServerStream createRequest(int streamId, Http2Headers headers, boolean streamEnded) {
     Http2Stream stream = handler.connection().stream(streamId);
     String contentEncoding = options.isCompressionSupported() ? determineContentEncoding(headers) : null;
-    Http2ServerRequest request = new Http2ServerRequest(this, options.getTracingPolicy(), streamContextSupplier.get(), serverOrigin, headers, contentEncoding, streamEnded);
-    request.isConnect = request.method() == HttpMethod.CONNECT;
-    request.init(stream);
-    return request;
+    Http2ServerStream vertxStream = new Http2ServerStream(this, streamContextSupplier.get(), headers, serverOrigin);
+    Http2ServerRequest request = new Http2ServerRequest(vertxStream, serverOrigin, options.getTracingPolicy(), headers, contentEncoding, streamEnded);
+    vertxStream.request = request;
+    vertxStream.isConnect = request.method() == HttpMethod.CONNECT;
+    vertxStream.init(stream);
+    return vertxStream;
   }
 
   @Override
@@ -188,9 +190,11 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
           int promisedStreamId = future.getNow();
           String contentEncoding = determineContentEncoding(headers_);
           Http2Stream promisedStream = handler.connection().stream(promisedStreamId);
-          Push push = new Push(context, contentEncoding, method, path, promise);
-          push.priority(streamPriority);
-          push.init(promisedStream);
+          Http2ServerStream vertxStream = new Http2ServerStream(this, context, method, path);
+          Push push = new Push(vertxStream, contentEncoding, promise);
+          vertxStream.request = push;
+          push.stream.priority(streamPriority);
+          push.stream.init(promisedStream);
           int maxConcurrentStreams = handler.maxConcurrentStreams();
           if (concurrentStreams < maxConcurrentStreams) {
             concurrentStreams++;
@@ -210,46 +214,48 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
     super.updateSettings(settingsUpdate, completionHandler);
   }
 
-  private class Push extends Http2ServerStream {
+  private class Push implements Http2ServerStreamHandler {
 
+    protected final ContextInternal context;
+    protected final Http2ServerStream stream;
+    protected final Http2ServerResponse response;
     private final Promise<HttpServerResponse> promise;
 
-    public Push(ContextInternal context,
+    public Push(Http2ServerStream stream,
                 String contentEncoding,
-                HttpMethod method,
-                String uri,
                 Promise<HttpServerResponse> promise) {
-      super(Http2ServerConnection.this, context, contentEncoding, method, uri);
+      this.context = stream.context;
+      this.stream = stream;
+      this.response = new Http2ServerResponse(stream.conn, stream, true, contentEncoding);
       this.promise = promise;
     }
 
     @Override
-    void dispatch(Handler<HttpServerRequest> handler) {
+    public Http2ServerResponse response() {
+      return response;
+    }
+
+    @Override
+    public  void dispatch(Handler<HttpServerRequest> handler) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    void handleWritabilityChanged(boolean writable) {
-      response.handlerWritabilityChanged(writable);
-    }
-
-    @Override
-    void handleReset(long errorCode) {
+    public void handleReset(long errorCode) {
       if (!promise.tryFail(new StreamResetException(errorCode))) {
         response.handleReset(errorCode);
       }
     }
 
     @Override
-    void handleException(Throwable cause) {
+    public  void handleException(Throwable cause) {
       if (response != null) {
         response.handleException(cause);
       }
     }
 
     @Override
-    void handleClose(HttpClosedException ex) {
-      super.handleClose(ex);
+    public  void handleClose(HttpClosedException ex) {
       if (pendingPushes.remove(this)) {
         promise.fail("Push reset by client");
       } else {
@@ -265,7 +271,7 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
     }
 
     void complete() {
-      registerMetrics();
+      stream.registerMetrics();
       promise.complete(response);
     }
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -60,7 +60,7 @@ import java.util.Set;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class Http2ServerRequest implements HttpServerRequestInternal, Http2ServerStreamHandler, io.vertx.core.spi.observability.HttpRequest {
+public class Http2ServerRequest extends HttpServerRequestInternal implements Http2ServerStreamHandler, io.vertx.core.spi.observability.HttpRequest {
 
   private static final Logger log = LoggerFactory.getLogger(Http1xServerRequest.class);
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -53,7 +53,6 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
   private final ChannelHandlerContext ctx;
   private final Http2ServerConnection conn;
   private final boolean push;
-  private final String host;
   private final String contentEncoding;
   private final Http2Headers headers = new DefaultHttp2Headers();
   private Http2HeadersAdaptor headersMap;
@@ -77,13 +76,11 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
   public Http2ServerResponse(Http2ServerConnection conn,
                              Http2ServerStream stream,
                              boolean push,
-                             String contentEncoding,
-                             String host) {
+                             String contentEncoding) {
     this.stream = stream;
     this.ctx = conn.handlerContext;
     this.conn = conn;
     this.push = push;
-    this.host = host;
     this.contentEncoding = contentEncoding;
   }
 
@@ -421,7 +418,7 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
           netSocket = stream.context.failedFuture("Response for CONNECT already sent");
         } else {
           ctx.flush();
-          HttpNetSocket ns = HttpNetSocket.netSocket(conn, stream.context, (ReadStream<Buffer>) stream, this);
+          HttpNetSocket ns = HttpNetSocket.netSocket(conn, stream.context, (ReadStream<Buffer>) stream.request, this);
           netSocket = Future.succeededFuture(ns);
         }
       }
@@ -695,7 +692,7 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
       throw new IllegalStateException("A push response cannot promise another push");
     }
     if (host == null) {
-      host = this.host;
+      host = stream.host;
     }
     synchronized (conn) {
       checkValid();

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerStreamHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerStreamHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClosedException;
+import io.vertx.core.http.HttpFrame;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.StreamPriority;
+import io.vertx.core.impl.ContextInternal;
+
+interface Http2ServerStreamHandler {
+
+  Http2ServerResponse response();
+
+  void dispatch(Handler<HttpServerRequest> handler);
+
+  void handleReset(long errorCode);
+
+  void handleException(Throwable cause);
+
+  void handleClose(HttpClosedException ex);
+
+  default void handleData(Buffer data) {
+  }
+
+  default void handleEnd(MultiMap trailers) {
+  }
+
+  default void handleCustomFrame(HttpFrame frame) {
+  }
+
+  default void handlePriorityChange(StreamPriority streamPriority) {
+  }
+
+  default void onClose(HttpClosedException ex) {
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestInternal.java
@@ -19,16 +19,16 @@ import io.vertx.core.spi.observability.HttpRequest;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public interface HttpServerRequestInternal extends HttpServerRequest {
+public abstract class HttpServerRequestInternal implements HttpServerRequest {
 
   /**
    * @return the Vert.x context associated with this server request
    */
-  Context context();
+  public abstract Context context();
 
   /**
    * @return the metric object returned by the {@link io.vertx.core.spi.metrics.HttpServerMetrics#requestBegin(Object, HttpRequest)} call
    */
-  Object metric();
+  public abstract Object metric();
 
 }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
@@ -1,0 +1,391 @@
+package io.vertx.core.http.impl;
+
+import io.netty.handler.codec.DecoderResult;
+import io.vertx.codegen.annotations.CacheReturn;
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.Cookie;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpFrame;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerFileUpload;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.http.StreamPriority;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.streams.Pipe;
+import io.vertx.core.streams.WriteStream;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.cert.X509Certificate;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A wrapper class that delegates all method calls to the {@link #delegate} instance.
+ *
+ * Implementing {@link HttpServerRequest} or extending {@link HttpServerRequestInternal} is not encouraged however if that is necessary,
+ * implementations should favor extending this class to ensure minimum breakage when new methods are added to the interface.
+ *
+ * The delegate instance can be accessed using protected final {@link #delegate} field, any implemented method can be overridden.
+ */
+public class HttpServerRequestWrapper extends HttpServerRequestInternal {
+
+  private HttpServerRequestInternal delegate;
+
+  public HttpServerRequestWrapper(HttpServerRequestInternal delegate) {
+    if (delegate == null) {
+      throw new NullPointerException("Null delegate not allowed");
+    }
+    this.delegate = delegate;
+  }
+
+  @Override
+  public HttpServerRequest exceptionHandler(Handler<Throwable> handler) {
+    return delegate.exceptionHandler(handler);
+  }
+
+  @Override
+  public HttpServerRequest handler(Handler<Buffer> handler) {
+    return delegate.handler(handler);
+  }
+
+  @Override
+  public HttpServerRequest pause() {
+    return delegate.pause();
+  }
+
+  @Override
+  public HttpServerRequest resume() {
+    return delegate.resume();
+  }
+
+  @Override
+  public HttpServerRequest fetch(long amount) {
+    return delegate.fetch(amount);
+  }
+
+  @Override
+  public HttpServerRequest endHandler(Handler<Void> endHandler) {
+    return delegate.endHandler(endHandler);
+  }
+
+  @Override
+  public HttpVersion version() {
+    return delegate.version();
+  }
+
+  @Override
+  public HttpMethod method() {
+    return delegate.method();
+  }
+
+  @Override
+  public boolean isSSL() {
+    return delegate.isSSL();
+  }
+
+  @Override
+  @Nullable
+  public String scheme() {
+    return delegate.scheme();
+  }
+
+  @Override
+  public String uri() {
+    return delegate.uri();
+  }
+
+  @Override
+  @Nullable
+  public String path() {
+    return delegate.path();
+  }
+
+  @Override
+  @Nullable
+  public String query() {
+    return delegate.query();
+  }
+
+  @Override
+  @Nullable
+  public String host() {
+    return delegate.host();
+  }
+
+  @Override
+  public long bytesRead() {
+    return delegate.bytesRead();
+  }
+
+  @Override
+  @CacheReturn
+  public HttpServerResponse response() {
+    return delegate.response();
+  }
+
+  @Override
+  @CacheReturn
+  public MultiMap headers() {
+    return delegate.headers();
+  }
+
+  @Override
+  @Nullable
+  public String getHeader(String headerName) {
+    return delegate.getHeader(headerName);
+  }
+
+  @Override
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  public String getHeader(CharSequence headerName) {
+    return delegate.getHeader(headerName);
+  }
+
+  @Override
+  @Fluent
+  public HttpServerRequest setParamsCharset(String charset) {
+    return delegate.setParamsCharset(charset);
+  }
+
+  @Override
+  public String getParamsCharset() {
+    return delegate.getParamsCharset();
+  }
+
+  @Override
+  @CacheReturn
+  public MultiMap params() {
+    return delegate.params();
+  }
+
+  @Override
+  @Nullable
+  public String getParam(String paramName) {
+    return delegate.getParam(paramName);
+  }
+
+  @Override
+  public String getParam(String paramName, String defaultValue) {
+    return delegate.getParam(paramName, defaultValue);
+  }
+
+  @Override
+  @CacheReturn
+  public SocketAddress remoteAddress() {
+    return delegate.remoteAddress();
+  }
+
+  @Override
+  @CacheReturn
+  public SocketAddress localAddress() {
+    return delegate.localAddress();
+  }
+
+  @Override
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  public SSLSession sslSession() {
+    return delegate.sslSession();
+  }
+
+  @Override
+  @GenIgnore
+  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+    return delegate.peerCertificateChain();
+  }
+
+  @Override
+  public String absoluteURI() {
+    return delegate.absoluteURI();
+  }
+
+  @Override
+  @Fluent
+  public HttpServerRequest bodyHandler(@Nullable Handler<Buffer> bodyHandler) {
+    return delegate.bodyHandler(bodyHandler);
+  }
+
+  @Override
+  public HttpServerRequest body(Handler<AsyncResult<Buffer>> handler) {
+    return delegate.body(handler);
+  }
+
+  @Override
+  public Future<Buffer> body() {
+    return delegate.body();
+  }
+
+  @Override
+  public void end(Handler<AsyncResult<Void>> handler) {
+    delegate.end(handler);
+  }
+
+  @Override
+  public Future<Void> end() {
+    return delegate.end();
+  }
+
+  @Override
+  public void toNetSocket(Handler<AsyncResult<NetSocket>> handler) {
+    delegate.toNetSocket(handler);
+  }
+
+  @Override
+  public Future<NetSocket> toNetSocket() {
+    return delegate.toNetSocket();
+  }
+
+  @Override
+  @Fluent
+  public HttpServerRequest setExpectMultipart(boolean expect) {
+    return delegate.setExpectMultipart(expect);
+  }
+
+  @Override
+  public boolean isExpectMultipart() {
+    return delegate.isExpectMultipart();
+  }
+
+  @Override
+  @Fluent
+  public HttpServerRequest uploadHandler(@Nullable Handler<HttpServerFileUpload> uploadHandler) {
+    return delegate.uploadHandler(uploadHandler);
+  }
+
+  @Override
+  @CacheReturn
+  public MultiMap formAttributes() {
+    return delegate.formAttributes();
+  }
+
+  @Override
+  @Nullable
+  public String getFormAttribute(String attributeName) {
+    return delegate.getFormAttribute(attributeName);
+  }
+
+  @Override
+  @CacheReturn
+  public int streamId() {
+    return delegate.streamId();
+  }
+
+  @Override
+  public void toWebSocket(Handler<AsyncResult<ServerWebSocket>> handler) {
+    delegate.toWebSocket(handler);
+  }
+
+  @Override
+  public Future<ServerWebSocket> toWebSocket() {
+    return delegate.toWebSocket();
+  }
+
+  @Override
+  public boolean isEnded() {
+    return delegate.isEnded();
+  }
+
+  @Override
+  @Fluent
+  public HttpServerRequest customFrameHandler(Handler<HttpFrame> handler) {
+    return delegate.customFrameHandler(handler);
+  }
+
+  @Override
+  @CacheReturn
+  public HttpConnection connection() {
+    return delegate.connection();
+  }
+
+  @Override
+  public StreamPriority streamPriority() {
+    return delegate.streamPriority();
+  }
+
+  @Override
+  @Fluent
+  public HttpServerRequest streamPriorityHandler(Handler<StreamPriority> handler) {
+    return delegate.streamPriorityHandler(handler);
+  }
+
+  @Override
+  @GenIgnore
+  public DecoderResult decoderResult() {
+    return delegate.decoderResult();
+  }
+
+  @Override
+  public @Nullable Cookie getCookie(String name) {
+    return delegate.getCookie(name);
+  }
+
+  @Override
+  public @Nullable Cookie getCookie(String name, String domain, String path) {
+    return delegate.getCookie(name, domain, path);
+  }
+
+  @Override
+  public int cookieCount() {
+    return delegate.cookieCount();
+  }
+
+  @Override
+  @Deprecated
+  public Map<String, Cookie> cookieMap() {
+    return delegate.cookieMap();
+  }
+
+  @Override
+  public Set<Cookie> cookies(String name) {
+    return delegate.cookies(name);
+  }
+
+  @Override
+  public Set<Cookie> cookies() {
+    return delegate.cookies();
+  }
+
+  @Override
+  @Fluent
+  public HttpServerRequest routed(String route) {
+    return delegate.routed(route);
+  }
+
+  @Override
+  public Context context() {
+    return delegate.context();
+  }
+
+  @Override
+  public Object metric() {
+    return delegate.metric();
+  }
+
+  @Override
+  public Pipe<Buffer> pipe() {
+    return delegate.pipe();
+  }
+
+  @Override
+  public Future<Void> pipeTo(WriteStream<Buffer> dst) {
+    return delegate.pipeTo(dst);
+  }
+
+  @Override
+  public void pipeTo(WriteStream<Buffer> dst, Handler<AsyncResult<Void>> handler) {
+    delegate.pipeTo(dst, handler);
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
@@ -43,7 +43,7 @@ import java.util.Set;
  */
 public class HttpServerRequestWrapper extends HttpServerRequestInternal {
 
-  private HttpServerRequestInternal delegate;
+  protected final HttpServerRequestInternal delegate;
 
   public HttpServerRequestWrapper(HttpServerRequestInternal delegate) {
     if (delegate == null) {


### PR DESCRIPTION
Make `HttpServerRequestInternal` an abstract class to avoid hotspot type pollution, since this interface extends HttpServerRequest and can be implemented multiple times.