### PR TITLE
Openssl no longer has much better performance

### DIFF
--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -698,7 +698,8 @@ Protocol versions can be specified on the {@link io.vertx.core.net.NetServerOpti
 ==== SSL engine
 
 The engine implementation can be configured to use https://www.openssl.org[OpenSSL] instead of the JDK implementation.
-OpenSSL provides better performances and CPU usage than the JDK engine, as well as JDK version independence.
+Before JDK started to use hardware intrinsics (CPU instructions) for AES in Java 8 and for RSA in Java 9,
+OpenSSL provided much better performances and CPU usage than the JDK engine.
 
 The engine options to use is
 


### PR DESCRIPTION
https: //www.oracle.com/java/technologies/javase/8-whats-new.html "Hardware intrinsics were added to use Advanced Encryption Standard (AES)."
https: //openjdk.org/jeps/164 "JEP 164: Leverage CPU Instructions for AES Cryptography"
https: //docs.oracle.com/javase/9/whatsnew/#d1373e94 "Improves performance ranging from 34x to 150x for AES/GCM/NoPadding"
https: //openjdk.org/jeps/246 "JEP 246: Leverage CPU Instructions for GHASH and RSA"