### PR TITLE
Clear test upgrade to HTTP/2 fixes

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
@@ -196,7 +196,7 @@ public class HttpChannelConnector {
     });
     clientHandler.addHandler(conn -> {
       if (upgrade) {
-        future.complete(new Http2UpgradedClientConnection(client, conn));
+        future.complete(new Http2UpgradeClientConnection(client, conn));
       } else {
         future.complete(conn);
       }


### PR DESCRIPTION
The HTTP upgrade to H2C connection does not handle properly upgrade rejections leading to retrying an upgrade for every subsequent request on the same connection and accumulating upgrade request handler in the channel pipeline.

The HTTP upgrade connection after an upgrade (succesfull or not) should always delegate to the the current connection (HTTP/1 or HTTP/2) the creation of streams and avoid using upgrading stream.

The HTTP upgrade stream should also cleanup the temporary upgrade request handler from the pipeline after the upgrade.

see also #4476

