### PR TITLE
Use double-locking and lazySet to speedup init and steady-state ctx map loading

### DIFF
--- a/src/main/java/io/vertx/core/impl/ContextBase.java
+++ b/src/main/java/io/vertx/core/impl/ContextBase.java
@@ -177,13 +177,12 @@ public abstract class ContextBase implements ContextInternal {
     if (data != null) {
       return data;
     }
-    synchronized (this) {
-      data = this.data;
-      if (data == null) {
-        data = new ConcurrentHashMap<>();
-        DATA_UPDATER.lazySet(this, data);
-      }
+    data = new ConcurrentHashMap<>();
+    if (DATA_UPDATER.compareAndSet(this, null, data)) {
+      return data;
     }
+    data = this.data;
+    assert data != null;
     return data;
   }
 
@@ -193,13 +192,12 @@ public abstract class ContextBase implements ContextInternal {
     if (data != null) {
       return data;
     }
-    synchronized (this) {
-      data = this.localData;
-      if (data == null) {
-        data = new ConcurrentHashMap<>();
-        LOCAL_DATA_UPDATER.lazySet(this, data);
-      }
+    data = new ConcurrentHashMap<>();
+    if (LOCAL_DATA_UPDATER.compareAndSet(this, null, data)) {
+      return data;
     }
+    data = this.localData;
+    assert data != null;
     return data;
   }
 

--- a/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -124,13 +124,12 @@ class DuplicatedContext implements ContextInternal {
     if (data != null) {
       return data;
     }
-    synchronized (this) {
-      data = this.localData;
-      if (data == null) {
-        data = new ConcurrentHashMap<>();
-        LOCAL_DATA_UPDATER.lazySet(this, data);
-      }
+    data = new ConcurrentHashMap<>();
+    if (LOCAL_DATA_UPDATER.compareAndSet(this, null, data)) {
+      return data;
     }
+    data = this.localData;
+    assert data != null;
     return data;
   }
 

--- a/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -41,7 +41,7 @@ class DuplicatedContext implements ContextInternal {
 
 
   protected final ContextBase delegate;
-  private ConcurrentMap<Object, Object> localData;
+  private volatile ConcurrentMap<Object, Object> localData;
 
   DuplicatedContext(ContextBase delegate) {
     this.delegate = delegate;


### PR DESCRIPTION
Given that users can often retrieve and modify both local or not ctx maps, relying on optimized/cheap `synchronized` access isn't a good idea, especially after https://openjdk.org/jeps/374.

In theory we could have used a `getVolatile`/`compareAndSet` approach here, with no harm (if not that some wasteful empty CHMs can be allocated), but this one should be more known (see https://en.wikipedia.org/wiki/Double-checked_locking).
If you prefer me to just use the atomic reference variant I can do it @vietj (code will be slightly less).

I've introduced a variation on such (see http://psy-lob-saw.blogspot.com/2012/12/atomiclazyset-is-performance-win-for.html and https://shipilev.net/blog/2014/safe-public-construction/) which "relax" the total store ordering of the initialized map, but should always allow a safe-publication of the CHM instance (meaning, not half constructed maps).