### PR TITLE
fix #4660: incrementing the fetch for ping/pong

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -463,6 +463,10 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
           context.dispatch(frame.binaryData(), handler);
         }
         break;
+      case PING:
+      case PONG:
+        fetch(1);
+        break;
     }
   }
 

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -2402,6 +2402,31 @@ public class WebSocketTest extends VertxTestBase {
     }));
     await();
   }
+  
+  @Test
+  public void testWebSocketPausePing() throws InterruptedException {
+    server = vertx.createHttpServer(new HttpServerOptions().setIdleTimeout(1).setPort(DEFAULT_HTTP_PORT).setHost(HttpTestBase.DEFAULT_HTTP_HOST));
+    server.webSocketHandler(ws -> {
+      ws.pongHandler(buff -> {
+        assertEquals("ping", buff.toString());
+        ws.close();
+      });
+      ws.writePing(Buffer.buffer("ping"));
+    });
+    awaitFuture(server.listen());
+    client = vertx.createHttpClient();
+    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+      ws.pause();
+      ws.handler(buff -> {
+        fail("Should not receive a buffer");
+      });
+      ws.fetch(1);
+      ws.endHandler(v2 -> {
+        testComplete();
+      });
+    }));
+    await();
+  }
 
   @Test
   public void testServerWebSocketPingExceeds125Bytes() throws InterruptedException {


### PR DESCRIPTION
Motivation:

Addresses #4660

This is the simplest change - always increase the fetch whenever there's a ping or pong.  However the pong case is debatable since there is the ability to set a pong handler - if someone is already handling this situation in their pong handler, then this change will further increase the fetch.  

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
