### PR TITLE
[SimpleConnectionPool] Add release option to connection pool Lease

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/pool/Lease.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/Lease.java
@@ -10,6 +10,9 @@
  */
 package io.vertx.core.net.impl.pool;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
 /**
  * A recyclable object.
  */
@@ -25,4 +28,7 @@ public interface Lease<T> {
    */
   void recycle();
 
+  default void release(Handler<AsyncResult<T>> handler) {
+    recycle();
+  }
 }


### PR DESCRIPTION


Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines

Motivation:
This PR tries to implement https://github.com/eclipse-vertx/vert.x/issues/4680. 

A new method, `release(Handler<AsyncResult<T>> handler)` is added to the `Lease` interface, with the default implementation calling `recycle()`.

In `SimpleConnectionPool`, `LeaseImpl` implements the `release()` method by invoking `slot.pool.release()`.

The `release()` method in the Pool reduces `slot.usage` by 1, and if the usage count reaches 0, it invokes `pool.remove(slot)`.

The PR also introduces another member variable within the Slot object, called `inactive (boolean)`. When `release()` is invoked on a slot, the slot is marked as inactive irrespective of the usage count. `inactive` is also set to true in `Evict`, before we remove the slot (when usage count is 0).

A new `Slot` is initialized with `inactive` as `true`. The only time `inactive` gets set to `false` is when a connection is successfully established for the slot (`ConnectSuccess`).

In `pool.acquire`, we skip slots that are marked as inactive. This behavior means it is better to invoke `pool.connect()` whenever a slot is removed, even when there are no Waiters. This change will be made in a follow-up PR.

`release()` can subsequently be used by SqlConnectionPool instead of recycle(), when it determines that a given connection is past its maxLifetime (else it uses recycle()).


