### PR TITLE
Save expensive interface type checks (related JDK-8180450 and https://github.com/netty/netty/issues/12708)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <apacheds-protocol-dns.version>1.5.7</apacheds-protocol-dns.version>
     <generated.dir>${project.basedir}/src/main/generated</generated.dir>
     <stack.version>4.4.0-SNAPSHOT</stack.version>
-    <jmh.version>1.19</jmh.version>
+    <jmh.version>1.36</jmh.version>
     <vertx.testNativeTransport>false</vertx.testNativeTransport>
     <vertx.testDomainSockets>false</vertx.testDomainSockets>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -130,21 +130,24 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
   }
 
   public void handleMessage(Object msg) {
-    if (msg instanceof HttpRequest) {
-      DefaultHttpRequest request = (DefaultHttpRequest) msg;
-      ContextInternal requestCtx = streamContextSupplier.get();
-      Http1xServerRequest req = new Http1xServerRequest(this, request, requestCtx);
-      requestInProgress = req;
-      if (responseInProgress != null) {
-        enqueueRequest(req);
-        return;
-      }
-      responseInProgress = requestInProgress;
-      req.handleBegin(writable);
-      Handler<HttpServerRequest> handler = request.decoderResult().isSuccess() ? requestHandler : invalidRequestHandler;
-      req.context.emit(req, handler);
-    } else if (msg == LastHttpContent.EMPTY_LAST_CONTENT) {
+    assert msg != null;
+    // fast-path first
+    if (msg == LastHttpContent.EMPTY_LAST_CONTENT) {
       onEnd();
+    } else if (msg instanceof DefaultHttpRequest) {
+        // fast path type check vs concrete class
+        DefaultHttpRequest request = (DefaultHttpRequest) msg;
+        ContextInternal requestCtx = streamContextSupplier.get();
+        Http1xServerRequest req = new Http1xServerRequest(this, request, requestCtx);
+        requestInProgress = req;
+        if (responseInProgress != null) {
+          enqueueRequest(req);
+          return;
+        }
+        responseInProgress = requestInProgress;
+        req.handleBegin(writable);
+        Handler<HttpServerRequest> handler = request.decoderResult().isSuccess() ? requestHandler : invalidRequestHandler;
+        req.context.emit(req, handler);
     } else {
       handleOther(msg);
     }
@@ -157,7 +160,8 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
   }
 
   private void handleOther(Object msg) {
-    if (msg instanceof HttpContent) {
+    // concrete type check first
+    if (msg instanceof DefaultHttpContent || msg instanceof HttpContent) {
       onContent(msg);
     } else if (msg instanceof WebSocketFrame) {
       handleWsFrame((WebSocketFrame) msg);

--- a/src/main/java/io/vertx/core/http/impl/VertxHttpRequestDecoder.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttpRequestDecoder.java
@@ -37,4 +37,19 @@ public class VertxHttpRequestDecoder extends HttpRequestDecoder {
       initialLine[1],
       HeadersMultiMap.httpHeaders());
   }
+
+  @Override
+  protected boolean isContentAlwaysEmpty(HttpMessage msg) {
+    if (msg == null) {
+      return false;
+    }
+    // we are forced to perform exact type check here because
+    // users can override createMessage with a DefaultHttpRequest implements HttpResponse
+    // and we have to enforce
+    // if (msg instance HttpResponse) return super.isContentAlwaysEmpty(msg)
+    if (msg.getClass() == DefaultHttpRequest.class) {
+      return false;
+    }
+    return super.isContentAlwaysEmpty(msg);
+  }
 }


### PR DESCRIPTION
JDK-8180450 has forced Netty http encoding/decoding to order type checks in order to save a huge scalability hit.
And still this is not enough, perf-wise: vertx, as a Netty users, still consume Netty types and cannot ignore such ordering, or would have a similar performance hit.

Moreover, there are cases (outlined on https://github.com/TechEmpower/FrameworkBenchmarks/pull/7942) where the existing JDK mechanism for interface type checks waste CPU resources, but the "constrained" vertx http types can save it to happen both performing exact class type checks and/or instanceof vs concrete and known types.
