### PR TITLE
Native transport test profiles should work on aarch64 architectures 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -759,20 +759,6 @@
         <vertx.testNativeTransport>true</vertx.testNativeTransport>
         <vertx.testDomainSockets>false</vertx.testDomainSockets>
       </properties>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <optional>true</optional>
-          <classifier>linux-x86_64</classifier>
-        </dependency>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <optional>true</optional>
-          <classifier>osx-x86_64</classifier>
-        </dependency>
-      </dependencies>
     </profile>
 
     <!-- Run tests with native transport and domain sockets -->
@@ -782,20 +768,6 @@
         <vertx.testNativeTransport>true</vertx.testNativeTransport>
         <vertx.testDomainSockets>true</vertx.testDomainSockets>
       </properties>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <optional>true</optional>
-          <classifier>linux-x86_64</classifier>
-        </dependency>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <optional>true</optional>
-          <classifier>osx-x86_64</classifier>
-        </dependency>
-      </dependencies>
     </profile>
 
     <!-- Documentation generation : activate with -Pdocs -->
@@ -873,10 +845,28 @@
     </profile>
 
     <profile>
-      <id>mac</id>
+      <id>linux</id>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <classifier>linux-x86_64</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>osx-x86_64</id>
       <activation>
         <os>
           <family>mac</family>
+          <arch>x86_64</arch>
         </os>
       </activation>
       <dependencies>
@@ -884,6 +874,36 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-resolver-dns-native-macos</artifactId>
           <classifier>osx-x86_64</classifier>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <classifier>osx-x86_64</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>osx-aarch64</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <classifier>osx-aarch_64</classifier>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <classifier>osx-aarch_64</classifier>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -178,12 +178,13 @@ public abstract class HttpTest extends HttpTestBase {
     for (int i = 0;i < len;i++) {
       File sockFile = TestUtils.tmpFile(".sock");
       SocketAddress sockAddress = SocketAddress.domainSocketAddress(sockFile.getAbsolutePath());
-      HttpServer server = vertx
+      HttpServer server = vx
         .createHttpServer(createBaseServerOptions())
         .requestHandler(req -> req.response().end(sockAddress.path()));
       startServer(sockAddress, server);
       addresses.add(sockAddress);
     }
+    HttpClient client = vx.createHttpClient(createBaseClientOptions());
     for (int i = 0;i < len;i++) {
       SocketAddress sockAddress = addresses.get(i);
       for (int j = 0;j < len;j++) {

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -1985,7 +1985,7 @@ public class NetTest extends VertxTestBase {
     for (int i = 0;i < len;i++) {
       File sockFile = TestUtils.tmpFile(".sock");
       SocketAddress sockAddress = SocketAddress.domainSocketAddress(sockFile.getAbsolutePath());
-      NetServer server = vertx
+      NetServer server = vx
         .createNetServer()
         .connectHandler(so -> {
           so.end(Buffer.buffer(sockAddress.path()));
@@ -1993,6 +1993,7 @@ public class NetTest extends VertxTestBase {
       startServer(sockAddress, server);
       addresses.add(sockAddress);
     }
+    NetClient client = vx.createNetClient();
     for (int i = 0;i < len;i++) {
       for (int j = 0;j < len;j++) {
         SocketAddress sockAddress = addresses.get(i);

--- a/src/test/java/io/vertx/test/core/VertxTestBase.java
+++ b/src/test/java/io/vertx/test/core/VertxTestBase.java
@@ -19,6 +19,7 @@ import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingOptions;
 import io.vertx.test.fakecluster.FakeClusterManager;
+import junit.framework.AssertionFailedError;
 import org.junit.Assert;
 import org.junit.Rule;
 
@@ -64,7 +65,15 @@ public class VertxTestBase extends AsyncTestBase {
     VertxOptions options = getOptions();
     boolean nativeTransport = options.getPreferNativeTransport();
     vertx = vertx(options);
-    if (nativeTransport) {
+    if (nativeTransport && !vertx.isNativeTransportEnabled()) {
+      if (!vertx.isNativeTransportEnabled()) {
+        AssertionFailedError afe = new AssertionFailedError("Expected native transport");
+        Throwable cause = vertx.unavailableNativeTransportCause();
+        if (cause != null) {
+          afe.initCause(cause);
+        }
+        throw afe;
+      }
       assertTrue(vertx.isNativeTransportEnabled());
     }
   }


### PR DESCRIPTION
The build assumes that when testing native transports x86_64 should be used. We should be able to run test with aarch64 as well.

- Move native test dependency declaration to specific profiles activated by the OS and architecture.
- Add the native transport unavailability cause failure when expecting native to be active.
- Fix incorrect tests
