### PR TITLE
Provide SSLOptions to allow update the certificate of a TCP server or client

### DIFF
--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -618,6 +618,18 @@ Buffer configuration is also supported:
 
 Keep in mind that pem configuration, the private key is not crypted.
 
+==== Updating SSL/TLS configuration
+
+You can use the `updateSSLOptions` method to update the key/certifications or trust on a TCP server or client (e.g. to
+implement certificate rotation).
+
+[source,$lang]
+----
+{@link examples.NetExamples#updateSSLOptions}
+----
+
+When the update succeeds the new SSL configuration is used, otherwise the previous configuration is kept.
+
 ==== Self-signed certificates for testing and development purposes
 
 CAUTION: Do not use this in production settings, and note that the generated keys are very insecure.

--- a/src/main/generated/io/vertx/core/net/SSLOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/net/SSLOptionsConverter.java
@@ -1,0 +1,107 @@
+package io.vertx.core.net;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.core.net.SSLOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.SSLOptions} original class using Vert.x codegen.
+ */
+public class SSLOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+   static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, SSLOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "crlPaths":
+          if (member.getValue() instanceof JsonArray) {
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                obj.addCrlPath((String)item);
+            });
+          }
+          break;
+        case "crlValues":
+          if (member.getValue() instanceof JsonArray) {
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                obj.addCrlValue(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)item)));
+            });
+          }
+          break;
+        case "enabledCipherSuites":
+          if (member.getValue() instanceof JsonArray) {
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                obj.addEnabledCipherSuite((String)item);
+            });
+          }
+          break;
+        case "enabledSecureTransportProtocols":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.LinkedHashSet<java.lang.String> list =  new java.util.LinkedHashSet<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add((String)item);
+            });
+            obj.setEnabledSecureTransportProtocols(list);
+          }
+          break;
+        case "sslHandshakeTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setSslHandshakeTimeout(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "sslHandshakeTimeoutUnit":
+          if (member.getValue() instanceof String) {
+            obj.setSslHandshakeTimeoutUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
+          }
+          break;
+        case "useAlpn":
+          if (member.getValue() instanceof Boolean) {
+            obj.setUseAlpn((Boolean)member.getValue());
+          }
+          break;
+      }
+    }
+  }
+
+   static void toJson(SSLOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+   static void toJson(SSLOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getCrlPaths() != null) {
+      JsonArray array = new JsonArray();
+      obj.getCrlPaths().forEach(item -> array.add(item));
+      json.put("crlPaths", array);
+    }
+    if (obj.getCrlValues() != null) {
+      JsonArray array = new JsonArray();
+      obj.getCrlValues().forEach(item -> array.add(BASE64_ENCODER.encodeToString(item.getBytes())));
+      json.put("crlValues", array);
+    }
+    if (obj.getEnabledCipherSuites() != null) {
+      JsonArray array = new JsonArray();
+      obj.getEnabledCipherSuites().forEach(item -> array.add(item));
+      json.put("enabledCipherSuites", array);
+    }
+    if (obj.getEnabledSecureTransportProtocols() != null) {
+      JsonArray array = new JsonArray();
+      obj.getEnabledSecureTransportProtocols().forEach(item -> array.add(item));
+      json.put("enabledSecureTransportProtocols", array);
+    }
+    json.put("sslHandshakeTimeout", obj.getSslHandshakeTimeout());
+    if (obj.getSslHandshakeTimeoutUnit() != null) {
+      json.put("sslHandshakeTimeoutUnit", obj.getSslHandshakeTimeoutUnit().name());
+    }
+    json.put("useAlpn", obj.isUseAlpn());
+  }
+}

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -14,9 +14,11 @@ package examples;
 import io.netty.handler.logging.ByteBufFormat;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ClientAuth;
+import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.net.*;
 
