### PR TITLE
Remove callback methods from the WriteStream interface

### DIFF
--- a/src/main/java/io/vertx/core/datagram/impl/PacketWriteStreamImpl.java
+++ b/src/main/java/io/vertx/core/datagram/impl/PacketWriteStreamImpl.java
@@ -52,18 +52,11 @@ class PacketWriteStreamImpl implements WriteStream<Buffer>, Handler<AsyncResult<
   @Override
   public Future<Void> write(Buffer data) {
     Promise<Void> promise = Promise.promise();
-    write(data, promise);
-    return promise.future();
-  }
-
-  @Override
-  public void write(Buffer data, Handler<AsyncResult<Void>> handler) {
     datagramSocket.send(data, port, host, ar -> {
       PacketWriteStreamImpl.this.handle(ar);
-      if (handler != null) {
-        handler.handle(ar.mapEmpty());
-      }
+      promise.handle(ar.mapEmpty());
     });
+    return promise.future();
   }
 
   @Override
@@ -83,13 +76,8 @@ class PacketWriteStreamImpl implements WriteStream<Buffer>, Handler<AsyncResult<
 
   @Override
   public Future<Void> end() {
-    Promise<Void> promide = Promise.promise();
-    end(promide);
-    return promide.future();
-  }
-
-  @Override
-  public void end(Handler<AsyncResult<Void>> handler) {
-    datagramSocket.close(handler);
+    Promise<Void> promise = Promise.promise();
+    datagramSocket.close(promise);
+    return promise.future();
   }
 }

--- a/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -141,11 +141,6 @@ public class AsyncFileImpl implements AsyncFile {
   }
 
   @Override
