### PR TITLE
Add suspend/resume to ConnectionPool

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/pool/ConnectionPool.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/ConnectionPool.java
@@ -149,4 +149,18 @@ public interface ConnectionPool<C> {
    *         to take decisions, this can be used for statistic or testing purpose
    */
   int requests();
+
+  /**
+   * Removes all connections from the pool and returns them in the handler. The pool
+   * is blocked from creating new connections until {@link #resume()} is invoked.
+   *
+   * @param handler the callback handler with the result
+   */
+  void suspend(Handler<AsyncResult<List<Future<C>>>> handler);
+
+  /**
+   * Allows a {@link #suspend suspended} connection pool to continue allocating
+   * and serving new connections.
+   */
+  void resume();
 }


### PR DESCRIPTION
This new pair of methods intends to support snapshotting of the application when using OpenJDK CRaC.

There will be another PR to `vertx-sql-client` that will use these methods when actually handling the checkpoint/restore.