@@ -499,6 +501,14 @@ public class NetExamples {
       setSsl(true).
       setPemKeyCertOptions(pemOptions);
     NetClient client = vertx.createNetClient(options);
+  }
+
+  public void updateSSLOptions(HttpServer server) {
+    Future<Void> fut = server.updateSSLOptions(new SSLOptions()
+      .setKeyCertOptions(
+        new JksOptions()
+          .setPath("/path/to/your/server-keystore.jks").
+          setPassword("password-of-your-keystore")));
   }
 
   public void example42(Vertx vertx, JksOptions trustOptions) {

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -20,6 +20,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.metrics.Measured;
+import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.ReadStream;
 
@@ -187,6 +188,30 @@ public interface HttpClient extends Measured {
    * Like {@link #webSocketAbs(String, MultiMap, WebsocketVersion, List, Handler)} but returns a {@code Future} of the asynchronous result
    */
   Future<WebSocket> webSocketAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols);
+
+  /**
+   * Update the client SSL options.
+   *
+   * Update only happens if the SSL options is valid.
+   *
+   * @param options the new SSL options
+   * @return a future signaling the update success
+   */
+  Future<Void> updateSSLOptions(SSLOptions options);
+
+  /**
+   * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
+   * happened (or has failed).
+   *
+   * @param options the new SSL options
+   * @param handler the update handler
+   */
+  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Void>> handler) {
+    Future<Void> fut = updateSSLOptions(options);
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
+  }
 
   /**
    * Set a connection handler for the client. This handler is called when a new connection is established.

--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -19,6 +19,7 @@ import io.vertx.core.Handler;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.metrics.Measured;
+import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.ReadStream;
 
@@ -117,6 +118,30 @@ public interface HttpServer extends Measured {
    */
   @GenIgnore
   Handler<ServerWebSocket> webSocketHandler();
+
+  /**
+   * Update the server SSL options.
+   *
+   * Update only happens if the SSL options is valid.
+   *
+   * @param options the new SSL options
+   * @return a future signaling the update success
+   */
+  Future<Void> updateSSLOptions(SSLOptions options);
+
+  /**
+   * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
+   * happened (or has failed).
+   *
+   * @param options the new SSL options
+   * @param handler the update handler
+   */
+  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Void>> handler) {
+    Future<Void> fut = updateSSLOptions(options);
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
+  }
 
   /**
    * Tell the server to start listening. The server will listen on the port and host specified in the

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -32,7 +32,7 @@ import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.impl.NetSocketImpl;
-import io.vertx.core.net.impl.SSLHelper;
+import io.vertx.core.net.impl.SslContextProvider;
 import io.vertx.core.net.impl.VertxHandler;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
@@ -75,7 +75,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
 
   private final String serverOrigin;
   private final Supplier<ContextInternal> streamContextSupplier;
-  private final SSLHelper sslHelper;
+  private final SslContextProvider sslContextProvider ;
   private final TracingPolicy tracingPolicy;
   private boolean requestFailed;
 
@@ -91,7 +91,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
   final HttpServerOptions options;
 
   public Http1xServerConnection(Supplier<ContextInternal> streamContextSupplier,
-                                SSLHelper sslHelper,
+                                SslContextProvider sslContextProvider,
                                 HttpServerOptions options,
                                 ChannelHandlerContext chctx,
                                 ContextInternal context,
@@ -101,7 +101,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
     this.serverOrigin = serverOrigin;
     this.streamContextSupplier = streamContextSupplier;
     this.options = options;
-    this.sslHelper = sslHelper;
+    this.sslContextProvider = sslContextProvider;
     this.metrics = metrics;
     this.handle100ContinueAutomatically = options.isHandle100ContinueAutomatically();
     this.tracingPolicy = options.getTracingPolicy();
@@ -382,7 +382,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
       }
 
       pipeline.replace("handler", "handler", VertxHandler.create(ctx -> {
-        NetSocketImpl socket = new NetSocketImpl(context, ctx, sslHelper, metrics) {
+        NetSocketImpl socket = new NetSocketImpl(context, ctx, sslContextProvider, metrics) {
           @Override
           protected void handleClosed() {
             if (metrics != null) {

--- a/src/main/java/io/vertx/core/http/impl/Http1xUpgradeToH2CHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xUpgradeToH2CHandler.java
@@ -21,9 +21,9 @@ import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http2.*;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
+import io.vertx.core.net.impl.SslContextProvider;
 import io.vertx.core.net.impl.VertxHandler;
 
-import java.util.Iterator;
 import java.util.Map;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -33,12 +33,14 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 public class Http1xUpgradeToH2CHandler extends ChannelInboundHandlerAdapter {
 
   private final HttpServerWorker initializer;
+  private final SslContextProvider sslContextProvider;
   private VertxHttp2ConnectionHandler<Http2ServerConnection> handler;
   private final boolean isCompressionSupported;
   private final boolean isDecompressionSupported;
 
-  Http1xUpgradeToH2CHandler(HttpServerWorker initializer, boolean isCompressionSupported, boolean isDecompressionSupported) {
+  Http1xUpgradeToH2CHandler(HttpServerWorker initializer, SslContextProvider sslContextProvider, boolean isCompressionSupported, boolean isDecompressionSupported) {
     this.initializer = initializer;
+    this.sslContextProvider = sslContextProvider;
     this.isCompressionSupported = isCompressionSupported;
     this.isDecompressionSupported = isDecompressionSupported;
   }
@@ -116,7 +118,7 @@ public class Http1xUpgradeToH2CHandler extends ChannelInboundHandlerAdapter {
           ctx.writeAndFlush(res);
         }
       } else {
-        initializer.configureHttp1(ctx.pipeline());
+        initializer.configureHttp1(ctx.pipeline(), sslContextProvider);
         ctx.fireChannelRead(msg);
         ctx.pipeline().remove(this);
       }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -504,6 +504,11 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider, Clos
   }
 
   @Override
+  public Future<Void> updateSSLOptions(SSLOptions options) {
+    return netClient.updateSSLOptions(options);
+  }
+
+  @Override
   public HttpClient connectionHandler(Handler<HttpConnection> handler) {
     connectionHandler = handler;
     return this;

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -28,6 +28,7 @@ import io.vertx.core.spi.metrics.TCPMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.streams.ReadStream;
 
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -173,7 +174,7 @@ public class HttpServerImpl extends TCPServerBase implements HttpServer, Closeab
   }
 
   @Override
-  protected Handler<Channel> childHandler(ContextInternal context, SocketAddress address, SSLHelper sslHelper) {
+  protected BiConsumer<Channel, SslContextProvider> childHandler(ContextInternal context, SocketAddress address) {
     EventLoopContext connContext;
     if (context instanceof EventLoopContext) {
       connContext = (EventLoopContext) context;
@@ -190,7 +191,6 @@ public class HttpServerImpl extends TCPServerBase implements HttpServer, Closeab
       streamContextSupplier,
       this,
       vertx,
-      sslHelper,
       options,
       serverOrigin,
       disableH2c,

--- a/src/main/java/io/vertx/core/http/impl/SharedHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/SharedHttpClient.java
@@ -20,6 +20,7 @@ import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.future.PromiseInternal;
+import io.vertx.core.net.SSLOptions;
 
 import java.util.List;
 import java.util.function.Function;
@@ -140,6 +141,11 @@ public class SharedHttpClient implements HttpClientInternal {
   @Override
   public Future<WebSocket> webSocketAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
     return delegate.webSocketAbs(url, headers, version, subProtocols);
+  }
+
+  @Override
+  public Future<Void> updateSSLOptions(SSLOptions options) {
+    return delegate.updateSSLOptions(options);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/NetClient.java
+++ b/src/main/java/io/vertx/core/net/NetClient.java
@@ -114,4 +114,27 @@ public interface NetClient extends Measured {
    */
   Future<Void> close();
 
