### PR TITLE
Add annotations which helps code highlight in IntelliJ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <generated.dir>${project.basedir}/src/main/generated</generated.dir>
     <stack.version>5.0.0-SNAPSHOT</stack.version>
     <jmh.version>1.36</jmh.version>
+    <org.jetbrains.annotations.version>24.0.1</org.jetbrains.annotations.version>
     <vertx.testNativeTransport>false</vertx.testNativeTransport>
     <vertx.testDomainSockets>false</vertx.testDomainSockets>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
@@ -155,6 +156,14 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-docgen</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Intelli Sense -->
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>${org.jetbrains.annotations.version}</version>
       <optional>true</optional>
     </dependency>
 

--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -16,6 +16,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.jackson.JacksonFactory;
 import io.vertx.core.spi.JsonFactory;
 import io.vertx.core.spi.json.JsonCodec;
+import org.intellij.lang.annotations.Language;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -79,7 +80,7 @@ public class Json {
    * @return an instance of T
    * @throws DecodeException when there is a parsing or invalid mapping.
    */
-  public static <T> T decodeValue(String str, Class<T> clazz) throws DecodeException {
+  public static <T> T decodeValue(@Language("json") String str, Class<T> clazz) throws DecodeException {
     return CODEC.fromString(str, clazz);
   }
 
@@ -91,7 +92,7 @@ public class Json {
    * @return a JSON element which can be a {@link JsonArray}, {@link JsonObject}, {@link String}, ...etc if the content is an array, object, string, ...etc
    * @throws DecodeException when there is a parsing or invalid mapping.
    */
-  public static Object decodeValue(String str) throws DecodeException {
+  public static Object decodeValue(@Language("json") String str) throws DecodeException {
     return decodeValue(str, Object.class);
   }
 

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -19,6 +19,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import org.intellij.lang.annotations.Language;
 
 import static io.vertx.core.json.impl.JsonUtil.*;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
@@ -48,7 +49,7 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
    *
    * @param json the string of JSON
    */
-  public JsonArray(String json) {
+  public JsonArray(@Language("json") String json) {
     if (json == null) {
       throw new NullPointerException();
     }

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import org.intellij.lang.annotations.Language;
 
 import static io.vertx.core.json.impl.JsonUtil.*;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
@@ -44,7 +45,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
    *
    * @param json the string of JSON
    */
-  public JsonObject(String json) {
+  public JsonObject(@Language("json") String json) {
     if (json == null) {
       throw new NullPointerException();
     }


### PR DESCRIPTION
Motivation: Vert.X has method expecting json-formatted String. IntelliJ Idea IDE has an ability to highlight language syntax for such strings. The goal of this change is to have syntax highlight of Strings pages as inputs to JsonObject.

Note, that this annotation is optional (we don’t need to add real dependency) and it only highlights syntax in the specific IDE.