### PR TITLE
Connection pool post task stack overflow

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/pool/Task.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/Task.java
@@ -12,8 +12,9 @@ package io.vertx.core.net.impl.pool;
 
 public abstract class Task {
 
-  Task prev;
+  Task prev = this;
   Task next;
 
   public abstract void run();
+
 }


### PR DESCRIPTION
The connection pool post action task execution can lead to a stack overflow since those actions are simply executed by the owner thread after pool tasks execution. Post actions task should be trampolined to avoid this case.