+  /**
+   * Update the client SSL options.
+   *
+   * Update only happens if the SSL options is valid.
+   *
+   * @param options the new SSL options
+   * @return a future signaling the update success
+   */
+  Future<Void> updateSSLOptions(SSLOptions options);
+
+  /**
+   * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
+   * happened (or has failed).
+   *
+   * @param options the new SSL options
+   * @param handler the update handler
+   */
+  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Void>> handler) {
+    Future<Void> fut = updateSSLOptions(options);
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
+  }
 }

--- a/src/main/java/io/vertx/core/net/NetServer.java
+++ b/src/main/java/io/vertx/core/net/NetServer.java
@@ -170,4 +170,27 @@ public interface NetServer extends Measured {
    * @return the actual port the server is listening on.
    */
   int actualPort();
-}
+
+  /**
+   * Update the server SSL options.
+   *
+   * Update only happens if the SSL options is valid.
+   *
+   * @param options the new SSL options
+   * @return a future signaling the update success
+   */
+  Future<Void> updateSSLOptions(SSLOptions options);
+
+  /**
+   * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
+   * happened (or has failed).
+   *
+   * @param options the new SSL options
+   * @param handler the update handler
+   */
+  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Void>> handler) {
+    Future<Void> fut = updateSSLOptions(options);
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
+  }}

