### PR TITLE
SSL blocking operations can now be executed on the vertx internal worker pool

### DIFF
--- a/src/main/generated/io/vertx/core/net/OpenSSLEngineOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/net/OpenSSLEngineOptionsConverter.java
@@ -25,6 +25,11 @@ public class OpenSSLEngineOptionsConverter {
             obj.setSessionCacheEnabled((Boolean)member.getValue());
           }
           break;
+        case "useWorkerThread":
+          if (member.getValue() instanceof Boolean) {
+            obj.setUseWorkerThread((Boolean)member.getValue());
+          }
+          break;
       }
     }
   }
@@ -35,5 +40,6 @@ public class OpenSSLEngineOptionsConverter {
 
    static void toJson(OpenSSLEngineOptions obj, java.util.Map<String, Object> json) {
     json.put("sessionCacheEnabled", obj.isSessionCacheEnabled());
+    json.put("useWorkerThread", obj.getUseWorkerThread());
   }
 }

--- a/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
@@ -62,6 +62,12 @@ public class JdkSSLEngineOptions extends SSLEngineOptions {
   }
 
   public JdkSSLEngineOptions(JdkSSLEngineOptions that) {
+    super(that);
+  }
+
+  @Override
+  public JdkSSLEngineOptions setUseWorkerThread(boolean useWorkerThread) {
+    return (JdkSSLEngineOptions) super.setUseWorkerThread(useWorkerThread);
   }
 
   public JsonObject toJson() {
@@ -70,7 +76,7 @@ public class JdkSSLEngineOptions extends SSLEngineOptions {
 
   @Override
   public JdkSSLEngineOptions copy() {
-    return new JdkSSLEngineOptions();
+    return new JdkSSLEngineOptions(this);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/OpenSSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/OpenSSLEngineOptions.java
@@ -79,6 +79,11 @@ public class OpenSSLEngineOptions extends SSLEngineOptions {
     return sessionCacheEnabled;
   }
 
+  @Override
+  public OpenSSLEngineOptions setUseWorkerThread(boolean useWorkerThread) {
+    return (OpenSSLEngineOptions) super.setUseWorkerThread(useWorkerThread);
+  }
+
   public JsonObject toJson() {
     JsonObject json = new JsonObject();
     OpenSSLEngineOptionsConverter.toJson(this, json);

--- a/src/main/java/io/vertx/core/net/SSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/SSLEngineOptions.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.net;
 
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tls.SslContextFactory;
 
 /**
@@ -20,11 +21,47 @@ import io.vertx.core.spi.tls.SslContextFactory;
  */
 public abstract class SSLEngineOptions {
 
+  /**
+   * The default thread pool type for SSL blocking operations.
+   */
+  public static final boolean DEFAULT_USE_WORKER_POOL = false;
+
+  private boolean useWorkerThread;
+
   public abstract SSLEngineOptions copy();
+
+  public SSLEngineOptions() {
+    this.useWorkerThread = DEFAULT_USE_WORKER_POOL;
+  }
+
+  public SSLEngineOptions(SSLEngineOptions that) {
+    this.useWorkerThread = that.useWorkerThread;
+  }
+
+  public SSLEngineOptions(JsonObject json) {
+    this.useWorkerThread = json.getBoolean("useWorkerThread", DEFAULT_USE_WORKER_POOL);
+  }
 
   /**
    * @return a {@link SslContextFactory} that will be used to produce the Netty {@code SslContext}
    */
   public abstract SslContextFactory sslContextFactory();
 
+  /**
+   * @return whether to use the worker pool for SSL blocking operationsg
+   */
+  public boolean getUseWorkerThread() {
+    return useWorkerThread;
+  }
+
+  /**
+   * Set the thread pool to use for SSL blocking operations.
+   *
+   * @param useWorkerThread whether to use the vertx internal worker pool for SSL blocking operations
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SSLEngineOptions setUseWorkerThread(boolean useWorkerThread) {
+    this.useWorkerThread = useWorkerThread;
+    return this;
+  }
 }

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -13,31 +13,28 @@ package io.vertx.core.http;
 
 import static org.hamcrest.core.StringEndsWith.endsWith;
 
-import java.io.IOException;
+import java.io.*;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.KeyPairGenerator;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
+import java.security.*;
 import java.security.cert.Certificate;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+import java.security.cert.CertificateException;
+import java.security.interfaces.RSAPrivateKey;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import javax.net.ssl.ManagerFactoryParameters;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.TrustManagerFactorySpi;
+import javax.net.ssl.*;
 
+import io.vertx.core.impl.VertxThread;
 import io.vertx.core.net.SSLOptions;
+import io.vertx.core.net.impl.KeyStoreHelper;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1663,5 +1660,201 @@ public abstract class HttpTLSTest extends HttpTestBase {
       }));
     }));
     await();
+  }
+
+  @Test
+  public void testUseEventLoopThread() throws Exception {
+    testUseThreadPool(true);
+  }
+
+  @Test
+  public void testUseWorkerThreads() throws Exception {
+    testUseThreadPool(false);
+  }
+
+  private void testUseThreadPool(boolean useWorkerThreads) throws Exception {
+    JksOptions jksOptions = Cert.SERVER_JKS.get();
+    KeyStore ks = KeyStore.getInstance("JKS");
+    ks.load(new ByteArrayInputStream(vertx.fileSystem().readFileBlocking(jksOptions.getPath()).getBytes()), jksOptions.getPassword().toCharArray());
+    final Set<Thread> engineThreads = Collections.synchronizedSet(new HashSet<>());
+    class TestKeyStoreSpi extends KeyStoreSpi {
+      @Override
+      public Key engineGetKey(String alias, char[] password) throws NoSuchAlgorithmException, UnrecoverableKeyException {
+        try {
+          RSAPrivateKey key = (RSAPrivateKey) ks.getKey(alias, password);
+          return new RSAPrivateKey() {
+            private void addThread() {
+              engineThreads.add(Thread.currentThread());
+            }
+            @Override
+            public BigInteger getPrivateExponent() {
+              addThread();
+              return key.getPrivateExponent();
+            }
+            @Override
+            public String getAlgorithm() {
+              addThread();
+              return key.getAlgorithm();
+            }
+            @Override
+            public String getFormat() {
+              addThread();
+              return key.getFormat();
+            }
+            @Override
+            public byte[] getEncoded() {
+              addThread();
+              return key.getEncoded();
+            }
+            @Override
+            public BigInteger getModulus() {
+              addThread();
+              return key.getModulus();
+            }
+          };
+        } catch (KeyStoreException e) {
+          throw new UndeclaredThrowableException(e);
+        }
+      }
+      @Override
+      public Certificate[] engineGetCertificateChain(String alias) {
+        try {
+          return ks.getCertificateChain(alias);
+        } catch (KeyStoreException e) {
+          throw new UndeclaredThrowableException(e);
+        }
+      }
+      @Override
+      public Certificate engineGetCertificate(String alias) {
+        try {
+          return ks.getCertificate(alias);
+        } catch (KeyStoreException e) {
+          throw new UndeclaredThrowableException(e);
+        }
+      }
+      @Override
+      public Date engineGetCreationDate(String alias) {
+        try {
+          return ks.getCreationDate(alias);
+        } catch (KeyStoreException e) {
+          throw new UndeclaredThrowableException(e);
+        }
+      }
+      @Override
+      public void engineSetKeyEntry(String alias, Key key, char[] password, Certificate[] chain) throws KeyStoreException {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void engineSetKeyEntry(String alias, byte[] key, Certificate[] chain) throws KeyStoreException {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void engineSetCertificateEntry(String alias, Certificate cert) throws KeyStoreException {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void engineDeleteEntry(String alias) throws KeyStoreException {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public Enumeration<String> engineAliases() {
+        try {
+          return ks.aliases();
+        } catch (KeyStoreException e) {
+          throw new UndeclaredThrowableException(e);
+        }
+      }
+      @Override
+      public boolean engineContainsAlias(String alias) {
+        try {
+          return ks.containsAlias(alias);
+        } catch (KeyStoreException e) {
+          throw new UndeclaredThrowableException(e);
+        }
+      }
+      @Override
+      public int engineSize() {
+        try {
+          return ks.size();
+        } catch (KeyStoreException e) {
+          throw new UndeclaredThrowableException(e);
+        }
+      }
+      @Override
+      public boolean engineIsKeyEntry(String alias) {
+        try {
+          return ks.isKeyEntry(alias);
+        } catch (KeyStoreException e) {
+          throw new UndeclaredThrowableException(e);
+        }
+      }
+      @Override
+      public boolean engineIsCertificateEntry(String alias) {
+        try {
+          return ks.isCertificateEntry(alias);
+        } catch (KeyStoreException e) {
+          throw new UndeclaredThrowableException(e);
+        }
+      }
+      @Override
+      public String engineGetCertificateAlias(Certificate cert) {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void engineStore(OutputStream stream, char[] password) throws IOException, NoSuchAlgorithmException, CertificateException {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void engineLoad(InputStream stream, char[] password) throws IOException, NoSuchAlgorithmException, CertificateException {
+        // NOOP
+      }
+    }
+
+    KeyStore testKs = new KeyStore(new TestKeyStoreSpi(), ks.getProvider(), ks.getType()) {
+
+    };
+    testKs.load(new ByteArrayInputStream(new byte[0]), new char[0]);
+    KeyCertOptions testOptions = new KeyCertOptions() {
+      @Override
+      public KeyCertOptions copy() {
+        return this;
+      }
+      @Override
+      public KeyManagerFactory getKeyManagerFactory(Vertx vertx) throws Exception {
+        return new KeyStoreHelper(testKs, jksOptions.getPassword(), null).getKeyMgrFactory();
+      }
+      @Override
+      public Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) throws Exception {
+        throw new UnsupportedEncodingException();
+      }
+    };
+
+    server = createHttpServer(createBaseServerOptions()
+      .setJdkSslEngineOptions(new JdkSSLEngineOptions().setUseWorkerThread(useWorkerThreads))
+      .setSsl(true)
+      .setKeyCertOptions(testOptions)
+    )
+      .requestHandler(req -> {
+        req.response().end("Hello World");
+      });
+    startServer(testAddress);
+    Supplier<Future<Buffer>> request = () -> client.request(requestOptions).compose(req -> req.send().compose(HttpClientResponse::body));
+    CountDownLatch latch = new CountDownLatch(1);
+    client = createHttpClient(new HttpClientOptions().setKeepAlive(false).setSsl(true).setTrustOptions(Trust.SERVER_JKS.get()));
+    request.get().onComplete(onSuccess(body1 -> {
+      assertEquals("Hello World", body1.toString());
+      latch.countDown();
+    }));
+    awaitLatch(latch);
+    assertTrue(engineThreads.size() > 0);
+    long numWorkers = engineThreads.stream()
+      .map(thread -> (VertxThread) thread)
+      .filter(VertxThread::isWorker)
+      .count();
+    if (useWorkerThreads) {
+      assertTrue(numWorkers > 0);
+    } else {
+      assertEquals(0, numWorkers);
+    }
   }
 }

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -490,7 +490,9 @@ public class NetTest extends VertxTestBase {
     } else {
       sslEngine = "openSslEngineOptions";
       boolean sessionCacheEnabled = rand.nextBoolean();
-      sslEngineOptions = new JsonObject().put("sessionCacheEnabled", sessionCacheEnabled);
+      sslEngineOptions = new JsonObject()
+        .put("sessionCacheEnabled", sessionCacheEnabled)
+        .put("useWorkerThread", SSLEngineOptions.DEFAULT_USE_WORKER_POOL);
     }
     long sslHandshakeTimeout = TestUtils.randomPositiveLong();
 


### PR DESCRIPTION
By default SSL blocking operations are executed on the event-loop, it should be possible to execute SSL blocking operations on the internal worker pool of Vert.x.