### PR TITLE
Event bus streaming mockup

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/EventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBus.java
@@ -15,7 +15,6 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.impl.DefaultSerializableChecker;
@@ -198,6 +197,10 @@ public interface EventBus extends Measured {
    * @return The publisher
    */
   <T> MessageProducer<T> publisher(String address, DeliveryOptions options);
+
+  Future<Void> bindStream(String address, Handler<MessageStream> handler);
+
+  Future<MessageStream> connectStream(String address);
 
   /**
    * Register a message codec.

--- a/src/main/java/io/vertx/core/eventbus/MessageStream.java
+++ b/src/main/java/io/vertx/core/eventbus/MessageStream.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.eventbus;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+
+@VertxGen
+public interface MessageStream {
+
+  void handler(Handler<Message<String>> handler);
+
+  void endHandler(Handler<Void> handler);
+
+  void write(String msg);
+
+  void end();
+
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/ClientStream.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/ClientStream.java
@@ -1,0 +1,27 @@
+package io.vertx.core.eventbus.impl;
+
+import io.vertx.core.Promise;
+import io.vertx.core.eventbus.MessageStream;
+import io.vertx.core.impl.ContextInternal;
+
+class ClientStream extends StreamBase {
+
+  private final Promise<MessageStream> promise2;
+
+  public ClientStream(EventBusImpl eventBus, String sourceAddress, ContextInternal ctx, Promise<MessageStream> promise2) {
+    super(sourceAddress, ctx, eventBus, sourceAddress, true);
+    this.promise2 = promise2;
+  }
+
+  @Override
+  protected boolean doReceive(Frame frame) {
+    if (frame instanceof SynFrame) {
+      SynFrame syn = (SynFrame) frame;
+      remoteAddress = syn.src;
+      promise2.complete(this);
+      return true;
+    } else {
+      return super.doReceive(frame);
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -329,14 +329,14 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   }
 
   protected <T> void sendOrPub(ContextInternal ctx, MessageImpl<?, T> message, DeliveryOptions options, Promise<Void> writePromise) {
-    sendLocally(message, options, writePromise);
+    sendLocally(message, writePromise);
   }
 
   protected <T> void sendOrPub(OutboundDeliveryContext<T> sendContext) {
     sendOrPub(sendContext.ctx, sendContext.message, sendContext.options, sendContext);
   }
 
-  protected <T> void sendLocally(MessageImpl<?, T> message, DeliveryOptions options, Promise<Void> writePromise) {
+  protected <T> void sendLocally(MessageImpl<?, T> message, Promise<Void> writePromise) {
     ReplyException failure = deliverMessageLocally(message);
     if (failure != null) {
       writePromise.tryFail(failure);

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -258,9 +258,9 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     return msg;
   }
 
-  protected <T> Consumer<Promise<Void>> addRegistration(String address, HandlerRegistration<T> registration, boolean replyHandler, boolean localOnly, Promise<Void> promise) {
+  protected <T> Consumer<Promise<Void>> addRegistration(String address, HandlerRegistration<T> registration, boolean broadcast, boolean localOnly, Promise<Void> promise) {
     HandlerHolder<T> holder = addLocalRegistration(address, registration, localOnly);
-    if (!replyHandler) {
+    if (broadcast) {
       onLocalRegistration(holder, promise);
     } else {
       if (promise != null) {
@@ -268,7 +268,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
       }
     }
     return p -> {
-      removeRegistration(holder, replyHandler, p);
+      removeRegistration(holder, broadcast, p);
     };
   }
 
@@ -303,9 +303,9 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     return new HandlerHolder<>(registration, localOnly, context);
   }
 
-  protected <T> void removeRegistration(HandlerHolder<T> handlerHolder, boolean replyHandler, Promise<Void> promise) {
+  protected <T> void removeRegistration(HandlerHolder<T> handlerHolder, boolean broadcast, Promise<Void> promise) {
     removeLocalRegistration(handlerHolder);
-    if (!replyHandler) {
+    if (broadcast) {
       onLocalUnregistration(handlerHolder, promise);
     } else {
       promise.complete();

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -257,10 +258,12 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     return msg;
   }
 
-  protected <T> HandlerHolder<T> addRegistration(String address, HandlerRegistration<T> registration, boolean replyHandler, boolean localOnly, Promise<Void> promise) {
+  protected <T> Consumer<Promise<Void>> addRegistration(String address, HandlerRegistration<T> registration, boolean replyHandler, boolean localOnly, Promise<Void> promise) {
     HandlerHolder<T> holder = addLocalRegistration(address, registration, replyHandler, localOnly);
     onLocalRegistration(holder, promise);
-    return holder;
+    return p -> {
+      removeRegistration(holder, p);
+    };
   }
 
   protected <T> void onLocalRegistration(HandlerHolder<T> handlerHolder, Promise<Void> promise) {

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -395,7 +395,13 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
         return new ReplyException(ReplyFailure.NO_HANDLERS, "No handlers for address " + msg.address);
       }
     } else {
-      return new ReplyException(ReplyFailure.NO_HANDLERS, "No handlers for address " + frame.address());
+      if (handlers != null) {
+        HandlerHolder holder = nextHandler(handlers, messageLocal);
+        holder.handler.receive(frame);
+        return null;
+      } else {
+        return new ReplyException(ReplyFailure.NO_HANDLERS, "No handlers for address " + frame.address());
+      }
     }
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -156,6 +156,31 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   }
 
   @Override
+  public Future<Void> bindStream(String address, Handler<MessageStream> handler) {
+    ContextInternal ctx = vertx.getOrCreateContext();
+    HandlerRegistration reg = new StreamServer(this, ctx, address, handler);
+    Promise<Void> promise = ctx.promise();
+    reg.register(true, false, promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<MessageStream> connectStream(String address) {
+    ContextInternal ctx = vertx.getOrCreateContext();
+    String sourceAddress = generateReplyAddress();
+    Promise<MessageStream> promise2 = ctx.promise();
+    StreamBase reg = new ClientStream(this, sourceAddress, ctx, promise2);
+    Promise<Void> promise = ctx.promise();
+    reg.register(false, false, promise);
+    promise.future().onComplete(ar -> {
+      if (ar.succeeded()) {
+        sendLocally(new SynFrame(sourceAddress, address), ctx.promise());
+      }
+    });
+    return promise2.future();
+  }
+
+  @Override
   public EventBus publish(String address, Object message) {
     return publish(address, message, new DeliveryOptions());
   }

--- a/src/main/java/io/vertx/core/eventbus/impl/FinFrame.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/FinFrame.java
@@ -1,0 +1,27 @@
+package io.vertx.core.eventbus.impl;
+
+import io.vertx.core.buffer.Buffer;
+
+class FinFrame implements Frame {
+
+  final String addr;
+
+  public FinFrame(String addr) {
+    this.addr = addr;
+  }
+
+  @Override
+  public String address() {
+    return addr;
+  }
+
+  @Override
+  public Buffer encodeToWire() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isFromWire() {
+    return false;
+  }
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/Frame.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/Frame.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.eventbus.impl;
+
+import io.vertx.core.buffer.Buffer;
+
+public interface Frame {
+
+  String address();
+
+  Buffer encodeToWire();
+
+  boolean isFromWire();
+
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerHolder.java
@@ -22,14 +22,12 @@ public class HandlerHolder<T> {
 
   public final ContextInternal context;
   public final HandlerRegistration<T> handler;
-  public final boolean replyHandler;
   public final boolean localOnly;
   private boolean removed;
 
-  public HandlerHolder(HandlerRegistration<T> handler, boolean replyHandler, boolean localOnly, ContextInternal context) {
+  public HandlerHolder(HandlerRegistration<T> handler, boolean localOnly, ContextInternal context) {
     this.context = context;
     this.handler = handler;
-    this.replyHandler = replyHandler;
     this.localOnly = localOnly;
   }
 
@@ -74,10 +72,6 @@ public class HandlerHolder<T> {
 
   public HandlerRegistration<T> getHandler() {
     return handler;
-  }
-
-  public boolean isReplyHandler() {
-    return replyHandler;
   }
 
   public boolean isLocalOnly() {

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -58,13 +58,13 @@ public abstract class HandlerRegistration<T> implements Closeable {
 
   protected abstract void dispatch(Message<T> msg, ContextInternal context, Handler<Message<T>> handler);
 
-  synchronized void register(String repliedAddress, boolean localOnly, Promise<Void> promise) {
+  synchronized void register(boolean broadcast, boolean localOnly, Promise<Void> promise) {
     if (registered != null) {
       throw new IllegalStateException();
     }
-    registered = bus.addRegistration(address, this, repliedAddress != null, localOnly, promise);
+    registered = bus.addRegistration(address, this, broadcast, localOnly, promise);
     if (bus.metrics != null) {
-      metric = bus.metrics.handlerRegistered(address, repliedAddress);
+      metric = bus.metrics.handlerRegistered(address, null /* regression */);
     }
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -20,13 +20,15 @@ import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingPolicy;
 
