### PR TITLE
Use fast thread local and fix GC nepotism (Fixes #4749)

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/pool/Task.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/Task.java
@@ -25,10 +25,9 @@ public abstract class Task {
     return next;
   }
 
-  protected final void runNextTasks(CombinerExecutor.InProgressHead head) {
+  protected final void runNextTasks() {
     Task task = this;
     while (task != null) {
-      head.head = task;
       task.run();
       final Task next = task.next;
       // help GC :P

--- a/src/main/java/io/vertx/core/net/impl/pool/Task.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/Task.java
@@ -12,9 +12,30 @@ package io.vertx.core.net.impl.pool;
 
 public abstract class Task {
 
-  Task prev = this;
-  Task next;
+  private Task next;
+
+  public Task replaceNext(Task next) {
+    Task oldNext = this.next;
+    this.next = next;
+    return oldNext;
+  }
+
+  public Task next(Task next) {
+    this.next = next;
+    return next;
+  }
+
+  protected final void runNextTasks(CombinerExecutor.InProgressHead head) {
+    Task task = this;
+    while (task != null) {
+      head.head = task;
+      task.run();
+      final Task next = task.next;
+      // help GC :P
+      task.next = null;
+      task = next;
+    }
+  }
 
   public abstract void run();
-
 }


### PR DESCRIPTION
Thanks to make the list single linked, fixing GC nepotism is now simpler, but this has forced to remove `pollAndExecute`
because we need 2 state variables to hold the current head/tail of the task list.

For this same reason, we are forced to define an additional `InProgressHead` class to keep up to date the current head in order to allow reentrant tasks to keep on being added to the current one.
