### PR TITLE
copy nonProxyHosts list from other ClientOptionsBase.

### DIFF
--- a/src/main/java/io/vertx/core/net/ClientOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/ClientOptionsBase.java
@@ -70,6 +70,7 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
     this.metricsName = other.metricsName;
     this.proxyOptions = other.proxyOptions != null ? new ProxyOptions(other.proxyOptions) : null;
     this.localAddress = other.localAddress;
+    this.nonProxyHosts = other.nonProxyHosts != null ? new ArrayList<>(other.nonProxyHosts) : null;
   }
 
   /**


### PR DESCRIPTION
 4575-nonProxyHostList overrides to null by creating new WebClientOptions from existing WebClientOptions.  
