### PR TITLE
Update javadoc of DuplicatedContext as it's not maintain a seperated …

### DIFF
--- a/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -26,8 +26,6 @@ import java.util.concurrent.Executor;
  * A context that forwards most operations to a delegate. This context
  *
  * <ul>
- *   <li>maintains its own ordered task queue, ordered execute blocking are ordered on this
- *  context instead of the delegate.</li>
  *  <li>maintains its own local data instead of the delegate.</li>
  * </ul>
  *


### PR DESCRIPTION
Motivation:

The current DuplicatedContext is not maintaining a seperated TaskQueue anymore.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
