### PR TITLE
Deprecate un-necessary streams

### DIFF
--- a/src/main/asciidoc/streams.adoc
+++ b/src/main/asciidoc/streams.adoc
@@ -119,8 +119,7 @@ Let's now look at the methods on `ReadStream` and `WriteStream` in more detail:
 `ReadStream` is implemented by {@link io.vertx.core.http.HttpClientResponse}, {@link io.vertx.core.datagram.DatagramSocket},
 {@link io.vertx.core.http.HttpClientRequest}, {@link io.vertx.core.http.HttpServerFileUpload},
 {@link io.vertx.core.http.HttpServerRequest}, {@link io.vertx.core.eventbus.MessageConsumer},
-{@link io.vertx.core.net.NetSocket}, {@link io.vertx.core.http.WebSocket}, {@link io.vertx.core.TimeoutStream},
-{@link io.vertx.core.file.AsyncFile}.
+{@link io.vertx.core.net.NetSocket}, {@link io.vertx.core.http.WebSocket}, {@link io.vertx.core.file.AsyncFile}.
 
 - {@link io.vertx.core.streams.ReadStream#handler}:
 set a handler which will receive items from the ReadStream.

--- a/src/main/java/io/vertx/core/TimeoutStream.java
+++ b/src/main/java/io/vertx/core/TimeoutStream.java
@@ -23,7 +23,10 @@ import io.vertx.core.streams.ReadStream;
  * the timer.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ * @deprecated instead using {@link Vertx#setTimer}/{@link Vertx#setPeriodic}, Rx java like integrations should use
+ *             the Vert.s scheduler integration
  */
+@Deprecated()
 @VertxGen
 public interface TimeoutStream extends ReadStream<Long> {
 

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -276,7 +276,10 @@ public interface Vertx extends Measured {
    *
    * @param delay  the delay in milliseconds, after which the timer will fire
    * @return the timer stream
+   * @deprecated instead using {@link Vertx#setTimer}, Rx java like integrations should use
+   *             the Vert.s scheduler integration
    */
+  @Deprecated
   TimeoutStream timerStream(long delay);
 
   /**
@@ -308,7 +311,10 @@ public interface Vertx extends Measured {
    *
    * @param delay  the delay in milliseconds, after which the timer will fire
    * @return the periodic stream
+   * @deprecated instead using {@link Vertx#setPeriodic}, Rx java like integrations should use
+   *             the Vert.s scheduler integration
    */
+  @Deprecated
   default TimeoutStream periodicStream(long delay) {
     return periodicStream(0, delay);
   }
@@ -320,7 +326,10 @@ public interface Vertx extends Measured {
    * @param initialDelay the initial delay in milliseconds
    * @param delay the delay in milliseconds, after which the timer will fire
    * @return the periodic stream
+   * @deprecated instead using {@link Vertx#setPeriodic}, Rx java like integrations should use
+   *             the Vert.s scheduler integration
    */
+  @Deprecated
   TimeoutStream periodicStream(long initialDelay, long delay);
 
   /**

--- a/src/main/java/io/vertx/core/datagram/DatagramSocket.java
+++ b/src/main/java/io/vertx/core/datagram/DatagramSocket.java
@@ -253,15 +253,31 @@ public interface DatagramSocket extends ReadStream<DatagramPacket>, Measured {
    */
   Future<DatagramSocket> listen(int port, String host);
 
+  /**
+   * @deprecated no replacement for back-pressure, instead ignore the packet or buffer it somewhere
+   */
+  @Deprecated
   @Override
   DatagramSocket pause();
 
+  /**
+   * @deprecated no replacement for back-pressure, instead ignore the packet or buffer it somewhere
+   */
+  @Deprecated
   @Override
   DatagramSocket resume();
 
+  /**
+   * @deprecated no replacement for back-pressure, instead ignore the packet or buffer it somewhere
+   */
+  @Deprecated
   @Override
   DatagramSocket fetch(long amount);
 
+  /**
+   * @deprecated removed in Vert.x 5
+   */
+  @Deprecated
   @Override
   DatagramSocket endHandler(Handler<Void> endHandler);
 

--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -43,7 +43,9 @@ public interface HttpServer extends Measured {
    * instances of {@link HttpServerRequest} will be created and passed to the stream {@link io.vertx.core.streams.ReadStream#handler(io.vertx.core.Handler)}.
    *
    * @return the request stream
+   * @deprecated instead use {@link #requestHandler(Handler)}
    */
+  @Deprecated
   @CacheReturn
   ReadStream<HttpServerRequest> requestStream();
 
@@ -101,7 +103,9 @@ public interface HttpServer extends Measured {
    * new {@link ServerWebSocket} instance will be created and passed to the stream {@link io.vertx.core.streams.ReadStream#handler(io.vertx.core.Handler)}.
    *
    * @return the WebSocket stream
+   * @deprecated instead use {@link #webSocketHandler(Handler)}
    */
+  @Deprecated
   @CacheReturn
   ReadStream<ServerWebSocket> webSocketStream();
 

--- a/src/main/java/io/vertx/core/net/NetServer.java
+++ b/src/main/java/io/vertx/core/net/NetServer.java
@@ -36,7 +36,9 @@ public interface NetServer extends Measured {
    * connect stream {@link ReadStream#handler(io.vertx.core.Handler)}.
    *
    * @return the connect stream
+   * @deprecated instead use {@link #connectHandler(Handler)}
    */
+  @Deprecated
   ReadStream<NetSocket> connectStream();
 
   /**


### PR DESCRIPTION
A few streams were introduced in Vert.x 3 for the only purpose of RX like generated APIs. It turns out that such benefits are low compared to the cost of cluttering the API. These streams will be removed in Vert.x 5