### PR TITLE
HttpClient HTTP request/response API method design that provides non racy methods when called outside event-loop

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClient.java
@@ -15,6 +15,7 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * The API to interacts with an HTTP server.
@@ -41,6 +42,10 @@ public interface HttpClient {
    */
   Future<HttpClientRequest> request(RequestOptions options);
 
+  default <T> Future<T> request(RequestOptions options, Function<HttpClientRequest, Future<T>> handler) {
+    return request(options).compose(handler);
+  }
+
   /**
    * Create an HTTP request to send to the server at the {@code host} and {@code port}.
    *
@@ -52,6 +57,10 @@ public interface HttpClient {
    */
   default Future<HttpClientRequest> request(HttpMethod method, int port, String host, String requestURI) {
     return request(new RequestOptions().setMethod(method).setPort(port).setHost(host).setURI(requestURI));
+  }
+
+  default <T> Future<T> request(HttpMethod method, int port, String host, String requestURI, Function<HttpClientRequest, Future<T>> handler) {
+    return request(method, port, host, requestURI).compose(handler);
   }
 
   /**
@@ -66,6 +75,10 @@ public interface HttpClient {
     return request(new RequestOptions().setMethod(method).setHost(host).setURI(requestURI));
   }
 
+  default <T> Future<T> request(HttpMethod method, String host, String requestURI , Function<HttpClientRequest, Future<T>> handler) {
+    return request(method, host, requestURI).compose(handler);
+  }
+
   /**
    * Create an HTTP request to send to the server at the default host and port.
    *
@@ -75,6 +88,10 @@ public interface HttpClient {
    */
   default Future<HttpClientRequest> request(HttpMethod method, String requestURI) {
     return request(new RequestOptions().setMethod(method).setURI(requestURI));
+  }
+
+  default <T> Future<T> request(HttpMethod method, String requestURI, Function<HttpClientRequest, Future<T>> handler) {
+    return request(method, requestURI).compose(handler);
   }
 
   /**

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -6813,10 +6813,11 @@ public abstract class HttpTest extends HttpTestBase {
       }
     );
     startServer(testAddress);
-    client.request(requestOptions)
-      .compose(req -> req.send()
+    client.request(requestOptions, req -> req
+        .send()
         .expecting(HttpResponseExpectation.SC_OK)
-        .compose(HttpClientResponse::end))
+        .compose(HttpClientResponse::end)
+      )
       .onComplete(onSuccess(nothing -> complete()));
     await();
   }


### PR DESCRIPTION
Racy code called from a non event-loop/worker context thread 

```java
// Racy
Future<Buffer> fut = client
   .request(options)
   .compose(req -> req.send())
   .compose(resp -> resp.body());
```

Instead one should write

```java
// Not racy
Future<Buffer> fut = client
   .request(options)
   .compose(req -> req.send().compose(resp -> resp.body()));
```

This PR shows a new non racy API design `<T> Future<T> request(..., Function<HttpClientRequest, Future<T>>)`

```java
// Not racy
Future<Buffer> fut = client.request(options, req -> req
   .send()
   .compose(resp -> resp.body()));
```

which provides interesting usability:

```java
// Conversion
Future<JsonObject> fut = client.request(options, req -> req
   .send()
   .compose(resp -> resp.body())
   .map(body -> new JsonObject(body)));
```


