### PR TITLE
Improved path normalization and URI decoding

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -482,6 +482,9 @@ public final class HttpUtils {
     int queryStart = uri.indexOf('?', i);
     if (queryStart == -1) {
       queryStart = uri.length();
+      if (i == 0) {
+        return uri;
+      }
     }
     return uri.substring(i, queryStart);
   }


### PR DESCRIPTION
Http parsing and Vertx-web routing can improve performance on common path.

This changes:
- makes `decodeURIComponent` inlinable (but moving away unlikely paths)
- speedup `decodeURIComponent`  for the `plus = false` case, leveraging on `indexOf(char)` intrinsic (see https://chriswhocodes.com/hotspot_intrinsics_openjdk11.html)
- speedup string concatenation on `normalizePath` with https://bugs.openjdk.org/browse/JDK-8085796
- speedup `normalizePath` adding a zero garbage fast-path and reducing bytecode size
