### PR TITLE
Http validation improvements

### DIFF
--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersContainsBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersContainsBenchmark.java
@@ -15,6 +15,7 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -34,8 +35,8 @@ public class HeadersContainsBenchmark extends BenchmarkBase {
   public void setup() {
     nettySmallHeaders = new DefaultHttpHeaders();
     vertxSmallHeaders = HeadersMultiMap.httpHeaders();
-    setBaseHeaders(nettySmallHeaders);
-    setBaseHeaders(vertxSmallHeaders);
+    setBaseHeaders(nettySmallHeaders, true, true);
+    setBaseHeaders(vertxSmallHeaders, true, true);
   }
 
   @Benchmark

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersEncodeBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersEncodeBenchmark.java
@@ -20,6 +20,7 @@ import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -31,6 +32,12 @@ import static io.vertx.benchmarks.HeadersUtils.setBaseHeaders;
  */
 @State(Scope.Thread)
 public class HeadersEncodeBenchmark extends BenchmarkBase {
+
+  @Param({"true", "false"})
+  public boolean asciiNames;
+
+  @Param({"true", "false"})
+  public boolean asciiValues;
 
   @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public static void consume(final ByteBuf buf) {
@@ -58,8 +65,8 @@ public class HeadersEncodeBenchmark extends BenchmarkBase {
     emptyHeaders = EmptyHttpHeaders.INSTANCE;
     nettySmallHeaders = new DefaultHttpHeaders();
     vertxSmallHeaders = HeadersMultiMap.httpHeaders();
-    setBaseHeaders(nettySmallHeaders);
-    setBaseHeaders(vertxSmallHeaders);
+    setBaseHeaders(nettySmallHeaders, asciiNames, asciiValues);
+    setBaseHeaders(vertxSmallHeaders, asciiNames, asciiValues);
   }
 
   @Benchmark

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersUtils.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersUtils.java
@@ -28,10 +28,22 @@ public abstract class HeadersUtils {
   public static final CharSequence CONTENT_LENGTH_HEADER = io.vertx.core.http.HttpHeaders.createOptimized("20");
   public static final CharSequence DATE_HEADER = io.vertx.core.http.HttpHeaders.createOptimized(DATE_FORMAT.format(new Date()));
 
-  public static void setBaseHeaders(HttpHeaders headers) {
-    headers.add(io.vertx.core.http.HttpHeaders.CONTENT_TYPE, TEXT_PLAIN_HEADER);
-    headers.add(io.vertx.core.http.HttpHeaders.CONTENT_LENGTH, CONTENT_LENGTH_HEADER);
-    headers.add(io.vertx.core.http.HttpHeaders.SERVER, VERTX_HEADER);
-    headers.add(io.vertx.core.http.HttpHeaders.DATE, DATE_HEADER);
+  public static void setBaseHeaders(HttpHeaders headers, boolean asciiNames, boolean asciiValues) {
+    headers.add(toString(io.vertx.core.http.HttpHeaders.CONTENT_TYPE, !asciiNames),
+      toString(TEXT_PLAIN_HEADER, !asciiValues));
+    headers.add(toString(io.vertx.core.http.HttpHeaders.CONTENT_LENGTH, !asciiNames),
+      toString(CONTENT_LENGTH_HEADER, !asciiValues));
+    headers.add(toString(io.vertx.core.http.HttpHeaders.SERVER, !asciiNames),
+      toString(VERTX_HEADER, !asciiValues));
+    headers.add(toString(io.vertx.core.http.HttpHeaders.DATE, !asciiNames),
+      toString(DATE_HEADER, !asciiValues));
   }
+
+  private static CharSequence toString(CharSequence chars, boolean toString) {
+    if (!toString) {
+      return chars;
+    }
+    return chars.toString();
+  }
+
 }


### PR DESCRIPTION
In most of our benchmarks, HTTP validation is not enabled and it doesn't make easy to spot which cost it has.
This PR is addressing this by adding special flags to both test it with/without ASCII values and it improves it by removing branches out of its validation path.