### PR TITLE
Create SNI KeyManagerFactory in KeyCertOptions instead of SslContextProvider so it can be cached 

### DIFF
--- a/src/main/java/io/vertx/core/net/KeyCertOptions.java
+++ b/src/main/java/io/vertx/core/net/KeyCertOptions.java
@@ -12,6 +12,7 @@
 package io.vertx.core.net;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.net.impl.KeyStoreHelper;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.X509KeyManager;
@@ -40,24 +41,21 @@ public interface KeyCertOptions {
   KeyManagerFactory getKeyManagerFactory(Vertx vertx) throws Exception;
 
   /**
-   * Returns a function that maps SNI server names to {@link X509KeyManager} instance.
+   * Returns a function that maps SNI server names to {@link KeyManagerFactory} instance.
    *
-   * The returned {@code X509KeyManager} must satisfies these rules:
+   * The returned {@code KeyManagerFactory} must satisfies these rules:
    *
    * <ul>
-   *   <li>{@link X509KeyManager#getPrivateKey(String)} returns the private key for the indicated server name,
-   *   the {@code alias} parameter will be {@code null}.</li>
-   *   <li>{@link X509KeyManager#getCertificateChain(String)} returns the certificate chain for the indicated server name,
-   *   the {@code alias} parameter will be {@code null}.</li>
+   *   <li>The store private key must match the indicated server name for a null alias.</li>
+   *   <li>The store certificate chain must match the indicated server name for a null alias.</li>
    * </ul>
    *
    * The mapper is only used when the server has SNI enabled and the client indicated a server name.
    * <p>
-   * The returned function may return null in which case the default key manager provided by {@link #getKeyManagerFactory(Vertx)}
+   * The returned function may return {@code null} in which case the default key manager provided by {@link #getKeyManagerFactory(Vertx)}
    * will be used.
-   *
    */
-  Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) throws Exception;
+  Function<String, KeyManagerFactory> keyManagerFactoryMapper(Vertx vertx) throws Exception;
 
   /**
    * Returns a {@link KeyCertOptions} from the provided {@link X509KeyManager}

--- a/src/main/java/io/vertx/core/net/KeyManagerFactoryOptions.java
+++ b/src/main/java/io/vertx/core/net/KeyManagerFactoryOptions.java
@@ -13,6 +13,7 @@ package io.vertx.core.net;
 
 import io.vertx.core.Vertx;
 
+import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.X509KeyManager;
 import java.util.function.Function;
@@ -80,8 +81,7 @@ class KeyManagerFactoryOptions implements KeyCertOptions {
   }
 
   @Override
-  public Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) {
-    return keyManagerFactory.getKeyManagers()[0] instanceof X509KeyManager ? serverName -> (X509KeyManager) keyManagerFactory.getKeyManagers()[0] : null;
+  public Function<String, KeyManagerFactory> keyManagerFactoryMapper(Vertx vertx) throws Exception {
+    return name -> null;
   }
-
 }

--- a/src/main/java/io/vertx/core/net/KeyStoreOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/KeyStoreOptionsBase.java
@@ -207,9 +207,9 @@ public abstract class KeyStoreOptionsBase implements KeyCertOptions, TrustOption
   }
 
   @Override
-  public Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) throws Exception {
+  public Function<String, KeyManagerFactory> keyManagerFactoryMapper(Vertx vertx) throws Exception {
     KeyStoreHelper helper = getHelper(vertx);
-    return helper != null ? helper::getKeyMgr : null;
+    return helper != null ? helper::getKeyMgrFactory : null;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/PemKeyCertOptions.java
+++ b/src/main/java/io/vertx/core/net/PemKeyCertOptions.java
@@ -425,8 +425,8 @@ public class PemKeyCertOptions implements KeyCertOptions {
   }
 
   @Override
-  public Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) throws Exception {
+  public Function<String, KeyManagerFactory> keyManagerFactoryMapper(Vertx vertx) throws Exception {
     KeyStoreHelper helper = getHelper(vertx);
-    return helper != null ? helper::getKeyMgr : null;
+    return helper != null ? helper::getKeyMgrFactory : null;
   }
 }

--- a/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
@@ -74,8 +74,8 @@ public class KeyStoreHelper {
   private final String password;
   private final KeyStore store;
   private final String aliasPassword;
-  private final Map<String, X509KeyManager> wildcardMgrMap = new HashMap<>();
-  private final Map<String, X509KeyManager> mgrMap = new HashMap<>();
+  private final Map<String, KeyManagerFactory> wildcardMgrFactoryMap = new HashMap<>();
+  private final Map<String, KeyManagerFactory> mgrFactoryMap = new HashMap<>();
   private final Map<String, TrustManagerFactory> trustMgrMap = new HashMap<>();
 
   public KeyStoreHelper(KeyStore ks, String password, String aliasPassword) throws Exception {
@@ -138,11 +138,13 @@ public class KeyStoreHelper {
               return key;
             }
           };
+
+          KeyManagerFactory kmf = toKeyManagerFactory(mgr);
           for (String domain : domains) {
             if (domain.startsWith("*.")) {
-              wildcardMgrMap.put(domain.substring(2), mgr);
+              wildcardMgrFactoryMap.put(domain.substring(2), kmf);
             } else {
-              mgrMap.put(domain, mgr);
+              mgrFactoryMap.put(domain, kmf);
             }
           }
         }
@@ -151,6 +153,17 @@ public class KeyStoreHelper {
     this.store = ks;
     this.password = password;
     this.aliasPassword = aliasPassword;
+  }
+
+  public static KeyManagerFactory toKeyManagerFactory(X509KeyManager mgr) throws Exception {
+    String keyStoreType = KeyStore.getDefaultType();
+    KeyStore ks = KeyStore.getInstance(keyStoreType);
+    ks.load(null, null);
+    ks.setKeyEntry("key", mgr.getPrivateKey(null), new char[0], mgr.getCertificateChain(null));
+    String keyAlgorithm = KeyManagerFactory.getDefaultAlgorithm();
+    KeyManagerFactory kmf = KeyManagerFactory.getInstance(keyAlgorithm);
+    kmf.init(ks, new char[0]);
+    return kmf;
   }
 
   public KeyManagerFactory getKeyMgrFactory() throws Exception {
@@ -165,13 +178,13 @@ public class KeyStoreHelper {
     return (password != null) ? password.toCharArray() : null;
   }
 
-  public X509KeyManager getKeyMgr(String serverName) {
-    X509KeyManager mgr = mgrMap.get(serverName);
-    if (mgr == null && !wildcardMgrMap.isEmpty()) {
+  public KeyManagerFactory getKeyMgrFactory(String serverName) {
+    KeyManagerFactory mgr = mgrFactoryMap.get(serverName);
+    if (mgr == null && !wildcardMgrFactoryMap.isEmpty()) {
       int index = serverName.indexOf('.') + 1;
       if (index > 0) {
         String s = serverName.substring(index);
-        mgr = wildcardMgrMap.get(s);
+        mgr = wildcardMgrFactoryMap.get(s);
       }
     }
     return mgr;

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -107,7 +107,7 @@ public class SSLHelper {
   private final List<String> applicationProtocols;
   private KeyManagerFactory keyManagerFactory;
   private TrustManagerFactory trustManagerFactory;
-  private Function<String, X509KeyManager> keyManagerMapper;
+  private Function<String, KeyManagerFactory> keyManagerFactoryMapper;
   private Function<String, TrustManager[]> trustManagerMapper;
   private List<CRL> crls;
 
@@ -143,7 +143,7 @@ public class SSLHelper {
         sslOptions.getEnabledCipherSuites(),
         sslOptions.getEnabledSecureTransportProtocols(),
         keyManagerFactory,
-        keyManagerMapper,
+        keyManagerFactoryMapper,
         trustManagerFactory,
         trustManagerMapper,
         crls,
@@ -194,7 +194,7 @@ public class SSLHelper {
         try {
           if (sslOptions.getKeyCertOptions() != null) {
             keyManagerFactory = sslOptions.getKeyCertOptions().getKeyManagerFactory(ctx.owner());
-            keyManagerMapper = sslOptions.getKeyCertOptions().keyManagerMapper(ctx.owner());
+            keyManagerFactoryMapper = sslOptions.getKeyCertOptions().keyManagerFactoryMapper(ctx.owner());
           }
           if (sslOptions.getTrustOptions() != null) {
             trustManagerFactory = sslOptions.getTrustOptions().getTrustManagerFactory(ctx.owner());

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -1835,35 +1835,41 @@ public abstract class HttpTLSTest extends HttpTestBase {
         return new KeyStoreHelper(testKs, jksOptions.getPassword(), null).getKeyMgrFactory();
       }
       @Override
-      public Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) throws Exception {
+      public Function<String, KeyManagerFactory> keyManagerFactoryMapper(Vertx vertx) throws Exception {
         X509KeyManager keyManager = (X509KeyManager) getKeyManagerFactory(vertx).getKeyManagers()[0];
+        KeyManagerFactory kmf = KeyStoreHelper.toKeyManagerFactory(new X509KeyManager() {
+          @Override
+          public String[] getClientAliases(String keyType, Principal[] issuers) {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public String[] getServerAliases(String keyType, Principal[] issuers) {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public X509Certificate[] getCertificateChain(String alias) {
+            return keyManager.getCertificateChain("test-host2");
+          }
+
+          @Override
+          public PrivateKey getPrivateKey(String alias) {
+            return keyManager.getPrivateKey("test-host2");
+          }
+        });
         return serverName -> {
-          return new X509KeyManager() {
-            @Override
-            public String[] getClientAliases(String keyType, Principal[] issuers) {
-              throw new UnsupportedOperationException();
-            }
-            @Override
-            public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
-              throw new UnsupportedOperationException();
-            }
-            @Override
-            public String[] getServerAliases(String keyType, Principal[] issuers) {
-              throw new UnsupportedOperationException();
-            }
-            @Override
-            public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
-              throw new UnsupportedOperationException();
-            }
-            @Override
-            public X509Certificate[] getCertificateChain(String alias) {
-              return keyManager.getCertificateChain("test-host2");
-            }
-            @Override
-            public PrivateKey getPrivateKey(String alias) {
-              return keyManager.getPrivateKey("test-host2");
-            }
-          };
+          return kmf;
         };
       }
     };


### PR DESCRIPTION
When using SNI, SslContextProvider will always convert the mapped key manager to a key manager factory, that can be an expensive operation.
    
This conversion of the key manager to a factory has been moved to the KeyCertOptions interface to let implementations of this interface implement it with caching. Now KeyStoreOptionsBase caches the created factories.
    
This is a breaking of the KeyCertOptions SPI due to the removal of keyManagerMapper method removal.
