### PR TITLE
Make HTTP client collection be less aggressive with request in progress

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -436,12 +436,14 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
         timerID = -1;
       }
     }
-    httpCM.close();
-    webSocketCM.close();
+    httpCM.shutdown();
+    webSocketCM.shutdown();
     netClient.shutdown(closeTimeout, closeTimeoutUnit).onComplete(p);
   }
 
   private void doClose(Promise<Void> p) {
+    httpCM.close();
+    webSocketCM.close();
     netClient.close().onComplete(p);
   }
 


### PR DESCRIPTION
The switch to Java cleaners has made HttpClient collection close request in progress aggressively. In some tests this can lead to closing the request because the test method is async and the HTTP client created within the method has been collected.

The new behavior soften this and will first shutdown the pool forbidding any new request to be made and then finally close it when all connections have been closed.