+import java.util.function.Consumer;
+
 public abstract class HandlerRegistration<T> implements Closeable {
 
   public final ContextInternal context;
   public final EventBusImpl bus;
   public final String address;
   public final boolean src;
-  private HandlerHolder<T> registered;
+  private Consumer<Promise<Void>> registered;
   private Object metric;
 
   HandlerRegistration(ContextInternal context,
@@ -74,7 +76,7 @@ public abstract class HandlerRegistration<T> implements Closeable {
     Promise<Void> promise = context.promise();
     synchronized (this) {
       if (registered != null) {
-        bus.removeRegistration(registered, promise);
+        registered.accept(promise);
         registered = null;
         if (bus.metrics != null) {
           bus.metrics.handlerUnregistered(metric);

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -41,20 +41,22 @@ public abstract class HandlerRegistration<T> implements Closeable {
     this.address = address;
   }
 
-  void receive(MessageImpl msg) {
+  void receive(Frame msg) {
     if (bus.metrics != null) {
-      bus.metrics.scheduleMessage(metric, msg.isLocal());
+      bus.metrics.scheduleMessage(metric, ((MessageImpl)msg).isLocal()); // Will CCE
     }
     context.executor().execute(() -> {
       // Need to check handler is still there - the handler might have been removed after the message were sent but
       // before it was received
       if (!doReceive(msg)) {
-        discard(msg);
+        if (msg instanceof Message) {
+          discard((Message<T>) msg);
+        }
       }
     });
   }
 
-  protected abstract boolean doReceive(Message<T> msg);
+  protected abstract boolean doReceive(Frame msg);
 
   protected abstract void dispatch(Message<T> msg, ContextInternal context, Handler<Message<T>> handler);
 

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
@@ -216,7 +216,7 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
           registered = true;
           Promise<Void> p = result;
           Promise<Void> registration = context.promise();
-          register(null, localOnly, registration);
+          register(true, localOnly, registration);
           registration.future().onComplete(ar -> {
             if (ar.succeeded()) {
               p.tryComplete();

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
@@ -131,6 +131,15 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
     return fut;
   }
 
+  @Override
+  protected boolean doReceive(Frame msg) {
+    if (msg instanceof Message) {
+      return doReceive((Message<T>) msg);
+    } else {
+      return false;
+    }
+  }
+
   protected boolean doReceive(Message<T> message) {
     Handler<Message<T>> theHandler;
     synchronized (this) {

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -13,6 +13,7 @@ package io.vertx.core.eventbus.impl;
 
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.*;
 
 import java.util.List;
@@ -21,7 +22,7 @@ import java.util.Map;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class MessageImpl<U, V> implements Message<V> {
+public class MessageImpl<U, V> implements Message<V>, Frame {
 
   protected MessageCodec<U, V> messageCodec;
   protected final EventBusImpl bus;
@@ -139,5 +140,15 @@ public class MessageImpl<U, V> implements Message<V> {
 
   protected boolean isLocal() {
     return true;
+  }
+
+  @Override
+  public Buffer encodeToWire() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isFromWire() {
+    throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
@@ -45,14 +45,8 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
 
   @Override
   public Future<Void> write(T body) {
-    Promise<Void> promise = ((VertxInternal)vertx).getOrCreateContext().promise();
-    write(body, promise);
-    return promise.future();
-  }
-
-  private void write(T data, Promise<Void> handler) {
-    MessageImpl msg = bus.createMessage(send, address, options.getHeaders(), data, options.getCodecName());
-    bus.sendOrPubInternal(msg, options, null, handler);
+    MessageImpl msg = bus.createMessage(send, address, options.getHeaders(), body, options.getCodecName());
+    return bus.sendOrPubInternal(msg, options, null);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
@@ -83,7 +83,7 @@ class ReplyHandler<T> extends HandlerRegistration<T> implements Handler<Long> {
   }
 
   void register() {
-    register(repliedAddress, true, null);
+    register(repliedAddress, false, null);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
@@ -83,7 +83,7 @@ class ReplyHandler<T> extends HandlerRegistration<T> implements Handler<Long> {
   }
 
   void register() {
-    register(repliedAddress, false, null);
+    register(false, false, null);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
@@ -77,9 +77,13 @@ class ReplyHandler<T> extends HandlerRegistration<T> implements Handler<Long> {
   }
 
   @Override
-  protected boolean doReceive(Message<T> reply) {
-    dispatch(null, reply, context);
-    return true;
+  protected boolean doReceive(Frame msg) {
+    if (msg instanceof Message) {
+      dispatch(null, (Message<T>) msg, context);
+      return true;
+    } else {
+      return false;
+    }
   }
 
   void register() {

--- a/src/main/java/io/vertx/core/eventbus/impl/StreamBase.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/StreamBase.java
@@ -1,0 +1,75 @@
+package io.vertx.core.eventbus.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageStream;
+import io.vertx.core.impl.ContextInternal;
+
+class StreamBase extends HandlerRegistration implements MessageStream {
+
+  private Handler<Message<String>> handler;
+  private Handler<Void> endHandler;
+  final String localAddress;
+  String remoteAddress;
+  private boolean halfClosed;
+
+  StreamBase(String localAddress, ContextInternal context, EventBusImpl bus, String address, boolean src) {
+    super(context, bus, address, src);
+    this.localAddress = localAddress;
+  }
+
+  @Override
+  protected boolean doReceive(Frame frame) {
+    if (frame instanceof MessageImpl) {
+      MessageImpl msg = (MessageImpl) frame;
+      Handler<Message<String>> h = handler;
+      if (h != null) {
+        h.handle(msg);
+      }
+    } else if (frame instanceof FinFrame) {
+      Handler<Void> h = endHandler;
+      if (h != null) {
+        h.handle(null);
+      }
+      if (halfClosed) {
+        unregister();
+      } else {
+        halfClosed = true;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  protected void dispatch(Message msg, ContextInternal context, Handler handler) {
+
+  }
+
+  @Override
+  public void handler(Handler<Message<String>> handler) {
+    this.handler = handler;
+  }
+
+  @Override
+  public void endHandler(Handler<Void> handler) {
+    this.endHandler = handler;
+  }
+
+  @Override
+  public void write(String body) {
+    MessageImpl msg = new MessageImpl(remoteAddress, MultiMap.caseInsensitiveMultiMap(), body, CodecManager.STRING_MESSAGE_CODEC, true, bus);
+    bus.sendLocally(msg, context.promise());
+  }
+
+  @Override
+  public void end() {
+    FinFrame fin = new FinFrame(remoteAddress);
+    bus.sendLocally(fin, context.promise());
+    if (halfClosed) {
+      unregister();
+    } else {
+      halfClosed = true;
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/StreamServer.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/StreamServer.java
@@ -1,0 +1,42 @@
+package io.vertx.core.eventbus.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageStream;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.future.PromiseInternal;
+
+class StreamServer extends HandlerRegistration {
+  private final EventBusImpl eventBus;
+  private final Handler<MessageStream> handler;
+
+  public StreamServer(EventBusImpl eventBus, ContextInternal ctx, String address, Handler<MessageStream> handler) {
+    super(ctx, eventBus, address, false);
+    this.eventBus = eventBus;
+    this.handler = handler;
+  }
+
+  @Override
+  protected boolean doReceive(Frame frame) {
+    if (frame instanceof SynFrame) {
+      SynFrame syn = (SynFrame) frame;
+      String localAddress = eventBus.generateReplyAddress();
+      StreamBase ss = new StreamBase(localAddress, context, eventBus, localAddress, false);
+      ss.remoteAddress = syn.src;
+      PromiseInternal<Void> p = context.promise();
+      ss.register(false, true, p);
+      p.onComplete(ar -> {
+        if (ar.succeeded()) {
+          SynFrame reply = new SynFrame(localAddress, syn.src);
+          eventBus.sendLocally(reply, context.promise());
+          handler.handle(ss);
+        }
+      });
+    }
+    return true;
+  }
+
+  @Override
+  protected void dispatch(Message msg, ContextInternal context, Handler handler) {
+  }
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/SynFrame.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/SynFrame.java
@@ -1,0 +1,29 @@
+package io.vertx.core.eventbus.impl;
+
+import io.vertx.core.buffer.Buffer;
+
+public class SynFrame implements Frame {
+
+  final String src;
+  final String dst;
+
+  public SynFrame(String src, String dst) {
+    this.src = src;
+    this.dst = dst;
+  }
+
+  @Override
+  public String address() {
+    return dst;
+  }
+
+  @Override
+  public Buffer encodeToWire() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isFromWire() {
+    return false;
+  }
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -17,11 +17,7 @@ import io.vertx.core.eventbus.AddressHelper;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBusOptions;
 import io.vertx.core.eventbus.MessageCodec;
-import io.vertx.core.eventbus.impl.CodecManager;
-import io.vertx.core.eventbus.impl.EventBusImpl;
-import io.vertx.core.eventbus.impl.HandlerHolder;
-import io.vertx.core.eventbus.impl.HandlerRegistration;
-import io.vertx.core.eventbus.impl.MessageImpl;
+import io.vertx.core.eventbus.impl.*;
 import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.EventLoopContext;
@@ -227,7 +223,7 @@ public class ClusteredEventBus extends EventBusImpl {
   }
 
   @Override
-  protected boolean isMessageLocal(MessageImpl msg) {
+  protected boolean isMessageLocal(Frame msg) {
     ClusteredMessage clusteredMessage = (ClusteredMessage) msg;
     return !clusteredMessage.isFromWire();
   }
@@ -318,7 +314,7 @@ public class ClusteredEventBus extends EventBusImpl {
     };
   }
 
-  private <T> void sendToNode(String nodeId, MessageImpl<?, T> message, Promise<Void> writePromise) {
+  private <T> void sendToNode(String nodeId, Frame message, Promise<Void> writePromise) {
     if (nodeId != null && !nodeId.equals(this.nodeId)) {
       sendRemote(nodeId, message, writePromise);
     } else {
@@ -326,7 +322,7 @@ public class ClusteredEventBus extends EventBusImpl {
     }
   }
 
-  private <T> void sendToNodes(Iterable<String> nodeIds, MessageImpl<?, T> message, Promise<Void> writePromise) {
+  private <T> void sendToNodes(Iterable<String> nodeIds, Frame message, Promise<Void> writePromise) {
     boolean sentRemote = false;
     if (nodeIds != null) {
       for (String nid : nodeIds) {
@@ -350,7 +346,7 @@ public class ClusteredEventBus extends EventBusImpl {
     }
   }
 
-  private void sendRemote(String remoteNodeId, MessageImpl<?, ?> message, Promise<Void> writePromise) {
+  private void sendRemote(String remoteNodeId, Frame message, Promise<Void> writePromise) {
     // We need to deal with the fact that connecting can take some time and is async, and we cannot
     // block to wait for it. So we add any sends to a pending list if not connected yet.
     // Once we connect we send them.

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredHandlerHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredHandlerHolder.java
@@ -19,8 +19,8 @@ public class ClusteredHandlerHolder<T> extends HandlerHolder<T> {
 
   private final long seq;
 
-  public ClusteredHandlerHolder(HandlerRegistration<T> handler, boolean replyHandler, boolean localOnly, ContextInternal context, long seq) {
-    super(handler, replyHandler, localOnly, context);
+  public ClusteredHandlerHolder(HandlerRegistration<T> handler, boolean localOnly, ContextInternal context, long seq) {
+    super(handler, localOnly, context);
     this.seq = seq;
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
@@ -14,7 +14,7 @@ package io.vertx.core.eventbus.impl.clustered;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBusOptions;
-import io.vertx.core.eventbus.impl.OutboundDeliveryContext;
+import io.vertx.core.eventbus.impl.MessageImpl;
 import io.vertx.core.eventbus.impl.codecs.PingMessageCodec;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.logging.Logger;
@@ -41,11 +41,20 @@ class ConnectionHolder {
   private final VertxInternal vertx;
   private final EventBusMetrics metrics;
 
-  private Queue<OutboundDeliveryContext<?>> pending;
+  private Queue<SomeTask> pending;
   private NetSocket socket;
   private boolean connected;
   private long timeoutID = -1;
   private long pingTimeoutID = -1;
+
+  private static class SomeTask {
+    final MessageImpl<?, ?> message;
+    final Promise<Void> writePromise;
+    SomeTask(MessageImpl<?, ?> message, Promise<Void> writePromise) {
+      this.message = message;
+      this.writePromise = writePromise;
+    }
+  }
 
   ConnectionHolder(ClusteredEventBus eventBus, String remoteNodeId) {
     this.eventBus = eventBus;
@@ -70,13 +79,13 @@ class ConnectionHolder {
   }
 
   // TODO optimise this (contention on monitor)
-  synchronized void writeMessage(OutboundDeliveryContext<?> ctx) {
+  synchronized void writeMessage(MessageImpl<?, ?> message, Promise<Void> writePromise) {
     if (connected) {
-      Buffer data = ((ClusteredMessage) ctx.message).encodeToWire();
+      Buffer data = ((ClusteredMessage) message).encodeToWire();
       if (metrics != null) {
-        metrics.messageWritten(ctx.message.address(), data.length());
+        metrics.messageWritten(message.address(), data.length());
       }
-      socket.write(data).onComplete(ctx);
+      socket.write(data).onComplete(writePromise);
     } else {
       if (pending == null) {
         if (log.isDebugEnabled()) {
@@ -84,7 +93,7 @@ class ConnectionHolder {
         }
         pending = new ArrayDeque<>();
       }
-      pending.add(ctx);
+      pending.add(new SomeTask(message, writePromise));
     }
   }
 
@@ -100,10 +109,10 @@ class ConnectionHolder {
       vertx.cancelTimer(pingTimeoutID);
     }
     synchronized (this) {
-      OutboundDeliveryContext<?> msg;
+      SomeTask msg;
       if (pending != null) {
         while ((msg = pending.poll()) != null) {
-          msg.written(cause);
+          msg.writePromise.tryFail(cause);
         }
       }
     }
@@ -150,12 +159,12 @@ class ConnectionHolder {
       if (log.isDebugEnabled()) {
         log.debug("Draining the queue for server " + remoteNodeId);
       }
-      for (OutboundDeliveryContext<?> ctx : pending) {
+      for (SomeTask ctx : pending) {
         Buffer data = ((ClusteredMessage<?, ?>)ctx.message).encodeToWire();
         if (metrics != null) {
           metrics.messageWritten(ctx.message.address(), data.length());
         }
-        socket.write(data).onComplete(ctx);
+        socket.write(data).onComplete(ctx.writePromise);
       }
     }
     pending = null;

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
@@ -14,6 +14,7 @@ package io.vertx.core.eventbus.impl.clustered;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBusOptions;
+import io.vertx.core.eventbus.impl.Frame;
 import io.vertx.core.eventbus.impl.MessageImpl;
 import io.vertx.core.eventbus.impl.codecs.PingMessageCodec;
 import io.vertx.core.impl.VertxInternal;
@@ -48,9 +49,9 @@ class ConnectionHolder {
   private long pingTimeoutID = -1;
 
   private static class SomeTask {
-    final MessageImpl<?, ?> message;
+    final Frame message;
     final Promise<Void> writePromise;
-    SomeTask(MessageImpl<?, ?> message, Promise<Void> writePromise) {
+    SomeTask(Frame message, Promise<Void> writePromise) {
       this.message = message;
       this.writePromise = writePromise;
     }
@@ -79,9 +80,9 @@ class ConnectionHolder {
   }
 
   // TODO optimise this (contention on monitor)
-  synchronized void writeMessage(MessageImpl<?, ?> message, Promise<Void> writePromise) {
+  synchronized void writeMessage(Frame message, Promise<Void> writePromise) {
     if (connected) {
-      Buffer data = ((ClusteredMessage) message).encodeToWire();
+      Buffer data = message.encodeToWire();
       if (metrics != null) {
         metrics.messageWritten(message.address(), data.length());
       }

--- a/src/main/java/io/vertx/core/spi/cluster/NodeSelector.java
+++ b/src/main/java/io/vertx/core/spi/cluster/NodeSelector.java
@@ -13,7 +13,6 @@ package io.vertx.core.spi.cluster;
 
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.Message;
 import io.vertx.core.impl.VertxBuilder;
 import io.vertx.core.spi.VertxServiceProvider;
 
@@ -47,20 +46,16 @@ public interface NodeSelector extends VertxServiceProvider {
    *
    * <p> The provided {@code promise} needs to be completed with {@link Promise#tryComplete} and {@link Promise#tryFail}
    * as it might completed outside the selector.
-   *
-   * @throws IllegalArgumentException if {@link Message#isSend()} returns {@code false}
    */
-  void selectForSend(Message<?> message, Promise<String> promise);
+  void selectForSend(String address, Promise<String> promise);
 
   /**
    * Select a node for publishing the given {@code message}.
    *
    * <p> The provided {@code promise} needs to be completed with {@link Promise#tryComplete} and {@link Promise#tryFail}
    * as it might completed outside the selector.
-   *
-   * @throws IllegalArgumentException if {@link Message#isSend()} returns {@code true}
    */
-  void selectForPublish(Message<?> message, Promise<Iterable<String>> promise);
+  void selectForPublish(String address, Promise<Iterable<String>> promise);
 
   /**
    * Invoked by the {@link ClusterManager} when messaging handler registrations are added or removed.

--- a/src/main/java/io/vertx/core/spi/cluster/impl/DefaultNodeSelector.java
+++ b/src/main/java/io/vertx/core/spi/cluster/impl/DefaultNodeSelector.java
@@ -13,8 +13,6 @@ package io.vertx.core.spi.cluster.impl;
 
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.Message;
-import io.vertx.core.impl.Arguments;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.cluster.NodeSelector;
 import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
@@ -37,17 +35,15 @@ public class DefaultNodeSelector implements NodeSelector {
   }
 
   @Override
-  public void selectForSend(Message<?> message, Promise<String> promise) {
-    Arguments.require(message.isSend(), "selectForSend used for publishing");
-    selectors.withSelector(message, promise, (prom, selector) -> {
+  public void selectForSend(String address, Promise<String> promise) {
+    selectors.withSelector(address, promise, (prom, selector) -> {
       prom.tryComplete(selector.selectForSend());
     });
   }
 
   @Override
-  public void selectForPublish(Message<?> message, Promise<Iterable<String>> promise) {
-    Arguments.require(!message.isSend(), "selectForPublish used for sending");
-    selectors.withSelector(message, promise, (prom, selector) -> {
+  public void selectForPublish(String address, Promise<Iterable<String>> promise) {
+    selectors.withSelector(address, promise, (prom, selector) -> {
       prom.tryComplete(selector.selectForPublish());
     });
   }

--- a/src/main/java/io/vertx/core/spi/cluster/impl/selector/Selectors.java
+++ b/src/main/java/io/vertx/core/spi/cluster/impl/selector/Selectors.java
@@ -35,8 +35,7 @@ public class Selectors {
     this.clusterManager = clusterManager;
   }
 
-  public <T> void withSelector(Message<?> message, Promise<T> promise, BiConsumer<Promise<T>, RoundRobinSelector> task) {
-    String address = message.address();
+  public <T> void withSelector(String address, Promise<T> promise, BiConsumer<Promise<T>, RoundRobinSelector> task) {
     SelectorEntry entry = map.compute(address, (addr, curr) -> {
       return curr == null ? new SelectorEntry() : (curr.isNotReady() ? curr.increment() : curr);
     });

--- a/src/test/java/io/vertx/core/eventbus/CustomNodeSelectorTest.java
+++ b/src/test/java/io/vertx/core/eventbus/CustomNodeSelectorTest.java
@@ -105,12 +105,12 @@ public class CustomNodeSelectorTest extends VertxTestBase {
     }
 
     @Override
-    public void selectForSend(Message<?> message, Promise<String> promise) {
+    public void selectForSend(String address, Promise<String> promise) {
       promise.fail("Not implemented");
     }
 
     @Override
-    public void selectForPublish(Message<?> message, Promise<Iterable<String>> promise) {
+    public void selectForPublish(String address, Promise<Iterable<String>> promise) {
       List<String> nodes = clusterManager.getNodes();
       CompositeFuture future = nodes.stream()
         .map(nodeId -> {

--- a/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
@@ -1531,5 +1531,34 @@ public class LocalEventBusTest extends EventBusTestBase {
     });
     await();
   }
+
+  @Test
+  public void testStream() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    vertx.eventBus().bindStream(ADDRESS1, stream -> {
+      stream.handler(msg -> {
+        assertEquals("ping", msg.body());
+        stream.write(msg.body());
+      });
+      stream.endHandler(v -> {
+        stream.end();
+      });
+    }).onComplete(onSuccess(v -> {
+      latch.countDown();
+    }));
+    awaitLatch(latch);
+    vertx.eventBus().connectStream(ADDRESS1).onComplete(onSuccess(stream -> {
+      stream.write("ping");
+      stream.handler(msg -> {
+        assertEquals("ping", msg.body());
+        stream.end();
+      });
+      stream.endHandler(v -> {
+        testComplete();
+      });
+    }));
+    await();
+  }
+
 }
 

--- a/src/test/java/io/vertx/core/eventbus/MessageQueueOnWorkerThreadTest.java
+++ b/src/test/java/io/vertx/core/eventbus/MessageQueueOnWorkerThreadTest.java
@@ -89,7 +89,7 @@ public class MessageQueueOnWorkerThreadTest extends VertxTestBase {
     }
 
     @Override
-    public void selectForSend(Message<?> message, Promise<String> promise) {
+    public void selectForSend(String address, Promise<String> promise) {
       try {
         NANOSECONDS.sleep(150);
       } catch (InterruptedException e) {
@@ -99,7 +99,7 @@ public class MessageQueueOnWorkerThreadTest extends VertxTestBase {
     }
 
     @Override
-    public void selectForPublish(Message<?> message, Promise<Iterable<String>> promise) {
+    public void selectForPublish(String address, Promise<Iterable<String>> promise) {
       throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/io/vertx/core/eventbus/WriteHandlerLookupFailureTest.java
+++ b/src/test/java/io/vertx/core/eventbus/WriteHandlerLookupFailureTest.java
@@ -38,12 +38,12 @@ public final class WriteHandlerLookupFailureTest extends VertxTestBase {
       .setPort(0);
     NodeSelector nodeSelector = new DefaultNodeSelector() {
       @Override
-      public void selectForSend(Message<?> message, Promise<String> promise) {
+      public void selectForSend(String address, Promise<String> promise) {
         promise.fail(cause);
       }
 
       @Override
-      public void selectForPublish(Message<?> message, Promise<Iterable<String>> promise) {
+      public void selectForPublish(String address, Promise<Iterable<String>> promise) {
         promise.fail("Not implemented");
       }
     };

--- a/src/test/java/io/vertx/core/eventbus/eventbus.md
+++ b/src/test/java/io/vertx/core/eventbus/eventbus.md
@@ -11,37 +11,44 @@ P -> C: MSG(request)
 title Request and response
 hide footbox
 participant Producer as P
-[-> P: send(request)
+[-> P: request(request_message)
 create Source as S
 P --> S: bind ephemeral address
 participant Consumer as C
-P -> C: SYN(Source)/MSG(request)
-S <- C: FIN/MSG(response)
+P -> C: SYN(Source)/MSG(request_message)
+S <- C: FIN/MSG(reply_message)
 Destroy S
-[<- S: reply(response)
+[<- S: response(reply_message)
 ```
 
 ```plantuml
 title General case
 hide footbox
 participant Producer as P
-[-> P: begin
+[-> P: stream = connect("consumer")
 create Source as S
 P --> S: src = bind ephemeral address
 participant Consumer as C
-P -> C: SYN(Source)
+P -> C: SYN(src)
 create Destination as D
-C --> D: bind ephemeral address
-S <- C: ACK(Destination)
-S -> D: MSG
-D -> S: MSG
-S -> D: MSG
+C --> D: dst = bind ephemeral address
+S <- C: ACK(dst)
+[-> S: stream.write(m1)
+S -> D: MSG(m1)
+D -> S: MSG(m2)
+[<- S: handler.handle(m2)
+[-> S: stream.write(m3)
+S -> D: MSG(m3)
+[-> S: stream.end()
 S -> D: FIN
 Destroy D
-D -> S: MSG
-D -> S: MSG
+[<- S: handler.handle(m4)
+D -> S: MSG(m4)
+[<- S: handler.handle(m5)
+D -> S: MSG(m5)
 D -> S: FIN
 Destroy S
+[<- S: endHandler.handle(null)
 ```
 
 ## Todo

--- a/src/test/java/io/vertx/core/eventbus/eventbus.md
+++ b/src/test/java/io/vertx/core/eventbus/eventbus.md
@@ -44,9 +44,10 @@ D -> S: FIN
 Destroy S
 ```
 
-. Todo request and reply
-. Fragmentation
-. Gauge interest
-.. Pascal K.
-.. Stephane Martin
-. service-proxy usage
+## Todo
+
+- Fragmentation
+- Gauge interest
+  - Pascal K.
+  - Stephane Martin
+- service-proxy usage

--- a/src/test/java/io/vertx/core/eventbus/eventbus.md
+++ b/src/test/java/io/vertx/core/eventbus/eventbus.md
@@ -1,0 +1,52 @@
+```plantuml
+title Send
+hide footbox
+participant Producer as P
+[-> P: send(message)
+participant Consumer as C
+P -> C: MSG(request)
+```
+
+```plantuml
+title Request and response
+hide footbox
+participant Producer as P
+[-> P: send(request)
+create Source as S
+P --> S: bind ephemeral address
+participant Consumer as C
+P -> C: SYN(Source)/MSG(request)
+S <- C: FIN/MSG(response)
+Destroy S
+[<- S: reply(response)
+```
+
+```plantuml
+title General case
+hide footbox
+participant Producer as P
+[-> P: begin
+create Source as S
+P --> S: src = bind ephemeral address
+participant Consumer as C
+P -> C: SYN(Source)
+create Destination as D
+C --> D: bind ephemeral address
+S <- C: ACK(Destination)
+S -> D: MSG
+D -> S: MSG
+S -> D: MSG
+S -> D: FIN
+Destroy D
+D -> S: MSG
+D -> S: MSG
+D -> S: FIN
+Destroy S
+```
+
+. Todo request and reply
+. Fragmentation
+. Gauge interest
+.. Pascal K.
+.. Stephane Martin
+. service-proxy usage

--- a/src/test/java/io/vertx/core/spi/cluster/WrappedNodeSelector.java
+++ b/src/test/java/io/vertx/core/spi/cluster/WrappedNodeSelector.java
@@ -34,13 +34,13 @@ public class WrappedNodeSelector implements NodeSelector {
   }
 
   @Override
-  public void selectForSend(Message<?> message, Promise<String> promise) {
-    delegate.selectForSend(message, promise);
+  public void selectForSend(String address, Promise<String> promise) {
+    delegate.selectForSend(address, promise);
   }
 
   @Override
-  public void selectForPublish(Message<?> message, Promise<Iterable<String>> promise) {
-    delegate.selectForPublish(message, promise);
+  public void selectForPublish(String address, Promise<Iterable<String>> promise) {
+    delegate.selectForPublish(address, promise);
   }
 
   @Override


### PR DESCRIPTION
A refactoring that decouples a few things + framing introduction

- decouple the registration handlers from current interactions (e.g remove the reply handler knowledge from the registration handler)
- a registration handler now process generic frames
- a message is a frame
- clustering are responsible to send frames to peers very much like they are sending messages (which is now a specific frame)

Thanks to frames we keep existing interactions as well as allow new interactions to support bidi streaming. Very similar to TCP we have syn/fin frames between peers to control stream boundaries.

See also https://github.com/eclipse-vertx/vert.x/pull/4712 that does the same but keep the existing protocol using codecs to implement the protocol instead of adding frames.




