### PR TITLE
Vert.x HTTP h2c client gets an option to ensure client connection is always HTTP/2 when using h2c

### DIFF
--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -55,6 +55,11 @@ public class HttpClientOptionsConverter {
             obj.setHttp2ClearTextUpgrade((Boolean)member.getValue());
           }
           break;
+        case "http2ClearTextUpgradeWithPreflightRequest":
+          if (member.getValue() instanceof Boolean) {
+            obj.setHttp2ClearTextUpgradeWithPreflightRequest((Boolean)member.getValue());
+          }
+          break;
         case "http2ConnectionWindowSize":
           if (member.getValue() instanceof Number) {
             obj.setHttp2ConnectionWindowSize(((Number)member.getValue()).intValue());
@@ -243,6 +248,7 @@ public class HttpClientOptionsConverter {
     json.put("defaultPort", obj.getDefaultPort());
     json.put("forceSni", obj.isForceSni());
     json.put("http2ClearTextUpgrade", obj.isHttp2ClearTextUpgrade());
+    json.put("http2ClearTextUpgradeWithPreflightRequest", obj.isHttp2ClearTextUpgradeWithPreflightRequest());
     json.put("http2ConnectionWindowSize", obj.getHttp2ConnectionWindowSize());
     json.put("http2KeepAliveTimeout", obj.getHttp2KeepAliveTimeout());
     json.put("http2MaxPoolSize", obj.getHttp2MaxPoolSize());

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -151,6 +151,11 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final boolean DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE = true;
 
   /**
+   * Default to use a preflight OPTIONS request for <i>h2C</i> without prior knowledge connection = {@code false}
+   */
+  public static final boolean DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE_WITH_PREFLIGHT_REQUEST = false;
+
+  /**
    * Default WebSocket masked bit is true as depicted by RFC = {@code false}
    */
   public static final boolean DEFAULT_SEND_UNMASKED_FRAMES = false;
@@ -252,6 +257,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   private Http2Settings initialSettings;
   private List<HttpVersion> alpnVersions;
   private boolean http2ClearTextUpgrade;
+  private boolean http2ClearTextUpgradeWithPreflightRequest;
   private boolean sendUnmaskedFrames;
   private int maxRedirects;
   private boolean forceSni;
@@ -308,6 +314,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.initialSettings = other.initialSettings != null ? new Http2Settings(other.initialSettings) : null;
     this.alpnVersions = other.alpnVersions != null ? new ArrayList<>(other.alpnVersions) : null;
     this.http2ClearTextUpgrade = other.http2ClearTextUpgrade;
+    this.http2ClearTextUpgradeWithPreflightRequest = other.http2ClearTextUpgradeWithPreflightRequest;
     this.sendUnmaskedFrames = other.isSendUnmaskedFrames();
     this.maxRedirects = other.maxRedirects;
     this.forceSni = other.forceSni;
@@ -372,6 +379,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     initialSettings = new Http2Settings();
     alpnVersions = new ArrayList<>(DEFAULT_ALPN_VERSIONS);
     http2ClearTextUpgrade = DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE;
+    http2ClearTextUpgradeWithPreflightRequest = DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE_WITH_PREFLIGHT_REQUEST;
     sendUnmaskedFrames = DEFAULT_SEND_UNMASKED_FRAMES;
     maxRedirects = DEFAULT_MAX_REDIRECTS;
     forceSni = DEFAULT_FORCE_SNI;
@@ -1140,6 +1148,26 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public HttpClientOptions setHttp2ClearTextUpgrade(boolean value) {
     this.http2ClearTextUpgrade = value;
+    return this;
+  }
+
+  /**
+   * @return {@code true} when an <i>h2c</i> connection established using an HTTP/1.1 upgrade request should perform
+   *         a preflight {@code OPTIONS} request to the origin server to establish the <i>h2c</i> connection
+   */
+  public boolean isHttp2ClearTextUpgradeWithPreflightRequest() {
+    return http2ClearTextUpgradeWithPreflightRequest;
+  }
+
+  /**
+   * Set to {@code true} when an <i>h2c</i> connection established using an HTTP/1.1 upgrade request should perform
+   * a preflight {@code OPTIONS} request to the origin server to establish the <i>h2c</i> connection.
+   *
+   * @param value the upgrade value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientOptions setHttp2ClearTextUpgradeWithPreflightRequest(boolean value) {
+    this.http2ClearTextUpgradeWithPreflightRequest = value;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -68,6 +68,10 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
     this.current = connection;
   }
 
+  public HttpClientConnection unwrap() {
+    return current;
+  }
+
   @Override
   public long concurrency() {
     return upgradeProcessed ? current.concurrency() : 1L;


### PR DESCRIPTION
Vert.x HTTP client initially sends an HTTP/1.1 request to the origin server while perfoming the HTTP upgrade to h2c when establishing an h2c connection without prior knowledge. This cause the first request to use HTTP/1.1 and subsequent requests using the same connection to use HTTP/2.

This adds an option to have the client perform a preflight OPTIONS request before, consequently the client will always provide an HTTP/2 request since the preflight request will establish the connection.

fixes #4638