### PR TITLE
MimeMapping.getMimeType should be case insensitive 

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/MimeMapping.java
+++ b/src/main/java/io/vertx/core/http/impl/MimeMapping.java
@@ -1014,7 +1014,10 @@ public class MimeMapping {
   }
 
   public static String getMimeTypeForExtension(String ext) {
-    return m.get(ext);
+    if (ext == null) {
+      return null;
+    }
+    return m.get(ext.toLowerCase());
   }
   public static String getMimeTypeForFilename(String filename) {
     int li = filename.lastIndexOf('.');

--- a/src/test/java/io/vertx/core/http/MimeTypeTest.java
+++ b/src/test/java/io/vertx/core/http/MimeTypeTest.java
@@ -1,0 +1,21 @@
+package io.vertx.core.http;
+
+import io.vertx.core.http.impl.MimeMapping;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MimeTypeTest {
+  @Test
+  public void testGetMimeTypeFromPath() {
+    String filepath = "/Users/leo/Pictures/IMG_4157.jpg";
+    String mimeType = MimeMapping.getMimeTypeForFilename(filepath);
+    Assert.assertEquals("get wrong mime type", "image/jpeg", mimeType);
+  }
+
+  @Test
+  public void testGetMimeTypeCaseInsensitive() {
+    String filepath = "/Users/leo/Pictures/IMG_4157.JPG";
+    String mimeType = MimeMapping.getMimeTypeForFilename(filepath);
+    Assert.assertEquals("get wrong mime type", "image/jpeg", mimeType);
+  }
+}


### PR DESCRIPTION
Motivation:

- MimeMapping.getMimeType should be case insensitive  https://github.com/eclipse-vertx/vert.x/issues/4499
- add MimeMapping's test