### PR TITLE
Blocked thread checker named worker threads leak

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -1135,7 +1135,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     AtomicInteger threadCount = new AtomicInteger(0);
     return runnable -> {
       VertxThread thread = threadFactory.newVertxThread(runnable, prefix + threadCount.getAndIncrement(), worker, maxExecuteTime, maxExecuteTimeUnit);
-      checker.registerThread(thread, thread);
+      checker.registerThread(thread, thread.info);
       if (useDaemonThread != null && thread.isDaemon() != useDaemonThread) {
         thread.setDaemon(useDaemonThread);
       }

--- a/src/main/java/io/vertx/core/impl/VertxThread.java
+++ b/src/main/java/io/vertx/core/impl/VertxThread.java
@@ -12,27 +12,24 @@
 package io.vertx.core.impl;
 
 import io.netty.util.concurrent.FastThreadLocalThread;
-import io.vertx.core.impl.btc.BlockedThreadChecker;
+import io.vertx.core.impl.btc.ThreadInfo;
 
 import java.util.concurrent.TimeUnit;
 
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-public class VertxThread extends FastThreadLocalThread implements BlockedThreadChecker.Task {
+public class VertxThread extends FastThreadLocalThread {
 
   private final boolean worker;
-  private final long maxExecTime;
-  private final TimeUnit maxExecTimeUnit;
-  private long execStart;
+  final ThreadInfo info;
   ContextInternal context;
   ClassLoader topLevelTCCL;
 
   public VertxThread(Runnable target, String name, boolean worker, long maxExecTime, TimeUnit maxExecTimeUnit) {
     super(target, name);
     this.worker = worker;
-    this.maxExecTime = maxExecTime;
-    this.maxExecTimeUnit = maxExecTimeUnit;
+    this.info = new ThreadInfo(maxExecTimeUnit, maxExecTime);
   }
 
   /**
@@ -44,32 +41,30 @@ public class VertxThread extends FastThreadLocalThread implements BlockedThreadC
 
   void executeStart() {
     if (context == null) {
-      execStart = System.nanoTime();
+      info.startTime = System.nanoTime();
     }
   }
 
   void executeEnd() {
     if (context == null) {
-      execStart = 0;
+      info.startTime = 0;
     }
   }
 
   public long startTime() {
-    return execStart;
+    return info.startTime;
   }
 
   public boolean isWorker() {
     return worker;
   }
 
-  @Override
   public long maxExecTime() {
-    return maxExecTime;
+    return info.maxExecTime;
   }
 
-  @Override
   public TimeUnit maxExecTimeUnit() {
-    return maxExecTimeUnit;
+    return info.maxExecTimeUnit;
   }
 
 }

--- a/src/main/java/io/vertx/core/impl/btc/ThreadInfo.java
+++ b/src/main/java/io/vertx/core/impl/btc/ThreadInfo.java
@@ -1,0 +1,18 @@
+package io.vertx.core.impl.btc;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Thread execution activity monitored by the {@link BlockedThreadChecker}
+ */
+public final class ThreadInfo {
+
+  public long startTime;
+  public final TimeUnit maxExecTimeUnit;
+  public final long maxExecTime;
+
+  public ThreadInfo(TimeUnit maxExecTimeUnit, long maxExecTime) {
+    this.maxExecTimeUnit = maxExecTimeUnit;
+    this.maxExecTime = maxExecTime;
+  }
+}

--- a/src/main/java/io/vertx/core/impl/btc/ThreadInfo.java
+++ b/src/main/java/io/vertx/core/impl/btc/ThreadInfo.java
@@ -1,4 +1,14 @@
-package io.vertx.core.impl.btc;
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+ package io.vertx.core.impl.btc;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -633,7 +633,7 @@ public class ContextTest extends VertxTestBase {
         assertSame(ctx, Vertx.currentContext());
         assertSame(cl, Thread.currentThread().getContextClassLoader());
         int[] called = new int[1];
-        BlockedThreadChecker.Task thread = (BlockedThreadChecker.Task) Thread.currentThread();
+        VertxThread thread = (VertxThread) Thread.currentThread();
         long start = thread.startTime();
         ctx.dispatch(v2 -> {
           called[0]++;


### PR DESCRIPTION
The blocked thread checker implementation leak Vert.x named worker threads that are no longer available (due to shared worker executor disposal or verticle named worker pool undeployment).
