### PR TITLE
Update the JSON toString() to allow better debugging

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -621,7 +621,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
 
   @Override
   public String toString() {
-    return encode();
+    return inspect(this);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -1155,7 +1155,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
 
   @Override
   public String toString() {
-    return encode();
+    return inspect(this);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/json/impl/Inspector.java
+++ b/src/main/java/io/vertx/core/json/impl/Inspector.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.json.impl;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation utilities (details) affecting the way JSON objects are debugged.
+ */
+final class Inspector {
+
+  private Inspector() {
+  }
+
+  private static final class Stack {
+    private final Object[] stack = new Object[MAX_DEEP];
+    private int pos;
+
+    Stack(Object first) {
+      push(first);
+    }
+
+    void push(Object element) {
+      stack[pos++] = element;
+    }
+
+    void pop() {
+      --pos;
+    }
+
+    public boolean contains(Object needle) {
+      for (int i = 0; i < pos; i++) {
+        if (stack[i] == needle) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    public int size() {
+      return pos;
+    }
+  }
+
+  /**
+   * The maximum allowed deepness of the object graph. To avoid stack overflow or complex serialization.
+   */
+  private static final int MAX_DEEP = 3;
+  /**
+   * The maximum allowed elements of an object or array. To avoid complex serialization.
+   */
+  private static final int MAX_ELEMENTS = 100;
+  /**
+   * The maximum allowed length of Strings. To avoid complex serialization.
+   */
+  private static final int MAX_STRING_LENGTH = 10000;
+
+  /**
+   * Inspects a JsonObject. Inspect is a string representation of the object. It will display a JSON-like representation
+   * of the object. Keys and values are not escaped. When the object contains circular references a warning is
+   * displayed.
+   *
+   * @param obj the JsonObject to inspect or {@code null}.
+   * @param seen the stack of seen objects or {@code null} for lazy init.
+   * @return String representation of the object.
+   */
+  static String inspect(JsonObject obj, Stack seen) {
+    StringBuilder sb = new StringBuilder();
+    sb.append('{');
+
+    int count = 0;
+    for (Map.Entry<String, Object> entry : obj) {
+      if (count >= MAX_ELEMENTS) {
+        sb.append(", ...");
+        break;
+      }
+      if (count > 0) {
+        sb.append(", ");
+      }
+      sb.append(entry.getKey());
+      sb.append(": ");
+      format(obj.getMap(), entry.getValue(), sb, seen);
+      count++;
+    }
+
+    sb.append('}');
+    return sb.toString();
+  }
+
+  /**
+   * Inspects a JsonArray. Inspect is a string representation of the object. It will display a JSON-like representation
+   * of the object. Keys and values are not escaped. When the object contains circular references a warning is
+   * displayed.
+   *
+   * @param obj the JsonArray to inspect or {@code null}.
+   * @param seen the stack of seen objects or {@code null} for lazy init.
+   * @return String representation of the object.
+   */
+  static String inspect(JsonArray obj, Stack seen) {
+    StringBuilder sb = new StringBuilder();
+    sb.append('[');
+
+    for (int i = 0; i < obj.size(); i++) {
+      if (i >= MAX_ELEMENTS) {
+        sb.append(", ...");
+        break;
+      }
+      if (i > 0) {
+        sb.append(", ");
+      }
+      format(obj.getList(), obj.getValue(i), sb, seen);
+    }
+
+    sb.append(']');
+    return sb.toString();
+  }
+
+  /**
+   * Formats the object to a string. Follows the basic rules of JSON encoding with some freedoms:
+   * <ul>
+   *   <li>{@code null}, {@link Number} and {@link Boolean} are not quoted</li>
+   *   <li>{@link JsonObject} and {@link JsonArray} are limited in nested elements</li>
+   *   <li>{@link JsonObject} and {@link JsonArray} are limited in number of elements/properties</li>
+   *   <li>{@link JsonObject} and {@link JsonArray} trace circular references</li>
+   *   <li>Strings are not escaped</li>
+   *   <li>Strings are limited in length</li>
+   *   <li>Any other type is handled as a String using {@link Object#toString()}</li>
+   * </ul>
+   */
+  private static void format(Object parent, Object obj, StringBuilder sb, Stack seen) {
+    if (obj == null) {
+      sb.append("null");
+    } else if (obj instanceof Boolean) {
+      sb.append(obj);
+    } else if (obj instanceof Number) {
+      sb.append(obj);
+    } else if (obj instanceof JsonObject) {
+      // unwrap the vert.x type
+      Map<String, ?> container = ((JsonObject) obj).getMap();
+      if (continueInspecting(sb, seen, container, '{', '}')) {
+        if (seen == null) {
+          seen = new Stack(parent);
+        }
+        seen.push(container);
+        sb.append(inspect((JsonObject) obj, seen));
+        seen.pop();
+      }
+    } else if (obj instanceof JsonArray) {
+      // unwrap the vert.x type
+      List<?> container = ((JsonArray) obj).getList();
+      if (continueInspecting(sb, seen, container, '[', ']')) {
+        if (seen == null) {
+          seen = new Stack(parent);
+        }
+        seen.push(container);
+        sb.append(inspect((JsonArray) obj, seen));
+        seen.pop();
+      }
+    } else {
+      sb.append('"');
+      String str = obj.toString();
+      if (str.length() >= MAX_STRING_LENGTH) {
+        sb.append(str, 0, MAX_STRING_LENGTH);
+        sb.append("...");
+      } else {
+        sb.append(str);
+      }
+      sb.append('"');
+    }
+  }
+
+  /**
+   * Checks if the container should be inspected further or not. Stop conditions are:
+   *
+   * <ul>
+   *   <li>the container is already in the stack - meaning we found a circular reference</li>
+   *   <li>the stack is too deep - meaning we are inspecting too many nested objects</li>
+   * </ul>
+   *
+   * Given that the stack is lazy initialized, this method will return {@code true} if the stack is {@code null}.
+   */
+  private static boolean continueInspecting(StringBuilder sb, Stack seen, Object container, char open, char close) {
+    if (seen == null) {
+      return true;
+    }
+
+    if (seen.size() >= MAX_DEEP) {
+      sb
+        .append(open)
+        .append("...")
+        .append(close);
+      return false;
+    }
+
+    if (seen.contains(container)) {
+      sb
+        .append(open)
+        .append("Circular *")
+        .append(System.identityHashCode(container))
+        .append(close);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/main/java/io/vertx/core/json/impl/JsonUtil.java
+++ b/src/main/java/io/vertx/core/json/impl/JsonUtil.java
@@ -128,4 +128,52 @@ public final class JsonUtil {
     Iterable<T> iterable = () -> sourceIterator;
     return StreamSupport.stream(iterable.spliterator(), false);
   }
+
+  /**
+   * Inspect a JsonObject. Inspect is a debug method that returns a string representation of the object. It will display
+   * a JSON-like representation of the object. Keys and values are not escaped. When the object contains circular
+   * references a warning is displayed {@code (Circular *int)} the integer value is the offending object hash code as
+   * computed by: {@link System#identityHashCode(Object)}.
+   *
+   * The inspector will enforce some limits to avoid stack overflow errors. The limits are:
+   *
+   * <ul>
+   *   <li>max nested level of objects and/or arrays: {@code 3} - The current object + 2 levels</li>
+   *   <li>max length of arrays or object properties: {@code 100} - Ellipsis will be printed after</li>
+   *   <li>max string length: {@code 10000} - Ellipsis will be printed after</li>
+   * </ul>
+   *
+   * @param obj the JsonObject to inspect
+   * @return String representation
+   */
+  public static String inspect(JsonObject obj) {
+    if (obj == null) {
+      return "null";
+    }
+    return Inspector.inspect(obj, null);
+  }
+
+  /**
+   * Inspect a JsonArray. Inspect is a debug method that returns a string representation of the object. It will display
+   * a JSON-like representation of the object. Keys and values are not escaped. When the object contains circular
+   * references a warning is displayed {@code (Circular *int)} the integer value is the offending object hash code as
+   * computed by: {@link System#identityHashCode(Object)}.
+   *
+   * The inspector will enforce some limits to avoid stack overflow errors. The limits are:
+   *
+   * <ul>
+   *   <li>max nested level of objects and/or arrays: {@code 3} - The current object + 2 levels</li>
+   *   <li>max length of arrays or object properties: {@code 100} - Ellipsis will be printed after</li>
+   *   <li>max string length: {@code 10000} - Ellipsis will be printed after</li>
+   * </ul>
+   *
+   * @param obj the JsonObject to inspect
+   * @return String representation
+   */
+  public static String inspect(JsonArray obj) {
+    if (obj == null) {
+      return "null";
+    }
+    return Inspector.inspect(obj, null);
+  }
 }

--- a/src/test/java/io/vertx/core/LauncherTest.java
+++ b/src/test/java/io/vertx/core/LauncherTest.java
@@ -478,7 +478,7 @@ public class LauncherTest extends VertxTestBase {
       Files.write(file.toPath(), json.toBuffer().getBytes());
       optionsArg = file.getPath();
     } else {
-      optionsArg = json.toString();
+      optionsArg = json.encode();
     }
 
     MyLauncher launcher = new MyLauncher();
@@ -579,7 +579,7 @@ public class LauncherTest extends VertxTestBase {
       Files.write(file.toPath(), json.toBuffer().getBytes());
       optionsArg = file.getPath();
     } else {
-      optionsArg = json.toString();
+      optionsArg = json.encode();
     }
 
     MyLauncher launcher = new MyLauncher();

--- a/src/test/java/io/vertx/core/json/JsonArrayTest.java
+++ b/src/test/java/io/vertx/core/json/JsonArrayTest.java
@@ -853,7 +853,7 @@ public class JsonArrayTest {
   @Test
   public void testToString() {
     jsonArray.add("foo").add(123);
-    assertEquals(jsonArray.encode(), jsonArray.toString());
+    assertEquals("[\"foo\", 123]", jsonArray.toString());
   }
 
   @Test

--- a/src/test/java/io/vertx/core/json/JsonCodecTest.java
+++ b/src/test/java/io/vertx/core/json/JsonCodecTest.java
@@ -491,10 +491,10 @@ public class JsonCodecTest {
     assertNull(asBuffer ? mapper.fromBuffer(Buffer.buffer(nullText)) : mapper.fromString(nullText));
 
     JsonObject obj = new JsonObject().put("foo", "bar");
-    assertEquals(obj, asBuffer ? mapper.fromBuffer(obj.toBuffer()) : mapper.fromString(obj.toString()));
+    assertEquals(obj, asBuffer ? mapper.fromBuffer(obj.toBuffer()) : mapper.fromString(obj.encode()));
 
     JsonArray arr = new JsonArray().add(1).add(false).add("whatever").add(obj);
-    assertEquals(arr, asBuffer ? mapper.fromBuffer(arr.toBuffer()) : mapper.fromString(arr.toString()));
+    assertEquals(arr, asBuffer ? mapper.fromBuffer(arr.toBuffer()) : mapper.fromString(arr.encode()));
 
     String invalidText = "\"invalid";
     try {

--- a/src/test/java/io/vertx/core/json/JsonInspectorTest.java
+++ b/src/test/java/io/vertx/core/json/JsonInspectorTest.java
@@ -1,0 +1,284 @@
+package io.vertx.core.json;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.vertx.core.json.impl.JsonUtil.inspect;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JsonInspectorTest {
+
+  @Test
+  public void testColors() {
+    JsonObject o = new JsonObject("{\n" +
+      "  \"colors\": [\n" +
+      "    {\n" +
+      "      \"color\": \"black\",\n" +
+      "      \"category\": \"hue\",\n" +
+      "      \"type\": \"primary\",\n" +
+      "      \"code\": {\n" +
+      "        \"rgba\": [255,255,255,1],\n" +
+      "        \"hex\": \"#000\"\n" +
+      "      }\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"color\": \"white\",\n" +
+      "      \"category\": \"value\",\n" +
+      "      \"code\": {\n" +
+      "        \"rgba\": [0,0,0,1],\n" +
+      "        \"hex\": \"#FFF\"\n" +
+      "      }\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"color\": \"red\",\n" +
+      "      \"category\": \"hue\",\n" +
+      "      \"type\": \"primary\",\n" +
+      "      \"code\": {\n" +
+      "        \"rgba\": [255,0,0,1],\n" +
+      "        \"hex\": \"#FF0\"\n" +
+      "      }\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"color\": \"blue\",\n" +
+      "      \"category\": \"hue\",\n" +
+      "      \"type\": \"primary\",\n" +
+      "      \"code\": {\n" +
+      "        \"rgba\": [0,0,255,1],\n" +
+      "        \"hex\": \"#00F\"\n" +
+      "      }\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"color\": \"yellow\",\n" +
+      "      \"category\": \"hue\",\n" +
+      "      \"type\": \"primary\",\n" +
+      "      \"code\": {\n" +
+      "        \"rgba\": [255,255,0,1],\n" +
+      "        \"hex\": \"#FF0\"\n" +
+      "      }\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"color\": \"green\",\n" +
+      "      \"category\": \"hue\",\n" +
+      "      \"type\": \"secondary\",\n" +
+      "      \"code\": {\n" +
+      "        \"rgba\": [0,255,0,1],\n" +
+      "        \"hex\": \"#0F0\"\n" +
+      "      }\n" +
+      "    }\n" +
+      "  ]\n" +
+      "}");
+
+    // collapase large objects
+    assertEquals(
+      "{colors: [{color: \"black\", category: \"hue\", type: \"primary\", code: {...}}, {color: \"white\", category: \"value\", code: {...}}, {color: \"red\", category: \"hue\", type: \"primary\", code: {...}}, {color: \"blue\", category: \"hue\", type: \"primary\", code: {...}}, {color: \"yellow\", category: \"hue\", type: \"primary\", code: {...}}, {color: \"green\", category: \"hue\", type: \"secondary\", code: {...}}]}",
+      inspect(o));
+  }
+
+  @Test
+  public void testCircularContainer() {
+    List list = new ArrayList();
+    JsonObject o = new JsonObject();
+    JsonArray a = new JsonArray(list);
+
+    a.add(1);
+    list.add(list);
+    o.put("a", a);
+    o.put("o", o);
+    o.put("s", "s");
+    o.put("n", 1);
+    o.put("b", true);
+    o.put("null", null);
+
+    // a wrapper should be detected as a circular reference
+    int ref1 = System.identityHashCode(a.getList());
+    int ref2 = System.identityHashCode(o.getMap());
+
+    assertEquals(
+      String.format("{a: [1, [Circular *%d]], o: {a: [1, [...]], o: {Circular *%d}, s: \"s\", n: 1, b: true, null: null}, s: \"s\", n: 1, b: true, null: null}", ref1, ref2),
+      inspect(o));
+  }
+
+  @Test
+  public void testCircularWrapper() {
+    JsonObject o = new JsonObject();
+    JsonArray a = new JsonArray();
+
+    a.add(1);
+    a.add(new JsonArray(a.getList()));
+    o.put("a", a);
+    o.put("o", o);
+    o.put("s", "s");
+    o.put("n", 1);
+    o.put("b", true);
+    o.put("null", null);
+
+    // a wrapper around the same containers should be detected as a circular reference
+    int ref1 = System.identityHashCode(a.getList());
+    int ref2 = System.identityHashCode(o.getMap());
+
+    assertEquals(
+      String.format("{a: [1, [Circular *%d]], o: {a: [1, [...]], o: {Circular *%d}, s: \"s\", n: 1, b: true, null: null}, s: \"s\", n: 1, b: true, null: null}", ref1, ref2),
+      inspect(o));
+  }
+
+  @Test
+  public void testDuplicatesAreOk()  {
+    JsonObject o = new JsonObject();
+    JsonArray a = new JsonArray();
+    a.add(1);
+    a.add(2);
+
+    o.put("a0", a);
+    o.put("a1", a);
+
+    // verify that the circular reference is not mistaken for a duplicate references
+    assertEquals(
+      "{a0: [1, 2], a1: [1, 2]}",
+      inspect(o));
+  }
+
+  @Test
+  public void testDeepJson() {
+    JsonObject o = new JsonObject("{\n" +
+      "    \"created\": \"2020-05-12T15:10:37Z\",\n" +
+      "    \"device\": {\n" +
+      "        \"device_info\": {\n" +
+      "            \"device_fw\": 204,\n" +
+      "            \"device_sn\": \"06-02133\",\n" +
+      "            \"device_trait\": 2,\n" +
+      "            \"device_type\": 190\n" +
+      "        },\n" +
+      "        \"timeseries\": [\n" +
+      "            {\n" +
+      "                \"configuration\": {\n" +
+      "                    \"sensors\": [\n" +
+      "                        {\n" +
+      "                            \"measurements\": [\n" +
+      "                                \"BATTERY\",\n" +
+      "                                \"BATTERY_MV\"\n" +
+      "                            ],\n" +
+      "                            \"port\": 7,\n" +
+      "                            \"sensor_bonus_value\": \"Unavailable\",\n" +
+      "                            \"sensor_firmware_ver\": \"Unavailable\",\n" +
+      "                            \"sensor_number\": 133,\n" +
+      "                            \"sensor_sn\": \"Unavailable\"\n" +
+      "                        },\n" +
+      "                        {\n" +
+      "                            \"measurements\": [\n" +
+      "                                \"REFERENCE_KPA\",\n" +
+      "                                \"TEMPC_LOGGER\"\n" +
+      "                            ],\n" +
+      "                            \"port\": 8,\n" +
+      "                            \"sensor_bonus_value\": \"Unavailable\",\n" +
+      "                            \"sensor_firmware_ver\": \"Unavailable\",\n" +
+      "                            \"sensor_number\": 134,\n" +
+      "                            \"sensor_sn\": \"Unavailable\"\n" +
+      "                        }\n" +
+      "                    ],\n" +
+      "                    \"valid_since\": \"2018-08-11T21:45:00Z\",\n" +
+      "                    \"values\": [\n" +
+      "                        [\n" +
+      "                            1534023900,\n" +
+      "                            0,\n" +
+      "                            19,\n" +
+      "                            [\n" +
+      "                                {\n" +
+      "                                    \"description\": \"Battery Percent\",\n" +
+      "                                    \"error\": false,\n" +
+      "                                    \"units\": \"%\",\n" +
+      "                                    \"value\": 100\n" +
+      "                                },\n" +
+      "                                {\n" +
+      "                                    \"description\": \"Battery Voltage\",\n" +
+      "                                    \"error\": false,\n" +
+      "                                    \"units\": \" mV\",\n" +
+      "                                    \"value\": 7864\n" +
+      "                                }\n" +
+      "                            ],\n" +
+      "                            [\n" +
+      "                                {\n" +
+      "                                    \"description\": \"Reference Pressure\",\n" +
+      "                                    \"error\": false,\n" +
+      "                                    \"units\": \" kPa\",\n" +
+      "                                    \"value\": 100.62\n" +
+      "                                },\n" +
+      "                                {\n" +
+      "                                    \"description\": \"Logger Temperature\",\n" +
+      "                                    \"error\": false,\n" +
+      "                                    \"units\": \" \\u00b0C\",\n" +
+      "                                    \"value\": 28.34\n" +
+      "                                }\n" +
+      "                            ]\n" +
+      "                        ]\n" +
+      "                            ]\n" +
+      "                    }\n" +
+      "                }]\n" +
+      "            }\n" +
+      "}     ");
+
+    // inspect will collapse the timeseries array as it contains multiple levels of nested objects
+    assertEquals(
+      "{created: \"2020-05-12T15:10:37Z\", device: {device_info: {device_fw: 204, device_sn: \"06-02133\", device_trait: 2, device_type: 190}, timeseries: [{...}]}}",
+      inspect(o));
+  }
+
+  @Test
+  public void testDoubleCircularRef() {
+  JsonObject obj = new JsonObject();
+    obj.put("a", new JsonArray().add(obj));
+    obj.put("b", new JsonObject());
+    obj.getJsonObject("b").put("inner", obj.getValue("b"));
+    obj.getJsonObject("b").put("obj", obj);
+
+    // references are to the internal map as vert.x json types are wrappers, multiple wrapper can refer to the same
+    // container instance
+    int ref1 = System.identityHashCode(obj.getMap());
+    int ref2 = System.identityHashCode(obj.getJsonObject("b").getMap());
+
+    assertEquals(
+      String.format("{a: [{Circular *%d}], b: {inner: {Circular *%d}, obj: {Circular *%d}}}", ref1, ref2, ref1),
+      inspect(obj));
+  }
+
+  @Test
+  public void testLargeArrays() {
+    JsonArray arr = new JsonArray();
+    for (int i = 0; i < 200; i++) {
+      arr.add(i);
+    }
+    assertEquals(
+      "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, ...]",
+      inspect(arr));
+  }
+
+  @Test
+  public void testLargeObjects() {
+    JsonObject obj = new JsonObject();
+    for (int i = 0; i < 200; i++) {
+      obj.put(Integer.toString(i), i);
+    }
+    assertEquals(
+      "{0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10, 11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20, 21: 21, 22: 22, 23: 23, 24: 24, 25: 25, 26: 26, 27: 27, 28: 28, 29: 29, 30: 30, 31: 31, 32: 32, 33: 33, 34: 34, 35: 35, 36: 36, 37: 37, 38: 38, 39: 39, 40: 40, 41: 41, 42: 42, 43: 43, 44: 44, 45: 45, 46: 46, 47: 47, 48: 48, 49: 49, 50: 50, 51: 51, 52: 52, 53: 53, 54: 54, 55: 55, 56: 56, 57: 57, 58: 58, 59: 59, 60: 60, 61: 61, 62: 62, 63: 63, 64: 64, 65: 65, 66: 66, 67: 67, 68: 68, 69: 69, 70: 70, 71: 71, 72: 72, 73: 73, 74: 74, 75: 75, 76: 76, 77: 77, 78: 78, 79: 79, 80: 80, 81: 81, 82: 82, 83: 83, 84: 84, 85: 85, 86: 86, 87: 87, 88: 88, 89: 89, 90: 90, 91: 91, 92: 92, 93: 93, 94: 94, 95: 95, 96: 96, 97: 97, 98: 98, 99: 99, ...}",
+      inspect(obj));
+  }
+
+
+  @Test
+  public void testLargeStrings() {
+    String loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pellentesque habitant morbi tristique senectus et. Mi in nulla posuere sollicitudin aliquam. Adipiscing enim eu turpis egestas pretium aenean pharetra magna ac. Duis convallis convallis tellus id interdum velit laoreet id. Consectetur libero id faucibus nisl. Dui faucibus in ornare quam viverra. Gravida quis blandit turpis cursus in hac habitasse. Ac tortor vitae purus faucibus ornare suspendisse. Nec sagittis aliquam malesuada bibendum arcu vitae elementum curabitur vitae. In nulla posuere sollicitudin aliquam ultrices sagittis orci. Sed odio morbi quis commodo odio aenean sed. Risus nullam eget felis eget nunc lobortis mattis aliquam faucibus. ";
+
+    for (int i = 0; i < 10; i++) {
+      loremIpsum += loremIpsum;
+    }
+
+    JsonObject obj = new JsonObject().put("msg", loremIpsum);
+
+    assertEquals(
+      12 // {msg: "..."} (12 is the number of extra characters in the format)
+        + 10000,  // the inspection string length limit
+      inspect(obj).length());
+  }
+}

--- a/src/test/java/io/vertx/core/json/JsonInspectorTest.java
+++ b/src/test/java/io/vertx/core/json/JsonInspectorTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import static io.vertx.core.json.impl.JsonUtil.inspect;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class JsonInspectorTest {
 

--- a/src/test/java/io/vertx/core/json/JsonInspectorTest.java
+++ b/src/test/java/io/vertx/core/json/JsonInspectorTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import static io.vertx.core.json.impl.JsonUtil.inspect;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class JsonInspectorTest {
 
@@ -272,6 +273,8 @@ public class JsonInspectorTest {
     for (int i = 0; i < 10; i++) {
       loremIpsum += loremIpsum;
     }
+
+    assertTrue(loremIpsum.length() > 10000);
 
     JsonObject obj = new JsonObject().put("msg", loremIpsum);
 

--- a/src/test/java/io/vertx/core/json/JsonInspectorTest.java
+++ b/src/test/java/io/vertx/core/json/JsonInspectorTest.java
@@ -281,4 +281,31 @@ public class JsonInspectorTest {
         + 10000,  // the inspection string length limit
       inspect(obj).length());
   }
+
+  @Test
+  public void testDeep() {
+    JsonObject obj = new JsonObject()
+      .put("0", new JsonObject()
+        .put("1", new JsonObject()
+          .put("2", new JsonObject()
+            .put("3", new JsonObject()))));
+
+    // only 3 levels are printed (3 is dotted)
+    assertEquals(
+      "{0: {1: {2: {...}}}}",
+      inspect(obj));
+  }
+
+  @Test
+  public void testDeepCircular() {
+    JsonObject obj = new JsonObject();
+    obj
+      .put("0", new JsonObject()
+        .put("1", obj));
+
+    // circular doesn't need to be directly nested
+    assertEquals(
+      String.format("{0: {1: {Circular *%d}}}", System.identityHashCode(obj.getMap())),
+      inspect(obj));
+  }
 }

--- a/src/test/java/io/vertx/core/json/JsonObjectTest.java
+++ b/src/test/java/io/vertx/core/json/JsonObjectTest.java
@@ -1263,7 +1263,7 @@ public class JsonObjectTest {
   @Test
   public void testToString() {
     jsonObject.put("foo", "bar");
-    assertEquals(jsonObject.encode(), jsonObject.toString());
+    assertEquals("{foo: \"bar\"}", jsonObject.toString());
   }
 
   @Test

--- a/src/test/java/io/vertx/it/CustomJsonCodecTest.java
+++ b/src/test/java/io/vertx/it/CustomJsonCodecTest.java
@@ -25,13 +25,13 @@ public class CustomJsonCodecTest extends VertxTestBase {
   public void testJsonObject() {
     JsonObject obj = new JsonObject();
     obj.put("foo", "bar");
-    assertEquals("{\"foo\":\"bar\"}", obj.toString());
+    assertEquals("{\"foo\":\"bar\"}", obj.encode());
   }
 
   @Test
   public void testJsonArray() {
     JsonArray array = new JsonArray();
     array.add("foo");
-    assertEquals("[\"foo\"]", array.toString());
+    assertEquals("[\"foo\"]", array.encode());
   }
 }

--- a/src/test/java/io/vertx/it/JsonCodecTest.java
+++ b/src/test/java/io/vertx/it/JsonCodecTest.java
@@ -25,7 +25,7 @@ public class JsonCodecTest extends VertxTestBase {
   public void testJsonObject() {
     JsonObject obj = new JsonObject("{\"foo\":\"bar\"}");
     assertEquals("bar", obj.getString("foo"));
-    assertEquals("{\"foo\":\"bar\"}", obj.toString());
+    assertEquals("{\"foo\":\"bar\"}", obj.encode());
     try {
       obj.mapTo(Object.class);
       fail();

--- a/src/test/java/io/vertx/it/JsonTest.java
+++ b/src/test/java/io/vertx/it/JsonTest.java
@@ -35,7 +35,7 @@ public class JsonTest extends VertxTestBase {
     JsonObject obj = new JsonObject();
     obj.put("foo", "bar");
     try {
-      obj.toString();
+      obj.encode();
       fail();
     } catch (NoClassDefFoundError ignore) {
     }
@@ -48,7 +48,7 @@ public class JsonTest extends VertxTestBase {
     JsonArray array = new JsonArray();
     array.add("foo");
     try {
-      array.toString();
+      array.encode();
       fail();
     } catch (NoClassDefFoundError ignore) {
     }


### PR DESCRIPTION
Motivation:

Vert.x JsonObject/JsonArray `toString()` methods call the codec encode method. While this is handy for debugging it has several drawbacks. When dealing with very large objects, a log statement or debug can incur on some performance penalty. Worse, when debugging, IDEs will try to show you a string representation of the object so it can impact your productivity.

When debugging circular references, you will notice that the debugger will constantly throw `StackOverflowError` slowing your IDE to a non use state.

This PR introduces a breaking change in the `toString()` methods of `JsonObject` and `JsonArray`, note that this should not impact most users as JSON encoding should always be done with `encode()` or `encodePrettilly()`.

The changes try to follow what other runtimes do. Like with V8 or Python `inspect`/`dirs`, the proposed `toString()` methods will return a JSON like representation of the object/array. It will enforce a few limits:

1. max nested objects/arrays 3 (this means that deep objects will be shown as ellipsis, but calling `toString()` from a nested object will start counting from that node)
2. Arrays and Objects will only list the 1st 100 elements
3. String values will be truncated to the 1st 10000 characters
4. Circular references are detected and identified by the system hashcode of the json wrapper container.

The reason to avoid using the container directly is that, although `Map` and `List` will detect `self` references, they would fail to detect other circular references, leading again to `StackOverflowError`.
