### PR TITLE
Use class declared constructor

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/ClusterSerializableCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/ClusterSerializableCodec.java
@@ -47,7 +47,7 @@ public class ClusterSerializableCodec implements MessageCodec<ClusterSerializabl
     ClusterSerializable clusterSerializable;
     try {
       Class<?> clazz = getClassLoader().loadClass(className);
-      clusterSerializable = (ClusterSerializable) clazz.newInstance();
+      clusterSerializable = (ClusterSerializable) clazz.getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/io/vertx/core/impl/JavaVerticleFactory.java
+++ b/src/main/java/io/vertx/core/impl/JavaVerticleFactory.java
@@ -44,7 +44,7 @@ public class JavaVerticleFactory implements VerticleFactory {
       promise.fail(e);
       return;
     }
-    promise.complete(clazz::newInstance);
+    promise.complete(() -> clazz.getDeclaredConstructor().newInstance());
   }
 
 }

--- a/src/main/java/io/vertx/core/impl/VertxBuilder.java
+++ b/src/main/java/io/vertx/core/impl/VertxBuilder.java
@@ -313,7 +313,7 @@ public class VertxBuilder {
         // We allow specify a sys prop for the cluster manager factory which overrides ServiceLoader
         try {
           Class<?> clazz = Class.forName(clusterManagerClassName);
-          clusterManager = (ClusterManager) clazz.newInstance();
+          clusterManager = (ClusterManager) clazz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
           throw new IllegalStateException("Failed to instantiate " + clusterManagerClassName, e);
         }

--- a/src/main/java/io/vertx/core/logging/LoggerFactory.java
+++ b/src/main/java/io/vertx/core/logging/LoggerFactory.java
@@ -61,7 +61,7 @@ public class LoggerFactory {
   private static boolean configureWith(String name, boolean shortName, ClassLoader loader) {
     try {
       Class<?> clazz = Class.forName(shortName ? "io.vertx.core.logging." + name + "LogDelegateFactory" : name, true, loader);
-      LogDelegateFactory factory = (LogDelegateFactory) clazz.newInstance();
+      LogDelegateFactory factory = (LogDelegateFactory) clazz.getDeclaredConstructor().newInstance();
       if (!factory.isAvailable()) {
         return false;
       }


### PR DESCRIPTION
Motivation:

Quoting from the Javadocs 

> Deprecated
> This method propagates any exception thrown by the nullary constructor, including a checked exception. Use of this method effectively bypasses the compile-time exception checking that would otherwise be performed by the compiler. The Constructor.newInstance method avoids this problem by wrapping any exception thrown by the constructor in a (checked) InvocationTargetException.
> The call
>  clazz.newInstance()
> can be replaced by
>  clazz.getDeclaredConstructor().newInstance()
> The latter sequence of calls is inferred to be able to throw the additional exception types InvocationTargetException and NoSuchMethodException. Both of these exception types are subclasses of ReflectiveOperationException.


