### PR TITLE
SSL improvements

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -32,7 +32,7 @@ import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.impl.NetSocketImpl;
-import io.vertx.core.net.impl.SslContextProvider;
+import io.vertx.core.net.impl.SslChannelProvider;
 import io.vertx.core.net.impl.VertxHandler;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
@@ -75,7 +75,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
 
   private final String serverOrigin;
   private final Supplier<ContextInternal> streamContextSupplier;
-  private final SslContextProvider sslContextProvider ;
+  private final SslChannelProvider sslChannelProvider;
   private final TracingPolicy tracingPolicy;
   private boolean requestFailed;
 
@@ -91,7 +91,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
   final HttpServerOptions options;
 
   public Http1xServerConnection(Supplier<ContextInternal> streamContextSupplier,
-                                SslContextProvider sslContextProvider,
+                                SslChannelProvider sslChannelProvider,
                                 HttpServerOptions options,
                                 ChannelHandlerContext chctx,
                                 ContextInternal context,
@@ -101,7 +101,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
     this.serverOrigin = serverOrigin;
     this.streamContextSupplier = streamContextSupplier;
     this.options = options;
-    this.sslContextProvider = sslContextProvider;
+    this.sslChannelProvider = sslChannelProvider;
     this.metrics = metrics;
     this.handle100ContinueAutomatically = options.isHandle100ContinueAutomatically();
     this.tracingPolicy = options.getTracingPolicy();
@@ -382,7 +382,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
       }
 
       pipeline.replace("handler", "handler", VertxHandler.create(ctx -> {
-        NetSocketImpl socket = new NetSocketImpl(context, ctx, sslContextProvider, metrics) {
+        NetSocketImpl socket = new NetSocketImpl(context, ctx, sslChannelProvider, metrics) {
           @Override
           protected void handleClosed() {
             if (metrics != null) {

--- a/src/main/java/io/vertx/core/http/impl/Http1xUpgradeToH2CHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xUpgradeToH2CHandler.java
@@ -21,7 +21,7 @@ import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http2.*;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
-import io.vertx.core.net.impl.SslContextProvider;
+import io.vertx.core.net.impl.SslChannelProvider;
 import io.vertx.core.net.impl.VertxHandler;
 
 import java.util.Map;
@@ -33,14 +33,14 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 public class Http1xUpgradeToH2CHandler extends ChannelInboundHandlerAdapter {
 
   private final HttpServerWorker initializer;
-  private final SslContextProvider sslContextProvider;
+  private final SslChannelProvider sslChannelProvider;
   private VertxHttp2ConnectionHandler<Http2ServerConnection> handler;
   private final boolean isCompressionSupported;
   private final boolean isDecompressionSupported;
 
-  Http1xUpgradeToH2CHandler(HttpServerWorker initializer, SslContextProvider sslContextProvider, boolean isCompressionSupported, boolean isDecompressionSupported) {
+  Http1xUpgradeToH2CHandler(HttpServerWorker initializer, SslChannelProvider sslChannelProvider, boolean isCompressionSupported, boolean isDecompressionSupported) {
     this.initializer = initializer;
-    this.sslContextProvider = sslContextProvider;
+    this.sslChannelProvider = sslChannelProvider;
     this.isCompressionSupported = isCompressionSupported;
     this.isDecompressionSupported = isDecompressionSupported;
   }
@@ -118,7 +118,7 @@ public class Http1xUpgradeToH2CHandler extends ChannelInboundHandlerAdapter {
           ctx.writeAndFlush(res);
         }
       } else {
-        initializer.configureHttp1(ctx.pipeline(), sslContextProvider);
+        initializer.configureHttp1(ctx.pipeline(), sslChannelProvider);
         ctx.fireChannelRead(msg);
         ctx.pipeline().remove(this);
       }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -137,7 +137,7 @@ public class HttpServerImpl extends TCPServerBase implements HttpServer, Closeab
   }
 
   @Override
-  protected BiConsumer<Channel, SslContextProvider> childHandler(ContextInternal context, SocketAddress address) {
+  protected BiConsumer<Channel, SslChannelProvider> childHandler(ContextInternal context, SocketAddress address) {
     EventLoopContext connContext;
     if (context instanceof EventLoopContext) {
       connContext = (EventLoopContext) context;

--- a/src/main/java/io/vertx/core/http/impl/HttpServerWorker.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerWorker.java
@@ -130,7 +130,7 @@ public class HttpServerWorker implements BiConsumer<Channel, SslContextProvider>
   private void configurePipeline(Channel ch, SslContextProvider sslContextProvider) {
     ChannelPipeline pipeline = ch.pipeline();
     if (sslContextProvider.isSsl()) {
-      pipeline.addLast("ssl", sslContextProvider.createHandler(vertx));
+      pipeline.addLast("ssl", sslContextProvider.createHandler(vertx, context));
       ChannelPromise p = ch.newPromise();
       pipeline.addLast("handshaker", new SslHandshakeCompletionHandler(p));
       p.addListener(future -> {

--- a/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
@@ -26,7 +26,6 @@ import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 import io.vertx.core.net.SocketAddress;
 
-import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLHandshakeException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -42,14 +41,14 @@ import java.net.InetSocketAddress;
 public final class ChannelProvider {
 
   private final Bootstrap bootstrap;
-  private final SslContextProvider sslContextProvider;
+  private final SslChannelProvider sslContextProvider;
   private final ContextInternal context;
   private ProxyOptions proxyOptions;
   private String applicationProtocol;
   private Handler<Channel> handler;
 
   public ChannelProvider(Bootstrap bootstrap,
-                         SslContextProvider sslContextProvider,
+                         SslChannelProvider sslContextProvider,
                          ContextInternal context) {
     this.bootstrap = bootstrap;
     this.context = context;
@@ -107,7 +106,7 @@ public final class ChannelProvider {
 
   private void initSSL(Handler<Channel> handler, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, Channel ch, Promise<Channel> channelHandler) {
     if (ssl) {
-      SslHandler sslHandler = sslContextProvider.createSslHandler(context.owner(), peerAddress, serverName, useAlpn);
+      SslHandler sslHandler = sslContextProvider.createClientSslHandler(peerAddress, serverName, useAlpn);
       ChannelPipeline pipeline = ch.pipeline();
       pipeline.addLast("ssl", sslHandler);
       pipeline.addLast(new ChannelInboundHandlerAdapter() {

--- a/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
@@ -214,7 +214,7 @@ public class NetServerImpl extends TCPServerBase implements Closeable, MetricsPr
 
     private void configurePipeline(Channel ch, SslContextProvider sslContextProvider) {
       if (sslContextProvider.isSsl()) {
-        ch.pipeline().addLast("ssl", sslContextProvider.createHandler(vertx));
+        ch.pipeline().addLast("ssl", sslContextProvider.createHandler(vertx, context));
         ChannelPromise p = ch.newPromise();
         ch.pipeline().addLast("handshaker", new SslHandshakeCompletionHandler(p));
         p.addListener(future -> {

--- a/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
@@ -121,7 +121,7 @@ public class NetServerImpl extends TCPServerBase implements Closeable, MetricsPr
   }
 
   @Override
-  protected BiConsumer<Channel, SslContextProvider> childHandler(ContextInternal context, SocketAddress socketAddress) {
+  protected BiConsumer<Channel, SslChannelProvider> childHandler(ContextInternal context, SocketAddress socketAddress) {
     return new NetServerWorker(context, handler, exceptionHandler);
   }
 
@@ -168,7 +168,7 @@ public class NetServerImpl extends TCPServerBase implements Closeable, MetricsPr
     return !isListening();
   }
 
-  private class NetServerWorker implements BiConsumer<Channel, SslContextProvider> {
+  private class NetServerWorker implements BiConsumer<Channel, SslChannelProvider> {
 
     private final ContextInternal context;
     private final Handler<NetSocket> connectionHandler;
@@ -181,7 +181,7 @@ public class NetServerImpl extends TCPServerBase implements Closeable, MetricsPr
     }
 
     @Override
-    public void accept(Channel ch, SslContextProvider sslContextProvider) {
+    public void accept(Channel ch, SslChannelProvider sslChannelProvider) {
       if (!NetServerImpl.this.accept()) {
         ch.close();
         return;
@@ -201,31 +201,31 @@ public class NetServerImpl extends TCPServerBase implements Closeable, MetricsPr
             if (idle != null) {
               ch.pipeline().remove(idle);
             }
-            configurePipeline(future.getNow(), sslContextProvider);
+            configurePipeline(future.getNow(), sslChannelProvider);
           } else {
             //No need to close the channel.HAProxyMessageDecoder already did
             handleException(future.cause());
           }
         });
       } else {
-        configurePipeline(ch, sslContextProvider);
+        configurePipeline(ch, sslChannelProvider);
       }
     }
 
-    private void configurePipeline(Channel ch, SslContextProvider sslContextProvider) {
-      if (sslContextProvider.isSsl()) {
-        ch.pipeline().addLast("ssl", sslContextProvider.createHandler(vertx, context));
+    private void configurePipeline(Channel ch, SslChannelProvider sslChannelProvider) {
+      if (options.isSsl()) {
+        ch.pipeline().addLast("ssl", sslChannelProvider.createServerHandler());
         ChannelPromise p = ch.newPromise();
         ch.pipeline().addLast("handshaker", new SslHandshakeCompletionHandler(p));
         p.addListener(future -> {
           if (future.isSuccess()) {
-            connected(ch, sslContextProvider);
+            connected(ch, sslChannelProvider);
           } else {
             handleException(future.cause());
           }
         });
       } else {
-        connected(ch, sslContextProvider);
+        connected(ch, sslChannelProvider);
       }
     }
 
@@ -235,10 +235,10 @@ public class NetServerImpl extends TCPServerBase implements Closeable, MetricsPr
       }
     }
 
-    private void connected(Channel ch, SslContextProvider sslContextProvider) {
-      NetServerImpl.this.initChannel(ch.pipeline(), sslContextProvider.isSsl());
+    private void connected(Channel ch, SslChannelProvider sslChannelProvider) {
+      NetServerImpl.this.initChannel(ch.pipeline(), options.isSsl());
       TCPMetrics<?> metrics = getMetrics();
-      VertxHandler<NetSocketImpl> handler = VertxHandler.create(ctx -> new NetSocketImpl(context, ctx, sslContextProvider, metrics));
+      VertxHandler<NetSocketImpl> handler = VertxHandler.create(ctx -> new NetSocketImpl(context, ctx, sslChannelProvider, metrics));
       handler.removeHandler(NetSocketImpl::unregisterEventBusHandler);
       handler.addHandler(conn -> {
         if (metrics != null) {

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -353,7 +353,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
       if (remoteAddress != null) {
         sslHandler = sslContextProvider.createSslHandler(vertx, remoteAddress, serverName, false);
       } else {
-        sslHandler = sslContextProvider.createHandler(vertx);
+        sslHandler = sslContextProvider.createHandler(vertx, context);
       }
       chctx.pipeline().addFirst("ssl", sslHandler);
     }

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -52,7 +52,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
   private static final Logger log = LoggerFactory.getLogger(NetSocketImpl.class);
 
   private final String writeHandlerID;
-  private final SslContextProvider sslContextProvider;
+  private final SslChannelProvider sslChannelProvider;
   private final SocketAddress remoteAddress;
   private final TCPMetrics metrics;
   private final InboundBuffer<Object> pending;
@@ -64,18 +64,18 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
   private Handler<Object> messageHandler;
   private Handler<Object> eventHandler;
 
-  public NetSocketImpl(ContextInternal context, ChannelHandlerContext channel, SslContextProvider sslContextProvider, TCPMetrics metrics) {
-    this(context, channel, null, sslContextProvider, metrics, null);
+  public NetSocketImpl(ContextInternal context, ChannelHandlerContext channel, SslChannelProvider sslChannelProvider, TCPMetrics metrics) {
+    this(context, channel, null, sslChannelProvider, metrics, null);
   }
 
   public NetSocketImpl(ContextInternal context,
                        ChannelHandlerContext channel,
                        SocketAddress remoteAddress,
-                       SslContextProvider sslContextProvider,
+                       SslChannelProvider sslChannelProvider,
                        TCPMetrics metrics,
                        String negotiatedApplicationLayerProtocol) {
     super(context, channel);
-    this.sslContextProvider = sslContextProvider;
+    this.sslChannelProvider = sslChannelProvider;
     this.writeHandlerID = "__vertx.net." + UUID.randomUUID().toString();
     this.remoteAddress = remoteAddress;
     this.metrics = metrics;
@@ -351,9 +351,9 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
         }
       });
       if (remoteAddress != null) {
-        sslHandler = sslContextProvider.createSslHandler(vertx, remoteAddress, serverName, false);
+        sslHandler = sslChannelProvider.createClientSslHandler(remoteAddress, serverName, false);
       } else {
-        sslHandler = sslContextProvider.createHandler(vertx, context);
+        sslHandler = sslChannelProvider.createServerHandler();
       }
       chctx.pipeline().addFirst("ssl", sslHandler);
     }

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -171,6 +171,16 @@ public class SSLHelper {
    * @return a future resolved when the helper is initialized
    */
   public Future<SslContextProvider> init(SSLOptions sslOptions, ContextInternal ctx) {
+    return initInternal(new SSLOptions(sslOptions), ctx);
+  }
+
+  /**
+   * Initialize the helper, this loads and validates the configuration.
+   *
+   * @param ctx the context
+   * @return a future resolved when the helper is initialized
+   */
+  private Future<SslContextProvider> initInternal(SSLOptions sslOptions, ContextInternal ctx) {
     Future<EngineConfig> sslContextFactorySupplier;
     KeyCertOptions keyCertOptions = sslOptions.getKeyCertOptions();
     TrustOptions trustOptions = sslOptions.getTrustOptions();

--- a/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net.impl;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandler;
+import io.netty.handler.ssl.SniHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.AsyncMapping;
+import io.netty.util.concurrent.ImmediateExecutor;
+import io.vertx.core.net.SocketAddress;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManager;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Provider for {@link SslHandler} and {@link SniHandler}.
+ * <br/>
+ * {@link SslContext} instances are cached and reused.
+ */
+public class SslChannelProvider {
+
+  private final long sslHandshakeTimeout;
+  private final TimeUnit sslHandshakeTimeoutUnit;
+  private final Executor workerPool;
+  private final boolean useWorkerPool;
+  private final boolean sni;
+  private final boolean useAlpn;
+  private final boolean trustAll;
+  private final SslContextProvider sslContextProvider;
+  private final SslContext[] sslContexts = new SslContext[2];
+  private final Map<String, SslContext>[] sslContextMaps = new Map[]{
+    new ConcurrentHashMap<>(), new ConcurrentHashMap<>()
+  };
+
+  public SslChannelProvider(SslContextProvider sslContextProvider,
+                            long sslHandshakeTimeout,
+                            TimeUnit sslHandshakeTimeoutUnit,
+                            boolean sni,
+                            boolean trustAll,
+                            boolean useAlpn,
+                            Executor workerPool,
+                            boolean useWorkerPool) {
+    this.workerPool = workerPool;
+    this.useWorkerPool = useWorkerPool;
+    this.useAlpn = useAlpn;
+    this.sni = sni;
+    this.trustAll = trustAll;
+    this.sslHandshakeTimeout = sslHandshakeTimeout;
+    this.sslHandshakeTimeoutUnit = sslHandshakeTimeoutUnit;
+    this.sslContextProvider = sslContextProvider;
+  }
+
+  public SslContextProvider sslContextProvider() {
+    return sslContextProvider;
+  }
+
+  public SslContext sslClientContext(String serverName, boolean useAlpn) {
+    return sslClientContext(serverName, useAlpn, trustAll);
+  }
+
+  public SslContext sslClientContext(String serverName, boolean useAlpn, boolean trustAll) {
+    int idx = idx(useAlpn);
+    if (sslContexts[idx] == null) {
+      SslContext context = sslContextProvider.createClientContext(serverName, useAlpn, trustAll);
+      sslContexts[idx] = context;
+    }
+    return sslContexts[idx];
+  }
+
+  public SslContext sslServerContext(boolean useAlpn) {
+    int idx = idx(useAlpn);
+    if (sslContexts[idx] == null) {
+      sslContexts[idx] = sslContextProvider.createServerContext(useAlpn);
+    }
+    return sslContexts[idx];
+  }
+
+  /**
+   * Server name {@link AsyncMapping} for {@link SniHandler}, mapping happens on a Vert.x worker thread.
+   *
+   * @return the {@link AsyncMapping}
+   */
+  public AsyncMapping<? super String, ? extends SslContext> serverNameMapping() {
+    return (AsyncMapping<String, SslContext>) (serverName, promise) -> {
+      workerPool.execute(() -> {
+        if (serverName == null) {
+          promise.setSuccess(sslServerContext(useAlpn));
+        } else {
+          KeyManagerFactory kmf;
+          try {
+            kmf = sslContextProvider.resolveKeyManagerFactory(serverName);
+          } catch (Exception e) {
+            promise.setFailure(e);
+            return;
+          }
+          TrustManager[] trustManagers;
+          try {
+            trustManagers = sslContextProvider.resolveTrustManagers(serverName);
+          } catch (Exception e) {
+            promise.setFailure(e);
+            return;
+          }
+          int idx = idx(useAlpn);
+          SslContext sslContext = sslContextMaps[idx].computeIfAbsent(serverName, s -> sslContextProvider.createServerContext(kmf, trustManagers, s, useAlpn));
+          promise.setSuccess(sslContext);
+        }
+      });
+      return promise;
+    };
+  }
+
+  public SslHandler createClientSslHandler(SocketAddress remoteAddress, String serverName, boolean useAlpn) {
+    SslContext sslContext = sslClientContext(serverName, useAlpn);
+    SslHandler sslHandler;
+    Executor delegatedTaskExec = useWorkerPool ? workerPool : ImmediateExecutor.INSTANCE;
+    if (remoteAddress.isDomainSocket()) {
+      sslHandler = sslContext.newHandler(ByteBufAllocator.DEFAULT, delegatedTaskExec);
+    } else {
+      sslHandler = sslContext.newHandler(ByteBufAllocator.DEFAULT, remoteAddress.host(), remoteAddress.port(), delegatedTaskExec);
+    }
+    sslHandler.setHandshakeTimeout(sslHandshakeTimeout, sslHandshakeTimeoutUnit);
+    return sslHandler;
+  }
+
+  public ChannelHandler createServerHandler() {
+    if (sni) {
+      return createSniHandler();
+    } else {
+      return createServerSslHandler(useAlpn);
+    }
+  }
+
+  private SslHandler createServerSslHandler(boolean useAlpn) {
+    SslContext sslContext = sslServerContext(useAlpn);
+    Executor delegatedTaskExec = useWorkerPool ? workerPool : ImmediateExecutor.INSTANCE;
+    SslHandler sslHandler = sslContext.newHandler(ByteBufAllocator.DEFAULT, delegatedTaskExec);
+    sslHandler.setHandshakeTimeout(sslHandshakeTimeout, sslHandshakeTimeoutUnit);
+    return sslHandler;
+  }
+
+  private SniHandler createSniHandler() {
+    Executor delegatedTaskExec = useWorkerPool ? workerPool : ImmediateExecutor.INSTANCE;
+    return new VertxSniHandler(serverNameMapping(), sslHandshakeTimeoutUnit.toMillis(sslHandshakeTimeout), delegatedTaskExec);
+  }
+
+  private static int idx(boolean useAlpn) {
+    return useAlpn ? 0 : 1;
+  }
+}

--- a/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
@@ -71,8 +71,8 @@ public class SslContextProvider {
     this.sslHandshakeTimeout = options.getSslHandshakeTimeout();
     this.sslHandshakeTimeoutUnit = options.getSslHandshakeTimeoutUnit();
     this.enabledProtocols = options.getEnabledSecureTransportProtocols();
-    this.keyCertOptions = options.getKeyCertOptions() != null ? options.getKeyCertOptions().copy() : null;
-    this.trustOptions = options.getTrustOptions() != null ? options.getTrustOptions().copy() : null;
+    this.keyCertOptions = options.getKeyCertOptions();
+    this.trustOptions = options.getTrustOptions();
     this.useWorkerPool = useWorkerPool;
   }
 

--- a/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
@@ -184,6 +184,7 @@ public class SslContextProvider {
   }
 
   public SniHandler createSniHandler(VertxInternal vertx) {
-    return new VertxSniHandler(serverNameMapper(vertx), sslHandshakeTimeoutUnit.toMillis(sslHandshakeTimeout));
+    Executor delegatedTaskExec = useWorkerPool ? vertx.getInternalWorkerPool().executor() : ImmediateExecutor.INSTANCE;
+    return new VertxSniHandler(serverNameMapper(vertx), sslHandshakeTimeoutUnit.toMillis(sslHandshakeTimeout), delegatedTaskExec);
   }
 }

--- a/src/main/java/io/vertx/core/net/impl/VertxSniHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxSniHandler.java
@@ -11,56 +11,31 @@
 package io.vertx.core.net.impl;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.handler.ssl.SniHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AsyncMapping;
-import io.netty.util.Mapping;
-import io.netty.util.concurrent.ScheduledFuture;
 
-import javax.net.ssl.SSLException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Extend the {@code SniHandler} to support handshake timeout
+ * Extend the {@code SniHandler} to support delegated  task executor
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 class VertxSniHandler extends SniHandler {
 
-  private final long handshakeTimeoutMillis;
-  private ScheduledFuture<?> timeoutFuture;
   private final Executor delegatedTaskExec;
 
   public VertxSniHandler(AsyncMapping<? super String, ? extends SslContext> mapping, long handshakeTimeoutMillis, Executor delegatedTaskExec) {
-    super(mapping);
+    super(mapping, handshakeTimeoutMillis);
 
-    this.handshakeTimeoutMillis = handshakeTimeoutMillis;
     this.delegatedTaskExec = delegatedTaskExec;
   }
 
   @Override
-  public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-    if (handshakeTimeoutMillis > 0) {
-      // We assume to always be added in an active channel
-      assert(ctx.channel().isActive());
-      timeoutFuture = ctx.executor().schedule(() -> {
-        SSLException exception = new SSLException("handshake timed out after " + handshakeTimeoutMillis + "ms");
-        ctx.fireUserEventTriggered(new SniCompletionEvent(exception));
-        ctx.close();
-      }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
-    }
-    super.handlerAdded(ctx);
-  }
-
-  @Override
   protected SslHandler newSslHandler(SslContext context, ByteBufAllocator allocator) {
-    if (timeoutFuture != null) {
-      timeoutFuture.cancel(false);
-    }
     SslHandler sslHandler = context.newHandler(allocator, delegatedTaskExec);
     sslHandler.setHandshakeTimeout(handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
     return sslHandler;

--- a/src/main/java/io/vertx/core/net/impl/VertxSniHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxSniHandler.java
@@ -21,6 +21,7 @@ import io.netty.util.Mapping;
 import io.netty.util.concurrent.ScheduledFuture;
 
 import javax.net.ssl.SSLException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -32,11 +33,13 @@ class VertxSniHandler extends SniHandler {
 
   private final long handshakeTimeoutMillis;
   private ScheduledFuture<?> timeoutFuture;
+  private final Executor delegatedTaskExec;
 
-  public VertxSniHandler(Mapping<? super String, ? extends SslContext> mapping, long handshakeTimeoutMillis) {
+  public VertxSniHandler(Mapping<? super String, ? extends SslContext> mapping, long handshakeTimeoutMillis, Executor delegatedTaskExec) {
     super(mapping);
 
     this.handshakeTimeoutMillis = handshakeTimeoutMillis;
+    this.delegatedTaskExec = delegatedTaskExec;
   }
 
   @Override
@@ -58,7 +61,7 @@ class VertxSniHandler extends SniHandler {
     if (timeoutFuture != null) {
       timeoutFuture.cancel(false);
     }
-    SslHandler sslHandler = super.newSslHandler(context, allocator);
+    SslHandler sslHandler = context.newHandler(allocator, delegatedTaskExec);
     sslHandler.setHandshakeTimeout(handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
     return sslHandler;
   }

--- a/src/main/java/io/vertx/core/net/impl/VertxSniHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxSniHandler.java
@@ -16,7 +16,7 @@ import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.handler.ssl.SniHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import io.netty.util.AsyncMapping;
 import io.netty.util.Mapping;
 import io.netty.util.concurrent.ScheduledFuture;
 
@@ -35,7 +35,7 @@ class VertxSniHandler extends SniHandler {
   private ScheduledFuture<?> timeoutFuture;
   private final Executor delegatedTaskExec;
 
-  public VertxSniHandler(Mapping<? super String, ? extends SslContext> mapping, long handshakeTimeoutMillis, Executor delegatedTaskExec) {
+  public VertxSniHandler(AsyncMapping<? super String, ? extends SslContext> mapping, long handshakeTimeoutMillis, Executor delegatedTaskExec) {
     super(mapping);
 
     this.handshakeTimeoutMillis = handshakeTimeoutMillis;

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -1664,15 +1664,15 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testEngineUseEventLoopThread() throws Exception {
-    testUseThreadPool(false);
+    testUseThreadPool(false, false);
   }
 
   @Test
   public void testEngineUseWorkerThreads() throws Exception {
-    testUseThreadPool(true);
+    testUseThreadPool(true, true);
   }
 
-  private void testUseThreadPool(boolean useWorkerThreads) throws Exception {
+  private void testUseThreadPool(boolean useWorkerThreads, boolean useSni) throws Exception {
     JksOptions jksOptions = Cert.SERVER_JKS.get();
     KeyStore ks = KeyStore.getInstance("JKS");
     ks.load(new ByteArrayInputStream(vertx.fileSystem().readFileBlocking(jksOptions.getPath()).getBytes()), jksOptions.getPassword().toCharArray());
@@ -1832,6 +1832,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
     server = createHttpServer(createBaseServerOptions()
       .setJdkSslEngineOptions(new JdkSSLEngineOptions().setUseWorkerThread(useWorkerThreads))
       .setSsl(true)
+      .setSni(useSni)
       .setKeyCertOptions(testOptions)
     )
       .requestHandler(req -> {

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -16,12 +16,14 @@ import static org.hamcrest.core.StringEndsWith.endsWith;
 import java.io.*;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.math.BigInteger;
+import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.security.*;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
@@ -1669,11 +1671,21 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testEngineUseWorkerThreads() throws Exception {
+    testUseThreadPool(true, false);
+  }
+
+  @Test
+  public void testSniEngineUseEventLoopThread() throws Exception {
+    testUseThreadPool(false, true);
+  }
+
+  @Test
+  public void testSniEngineUseWorkerThreads() throws Exception {
     testUseThreadPool(true, true);
   }
 
   private void testUseThreadPool(boolean useWorkerThreads, boolean useSni) throws Exception {
-    JksOptions jksOptions = Cert.SERVER_JKS.get();
+    JksOptions jksOptions = Cert.SNI_JKS.get();
     KeyStore ks = KeyStore.getInstance("JKS");
     ks.load(new ByteArrayInputStream(vertx.fileSystem().readFileBlocking(jksOptions.getPath()).getBytes()), jksOptions.getPassword().toCharArray());
     final Set<Thread> engineThreads = Collections.synchronizedSet(new HashSet<>());
@@ -1825,7 +1837,35 @@ public abstract class HttpTLSTest extends HttpTestBase {
       }
       @Override
       public Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) throws Exception {
-        throw new UnsupportedEncodingException();
+        X509KeyManager keyManager = (X509KeyManager) getKeyManagerFactory(vertx).getKeyManagers()[0];
+        return serverName -> {
+          return new X509KeyManager() {
+            @Override
+            public String[] getClientAliases(String keyType, Principal[] issuers) {
+              throw new UnsupportedOperationException();
+            }
+            @Override
+            public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+              throw new UnsupportedOperationException();
+            }
+            @Override
+            public String[] getServerAliases(String keyType, Principal[] issuers) {
+              throw new UnsupportedOperationException();
+            }
+            @Override
+            public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+              throw new UnsupportedOperationException();
+            }
+            @Override
+            public X509Certificate[] getCertificateChain(String alias) {
+              return keyManager.getCertificateChain("test-host2");
+            }
+            @Override
+            public PrivateKey getPrivateKey(String alias) {
+              return keyManager.getPrivateKey("test-host2");
+            }
+          };
+        };
       }
     };
 
@@ -1839,9 +1879,18 @@ public abstract class HttpTLSTest extends HttpTestBase {
         req.response().end("Hello World");
       });
     startServer(testAddress);
-    Supplier<Future<Buffer>> request = () -> client.request(requestOptions).compose(req -> req.send().compose(HttpClientResponse::body));
+    Supplier<Future<Buffer>> request = () -> {
+      RequestOptions options = new RequestOptions(requestOptions);
+      if (useSni) {
+        options.setHost("host2.com");
+      }
+      return client.request(options)
+        .compose(req -> req.send()
+          .compose(HttpClientResponse::body)
+        );
+    };
     CountDownLatch latch = new CountDownLatch(1);
-    client = createHttpClient(new HttpClientOptions().setKeepAlive(false).setSsl(true).setTrustOptions(Trust.SERVER_JKS.get()));
+    client = createHttpClient(new HttpClientOptions().setKeepAlive(false).setSsl(true).setTrustAll(true));
     request.get().onComplete(onSuccess(body1 -> {
       assertEquals("Hello World", body1.toString());
       latch.countDown();
@@ -1855,7 +1904,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
     if (useWorkerThreads) {
       assertTrue(numWorkers > 0);
     } else {
-      assertEquals(0, numWorkers);
+      // It is fine using worker threads in this case
     }
   }
 }

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -1663,13 +1663,13 @@ public abstract class HttpTLSTest extends HttpTestBase {
   }
 
   @Test
-  public void testUseEventLoopThread() throws Exception {
-    testUseThreadPool(true);
+  public void testEngineUseEventLoopThread() throws Exception {
+    testUseThreadPool(false);
   }
 
   @Test
-  public void testUseWorkerThreads() throws Exception {
-    testUseThreadPool(false);
+  public void testEngineUseWorkerThreads() throws Exception {
+    testUseThreadPool(true);
   }
 
   private void testUseThreadPool(boolean useWorkerThreads) throws Exception {

--- a/src/test/java/io/vertx/it/SSLEngineTest.java
+++ b/src/test/java/io/vertx/it/SSLEngineTest.java
@@ -13,17 +13,16 @@ package io.vertx.it;
 
 import io.netty.handler.ssl.JdkSslContext;
 import io.netty.handler.ssl.OpenSslContext;
+import io.netty.handler.ssl.OpenSslSessionContext;
 import io.netty.handler.ssl.SslContext;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.impl.HttpServerImpl;
-import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.JdkSSLEngineOptions;
 import io.vertx.core.net.OpenSSLEngineOptions;
 import io.vertx.core.net.SSLEngineOptions;
-import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.core.http.HttpTestBase;
 import io.vertx.core.net.impl.SslContextProvider;
 import io.vertx.test.tls.Cert;
@@ -106,13 +105,13 @@ public class SSLEngineTest extends HttpTestBase {
       }
     }
     SslContextProvider provider = ((HttpServerImpl)server).sslContextProvider();
-    SslContext ctx = provider.createContext((VertxInternal) vertx);
+    SslContext ctx = provider.createClientContext(null, false, false);
     switch (expectedSslContext != null ? expectedSslContext : "jdk") {
       case "jdk":
-        assertTrue(ctx instanceof JdkSslContext);
+        assertTrue(ctx.sessionContext().getClass().getName().equals("sun.security.ssl.SSLSessionContextImpl"));
         break;
       case "openssl":
-        assertTrue(ctx instanceof OpenSslContext);
+        assertTrue(ctx.sessionContext() instanceof OpenSslSessionContext);
         break;
     }
     client = vertx.createHttpClient(new HttpClientOptions()


### PR DESCRIPTION
- refactor the code to decouple the `SslContext` creation and SSL handlers creation
- the SNI mapping function should be executed on the internal worker pool
- SNI SSL engine should use the internal worker pool when configured to do so
- cleanup `VertxSniHandler` handshake timeout since now it is supported in `SniHandler`