### PR TITLE
Favour inlining without metrics reporting

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -416,16 +416,20 @@ public abstract class ConnectionBase {
   public final void reportBytesRead(Object msg) {
     NetworkMetrics metrics = metrics();
     if (metrics != null) {
-      long bytes = remainingBytesRead;
-      long numberOfBytes = sizeof(msg);
-      bytes += numberOfBytes;
-      long val = bytes & METRICS_REPORTED_BYTES_HIGH_MASK;
-      if (val > 0) {
-        bytes &= METRICS_REPORTED_BYTES_LOW_MASK;
-        metrics.bytesRead(metric(), remoteAddress(), val);
-      }
-      remainingBytesRead = bytes;
+      doReportBytesRead(msg, metrics);
     }
+  }
+
+  private void doReportBytesRead(Object msg, NetworkMetrics metrics) {
+    long bytes = remainingBytesRead;
+    long numberOfBytes = sizeof(msg);
+    bytes += numberOfBytes;
+    long val = bytes & METRICS_REPORTED_BYTES_HIGH_MASK;
+    if (val > 0) {
+      bytes &= METRICS_REPORTED_BYTES_LOW_MASK;
+      metrics.bytesRead(metric(), remoteAddress(), val);
+    }
+    remainingBytesRead = bytes;
   }
 
   protected long sizeof(Object msg) {


### PR DESCRIPTION
It allow to have the same performance of no metrics configured, improving the inlining chances when no metrics reporting is configured.