### PR TITLE
 SSL blocking operations can now be executed on the vertx internal worker pool

### DIFF
--- a/src/main/generated/io/vertx/core/net/OpenSSLEngineOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/net/OpenSSLEngineOptionsConverter.java
@@ -25,6 +25,11 @@ public class OpenSSLEngineOptionsConverter {
             obj.setSessionCacheEnabled((Boolean)member.getValue());
           }
           break;
+        case "useWorkerThread":
+          if (member.getValue() instanceof Boolean) {
+            obj.setUseWorkerThread((Boolean)member.getValue());
+          }
+          break;
       }
     }
   }
@@ -35,5 +40,6 @@ public class OpenSSLEngineOptionsConverter {
 
    static void toJson(OpenSSLEngineOptions obj, java.util.Map<String, Object> json) {
     json.put("sessionCacheEnabled", obj.isSessionCacheEnabled());
+    json.put("useWorkerThread", obj.getUseWorkerThread());
   }
 }

--- a/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
@@ -62,6 +62,12 @@ public class JdkSSLEngineOptions extends SSLEngineOptions {
   }
 
   public JdkSSLEngineOptions(JdkSSLEngineOptions that) {
+    super(that);
+  }
+
+  @Override
+  public JdkSSLEngineOptions setUseWorkerThread(boolean useWorkerThread) {
+    return (JdkSSLEngineOptions) super.setUseWorkerThread(useWorkerThread);
   }
 
   public JsonObject toJson() {
@@ -70,7 +76,7 @@ public class JdkSSLEngineOptions extends SSLEngineOptions {
 
   @Override
   public JdkSSLEngineOptions copy() {
-    return new JdkSSLEngineOptions();
+    return new JdkSSLEngineOptions(this);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/OpenSSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/OpenSSLEngineOptions.java
@@ -79,6 +79,11 @@ public class OpenSSLEngineOptions extends SSLEngineOptions {
     return sessionCacheEnabled;
   }
 
+  @Override
+  public OpenSSLEngineOptions setUseWorkerThread(boolean useWorkerThread) {
+    return (OpenSSLEngineOptions) super.setUseWorkerThread(useWorkerThread);
+  }
+
   public JsonObject toJson() {
     JsonObject json = new JsonObject();
     OpenSSLEngineOptionsConverter.toJson(this, json);

--- a/src/main/java/io/vertx/core/net/SSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/SSLEngineOptions.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.net;
 
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tls.SslContextFactory;
 
 /**
@@ -20,11 +21,47 @@ import io.vertx.core.spi.tls.SslContextFactory;
  */
 public abstract class SSLEngineOptions {
 
+  /**
+   * The default thread pool type for SSL blocking operations.
+   */
+  public static final boolean DEFAULT_USE_WORKER_POOL = false;
+
+  private boolean useWorkerThread;
+
   public abstract SSLEngineOptions copy();
+
+  public SSLEngineOptions() {
+    this.useWorkerThread = DEFAULT_USE_WORKER_POOL;
+  }
+
+  public SSLEngineOptions(SSLEngineOptions that) {
+    this.useWorkerThread = that.useWorkerThread;
+  }
+
+  public SSLEngineOptions(JsonObject json) {
+    this.useWorkerThread = json.getBoolean("useWorkerThread", DEFAULT_USE_WORKER_POOL);
+  }
 
   /**
    * @return a {@link SslContextFactory} that will be used to produce the Netty {@code SslContext}
    */
   public abstract SslContextFactory sslContextFactory();
 
+  /**
+   * @return whether to use the worker pool for SSL blocking operationsg
+   */
+  public boolean getUseWorkerThread() {
+    return useWorkerThread;
+  }
+
+  /**
+   * Set the thread pool to use for SSL blocking operations.
+   *
+   * @param useWorkerThread whether to use the vertx internal worker pool for SSL blocking operations
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SSLEngineOptions setUseWorkerThread(boolean useWorkerThread) {
+    this.useWorkerThread = useWorkerThread;
+    return this;
+  }
 }

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -489,7 +489,9 @@ public class NetTest extends VertxTestBase {
     } else {
       sslEngine = "openSslEngineOptions";
       boolean sessionCacheEnabled = rand.nextBoolean();
-      sslEngineOptions = new JsonObject().put("sessionCacheEnabled", sessionCacheEnabled);
+      sslEngineOptions = new JsonObject()
+        .put("sessionCacheEnabled", sessionCacheEnabled)
+        .put("useWorkerThread", SSLEngineOptions.DEFAULT_USE_WORKER_POOL);
     }
     long sslHandshakeTimeout = TestUtils.randomPositiveLong();
 


### PR DESCRIPTION
 SSL blocking operations can now be executed on the vertx internal worker pool, the default remaining on event-loop thread.

The configuration is on the SSLEngineOptions as this configures how the SSLEngine behaviour.
