### PR TITLE
Optimise connection metrics reporting

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
@@ -177,22 +177,7 @@ abstract class Http1xConnectionBase<S extends WebSocketImplBase<S>> extends Conn
   }
 
   @Override
-  protected void reportsBytesWritten(Object msg) {
-    long size = sizeOf(msg);
-    reportBytesWritten(size);
-  }
-
-  @Override
-  protected void reportBytesRead(Object msg) {
-    long size = sizeOf(msg);
-    reportBytesRead(size);
-  }
-
-  static long sizeOf(WebSocketFrame obj) {
-    return obj.content().readableBytes();
-  }
-
-  static long sizeOf(Object obj) {
+  protected long sizeof(Object obj) {
     // https://github.com/netty/netty/issues/12708
     // try first Netty HTTP singleton types, without any instanceof/checkcast bytecodes
     if (obj == Unpooled.EMPTY_BUFFER || obj == LastHttpContent.EMPTY_LAST_CONTENT) {
@@ -215,7 +200,7 @@ abstract class Http1xConnectionBase<S extends WebSocketImplBase<S>> extends Conn
     } else if (obj instanceof  HttpContent) {
       return ((HttpContent) obj).content().readableBytes();
     } else if (obj instanceof WebSocketFrame) {
-      return sizeOf((WebSocketFrame) obj);
+      return ((WebSocketFrame) obj).content().readableBytes();
     } else if (obj instanceof FileRegion) {
       return ((FileRegion) obj).count();
     } else if (obj instanceof ChunkedFile) {

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -139,20 +139,6 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
   }
 
   @Override
-  protected void reportsBytesWritten(Object msg) {
-    if (msg instanceof ByteBuf) {
-      reportBytesWritten(((ByteBuf)msg).readableBytes());
-    }
-  }
-
-  @Override
-  protected void reportBytesRead(Object msg) {
-    if (msg instanceof ByteBuf) {
-      reportBytesRead(((ByteBuf)msg).readableBytes());
-    }
-  }
-
-  @Override
   public String applicationLayerProtocol() {
     return negotiatedApplicationLayerProtocol;
   }


### PR DESCRIPTION
Metrics size of connection messages are computed even though no metrics is configured to report to. We can refactor the internal API a bit to only compute the message size when it shall be effectively reported.