### PR TITLE
4700 Provide a default implementation for KeyCertOptions.keyManagerMapper

### DIFF
--- a/src/main/java/io/vertx/core/net/KeyCertOptions.java
+++ b/src/main/java/io/vertx/core/net/KeyCertOptions.java
@@ -60,7 +60,9 @@ public interface KeyCertOptions {
    * @deprecated instead use {@link #keyManagerFactoryMapper(Vertx)}
    */
   @Deprecated
-  Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) throws Exception;
+  default Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) throws Exception {
+    return name -> null;
+  }
 
   /**
    * Returns a function that maps SNI server names to {@link KeyManagerFactory} instance.


### PR DESCRIPTION
This way there is no need to implement this method anymore and KeyCertOptions implementations will not get a compilation warning.