--- a/src/main/java/io/vertx/core/net/SSLOptions.java
+++ b/src/main/java/io/vertx/core/net/SSLOptions.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * SSL options
+ *
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+@DataObject(generateConverter = true, publicConverter = false)
+public class SSLOptions {
+
+  /**
+   * Default use alpn = false
+   */
+  public static final boolean DEFAULT_USE_ALPN = false;
+
+  /**
+   * The default value of SSL handshake timeout = 10
+   */
+  public static final long DEFAULT_SSL_HANDSHAKE_TIMEOUT = 10L;
+
+  /**
+   * Default SSL handshake time unit = SECONDS
+   */
+  public static final TimeUnit DEFAULT_SSL_HANDSHAKE_TIMEOUT_TIME_UNIT = TimeUnit.SECONDS;
+
+  /**
+   * The default ENABLED_SECURE_TRANSPORT_PROTOCOLS value = { "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" }
+   * <p/>
+   * SSLv3 is NOT enabled due to POODLE vulnerability http://en.wikipedia.org/wiki/POODLE
+   * <p/>
+   * "SSLv2Hello" is NOT enabled since it's disabled by default since JDK7
+   */
+  public static final List<String> DEFAULT_ENABLED_SECURE_TRANSPORT_PROTOCOLS = Collections.unmodifiableList(Arrays.asList("TLSv1.2", "TLSv1.3"));
+
+  private long sslHandshakeTimeout;
+  private TimeUnit sslHandshakeTimeoutUnit;
+  private KeyCertOptions keyCertOptions;
+  private TrustOptions trustOptions;
+  private Set<String> enabledCipherSuites;
+  private ArrayList<String> crlPaths;
+  private ArrayList<Buffer> crlValues;
+  private boolean useAlpn;
+  private Set<String> enabledSecureTransportProtocols;
+
+  /**
+   * Create options from JSON
+   *
+   * @param json the JSON
+   */
+  public SSLOptions(JsonObject json) {
+    this();
+    SSLOptionsConverter.fromJson(json ,this);
+  }
+
+  /**
+   * Default constructor
+   */
+  public SSLOptions() {
+    init();
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param other  the options to copy
+   */
+  public SSLOptions(SSLOptions other) {
+    this.sslHandshakeTimeout = other.sslHandshakeTimeout;
+    this.sslHandshakeTimeoutUnit = other.getSslHandshakeTimeoutUnit() != null ? other.getSslHandshakeTimeoutUnit() : DEFAULT_SSL_HANDSHAKE_TIMEOUT_TIME_UNIT;
+    this.keyCertOptions = other.getKeyCertOptions() != null ? other.getKeyCertOptions().copy() : null;
+    this.trustOptions = other.getTrustOptions() != null ? other.getTrustOptions().copy() : null;
+    this.enabledCipherSuites = other.getEnabledCipherSuites() == null ? new LinkedHashSet<>() : new LinkedHashSet<>(other.getEnabledCipherSuites());
+    this.crlPaths = new ArrayList<>(other.getCrlPaths());
+    this.crlValues = new ArrayList<>(other.getCrlValues());
+    this.useAlpn = other.useAlpn;
+    this.enabledSecureTransportProtocols = other.getEnabledSecureTransportProtocols() == null ? new LinkedHashSet<>() : new LinkedHashSet<>(other.getEnabledSecureTransportProtocols());
+  }
+
+
+  private void init() {
+    sslHandshakeTimeout = DEFAULT_SSL_HANDSHAKE_TIMEOUT;
+    sslHandshakeTimeoutUnit = DEFAULT_SSL_HANDSHAKE_TIMEOUT_TIME_UNIT;
+    enabledCipherSuites = new LinkedHashSet<>();
+    crlPaths = new ArrayList<>();
+    crlValues = new ArrayList<>();
+    useAlpn = DEFAULT_USE_ALPN;
+    enabledSecureTransportProtocols = new LinkedHashSet<>(DEFAULT_ENABLED_SECURE_TRANSPORT_PROTOCOLS);
+  }
+
+  /**
+   * @return the key/cert options
+   */
+  @GenIgnore
+  public KeyCertOptions getKeyCertOptions() {
+    return keyCertOptions;
+  }
+
+  /**
+   * Set the key/cert options.
+   *
+   * @param options the key store options
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore
+  public SSLOptions setKeyCertOptions(KeyCertOptions options) {
+    this.keyCertOptions = options;
+    return this;
+  }
+
+  /**
+   * @return the trust options
+   */
+  public TrustOptions getTrustOptions() {
+    return trustOptions;
+  }
+
+  /**
+   * Set the trust options.
+   * @param options the trust options
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SSLOptions setTrustOptions(TrustOptions options) {
+    this.trustOptions = options;
+    return this;
+  }
+
+  /**
+   * Add an enabled cipher suite, appended to the ordered suites.
+   *
+   * @param suite  the suite
+   * @return a reference to this, so the API can be used fluently
+   * @see #getEnabledCipherSuites()
+   */
+  public SSLOptions addEnabledCipherSuite(String suite) {
+    enabledCipherSuites.add(suite);
+    return this;
+  }
+
+  /**
+   * Removes an enabled cipher suite from the ordered suites.
+   *
+   * @param suite  the suite
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SSLOptions removeEnabledCipherSuite(String suite) {
+    enabledCipherSuites.remove(suite);
+    return this;
+  }
+
+  /**
+   * Return an ordered set of the cipher suites.
+   *
+   * <p> The set is initially empty and suite should be added to this set in the desired order.
+   *
+   * <p> When suites are added and therefore the list is not empty, it takes precedence over the
+   * default suite defined by the {@link SSLEngineOptions} in use.
+   *
+   * @return the enabled cipher suites
+   */
+  public Set<String> getEnabledCipherSuites() {
+    return enabledCipherSuites;
+  }
+
+  /**
+   *
+   * @return the CRL (Certificate revocation list) paths
+   */
+  public List<String> getCrlPaths() {
+    return crlPaths;
+  }
+
+  /**
+   * Add a CRL path
+   * @param crlPath  the path
+   * @return a reference to this, so the API can be used fluently
+   * @throws NullPointerException
+   */
+  public SSLOptions addCrlPath(String crlPath) throws NullPointerException {
+    Objects.requireNonNull(crlPath, "No null crl accepted");
+    crlPaths.add(crlPath);
+    return this;
+  }
+
+  /**
+   * Get the CRL values
+   *
+   * @return the list of values
+   */
+  public List<Buffer> getCrlValues() {
+    return crlValues;
+  }
+
+  /**
+   * Add a CRL value
+   *
+   * @param crlValue  the value
+   * @return a reference to this, so the API can be used fluently
+   * @throws NullPointerException
+   */
+  public SSLOptions addCrlValue(Buffer crlValue) throws NullPointerException {
+    Objects.requireNonNull(crlValue, "No null crl accepted");
+    crlValues.add(crlValue);
+    return this;
+  }
+
+  /**
+   * @return whether to use or not Application-Layer Protocol Negotiation
+   */
+  public boolean isUseAlpn() {
+    return useAlpn;
+  }
+
+  /**
+   * Set the ALPN usage.
+   *
+   * @param useAlpn true when Application-Layer Protocol Negotiation should be used
+   */
+  public SSLOptions setUseAlpn(boolean useAlpn) {
+    this.useAlpn = useAlpn;
+    return this;
+  }
+
+  /**
+   * Returns the enabled SSL/TLS protocols
+   * @return the enabled protocols
+   */
+  public Set<String> getEnabledSecureTransportProtocols() {
+    return new LinkedHashSet<>(enabledSecureTransportProtocols);
+  }
+
+  /**
+   * @return the SSL handshake timeout, in time unit specified by {@link #getSslHandshakeTimeoutUnit()}.
+   */
+  public long getSslHandshakeTimeout() {
+    return sslHandshakeTimeout;
+  }
+
+  /**
+   * Set the SSL handshake timeout, default time unit is seconds.
+   *
+   * @param sslHandshakeTimeout the SSL handshake timeout to set, in milliseconds
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SSLOptions setSslHandshakeTimeout(long sslHandshakeTimeout) {
+    if (sslHandshakeTimeout < 0) {
+      throw new IllegalArgumentException("sslHandshakeTimeout must be >= 0");
+    }
+    this.sslHandshakeTimeout = sslHandshakeTimeout;
+    return this;
+  }
+
+  /**
+   * Set the SSL handshake timeout unit. If not specified, default is seconds.
+   *
+   * @param sslHandshakeTimeoutUnit specify time unit.
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SSLOptions setSslHandshakeTimeoutUnit(TimeUnit sslHandshakeTimeoutUnit) {
+    this.sslHandshakeTimeoutUnit = sslHandshakeTimeoutUnit;
+    return this;
+  }
+
+  /**
+   * @return the SSL handshake timeout unit.
+   */
+  public TimeUnit getSslHandshakeTimeoutUnit() {
+    return sslHandshakeTimeoutUnit;
+  }
+
+  /**
+   * Sets the list of enabled SSL/TLS protocols.
+   *
+   * @param enabledSecureTransportProtocols  the SSL/TLS protocols to enable
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SSLOptions setEnabledSecureTransportProtocols(Set<String> enabledSecureTransportProtocols) {
+    this.enabledSecureTransportProtocols = enabledSecureTransportProtocols;
+    return this;
+  }
+
+  /**
+   * Add an enabled SSL/TLS protocols, appended to the ordered protocols.
+   *
+   * @param protocol  the SSL/TLS protocol to enable
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SSLOptions addEnabledSecureTransportProtocol(String protocol) {
+    enabledSecureTransportProtocols.add(protocol);
+    return this;
+  }
+
+  /**
+   * Removes an enabled SSL/TLS protocol from the ordered protocols.
+   *
+   * @param protocol the SSL/TLS protocol to disable
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SSLOptions removeEnabledSecureTransportProtocol(String protocol) {
+    enabledSecureTransportProtocols.remove(protocol);
+    return this;
+  }
+
+  /**
+   * Convert to JSON
+   *
+   * @return the JSON
+   */
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    SSLOptionsConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
@@ -12,10 +12,8 @@
 package io.vertx.core.net.impl;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.*;
 import io.netty.handler.proxy.*;
-import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.resolver.NoopAddressResolverGroup;
@@ -44,18 +42,18 @@ import java.net.InetSocketAddress;
 public final class ChannelProvider {
 
   private final Bootstrap bootstrap;
-  private final SSLHelper sslHelper;
+  private final SslContextProvider sslContextProvider;
   private final ContextInternal context;
   private ProxyOptions proxyOptions;
   private String applicationProtocol;
   private Handler<Channel> handler;
 
   public ChannelProvider(Bootstrap bootstrap,
-                         SSLHelper sslHelper,
+                         SslContextProvider sslContextProvider,
                          ContextInternal context) {
     this.bootstrap = bootstrap;
     this.context = context;
-    this.sslHelper = sslHelper;
+    this.sslContextProvider = sslContextProvider;
   }
 
   /**
@@ -109,7 +107,7 @@ public final class ChannelProvider {
 
   private void initSSL(Handler<Channel> handler, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, Channel ch, Promise<Channel> channelHandler) {
     if (ssl) {
-      SslHandler sslHandler = sslHelper.createSslHandler(context.owner(), peerAddress, serverName, useAlpn);
+      SslHandler sslHandler = sslContextProvider.createSslHandler(context.owner(), peerAddress, serverName, useAlpn);
       ChannelPipeline pipeline = ch.pipeline();
       pipeline.addLast("ssl", sslHandler);
       pipeline.addLast(new ChannelInboundHandlerAdapter() {

--- a/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net.impl;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandler;
+import io.netty.handler.ssl.DelegatingSslContext;
+import io.netty.handler.ssl.SniHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.Mapping;
+import io.vertx.core.VertxException;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.KeyCertOptions;
+import io.vertx.core.net.SSLOptions;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.TrustOptions;
+import io.vertx.core.spi.tls.SslContextFactory;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManagerFactory;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * Provides Netty's {@link SslContext}.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class SslContextProvider {
+
+  private final SSLHelper sslHelper;
+  private final Supplier<SslContextFactory> provider;
+  private final long sslHandshakeTimeout;
+  private final TimeUnit sslHandshakeTimeoutUnit;
+  final Set<String> enabledProtocols;
+  private final KeyCertOptions keyCertOptions;
+  private final TrustOptions trustOptions;
+  private final ArrayList<String> crlPaths;
+  private final ArrayList<Buffer> crlValues;
+  private final Set<String> enabledCipherSuites;
+  private final SslContext[] sslContexts = new SslContext[2];
+  private final Map<String, SslContext>[] sslContextMaps = new Map[]{
+    new ConcurrentHashMap<>(), new ConcurrentHashMap<>()
+  };
+
+  public SslContextProvider(SSLHelper sslHelper, SSLOptions options, Supplier<SslContextFactory> provider) {
+    this.sslHelper = sslHelper;
+    this.provider = provider;
+    this.crlPaths = new ArrayList<>(options.getCrlPaths());
+    this.crlValues = new ArrayList<>(options.getCrlValues());
+    this.enabledCipherSuites = new HashSet<>(options.getEnabledCipherSuites());
+    this.sslHandshakeTimeout = options.getSslHandshakeTimeout();
+    this.sslHandshakeTimeoutUnit = options.getSslHandshakeTimeoutUnit();
+    this.enabledProtocols = options.getEnabledSecureTransportProtocols();
+    this.keyCertOptions = options.getKeyCertOptions() != null ? options.getKeyCertOptions().copy() : null;
+    this.trustOptions = options.getTrustOptions() != null ? options.getTrustOptions().copy() : null;
+  }
+
+  public boolean isSsl() {
+    return sslHelper.isSSL();
+  }
+
+  public SslContext createContext(VertxInternal vertx, String serverName, boolean useAlpn, boolean client, boolean trustAll) {
+    int idx = useAlpn ? 0 : 1;
+    if (serverName == null) {
+      if (sslContexts[idx] == null) {
+        sslContexts[idx] = createContext2(vertx, serverName, useAlpn, client, trustAll);
+      }
+      return sslContexts[idx];
+    } else {
+      return sslContextMaps[idx].computeIfAbsent(serverName, s -> createContext2(vertx, serverName, useAlpn, client, trustAll));
+    }
+  }
+
+  private SslContext createContext2(VertxInternal vertx, String serverName, boolean useAlpn, boolean client, boolean trustAll) {
+    try {
+      TrustManagerFactory tmf = SSLHelper.getTrustMgrFactory(vertx, trustOptions, crlPaths, crlValues, serverName, trustAll);
+      KeyManagerFactory kmf = SSLHelper.getKeyMgrFactory(vertx, keyCertOptions, serverName);
+      SslContextFactory factory = provider.get()
+        .useAlpn(useAlpn)
+        .forClient(client)
+        .enabledCipherSuites(enabledCipherSuites)
+        .applicationProtocols(sslHelper.applicationProtocols);
+      if (!client) {
+        factory.clientAuth(SSLHelper.CLIENT_AUTH_MAPPING.get(sslHelper.clientAuth));
+      }
+      if (kmf != null) {
+        factory.keyMananagerFactory(kmf);
+      }
+      if (tmf != null) {
+        factory.trustManagerFactory(tmf);
+      }
+      if (serverName != null) {
+        factory.serverName(serverName);
+      }
+      return factory.create();
+    } catch (Exception e) {
+      throw new VertxException(e);
+    }
+  }
+
+  public SslContext createContext(VertxInternal vertx) {
+    return createContext(vertx, null, sslHelper.useAlpn, sslHelper.client, sslHelper.trustAll);
+  }
+
+  public SslContext sslContext(VertxInternal vertx, String serverName, boolean useAlpn) {
+    SslContext context = createContext(vertx, null, useAlpn, sslHelper.client, sslHelper.trustAll);
+    return new DelegatingSslContext(context) {
+      @Override
+      protected void initEngine(SSLEngine engine) {
+        sslHelper.configureEngine(engine, enabledProtocols, serverName);
+      }
+    };
+  }
+
+  public Mapping<? super String, ? extends SslContext> serverNameMapper(VertxInternal vertx) {
+    return serverName -> {
+      SslContext ctx = createContext(vertx, serverName, sslHelper.useAlpn, sslHelper.client, sslHelper.trustAll);
+      if (ctx != null) {
+        ctx = new DelegatingSslContext(ctx) {
+          @Override
+          protected void initEngine(SSLEngine engine) {
+            sslHelper.configureEngine(engine, enabledProtocols, serverName);
+          }
+        };
+      }
+      return ctx;
+    };
+  }
+
+  public SSLEngine createEngine(VertxInternal vertx) {
+    SSLEngine engine = createContext(vertx).newEngine(ByteBufAllocator.DEFAULT);
+    sslHelper.configureEngine(engine, enabledProtocols, null);
+    return engine;
+  }
+
+  public SslHandler createSslHandler(VertxInternal vertx, String serverName) {
+    return createSslHandler(vertx, null, serverName);
+  }
+
+  public SslHandler createSslHandler(VertxInternal vertx, SocketAddress remoteAddress, String serverName) {
+    return createSslHandler(vertx, remoteAddress, serverName, sslHelper.useAlpn);
+  }
+
+  public SslHandler createSslHandler(VertxInternal vertx, SocketAddress remoteAddress, String serverName, boolean useAlpn) {
+    SslContext sslContext = sslContext(vertx, serverName, useAlpn);
+    SslHandler sslHandler;
+    if (remoteAddress == null || remoteAddress.isDomainSocket()) {
+      sslHandler = sslContext.newHandler(ByteBufAllocator.DEFAULT);
+    } else {
+      sslHandler = sslContext.newHandler(ByteBufAllocator.DEFAULT, remoteAddress.host(), remoteAddress.port());
+    }
+    sslHandler.setHandshakeTimeout(sslHandshakeTimeout, sslHandshakeTimeoutUnit);
+    return sslHandler;
+  }
+
+  public ChannelHandler createHandler(VertxInternal vertx) {
+    if (sslHelper.sni) {
+      return createSniHandler(vertx);
+    } else {
+      return createSslHandler(vertx, null);
+    }
+  }
+
+  public SniHandler createSniHandler(VertxInternal vertx) {
+    return new VertxSniHandler(serverNameMapper(vertx), sslHandshakeTimeoutUnit.toMillis(sslHandshakeTimeout));
+  }
+}

--- a/src/test/java/io/vertx/core/net/SSLHelperTest.java
+++ b/src/test/java/io/vertx/core/net/SSLHelperTest.java
@@ -46,9 +46,9 @@ public class SSLHelperTest extends VertxTestBase {
     SSLHelper helper = new SSLHelper(new HttpClientOptions().setKeyStoreOptions(Cert.CLIENT_JKS.get()).setTrustOptions(Trust.SERVER_JKS.get()),
       null);
     helper
-      .init((ContextInternal) vertx.getOrCreateContext())
-      .onComplete(onSuccess(v -> {
-        SslContext ctx = helper.createContext((VertxInternal) vertx);
+      .init(new SSLOptions().setKeyCertOptions(Cert.CLIENT_JKS.get()).setTrustOptions(Trust.SERVER_JKS.get()), (ContextInternal) vertx.getOrCreateContext())
+      .onComplete(onSuccess(provider -> {
+        SslContext ctx = provider.createContext((VertxInternal) vertx);
         assertEquals(new HashSet<>(Arrays.asList(expected)), new HashSet<>(ctx.cipherSuites()));
         testComplete();
     }));
@@ -61,8 +61,8 @@ public class SSLHelperTest extends VertxTestBase {
     SSLHelper helper = new SSLHelper(
         new HttpClientOptions().setOpenSslEngineOptions(new OpenSSLEngineOptions()).setPemKeyCertOptions(Cert.CLIENT_PEM.get()).setTrustOptions(Trust.SERVER_PEM.get()),
       null);
-    helper.init((ContextInternal) vertx.getOrCreateContext()).onComplete(onSuccess(v -> {
-      SslContext ctx = helper.createContext((VertxInternal) vertx);
+    helper.init(new SSLOptions().setKeyCertOptions(Cert.CLIENT_PEM.get()).setTrustOptions(Trust.SERVER_PEM.get()), (ContextInternal) vertx.getOrCreateContext()).onComplete(onSuccess(provider -> {
+      SslContext ctx = provider.createContext((VertxInternal) vertx);
       assertEquals(expected, new HashSet<>(ctx.cipherSuites()));
       testComplete();
     }));
@@ -90,9 +90,9 @@ public class SSLHelperTest extends VertxTestBase {
       null);
 
     defaultHelper
-      .init((ContextInternal) vertx.getOrCreateContext())
-      .onComplete(onSuccess(v -> {
-        SslContext ctx = defaultHelper.createContext((VertxInternal) vertx);
+      .init(httpServerOptions.getSslOptions(), (ContextInternal) vertx.getOrCreateContext())
+      .onComplete(onSuccess(provider -> {
+        SslContext ctx = provider.createContext((VertxInternal) vertx);
         assertTrue(ctx instanceof OpenSslServerContext);
 
         SSLSessionContext sslSessionContext = ctx.sessionContext();
@@ -122,9 +122,9 @@ public class SSLHelperTest extends VertxTestBase {
     assertEquals(new ArrayList<>(new HttpServerOptions(json).getEnabledCipherSuites()), Arrays.asList(engine.getEnabledCipherSuites()));
     SSLHelper helper = new SSLHelper(options.setKeyCertOptions(Cert.SERVER_JKS.get()), null);
     helper
-      .init((ContextInternal) vertx.getOrCreateContext())
-      .onComplete(onSuccess(v -> {
-        assertEquals(new HashSet<>(Arrays.asList(helper.createEngine((VertxInternal) vertx).getEnabledCipherSuites())), new HashSet<>(Arrays.asList(engine.getEnabledCipherSuites())));
+      .init(options.getSslOptions(), (ContextInternal) vertx.getOrCreateContext())
+      .onComplete(onSuccess(sslContextProvider -> {
+        assertEquals(new HashSet<>(Arrays.asList(sslContextProvider.createEngine((VertxInternal) vertx).getEnabledCipherSuites())), new HashSet<>(Arrays.asList(engine.getEnabledCipherSuites())));
         testComplete();
       }));
     await();
@@ -178,9 +178,9 @@ public class SSLHelperTest extends VertxTestBase {
   private void testTLSVersions(HttpServerOptions options, Consumer<SSLEngine> check) {
     SSLHelper helper = new SSLHelper(options.setSsl(true).setKeyCertOptions(Cert.SERVER_JKS.get()), null);
     helper
-      .init((ContextInternal) vertx.getOrCreateContext())
-      .onComplete(onSuccess(v -> {
-        SSLEngine engine = helper.createEngine((VertxInternal) vertx);
+      .init(options.getSslOptions(), (ContextInternal) vertx.getOrCreateContext())
+      .onComplete(onSuccess(sslContextProvider -> {
+        SSLEngine engine = sslContextProvider.createEngine((VertxInternal) vertx);
         check.accept(engine);
         testComplete();
       }));

--- a/src/test/java/io/vertx/it/SSLEngineTest.java
+++ b/src/test/java/io/vertx/it/SSLEngineTest.java
@@ -25,6 +25,7 @@ import io.vertx.core.net.OpenSSLEngineOptions;
 import io.vertx.core.net.SSLEngineOptions;
 import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.core.http.HttpTestBase;
+import io.vertx.core.net.impl.SslContextProvider;
 import io.vertx.test.tls.Cert;
 import org.junit.Test;
 
@@ -104,8 +105,8 @@ public class SSLEngineTest extends HttpTestBase {
         return;
       }
     }
-    SSLHelper sslHelper = ((HttpServerImpl)server).sslHelper();
-    SslContext ctx = sslHelper.createContext((VertxInternal) vertx);
+    SslContextProvider provider = ((HttpServerImpl)server).sslContextProvider();
+    SslContext ctx = provider.createContext((VertxInternal) vertx);
     switch (expectedSslContext != null ? expectedSslContext : "jdk") {
       case "jdk":
         assertTrue(ctx instanceof JdkSslContext);


### PR DESCRIPTION
Provides support for reloading of a TCP server or client, a new `SSLOptions` class has been introducing which captures the reloadable part of the current configuration.

Reconfiguration is explicit and requires a call to a new `updateSSLOptions` method that loads and validates the configuration and then updates the SSL context when it succeeds. 

```java
vertx.setPeriodic(REFRESH_PERIOD, id -> {
  Optional<SSLOptions> options = refreshUpdatedConfiguration();
  if (options.isPresent()) {
    Future<Void> fut = server.updateSSLOptions(options.get());
  }
});
```