### PR TITLE
Replace usage of `getCurrentTokenId` with `currentTokenId` in Jackson codec

### DIFF
--- a/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -188,7 +188,7 @@ public class JacksonCodec implements JsonCodec {
   }
 
   private static Object parseAny(JsonParser parser) throws IOException, DecodeException {
-    switch (parser.getCurrentTokenId()) {
+    switch (parser.currentTokenId()) {
       case JsonTokenId.ID_START_OBJECT:
         return parseObject(parser);
       case JsonTokenId.ID_START_ARRAY:
@@ -248,7 +248,7 @@ public class JacksonCodec implements JsonCodec {
     List<Object> array = new ArrayList<>();
     while (true) {
       parser.nextToken();
-      int tokenId = parser.getCurrentTokenId();
+      int tokenId = parser.currentTokenId();
       if (tokenId == JsonTokenId.ID_FIELD_NAME) {
         throw new UnsupportedOperationException();
       } else if (tokenId == JsonTokenId.ID_END_ARRAY) {


### PR DESCRIPTION
Motivation:

This method was deprecated in Jackson `2.12`



