### PR TITLE
Create SNI KeyManagerFactory in KeyCertOptions instead of SslContextProvider so it can be cached

### DIFF
--- a/src/main/java/io/vertx/core/net/KeyCertOptions.java
+++ b/src/main/java/io/vertx/core/net/KeyCertOptions.java
@@ -12,6 +12,7 @@
 package io.vertx.core.net;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.net.impl.KeyStoreHelper;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.X509KeyManager;
@@ -53,11 +54,47 @@ public interface KeyCertOptions {
    *
    * The mapper is only used when the server has SNI enabled and the client indicated a server name.
    * <p>
-   * The returned function may return null in which case the default key manager provided by {@link #getKeyManagerFactory(Vertx)}
+   * The returned function may return {@code null} in which case the default key manager provided by {@link #getKeyManagerFactory(Vertx)}
    * will be used.
    *
+   * @deprecated instead use {@link #keyManagerFactoryMapper(Vertx)}
    */
+  @Deprecated
   Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) throws Exception;
+
+  /**
+   * Returns a function that maps SNI server names to {@link KeyManagerFactory} instance.
+   *
+   * The returned {@code KeyManagerFactory} must satisfies these rules:
+   *
+   * <ul>
+   *   <li>The store private key must match the indicated server name for a null alias.</li>
+   *   <li>The store certificate chain must match the indicated server name for a null alias.</li>
+   * </ul>
+   *
+   * The mapper is only used when the server has SNI enabled and the client indicated a server name.
+   * <p>
+   * The returned function may return {@code null} in which case the default key manager provided by {@link #getKeyManagerFactory(Vertx)}
+   * will be used.
+   *
+   * @implSpec the default implementation converts they {@link #keyManagerMapper(Vertx)} to a {@link KeyManagerFactory}
+   * @implNote the default implementation does not any caching, creating a {@link KeyManagerFactory} can be expense, implementations
+   *           are encouraged to reimplement this method and cache the result
+   */
+  default Function<String, KeyManagerFactory> keyManagerFactoryMapper(Vertx vertx) throws Exception {
+    Function<String, X509KeyManager> mapper = keyManagerMapper(vertx);
+    return name -> {
+      X509KeyManager mgr = mapper.apply(name);
+      if (mgr != null) {
+        try {
+          return KeyStoreHelper.toKeyManagerFactory(mgr);
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+      return null;
+    };
+  }
 
   /**
    * Returns a {@link KeyCertOptions} from the provided {@link X509KeyManager}

--- a/src/main/java/io/vertx/core/net/KeyManagerFactoryOptions.java
+++ b/src/main/java/io/vertx/core/net/KeyManagerFactoryOptions.java
@@ -83,5 +83,4 @@ class KeyManagerFactoryOptions implements KeyCertOptions {
   public Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) {
     return keyManagerFactory.getKeyManagers()[0] instanceof X509KeyManager ? serverName -> (X509KeyManager) keyManagerFactory.getKeyManagers()[0] : null;
   }
-
 }

--- a/src/main/java/io/vertx/core/net/KeyStoreOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/KeyStoreOptionsBase.java
@@ -213,6 +213,12 @@ public abstract class KeyStoreOptionsBase implements KeyCertOptions, TrustOption
   }
 
   @Override
+  public Function<String, KeyManagerFactory> keyManagerFactoryMapper(Vertx vertx) throws Exception {
+    KeyStoreHelper helper = getHelper(vertx);
+    return helper != null ? helper::getKeyMgrFactory : null;
+  }
+
+  @Override
   public TrustManagerFactory getTrustManagerFactory(Vertx vertx) throws Exception {
     KeyStoreHelper helper = getHelper(vertx);
     return helper != null ? helper.getTrustMgrFactory((VertxInternal) vertx) : null;

--- a/src/main/java/io/vertx/core/net/PemKeyCertOptions.java
+++ b/src/main/java/io/vertx/core/net/PemKeyCertOptions.java
@@ -429,4 +429,10 @@ public class PemKeyCertOptions implements KeyCertOptions {
     KeyStoreHelper helper = getHelper(vertx);
     return helper != null ? helper::getKeyMgr : null;
   }
+
+  @Override
+  public Function<String, KeyManagerFactory> keyManagerFactoryMapper(Vertx vertx) throws Exception {
+    KeyStoreHelper helper = getHelper(vertx);
+    return helper != null ? helper::getKeyMgrFactory : null;
+  }
 }

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -107,7 +107,7 @@ public class SSLHelper {
   private final List<String> applicationProtocols;
   private KeyManagerFactory keyManagerFactory;
   private TrustManagerFactory trustManagerFactory;
-  private Function<String, X509KeyManager> keyManagerMapper;
+  private Function<String, KeyManagerFactory> keyManagerFactoryMapper;
   private Function<String, TrustManager[]> trustManagerMapper;
   private List<CRL> crls;
 
@@ -143,7 +143,7 @@ public class SSLHelper {
         sslOptions.getEnabledCipherSuites(),
         sslOptions.getEnabledSecureTransportProtocols(),
         keyManagerFactory,
-        keyManagerMapper,
+        keyManagerFactoryMapper,
         trustManagerFactory,
         trustManagerMapper,
         crls,
@@ -194,7 +194,7 @@ public class SSLHelper {
         try {
           if (sslOptions.getKeyCertOptions() != null) {
             keyManagerFactory = sslOptions.getKeyCertOptions().getKeyManagerFactory(ctx.owner());
-            keyManagerMapper = sslOptions.getKeyCertOptions().keyManagerMapper(ctx.owner());
+            keyManagerFactoryMapper = sslOptions.getKeyCertOptions().keyManagerFactoryMapper(ctx.owner());
           }
           if (sslOptions.getTrustOptions() != null) {
             trustManagerFactory = sslOptions.getTrustOptions().getTrustManagerFactory(ctx.owner());


### PR DESCRIPTION
When using SNI, SslContextProvider will always convert the mapped key manager to a key manager factory, that can be an expensive operation.

This conversion of the key manager to a factory has been moved to the KeyCertOptions interface as a default method, to let implementations of this interface override it with caching. The default Vert.x implementation based on KeyStoreOptionsBase caches the created factories.