-  public void end(Handler<AsyncResult<Void>> handler) {
-    close(handler);
-  }
-
-  @Override
   public synchronized AsyncFile read(Buffer buffer, int offset, long position, int length, Handler<AsyncResult<Buffer>> handler) {
     Objects.requireNonNull(handler, "handler");
     read(buffer, offset, position, length).onComplete(handler);
@@ -236,17 +231,12 @@ public class AsyncFileImpl implements AsyncFile {
   }
 
   @Override
-  public Future<Void> write(Buffer buffer) {
+  public synchronized Future<Void> write(Buffer buffer) {
     Promise<Void> promise = context.promise();
-    write(buffer, promise);
-    return promise.future();
-  }
-
-  @Override
-  public synchronized void write(Buffer buffer, Handler<AsyncResult<Void>> handler) {
     int length = buffer.length();
-    doWrite(buffer, writePos, handler);
+    doWrite(buffer, writePos, promise);
     writePos += length;
+    return promise.future();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -464,13 +464,6 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   Future<Void> end(Buffer chunk);
 
   /**
-   * Same as {@link #end(String)} but with an {@code handler} called when the operation completes
-   */
-  @Override
-  @Deprecated
-  void end(Buffer chunk, Handler<AsyncResult<Void>> handler);
-
-  /**
    * Ends the request. If no data has been written to the request body, and {@link #sendHead()} has not been called then
    * the actual request won't get written until this method gets called.
    * <p>
@@ -481,13 +474,6 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    */
   @Override
   Future<Void> end();
-
-  /**
-   * Same as {@link #end()} but with an {@code handler} called when the operation completes
-   */
-  @Override
-  @Deprecated
-  void end(Handler<AsyncResult<Void>> handler);
 
   /**
    * Set's the amount of time after which if the request does not return any data within the timeout period an

--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -299,13 +299,6 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   Future<Void> end(Buffer chunk);
 
   /**
-   * Same as {@link #end(Buffer)} but with an {@code handler} called when the operation completes
-   */
-  @Override
-  @Deprecated
-  void end(Buffer chunk, Handler<AsyncResult<Void>> handler);
-
-  /**
    * Ends the response. If no data has been written to the response body,
    * the actual response won't get written until this method gets called.
    * <p>
@@ -323,7 +316,10 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    */
   @Deprecated
   default void send(Handler<AsyncResult<Void>> handler) {
-    end(handler);
+    Future<Void> fut = end();
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
   }
 
   /**
@@ -357,7 +353,10 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    */
   @Deprecated
   default void send(Buffer body, Handler<AsyncResult<Void>> handler) {
-    end(body, handler);
+    Future<Void> fut = send(body);
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
   }
 
   /**

--- a/src/main/java/io/vertx/core/http/WebSocketBase.java
+++ b/src/main/java/io/vertx/core/http/WebSocketBase.java
@@ -315,15 +315,6 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
   Future<Void> end();
 
   /**
-   * {@inheritDoc}
-   *
-   * Calls {@link #close(Handler)}
-   */
-  @Override
-  @Deprecated
-  void end(Handler<AsyncResult<Void>> handler);
-
-  /**
    * Close the WebSocket sending the default close frame.
    * <p/>
    * No more messages can be sent.

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -326,11 +326,6 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public void write(Buffer chunk, Handler<AsyncResult<Void>> handler) {
-    write(chunk.getByteBuf(), handler == null ? null : context.promise(handler));
-  }
-
-  @Override
   public Future<Void> write(String chunk, String enc) {
     PromiseInternal<Void> promise = context.promise();
     write(Buffer.buffer(chunk, enc).getByteBuf(), promise);
@@ -389,7 +384,7 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
 
   @Override
   public void end(String chunk, Handler<AsyncResult<Void>> handler) {
-    end(Buffer.buffer(chunk), handler);
+    end(Buffer.buffer(chunk), handler == null ? null : context.promise(handler));
   }
 
   @Override
@@ -399,7 +394,7 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
 
   @Override
   public void end(String chunk, String enc, Handler<AsyncResult<Void>> handler) {
-    end(Buffer.buffer(chunk, enc), handler);
+    end(Buffer.buffer(chunk, enc), handler == null ? null : context.promise(handler));
   }
 
   @Override
@@ -407,11 +402,6 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
     PromiseInternal<Void> promise = context.promise();
     end(chunk, promise);
     return promise.future();
-  }
-
-  @Override
-  public void end(Buffer chunk, Handler<AsyncResult<Void>> handler) {
-    end(chunk, handler == null ? null : context.promise(handler));
   }
 
   private void end(Buffer chunk, PromiseInternal<Void> listener) {
@@ -475,11 +465,6 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
   @Override
   public Future<Void> end() {
     return end(EMPTY_BUFFER);
-  }
-
-  @Override
-  public void end(Handler<AsyncResult<Void>> handler) {
-    end(EMPTY_BUFFER, handler);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -354,12 +354,6 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public void write(Buffer chunk, Handler<AsyncResult<Void>> handler) {
-    ByteBuf buf = chunk.getByteBuf();
-    write(buf, false, handler);
-  }
-
-  @Override
   public Future<Void> write(String chunk, String enc) {
     Promise<Void> promise = stream.context.promise();
     write(Buffer.buffer(chunk, enc).getByteBuf(), false, promise);
@@ -395,7 +389,7 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
 
   @Override
   public void end(String chunk, Handler<AsyncResult<Void>> handler) {
-    end(Buffer.buffer(chunk), handler);
+    end(Buffer.buffer(chunk).getByteBuf(), handler);
   }
 
   @Override
@@ -416,20 +410,10 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public void end(Buffer chunk, Handler<AsyncResult<Void>> handler) {
-    end(chunk.getByteBuf(), handler);
-  }
-
-  @Override
   public Future<Void> end() {
     Promise<Void> promise = stream.context.promise();
     write(null, true, promise);
     return promise.future();
-  }
-
-  @Override
-  public void end(Handler<AsyncResult<Void>> handler) {
-    end((ByteBuf) null, handler);
   }
 
   Future<NetSocket> netSocket() {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -377,7 +377,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
 
   @Override
   public void end(String chunk, Handler<AsyncResult<Void>> handler) {
-    end(Buffer.buffer(chunk), handler);
+    write(Buffer.buffer(chunk).getByteBuf(), true, handler);
   }
 
   @Override
@@ -390,7 +390,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   @Override
   public void end(String chunk, String enc, Handler<AsyncResult<Void>> handler) {
     Objects.requireNonNull(enc, "no null encoding accepted");
-    end(Buffer.buffer(chunk, enc), handler);
+    write(Buffer.buffer(chunk, enc).getByteBuf(), true, handler);
   }
 
   @Override
@@ -401,33 +401,18 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   }
 
   @Override
-  public void end(Buffer chunk, Handler<AsyncResult<Void>> handler) {
-    write(chunk.getByteBuf(), true, handler);
-  }
-
-  @Override
   public Future<Void> end() {
     Promise<Void> promise = context.promise();
-    end(promise);
+    write(null, true, promise);
     return promise.future();
-  }
-
-  @Override
-  public void end(Handler<AsyncResult<Void>> handler) {
-    write(null, true, handler);
   }
 
   @Override
   public Future<Void> write(Buffer chunk) {
     Promise<Void> promise = context.promise();
-    write(chunk, promise);
-    return promise.future();
-  }
-
-  @Override
-  public void write(Buffer chunk, Handler<AsyncResult<Void>> handler) {
     ByteBuf buf = chunk.getByteBuf();
-    write(buf, false, handler);
+    write(buf, false, promise);
+    return promise.future();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -140,11 +140,6 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
-  public void write(Buffer data, Handler<AsyncResult<Void>> handler) {
-    throw new IllegalStateException();
-  }
-
-  @Override
   public void write(String chunk, Handler<AsyncResult<Void>> handler) {
     throw new IllegalStateException();
   }
@@ -210,17 +205,7 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
-  public void end(Buffer chunk, Handler<AsyncResult<Void>> handler) {
-    throw new IllegalStateException();
-  }
-
-  @Override
   public Future<Void> end() {
-    throw new IllegalStateException();
-  }
-
-  @Override
-  public void end(Handler<AsyncResult<Void>> handler) {
     throw new IllegalStateException();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -71,11 +71,6 @@ public interface HttpClientStream extends WriteStream<Buffer> {
   }
 
   @Override
-  default void write(Buffer data, Handler<AsyncResult<Void>> handler) {
-    writeBuffer(data.getByteBuf(), false, handler);
-  }
-
-  @Override
   default Future<Void> end(Buffer data) {
     PromiseInternal<Void> promise = getContext().promise();
     writeBuffer(data.getByteBuf(), true, promise);
@@ -83,20 +78,10 @@ public interface HttpClientStream extends WriteStream<Buffer> {
   }
 
   @Override
-  default void end(Buffer data, Handler<AsyncResult<Void>> handler) {
-    writeBuffer(data.getByteBuf(), true, handler);
-  }
-
-  @Override
   default Future<Void> end() {
     PromiseInternal<Void> promise = getContext().promise();
     writeBuffer(Unpooled.EMPTY_BUFFER, true, promise);
     return promise.future();
-  }
-
-  @Override
-  default void end(Handler<AsyncResult<Void>> handler) {
-    writeBuffer(Unpooled.EMPTY_BUFFER, true, handler);
   }
 
   void headHandler(Handler<HttpResponseHead> handler);

--- a/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
@@ -177,18 +177,13 @@ class HttpNetSocket implements NetSocket {
   }
 
   @Override
-  public void write(Buffer data, Handler<AsyncResult<Void>> handler) {
-    writeStream.write(data, handler);
-  }
-
-  @Override
   public Future<Void> write(String str, String enc) {
     return write(Buffer.buffer(str, enc));
   }
 
   @Override
   public void write(String str, String enc, Handler<AsyncResult<Void>> handler) {
-    writeStream.write(Buffer.buffer(str, enc), handler);
+    writeStream.write(Buffer.buffer(str, enc)).onComplete(handler);
   }
 
   @Override
@@ -198,7 +193,7 @@ class HttpNetSocket implements NetSocket {
 
   @Override
   public void write(String str, Handler<AsyncResult<Void>> handler) {
-    writeStream.write(Buffer.buffer(str), handler);
+    writeStream.write(Buffer.buffer(str)).onComplete(handler);
   }
 
   @Override
@@ -207,18 +202,8 @@ class HttpNetSocket implements NetSocket {
   }
 
   @Override
-  public void end(Buffer buffer, Handler<AsyncResult<Void>> handler) {
-    writeStream.end(buffer, handler);
-  }
-
-  @Override
   public Future<Void> end() {
     return writeStream.end();
-  }
-
-  @Override
-  public void end(Handler<AsyncResult<Void>> handler) {
-    writeStream.end(handler);
   }
 
   @Override
@@ -259,7 +244,10 @@ class HttpNetSocket implements NetSocket {
 
   @Override
   public void close(Handler<AsyncResult<Void>> handler) {
-    end(handler);
+    Future<Void> fut = writeStream.end();
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -326,14 +326,6 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
   }
 
   @Override
-  public final void write(Buffer data, Handler<AsyncResult<Void>> handler) {
-    Future<Void> fut = write(data);
-    if (handler != null) {
-      fut.onComplete(handler);
-    }
-  }
-
-  @Override
   public Future<Void> writePing(Buffer data) {
     if (data.length() > maxWebSocketFrameSize || data.length() > 125) {
       return context.failedFuture("Ping cannot exceed maxWebSocketFrameSize or 125 bytes");
@@ -841,8 +833,4 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
     return close();
   }
 
-  @Override
-  public void end(Handler<AsyncResult<Void>> handler) {
-    close(handler);
-  }
 }

--- a/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/src/main/java/io/vertx/core/net/NetSocket.java
@@ -121,13 +121,6 @@ public interface NetSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
   Future<Void> write(String str, String enc);
 
   /**
-   * Like {@link #write(Object)} but with an {@code handler} called when the message has been written
-   * or failed to be written.
-   */
-  @Deprecated
-  void write(Buffer message, Handler<AsyncResult<Void>> handler);
-
-  /**
    * Tell the operating system to stream a file as specified by {@code filename} directly from disk to the outgoing connection,
    * bypassing userspace altogether (where supported by the underlying operating system. This is a very efficient way to stream files.
    *
@@ -241,13 +234,6 @@ public interface NetSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
    */
   @Override
   Future<Void> end();
-
-  /**
-   * Calls {@link #end()}.
-   */
-  @Override
-  @Deprecated
-  void end(Handler<AsyncResult<Void>> handler);
 
   /**
    * Close the NetSocket

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -172,11 +172,6 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
     write(Unpooled.copiedBuffer(str, cs), handler);
   }
 
-  @Override
-  public void write(Buffer message, Handler<AsyncResult<Void>> handler) {
-    write(message.getByteBuf(), handler);
-  }
-
   private void write(ByteBuf buff, Handler<AsyncResult<Void>> handler) {
     reportBytesWritten(buff.readableBytes());
     writeMessage(buff, handler);
@@ -327,11 +322,6 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
   @Override
   protected void handleInterestedOpsChanged() {
     context.emit(null, v -> callDrainHandler());
-  }
-
-  @Override
-  public void end(Handler<AsyncResult<Void>> handler) {
-    close(handler);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/streams/WriteStream.java
+++ b/src/main/java/io/vertx/core/streams/WriteStream.java
@@ -59,17 +59,6 @@ public interface WriteStream<T> extends StreamBase {
   Future<Void> write(T data);
 
   /**
-   * Same as {@link #write(T)} but with an {@code handler} called when the operation completes
-   */
-  @Deprecated
-  default void write(T data, Handler<AsyncResult<Void>> handler) {
-    Future<Void> fut = write(data);
-    if (handler != null) {
-      fut.onComplete(handler);
-    }
-  }
-
-  /**
    * Ends the stream.
    * <p>
    * Once the stream has ended, it cannot be used any more.
@@ -77,17 +66,6 @@ public interface WriteStream<T> extends StreamBase {
    * @return a future completed with the result
    */
   Future<Void> end();
-
-  /**
-   * Same as {@link #end()} but with an {@code handler} called when the operation completes
-   */
-  @Deprecated
-  default void end(Handler<AsyncResult<Void>> handler) {
-    Future<Void> fut = end();
-    if (handler != null) {
-      fut.onComplete(handler);
-    }
-  }
 
   /**
    * Same as {@link #end()} but writes some data to the stream before ending.
@@ -99,17 +77,6 @@ public interface WriteStream<T> extends StreamBase {
    */
   default Future<Void> end(T data) {
     return write(data).compose(v -> end());
-  }
-
-  /**
-   * Same as {@link #end(T)} but with an {@code handler} called when the operation completes
-   */
-  @Deprecated
-  default void end(T data, Handler<AsyncResult<Void>> handler) {
-    Future<Void> fut = end(data);
-    if (handler != null) {
-      fut.onComplete(handler);
-    }
   }
 
   /**

--- a/src/test/java/io/vertx/core/streams/PumpTest.java
+++ b/src/test/java/io/vertx/core/streams/PumpTest.java
@@ -201,11 +201,6 @@ public class PumpTest {
       return fut;
     }
 
-    @Override
-    public void write(T data, Handler<AsyncResult<Void>> handler) {
-      throw new UnsupportedOperationException();
-    }
-
     public FakeWriteStream exceptionHandler(Handler<Throwable> handler) {
       return this;
     }
@@ -215,10 +210,6 @@ public class PumpTest {
       throw new UnsupportedOperationException();
     }
 
-    @Override
-    public void end(Handler<AsyncResult<Void>> handler) {
-      throw new UnsupportedOperationException();
-    }
   }
 
   static class MyClass {

--- a/src/test/java/io/vertx/core/streams/WriteStreamTest.java
+++ b/src/test/java/io/vertx/core/streams/WriteStreamTest.java
@@ -28,7 +28,7 @@ public class WriteStreamTest extends AsyncTestBase {
     @Override public StreamBase<T> setWriteQueueMaxSize(int maxSize) { throw new UnsupportedOperationException(); }
     @Override public boolean writeQueueFull() { throw new UnsupportedOperationException(); }
     @Override public StreamBase<T> drainHandler(@Nullable Handler<Void> handler) { throw new UnsupportedOperationException(); }
-    @Override public final Future<Void> end() { throw new UnsupportedOperationException(); }
+    @Override public Future<Void> end() { throw new UnsupportedOperationException(); }
   }
 
   static class EndWithItemStreamAsync extends StreamBase<Object> {
@@ -37,14 +37,14 @@ public class WriteStreamTest extends AsyncTestBase {
     AtomicInteger endCount = new AtomicInteger();
     Promise<Void> endFut = Promise.promise();
     @Override
-    public void write(Object data, Handler<AsyncResult<Void>> handler) {
+    public Future<Void> write(Object data) {
       writeCount.incrementAndGet();
-      writeFut.future().onComplete(handler);
+      return writeFut.future();
     }
     @Override
-    public void end(Handler<AsyncResult<Void>> handler) {
+    public Future<Void> end() {
       endCount.incrementAndGet();
-      endFut.future().onComplete(handler);
+      return endFut.future();
     }
   }
 

--- a/src/test/java/io/vertx/test/fakestream/FakeStreamTest.java
+++ b/src/test/java/io/vertx/test/fakestream/FakeStreamTest.java
@@ -133,7 +133,7 @@ public class FakeStreamTest extends AsyncTestBase {
     AtomicInteger ended = new AtomicInteger();
     AtomicReference<AsyncResult> endRes = new AtomicReference<>();
     stream.endHandler(v -> ended.incrementAndGet());
-    stream.end(endRes::set);
+    stream.end().onComplete(endRes::set);
     assertEquals(1, ended.get());
     assertTrue(endRes.get().succeeded());
     stream.fetch(1);
@@ -148,7 +148,7 @@ public class FakeStreamTest extends AsyncTestBase {
     AtomicReference<AsyncResult> endRes = new AtomicReference<>();
     stream.setEnd(end.future());
     stream.endHandler(v -> ended.incrementAndGet());
-    stream.end(endRes::set);
+    stream.end().onComplete(endRes::set);
     assertEquals(0, ended.get());
     assertNull(endRes.get());
     end.complete();
@@ -165,7 +165,7 @@ public class FakeStreamTest extends AsyncTestBase {
     stream.pause();
     stream.emit(3);
     stream.endHandler(v -> ended.incrementAndGet());
-    stream.end(endRes::set);
+    stream.end().onComplete(endRes::set);
     assertEquals(0, ended.get());
     assertNull(endRes.get());
     end.complete();


### PR DESCRIPTION
Remove the callback methods in the `WriteStream` interface. This is a preliminary step of the vertx 5 callback removal. This one is specifically done ahead because other vertx components implement the `WriteStream` interface.