### PR TITLE
Headless Service HttpClient Load Balancing

### DIFF
--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -95,6 +95,11 @@ public class HttpClientOptionsConverter {
             obj.setKeepAliveTimeout(((Number)member.getValue()).intValue());
           }
           break;
+        case "loadBalancePolicy":
+          if (member.getValue() instanceof String) {
+            obj.setLoadBalancePolicy(io.vertx.core.http.LoadBalancePolicy.valueOf((String)member.getValue()));
+          }
+          break;
         case "maxChunkSize":
           if (member.getValue() instanceof Number) {
             obj.setMaxChunkSize(((Number)member.getValue()).intValue());
@@ -258,6 +263,9 @@ public class HttpClientOptionsConverter {
     }
     json.put("keepAlive", obj.isKeepAlive());
     json.put("keepAliveTimeout", obj.getKeepAliveTimeout());
+    if (obj.getLoadBalancePolicy() != null) {
+      json.put("loadBalancePolicy", obj.getLoadBalancePolicy().name());
+    }
     json.put("maxChunkSize", obj.getMaxChunkSize());
     json.put("maxHeaderSize", obj.getMaxHeaderSize());
     json.put("maxInitialLineLength", obj.getMaxInitialLineLength());

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -221,6 +221,11 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final TracingPolicy DEFAULT_TRACING_POLICY = TracingPolicy.PROPAGATE;
 
   /**
+   * Default tracing control = {@link LoadBalancePolicy#NONE}
+   */
+  public static final LoadBalancePolicy DEFAULT_LOAD_BALANCE_POLICY = LoadBalancePolicy.NONE;
+
+  /**
    * Default shared client = {@code false}
    */
   public static final boolean DEFAULT_SHARED = false;
@@ -271,6 +276,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   private int webSocketClosingTimeout;
 
   private TracingPolicy tracingPolicy;
+  private LoadBalancePolicy loadBalancePolicy;
 
   private boolean shared;
   private String name;
@@ -328,6 +334,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.webSocketRequestServerNoContext = other.webSocketRequestServerNoContext;
     this.webSocketClosingTimeout = other.webSocketClosingTimeout;
     this.tracingPolicy = other.tracingPolicy;
+    this.loadBalancePolicy = other.loadBalancePolicy;
     this.shared = other.shared;
     this.name = other.name;
   }
@@ -393,6 +400,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     poolCleanerPeriod = DEFAULT_POOL_CLEANER_PERIOD;
     poolEventLoopSize = DEFAULT_POOL_EVENT_LOOP_SIZE;
     tracingPolicy = DEFAULT_TRACING_POLICY;
+    loadBalancePolicy = DEFAULT_LOAD_BALANCE_POLICY;
     shared = DEFAULT_SHARED;
     name = DEFAULT_NAME;
   }
@@ -1438,6 +1446,24 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public HttpClientOptions setTracingPolicy(TracingPolicy tracingPolicy) {
     this.tracingPolicy = tracingPolicy;
+    return this;
+  }
+
+  /**
+   * @return the load-balance policy
+   */
+  public LoadBalancePolicy getLoadBalancePolicy() {
+    return loadBalancePolicy;
+  }
+
+  /**
+   * Set the load balance policy for the HTTP client
+   *
+   * @param loadBalancePolicy the load balance policy
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientOptions setLoadBalancePolicy(LoadBalancePolicy loadBalancePolicy) {
+    this.loadBalancePolicy = loadBalancePolicy;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/LoadBalancePolicy.java
+++ b/src/main/java/io/vertx/core/http/LoadBalancePolicy.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * Policy controlling the behavior of HTTP client-side load balancing
+ */
+@VertxGen
+public enum LoadBalancePolicy {
+
+  /**
+   * Disable load balancing
+   */
+  NONE,
+
+  /**
+   * Distributes traffic randomly among available endpoints
+   */
+  RANDOM,
+}


### PR DESCRIPTION
Implement #4649 

Adding a `RANDOM` load-balancing policy. Will add `ROUND_ROBIN` method in near future.