### PR TITLE
Add convenient Trust/KeyCertOptions wrap() methods

### DIFF
--- a/src/main/java/io/vertx/core/net/KeyCertOptions.java
+++ b/src/main/java/io/vertx/core/net/KeyCertOptions.java
@@ -69,4 +69,13 @@ public interface KeyCertOptions {
     return new KeyManagerFactoryOptions(keyManager);
   }
 
+  /**
+   * Returns a {@link KeyCertOptions} from the provided {@link KeyManagerFactory}
+   *
+   * @param keyManagerFactory the keyManagerFactory instance
+   * @return the {@link KeyCertOptions}
+   */
+  static KeyCertOptions wrap(KeyManagerFactory keyManagerFactory) {
+    return new KeyManagerFactoryOptions(keyManagerFactory);
+  }
 }

--- a/src/main/java/io/vertx/core/net/KeyManagerFactoryOptions.java
+++ b/src/main/java/io/vertx/core/net/KeyManagerFactoryOptions.java
@@ -39,7 +39,11 @@ import java.util.function.Function;
  *
  * As this class is not available because it is part of the internal api the proper usage would be:
  * <pre>
+ * // with a KeyManager
  * options.setKeyCertOptions(KeyCertOptions.wrap(keyManager));
+ *
+ * // with a KeyManagerFactory
+ * options.setKeyCertOptions(KeyCertOptions.wrap(keyManagerFactory));
  * </pre>
  *
  * @author <a href="mailto:hakangoudberg@hotmail.com">Hakan Altindag</a>

--- a/src/main/java/io/vertx/core/net/TrustManagerFactoryOptions.java
+++ b/src/main/java/io/vertx/core/net/TrustManagerFactoryOptions.java
@@ -39,7 +39,11 @@ import java.util.function.Function;
  *
  * As this class is not available because it is part of the internal api the proper usage would be:
  * <pre>
+ * // with a TrustManager
  * options.setTrustOptions(TrustOptions.wrap(trustManager));
+ *
+ * // with a TrustManagerFactory
+ * options.setTrustOptions(TrustOptions.wrap(trustManagerFactory));
  * </pre>
  *
  * @author <a href="mailto:hakangoudberg@hotmail.com">Hakan Altindag</a>

--- a/src/main/java/io/vertx/core/net/TrustOptions.java
+++ b/src/main/java/io/vertx/core/net/TrustOptions.java
@@ -63,4 +63,13 @@ public interface TrustOptions {
     return new TrustManagerFactoryOptions(trustManager);
   }
 
+  /**
+   * Returns a {@link TrustOptions} from the provided {@link TrustManagerFactory}
+   *
+   * @param trustManagerFactory the trustManagerFactory instance
+   * @return the {@link TrustOptions}
+   */
+  static TrustOptions wrap(TrustManagerFactory trustManagerFactory) {
+    return new TrustManagerFactoryOptions(trustManagerFactory);
+  }
 }


### PR DESCRIPTION
TrustOptions class already contains a static `wrap()` method to create an instance using the provided `TrustManager` instance. The same is true for `KeyCertOptions.wrap(KeyManager)`. If we want to use several trust or key managers, we need to deal with `Trust/KeyManagerFactory`.
This PR contains 2 more convenient `wrap()` methods which receive `TrustManagerFactory` or `KeyManagerFactory`. The changes are pretty compact so far as`Trust/KeyManagerFactoryOptions` already have suitable package-private constructors.