### PR TITLE
use entries().size() when encoding headers to fix missing headers

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredMessage.java
@@ -200,7 +200,7 @@ public class ClusteredMessage<U, V> extends MessageImpl<U, V> {
     if (headers != null && !headers.isEmpty()) {
       int headersLengthPos = buffer.length();
       buffer.appendInt(0);
-      buffer.appendInt(headers.size());
+      buffer.appendInt(headers.entries().size());
       List<Map.Entry<String, String>> entries = headers.entries();
       for (Map.Entry<String, String> entry: entries) {
         writeString(buffer, entry.getKey());

--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
@@ -12,6 +12,7 @@
 package io.vertx.core.eventbus;
 
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
@@ -29,6 +30,8 @@ import org.junit.Test;
 
 import java.io.InvalidClassException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CountDownLatch;
@@ -654,5 +657,42 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
       vertices[0].eventBus().send("foo", message);
     }));
     await();
+  }
+
+  @Test
+  public void testMultiHeaders() {
+
+    startNodes(2);
+    waitFor(1);
+
+    MultiMap expectedHeaders = MultiMap.caseInsensitiveMultiMap()
+      .add("a", "1")
+      .add("c", "2")
+      .add("b", "3")
+      .add("d", "4")
+      .add("a", "5")
+      .add("a", "6")
+      .add("a", "7")
+      .add("b", "8")
+      .add("b", "9")
+      .add("c", "10");
+
+    vertices[1].eventBus().consumer(ADDRESS1, msg -> {
+
+      MultiMap headers = msg.headers();
+      assertEquals("headers should have expected size", 4, headers.size());
+      assertEquals("headers should have expected number of entries", 10, headers.entries().size());
+      assertEquals("entry 'a' should have 4 elements", Arrays.asList("1", "5", "6", "7"), headers.getAll("a"));
+      assertEquals("entry 'b' should have 3 elements", Arrays.asList("3", "8", "9"), headers.getAll("b"));
+      assertEquals("entry 'c' should have 2 elements", Arrays.asList("2", "10"), headers.getAll("c"));
+      assertEquals("entry 'd' should have 1 element", Collections.singletonList("4"), headers.getAll("d"));
+      complete();
+
+    }).completionHandler(v1 -> {
+      vertices[0].eventBus().send(ADDRESS1, "foo", new DeliveryOptions().setHeaders(expectedHeaders));
+    });
+
+    await();
+
   }
 }


### PR DESCRIPTION
**Motivation:**

This commit fixes an issue with message header encoding/decoding when using a clustered event bus. Without this change, headers have the potential to be lost when decoding. The reason for the header loss is that when encoding headers, the header length that gets written is based upon the `.size()` method. This method is based on the number of _unique_ header names. If a `MultiMap` has a header that contains more than one value, this causes a problem. The problem manifests itself during decoding. During decoding, the number of headers is read and then subsequently iterated over:

```
      ...

      int numHeaders = wireBuffer.getInt(headersPos);
      headersPos += 4;
      headers = MultiMap.caseInsensitiveMultiMap();
      for (int i = 0; i < numHeaders; i++) {

      ...
```

If there are any headers with more than one value, then the header(s) at the end of the list will not be decoded.

This commit fixes this by declaring the header size based on the entries, instead of the number of unique header names. A test has been added to assert the desired behavior.

**Conformance:**

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
