### PR TITLE
Update `isAlpnAvailable`  method

### DIFF
--- a/src/main/java/io/vertx/core/net/OpenSSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/OpenSSLEngineOptions.java
@@ -37,7 +37,7 @@ public class OpenSSLEngineOptions extends SSLEngineOptions {
    * @return when alpn support is available via OpenSSL engine
    */
   public static boolean isAlpnAvailable() {
-    return OpenSsl.isAlpnSupported();
+    return SslProvider.isAlpnSupported(SslProvider.OPENSSL);
   }
 
   /**


### PR DESCRIPTION
Motivation:

The existing usage is deprecated 

>     /**
>      * Returns {@code true} if the used version of openssl supports
>      * <a href="https://tools.ietf.org/html/rfc7301">ALPN</a>.
>      *
>      * @deprecated use {@link SslProvider#isAlpnSupported(SslProvider)} with {@link SslProvider#OPENSSL}.
>      */
>     @Deprecated
>     public static boolean isAlpnSupported() {
>         return version() >= 0x10002000L;
>
>    }