### PR TITLE
Allow late failure from main thread.

### DIFF
--- a/src/test/java/io/vertx/test/core/AsyncTestBaseTest.java
+++ b/src/test/java/io/vertx/test/core/AsyncTestBaseTest.java
@@ -11,6 +11,7 @@
 
 package io.vertx.test.core;
 
+import org.junit.Assert;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
@@ -289,7 +290,7 @@ public class AsyncTestBaseTest extends AsyncTestBase {
         } catch (Throwable ignore) {
         }
         latch.countDown();
-      }).run();
+      }).start();
     }
   }
 
@@ -303,5 +304,17 @@ public class AsyncTestBaseTest extends AsyncTestBase {
     }
     assertEquals(1, result.getFailureCount());
     assertEquals(IllegalStateException.class, result.getFailures().get(0).getException().getClass());
+  }
+
+  @Test
+  public void assertFailuresAfterCompleteFromMainThread() {
+    testComplete();
+    String msg = null;
+    try {
+      assertFalse("it failed", true);
+    } catch (AssertionError e) {
+      msg = e.getMessage();
+    }
+    Assert.assertEquals("it failed", msg);
   }
 }


### PR DESCRIPTION
The vertx test suite forbids failures to be reported from any thread after the test is considered as completed. While this is a good behavior, it seems too restrictive from the main thread (thus coordinating the thread and reporting the erros to the runner) and prevents from writing assertions after the test has completes, e.g use AsyncTestBase methods to assert a predicate after an await() call.
