### PR TITLE
Remove uses of classes in javax.security.cert

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -20,7 +20,6 @@ import io.vertx.core.net.SocketAddress;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import java.security.cert.Certificate;
 import java.util.List;
 
@@ -257,22 +256,6 @@ public interface HttpConnection {
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   SSLSession sslSession();
-
-  /**
-   * Note: Java SE 5+ recommends to use javax.net.ssl.SSLSession#getPeerCertificates() instead of
-   * of javax.net.ssl.SSLSession#getPeerCertificateChain() which this method is based on. Use {@link #sslSession()} to
-   * access that method.
-   *
-   * @return an ordered array of the peer certificates. Returns null if connection is
-   *         not SSL.
-   * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
-   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
-   * @see #sslSession()
-   * @deprecated instead use {@link #peerCertificates()} or {@link #sslSession()}
-   */
-  @Deprecated
-  @GenIgnore
-  X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
 
   /**
    * @return an ordered list of the peer certificates. Returns null if connection is

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -24,9 +24,7 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.ReadStream;
 
-import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -251,20 +249,6 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   default SSLSession sslSession() {
     return connection().sslSession();
   }
-
-  /**
-   * Note: Java SE 5+ recommends to use javax.net.ssl.SSLSession#getPeerCertificates() instead of
-   * of javax.net.ssl.SSLSession#getPeerCertificateChain() which this method is based on. Use {@link #sslSession()} to
-   * access that method.
-   *
-   * @return an ordered array of the peer certificates. Returns null if connection is
-   *         not SSL.
-   * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
-   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
-   * @see #sslSession()
-   */
-  @GenIgnore
-  X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
 
   /**
    * @return the absolute URI corresponding to the HTTP request

--- a/src/main/java/io/vertx/core/http/WebSocketBase.java
+++ b/src/main/java/io/vertx/core/http/WebSocketBase.java
@@ -26,7 +26,6 @@ import io.vertx.core.streams.WriteStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import java.security.cert.Certificate;
 import java.util.List;
 
@@ -323,18 +322,6 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   SSLSession sslSession();
-
-  /**
-   * @return an ordered array of the peer certificates. Returns null if connection is
-   *         not SSL.
-   * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
-   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
-   * @see #sslSession()
-   * @deprecated instead use {@link #peerCertificates()} or {@link #sslSession()}
-   */
-  @Deprecated
-  @GenIgnore
-  X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
 
   /**
    * @return an ordered list of the peer certificates. Returns null if connection is

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -40,8 +40,6 @@ import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.streams.impl.InboundBuffer;
 
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.security.cert.X509Certificate;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -385,11 +383,6 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   @Override
   public SocketAddress remoteAddress() {
     return conn.remoteAddress();
-  }
-
-  @Override
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    return conn.peerCertificateChain();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -45,8 +45,6 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.tracing.TracingPolicy;
 
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.security.cert.X509Certificate;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -376,11 +374,6 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
       }
       return params;
     }
-  }
-
-  @Override
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    return stream.conn.peerCertificateChain();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -35,7 +35,6 @@ import io.vertx.core.streams.WriteStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import java.security.cert.Certificate;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -923,11 +922,6 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
   @Override
   public SSLSession sslSession() {
     return current.sslSession();
-  }
-
-  @Override
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    return current.peerCertificateChain();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
@@ -26,8 +26,6 @@ import io.vertx.core.streams.WriteStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
-import java.nio.channels.ClosedChannelException;
 import java.security.cert.Certificate;
 import java.util.List;
 
@@ -263,10 +261,6 @@ class HttpNetSocket implements NetSocket {
     return conn.sslSession();
   }
 
-  @Override
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    return conn.peerCertificateChain();
-  }
 
   @Override
   public List<Certificate> peerCertificates() throws SSLPeerUnverifiedException {

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
@@ -25,9 +25,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.Pipe;
 import io.vertx.core.streams.WriteStream;
 
-import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import java.util.Map;
 import java.util.Set;
 
@@ -197,12 +195,6 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   public SSLSession sslSession() {
     return delegate.sslSession();
-  }
-
-  @Override
-  @GenIgnore
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    return delegate.peerCertificateChain();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -43,7 +43,6 @@ import io.vertx.core.streams.impl.InboundBuffer;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import java.security.cert.Certificate;
 import java.util.List;
 import java.util.UUID;
@@ -188,11 +187,6 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
   @Override
   public SSLSession sslSession() {
     return conn.sslSession();
-  }
-
-  @Override
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    return conn.peerCertificateChain();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/src/main/java/io/vertx/core/net/NetSocket.java
@@ -24,7 +24,6 @@ import io.vertx.core.streams.WriteStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import java.security.cert.Certificate;
 import java.util.List;
 
@@ -216,18 +215,6 @@ public interface NetSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   SSLSession sslSession();
-
-  /**
-   * @return an ordered array of the peer certificates. Returns null if connection is
-   *         not SSL.
-   * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
-   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
-   * @see #sslSession()
-   * @deprecated instead use {@link #peerCertificates()} or {@link #sslSession()}
-   */
-  @Deprecated
-  @GenIgnore
-  X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
 
   /**
    * @return an ordered list of the peer certificates. Returns null if connection is

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -33,7 +33,6 @@ import io.vertx.core.spi.metrics.TCPMetrics;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
@@ -563,15 +562,6 @@ public abstract class ConnectionBase {
     if (sslHandlerContext != null) {
       SslHandler sslHandler = (SslHandler) sslHandlerContext.handler();
       return sslHandler.engine().getSession();
-    } else {
-      return null;
-    }
-  }
-
-  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
-    SSLSession session = sslSession();
-    if (session != null) {
-      return session.getPeerCertificateChain();
     } else {
       return null;
     }

--- a/src/test/java/io/vertx/test/core/TestUtils.java
+++ b/src/test/java/io/vertx/test/core/TestUtils.java
@@ -33,8 +33,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import java.util.zip.GZIPOutputStream;
 
-import javax.security.cert.X509Certificate;
-
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.util.NetUtil;
@@ -465,12 +463,6 @@ public class TestUtils {
       return names.isEmpty() ? null : names.get(0);
     }
     return null;
-  }
-
-  public static String cnOf(X509Certificate cert) throws Exception {
-    String dn = cert.getSubjectDN().getName();
-    List<String> names = KeyStoreHelper.getX509CertificateCommonNames(dn);
-    return names.isEmpty() ? null : names.get(0);
   }
 
   /**


### PR DESCRIPTION
Motivation:

Efforts are underway in the OpenJDK project to remove the long deprecated-for-removal classes in the package `javax.security.cert`. These classes were introduced for backwards compatibility concerns with the unbundled JSSE release for JDK 1.2/1.3, but their use have been discouraged since they were introduced.

It would be good to update Vert.x to not depend on / use these archaic APIs.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
