### PR TITLE
Address resolver state validity check

### DIFF
--- a/src/main/java/io/vertx/core/spi/resolver/AddressResolver.java
+++ b/src/main/java/io/vertx/core/spi/resolver/AddressResolver.java
@@ -45,6 +45,16 @@ public interface AddressResolver<S, A extends Address, M> {
   Future<S> resolve(A address);
 
   /**
+   * Check the state validity.
+   *
+   * @param state the state to check
+   * @return whether the state is valid
+   */
+  default boolean isValid(S state) {
+    return true;
+  }
+
+  /**
    * Pick a socket address for the state.
    *
    * @param state the state


### PR DESCRIPTION
The AddressResolver interface now defines a method to check the validity of the resolver state, the endpoint now can call this method before obtaining a socket address and refresh the result when the state is stale.

This facilitates the implementation of resolvers returning results with a TTL.