### PR TITLE
Deprecate HTTP client host/port properties by an authority property

### DIFF
--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -182,9 +182,9 @@ It also has case-insensitive keys, that means you can do the following:
 {@link examples.HTTPExamples#example8}
 ----
 
-==== Request host
+==== Request authority
 
-Use {@link io.vertx.core.http.HttpServerRequest#host} to return the host of the HTTP request.
+Use {@link io.vertx.core.http.HttpServerRequest#authority} to return the authority of the HTTP request.
 
 For HTTP/1.x requests the `host` header is returned, for HTTP/1 requests the `:authority` pseudo header is returned.
 

--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -17,6 +17,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
@@ -63,19 +64,32 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   HttpClientRequest drainHandler(Handler<Void> handler);
 
   /**
+   * Set the request authority, when using HTTP/1.x this overrides the request {@code host} header, when using
+   * HTTP/2 this sets the {@code authority} pseudo header.
+   *
+   * @param authority the authority
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpClientRequest authority(HostAndPort authority);
+
+  /**
    * Set the host value of the HTTP/1.1 {@code host} header or HTTP/2 {@code authority} pseudo header
-   * <p>The initial value is the same than the server socket address host.
+   * <p>The initial value is the same as the server socket address host.
    * <p>Keep in mind that changing this value won't change the actual server socket address for this request.
    *
    * @param host the host part of the HTTP/1.1 {@code host} header or HTTP/2 {@code authority} pseudo header
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link #authority(HostAndPort)}
    */
+  @Deprecated
   @Fluent
   HttpClientRequest setHost(String host);
 
   /**
    * @return the host value of the HTTP/1.1 {@code host} header or HTTP/2 {@code authority} pseudo header
    */
+  @Deprecated
   String getHost();
 
   /**
@@ -86,13 +100,16 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    *
    * @param port the port part of the HTTP/1.1 {@code host} header or HTTP/2 {@code authority} pseudo header
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link #authority(HostAndPort)}
    */
+  @Deprecated
   @Fluent
   HttpClientRequest setPort(int port);
 
   /**
    * @return the port value of the HTTP/1.1 {@code host} header or HTTP/2 {@code authority} pseudo header
    */
+  @Deprecated
   int getPort();
 
   /**

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -21,6 +21,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.ReadStream;
@@ -136,8 +137,16 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   String query();
 
   /**
-   * @return the request host. For HTTP2 it returns the {@literal :authority} pseudo header otherwise it returns the {@literal Host} header
+   * @return the request authority. For HTTP2 it returns the {@literal :authority} pseudo header otherwise it returns the {@literal Host} header
    */
+  @Nullable
+  HostAndPort authority();
+
+  /**
+   * @return the request host. For HTTP2 it returns the {@literal :authority} pseudo header otherwise it returns the {@literal Host} header
+   * @deprecated instead use {@link #authority()}
+   */
+  @Deprecated
   @Nullable
   String host();
 

--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -17,6 +17,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 
@@ -540,7 +541,7 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    * Same as {@link #push(HttpMethod, String, MultiMap, Handler)} but with an {@code handler} called when the operation completes
    */
   default Future<HttpServerResponse> push(HttpMethod method, String path, MultiMap headers) {
-    return push(method, null, path, headers);
+    return push(method, (HostAndPort) null, path, headers);
   }
 
   /**
@@ -570,7 +571,7 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    * Push can be sent only for peer initiated streams and if the response is not ended.
    *
    * @param method the method of the promised request
-   * @param host the host of the promised request
+   * @param authority the authority of the promised request
    * @param path the path of the promised request
    * @param headers the headers of the promised request
    * @param handler the handler notified when the response can be written
@@ -588,6 +589,27 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   /**
    * Same as {@link #push(HttpMethod, String, String, MultiMap, Handler)} but with an {@code handler} called when the operation completes
    */
+  Future<HttpServerResponse> push(HttpMethod method, HostAndPort authority, String path, MultiMap headers);
+
+  /**
+   * Push a response to the client.<p/>
+   *
+   * The {@code handler} will be notified with a <i>success</i> when the push can be sent and with
+   * a <i>failure</i> when the client has disabled push or reset the push before it has been sent.<p/>
+   *
+   * The {@code handler} may be queued if the client has reduced the maximum number of streams the server can push
+   * concurrently.<p/>
+   *
+   * Push can be sent only for peer initiated streams and if the response is not ended.
+   *
+   * @param method the method of the promised request
+   * @param host the host of the promised request
+   * @param path the path of the promised request
+   * @param headers the headers of the promised request
+   * @return a future notified when the response can be written
+   * @deprecated instead use {@link #push(HttpMethod, HostAndPort, String, MultiMap)}
+   */
+  @Deprecated
   Future<HttpServerResponse> push(HttpMethod method, String host, String path, MultiMap headers);
 
   /**

--- a/src/main/java/io/vertx/core/http/ServerWebSocket.java
+++ b/src/main/java/io/vertx/core/http/ServerWebSocket.java
@@ -19,6 +19,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.HostAndPort;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -88,9 +89,17 @@ public interface ServerWebSocket extends WebSocketBase {
 
   /**
    * @return the WebSocket handshake host
+   * @deprecated use {@link #authority()} instead
    */
   @Nullable
+  @Deprecated
   String host();
+
+  /**
+   * @return the WebSocket handshake authority
+   */
+  @Nullable
+  HostAndPort authority();
 
   /*
    * @return the WebSocket handshake URI. This is a relative URI.

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -32,6 +32,8 @@ import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.impl.HostAndPortImpl;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
@@ -71,6 +73,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   private HttpRequest request;
   private io.vertx.core.http.HttpVersion version;
   private io.vertx.core.http.HttpMethod method;
+  private HostAndPort authority;
   private String uri;
   private String path;
   private String query;
@@ -249,6 +252,15 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
       query = HttpUtils.parseQuery(uri());
     }
     return query;
+  }
+
+  @Override
+  public synchronized HostAndPort authority() {
+    if (authority == null) {
+      String host = getHeader(HttpHeaderNames.HOST);
+      authority = HostAndPortImpl.parseHostAndPort(host, isSSL() ? 443 : 80);
+    }
+    return authority;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -40,6 +40,7 @@ import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.observability.HttpResponse;
@@ -814,6 +815,11 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
     }
     close();
     return true;
+  }
+
+  @Override
+  public Future<HttpServerResponse> push(HttpMethod method, HostAndPort authority, String path, MultiMap headers) {
+    return context.failedFuture("HTTP/1 does not support response push");
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -111,6 +111,18 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
       if (uri.getRawUserInfo() != null) {
         return true;
       }
+      CharSequence host = headers.get(HttpHeaders.HOST);
+      if (host != null) {
+        URI hostURI;
+        try {
+          hostURI = new URI(null, host.toString(), null, null, null);
+        } catch (URISyntaxException e) {
+          return true;
+        }
+        if (uri.getRawUserInfo() != null || !uri.getAuthority().equals(hostURI.getAuthority())) {
+          return true;
+        }
+      }
     }
     return false;
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -30,6 +30,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.http.*;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.EventLoopContext;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 
 import java.net.URI;
@@ -177,22 +178,24 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
     }
   }
 
-  void sendPush(int streamId, String host, HttpMethod method, MultiMap headers, String path, StreamPriority streamPriority, Promise<HttpServerResponse> promise) {
+  void sendPush(int streamId, HostAndPort authority, HttpMethod method, MultiMap headers, String path, StreamPriority streamPriority, Promise<HttpServerResponse> promise) {
     EventLoop eventLoop = context.nettyEventLoop();
     if (eventLoop.inEventLoop()) {
-      doSendPush(streamId, host, method, headers, path, streamPriority, promise);
+      doSendPush(streamId, authority, method, headers, path, streamPriority, promise);
     } else {
-      eventLoop.execute(() -> doSendPush(streamId, host, method, headers, path, streamPriority, promise));
+      eventLoop.execute(() -> doSendPush(streamId, authority, method, headers, path, streamPriority, promise));
     }
   }
 
-  private synchronized void doSendPush(int streamId, String host, HttpMethod method, MultiMap headers, String path, StreamPriority streamPriority, Promise<HttpServerResponse> promise) {
+  private synchronized void doSendPush(int streamId, HostAndPort authority, HttpMethod method, MultiMap headers, String path, StreamPriority streamPriority, Promise<HttpServerResponse> promise) {
+    boolean ssl = isSsl();
     Http2Headers headers_ = new DefaultHttp2Headers();
     headers_.method(method.name());
     headers_.path(path);
-    headers_.scheme(isSsl() ? "https" : "http");
-    if (host != null) {
-      headers_.authority(host);
+    headers_.scheme(ssl ? "https" : "http");
+    if (authority != null) {
+      String s = (ssl && authority.port() == 443) || (!ssl && authority.port() == 80) ? authority.host() : authority.host() + ':' + authority.port();
+      headers_.authority(s);
     }
     if (headers != null) {
       headers.forEach(header -> headers_.add(header.getKey(), header.getValue()));

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -41,9 +41,9 @@ import io.vertx.core.http.impl.headers.Http2HeadersAdaptor;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.tracing.TracingPolicy;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.security.cert.X509Certificate;
@@ -336,6 +336,11 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
   @Override
   public String host() {
     return stream.host;
+  }
+
+  @Override
+  public @Nullable HostAndPort authority() {
+    return stream.authority;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -31,7 +31,9 @@ import io.vertx.core.http.StreamPriority;
 import io.vertx.core.http.StreamResetException;
 import io.vertx.core.http.impl.headers.Http2HeadersAdaptor;
 import io.vertx.core.impl.future.PromiseInternal;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.impl.HostAndPortImpl;
 import io.vertx.core.spi.observability.HttpResponse;
 import io.vertx.core.streams.ReadStream;
 
@@ -698,18 +700,38 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public Future<HttpServerResponse> push(HttpMethod method, String host, String path, MultiMap headers) {
+  public Future<HttpServerResponse> push(HttpMethod method, HostAndPort authority, String path, MultiMap headers) {
     if (push) {
       throw new IllegalStateException("A push response cannot promise another push");
     }
-    if (host == null) {
-      host = stream.host;
+    if (authority == null) {
+      authority = stream.authority;
     }
     synchronized (conn) {
       checkValid();
     }
     Promise<HttpServerResponse> promise = stream.context.promise();
-    conn.sendPush(stream.id(), host, method, headers, path, stream.priority(), promise);
+    conn.sendPush(stream.id(), authority, method, headers, path, stream.priority(), promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<HttpServerResponse> push(HttpMethod method, String authority, String path, MultiMap headers) {
+    if (push) {
+      throw new IllegalStateException("A push response cannot promise another push");
+    }
+    HostAndPort hostAndPort = null;
+    if (authority != null) {
+      hostAndPort = HostAndPortImpl.parseHostAndPort(authority, conn.isSsl() ? 443 : 80);
+    }
+    if (hostAndPort == null) {
+      hostAndPort = stream.authority;
+    }
+    synchronized (conn) {
+      checkValid();
+    }
+    Promise<HttpServerResponse> promise = stream.context.promise();
+    conn.sendPush(stream.id(), hostAndPort, method, headers, path, stream.priority(), promise);
     return promise.future();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
@@ -23,6 +23,8 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.StreamPriority;
 import io.vertx.core.http.impl.headers.Http2HeadersAdaptor;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.impl.HostAndPortImpl;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.observability.HttpRequest;
@@ -37,7 +39,8 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
   protected final Http2Headers headers;
   protected final HttpMethod method;
   protected final String uri;
-  protected final String host;
+  protected final String host; // deprecated
+  protected final HostAndPort authority;
   private final TracingPolicy tracingPolicy;
   private Object metric;
   private Object trace;
@@ -58,6 +61,7 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
     this.method = method;
     this.uri = uri;
     this.host = null;
+    this.authority = null;
     this.tracingPolicy = tracingPolicy;
     this.halfClosedRemote = halfClosedRemote;
   }
@@ -72,7 +76,8 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
     }
 
     this.headers = headers;
-    this.host = host;
+    this.host =  host;
+    this.authority = HostAndPortImpl.parseHostAndPort(host, conn.isSsl() ? 443 : 80);
     this.uri = headers.get(":path") != null ? headers.get(":path").toString() : null;
     this.method = headers.get(":method") != null ? HttpMethod.valueOf(headers.get(":method").toString()) : null;
     this.tracingPolicy = tracingPolicy;

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -22,6 +22,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.StreamResetException;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.future.PromiseInternal;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 
 import java.util.Objects;
@@ -120,6 +121,14 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
 
   public String getHost() {
     return host;
+  }
+
+  @Override
+  public synchronized HttpClientRequest authority(HostAndPort authority) {
+    Objects.requireNonNull(authority);
+    this.host = authority.host();
+    this.port = authority.port();
+    return this;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
@@ -22,6 +22,7 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.StreamPriority;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.Pipe;
@@ -121,7 +122,11 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  @Nullable
+  public @Nullable HostAndPort authority() {
+    return delegate.authority();
+  }
+
+  @Override
   public String host() {
     return delegate.host();
   }

--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -20,9 +20,12 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.*;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.WebSocketFrame;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
@@ -44,6 +47,7 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocketImpl> 
   private final long closingTimeoutMS;
   private final String scheme;
   private final String host;
+  private final HostAndPort authority;
   private final String uri;
   private final String path;
   private final String query;
@@ -66,6 +70,7 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocketImpl> 
     this.closingTimeoutMS = closingTimeout >= 0 ? closingTimeout * 1000L : -1L;
     this.scheme = request.scheme();
     this.host = request.host();
+    this.authority = request.authority();
     this.uri = request.uri();
     this.path = request.path();
     this.query = request.query();
@@ -83,6 +88,11 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocketImpl> 
   @Override
   public String host() {
     return host;
+  }
+
+  @Override
+  public HostAndPort authority() {
+    return authority;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/HostAndPort.java
+++ b/src/main/java/io/vertx/core/net/HostAndPort.java
@@ -1,0 +1,33 @@
+package io.vertx.core.net;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.net.impl.HostAndPortImpl;
+
+/**
+ * A combination of host and port.
+ */
+@VertxGen
+public interface HostAndPort {
+
+  /**
+   * Create an instance.
+   *
+   * @param host the host value
+   * @param port the port value
+   * @return the instance.
+   */
+  static HostAndPort create(String host, int port) {
+    return new HostAndPortImpl(host, port);
+  }
+
+  /**
+   * @return the host value
+   */
+  String host();
+
+  /**
+   * @return the port value
+   */
+  int port();
+
+}

--- a/src/main/java/io/vertx/core/net/impl/HostAndPortImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/HostAndPortImpl.java
@@ -1,0 +1,162 @@
+package io.vertx.core.net.impl;
+
+import io.vertx.core.net.HostAndPort;
+
+public class HostAndPortImpl implements HostAndPort {
+
+  static int parseHost(String val, int from, int to) {
+    int pos;
+    if ((pos = parseIPLiteral(val, from, to)) != -1) {
+      return pos;
+    } else if ((pos = parseIPv4Address(val, from, to)) != -1) {
+      return pos;
+    } else if ((pos = parseRegName(val, from, to)) != -1) {
+      return pos;
+    }
+    return -1;
+  }
+
+  private static int foo(int v) {
+    return v == -1 ? -1 : v + 1;
+  }
+
+  static int parseIPv4Address(String s, int from, int to) {
+    for (int i = 0;i < 4;i++) {
+      if (i > 0 && from < to && s.charAt(from++) != '.') {
+        return -1;
+      }
+      from = parseDecOctet(s, from, to);
+      if (from == -1) {
+        return -1;
+      }
+    }
+    return from;
+  }
+
+  static int parseDecOctet(String s, int from, int to) {
+    int val = parseDigit(s, from++, to);
+    switch (val) {
+      case 0:
+        return from;
+      case 1:
+      case 2:
+      case 3:
+      case 4:
+      case 5:
+      case 6:
+      case 7:
+      case 8:
+      case 9:
+        int n = parseDigit(s, from, to);
+        if (n != -1) {
+          val = val * 10 + n;
+          n = parseDigit(s, ++from, to);
+          if (n != -1) {
+            from++;
+            val = val * 10 + n;
+          }
+        }
+        if (val < 256) {
+          return from;
+        }
+    }
+    return -1;
+  }
+
+  private static int parseDigit(String s, int from, int to) {
+    char c;
+    return from < to && isDIGIT(c = s.charAt(from)) ? c - '0' : -1;
+  }
+
+  public static int parseIPLiteral(String s, int from, int to) {
+    return from + 2 < to && s.charAt(from) == '[' ? foo(s.indexOf(']', from + 2)) : -1;
+  }
+
+  public static int parseRegName(String s, int from, int to) {
+    while (from < to) {
+      char c = s.charAt(from);
+      if (isUnreserved(c) || isSubDelims(c)) {
+        from++;
+      } else if (c == '%' && (from + 2) < to && isHEXDIG(s.charAt(c + 1)) && isHEXDIG(s.charAt(c + 2))) {
+        from += 3;
+      } else {
+        break;
+      }
+    }
+    return from;
+  }
+
+  private static boolean isUnreserved(char ch) {
+    return isALPHA(ch) || isDIGIT(ch) || ch == '-' || ch == '.' || ch == '_' || ch == '~';
+  }
+
+  private static boolean isALPHA(char ch) {
+    return ('A' <= ch && ch <= 'Z')
+      || ('a'<= ch && ch <= 'z');
+  }
+
+  private static boolean isDIGIT(char ch) {
+    return ('0' <= ch && ch <= '9');
+  }
+
+  private static boolean isSubDelims(char ch) {
+    return ch == '!' || ch == '$' || ch == '&' || ch == '\'' || ch == '(' || ch == ')' || ch == '*' || ch == '+' || ch == ',' || ch == ';' || ch == '=';
+  }
+
+  static boolean isHEXDIG(char ch) {
+    return isDIGIT(ch) || ('A' <= ch && ch <= 'F') || ('a' <= ch && ch <= 'f');
+  }
+
+  /**
+   * Parse an authority HTTP header, that is <i>host [':' port]</i>
+   * @param s the string to port
+   * @param schemePort the scheme port used when the optional port is specified
+   * @return the parsed value or {@code null} when the string cannot be parsed
+   */
+  public static HostAndPortImpl parseHostAndPort(String s, int schemePort) {
+    int pos = parseHost(s, 0, s.length());
+    if (pos < 1) {
+      return null;
+    }
+    if (pos == s.length()) {
+      return new HostAndPortImpl(s, schemePort);
+    }
+    if (pos < s.length() && s.charAt(pos) == ':') {
+      String host = s.substring(0, pos);
+      int port = 0;
+      while (++pos < s.length()) {
+        int digit = parseDigit(s, pos, s.length());
+        if (digit == -1) {
+          return null;
+        }
+        port = port * 10 + digit;
+      }
+      return new HostAndPortImpl(host, port);
+    }
+    return null;
+  }
+
+  private final String host;
+  private final int port;
+
+  public HostAndPortImpl(String host, int port) {
+    if (host == null) {
+      throw new NullPointerException();
+    }
+    this.host = host;
+    this.port = port;
+  }
+
+  public String host() {
+    return host;
+  }
+
+  public int port() {
+    return port;
+  }
+
+  @Override
+  public String toString() {
+    return host + ':' + port;
+  }
+}

--- a/src/test/java/io/vertx/core/http/Http2ClientTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientTest.java
@@ -272,6 +272,8 @@ public class Http2ClientTest extends Http2TestBase {
       assertEquals(HttpMethod.GET, req.method());
       assertEquals("/somepath", req.path());
       assertEquals(DEFAULT_HTTPS_HOST_AND_PORT, req.host());
+      assertEquals(DEFAULT_HTTPS_HOST, req.authority().host());
+      assertEquals(DEFAULT_HTTPS_PORT, req.authority().port());
       assertEquals("foo_request_value", req.getHeader("Foo_request"));
       assertEquals("bar_request_value", req.getHeader("bar_request"));
       assertEquals(2, req.headers().getAll("juu_request").size());
@@ -358,6 +360,8 @@ public class Http2ClientTest extends Http2TestBase {
   public void testOverrideAuthority() throws Exception {
     server.requestHandler(req -> {
       assertEquals("localhost:4444", req.host());
+      assertEquals("localhost", req.authority().host());
+      assertEquals(4444, req.authority().port());
       req.response().end();
     });
     startServer(testAddress);
@@ -1698,6 +1702,8 @@ public class Http2ClientTest extends Http2TestBase {
           assertNull(upgrade);
         }
         assertEquals(DEFAULT_HTTPS_HOST + ":" + DEFAULT_HTTPS_PORT, req.host());
+        assertEquals(DEFAULT_HTTPS_HOST, req.authority().host());
+        assertEquals(DEFAULT_HTTPS_PORT, req.authority().port());
         req.response().end("wibble");
         assertEquals(HttpVersion.HTTP_1_1, req.version());
       });

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -1302,6 +1302,11 @@ public class Http2ServerTest extends Http2TestBase {
   }
 
   @Test
+  public void testInvalidHost() throws Exception {
+    testMalformedRequestHeaders(new DefaultHttp2Headers().method("GET").scheme("http").authority(DEFAULT_HTTPS_HOST_AND_PORT).path("/").set("host", "something-else"));
+  }
+
+  @Test
   public void testConnectInvalidPath() throws Exception {
     testMalformedRequestHeaders(new DefaultHttp2Headers().method("CONNECT").path("/").authority(DEFAULT_HTTPS_HOST_AND_PORT));
   }

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -432,6 +432,8 @@ public class Http2ServerTest extends Http2TestBase {
       HttpServerResponse resp = req.response();
       assertEquals(HttpMethod.GET, req.method());
       assertEquals(DEFAULT_HTTPS_HOST_AND_PORT, req.host());
+      assertEquals(DEFAULT_HTTPS_HOST, req.authority().host());
+      assertEquals(DEFAULT_HTTPS_PORT, req.authority().port());
       assertEquals("/", req.path());
       assertTrue(req.isSSL());
       assertEquals(expectedStreamId.get(), req.streamId());
@@ -522,6 +524,7 @@ public class Http2ServerTest extends Http2TestBase {
       assertEquals("/some/path?foo=foo_value&bar=bar_value_1&bar=bar_value_2", req.uri());
       assertEquals("http://whatever.com/some/path?foo=foo_value&bar=bar_value_1&bar=bar_value_2", req.absoluteURI());
       assertEquals("whatever.com", req.host());
+      assertEquals("whatever.com", req.authority().host());
       MultiMap params = req.params();
       Set<String> names = params.names();
       assertEquals(2, names.size());
@@ -694,6 +697,7 @@ public class Http2ServerTest extends Http2TestBase {
     server.requestHandler(req -> {
       assertEquals(HttpMethod.CONNECT, req.method());
       assertEquals("whatever.com", req.host());
+      assertEquals("whatever.com", req.authority().host());
       assertNull(req.path());
       assertNull(req.query());
       assertNull(req.scheme());

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -35,11 +35,7 @@ import io.vertx.core.http.impl.ServerCookie;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.core.impl.Utils;
 import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.net.NetClient;
-import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.NetServerOptions;
-import io.vertx.core.net.NetSocket;
-import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.*;
 import io.vertx.core.net.impl.HAProxyMessageCompletionHandler;
 import io.vertx.core.streams.Pump;
 import io.vertx.core.streams.ReadStream;
@@ -332,6 +328,8 @@ public abstract class HttpTest extends HttpTestBase {
     server
       .requestHandler(request -> {
         assertEquals(host + ":" + port, request.host());
+        assertEquals(host, request.authority().host());
+        assertEquals((int)port, request.authority().port());
         request.response().end();
       });
     startServer(testAddress);
@@ -3149,6 +3147,8 @@ public abstract class HttpTest extends HttpTestBase {
   public void testHostHeaderOverridePossible() {
     server.requestHandler(req -> {
       assertEquals("localhost:4444", req.host());
+      assertEquals("localhost", req.authority().host());
+      assertEquals(4444, req.authority().port());
       req.response().end();
     });
 
@@ -4375,6 +4375,7 @@ public abstract class HttpTest extends HttpTestBase {
       public HttpClientRequest setMaxRedirects(int maxRedirects) { throw new UnsupportedOperationException(); }
       public HttpClientRequest setChunked(boolean chunked) { throw new UnsupportedOperationException(); }
       public boolean isChunked() { return false; }
+      public HttpClientRequest authority(HostAndPort authority) { throw new UnsupportedOperationException(); }
       public HttpMethod getMethod() { return method; }
       public String absoluteURI() { return baseURI; }
       public HttpVersion version() { return HttpVersion.HTTP_1_1; }

--- a/src/test/java/io/vertx/core/http/HttpUtilsTest.java
+++ b/src/test/java/io/vertx/core/http/HttpUtilsTest.java
@@ -229,5 +229,4 @@ public class HttpUtilsTest {
     URI uri = HttpUtils.resolveURIReference(base, ref);
     assertEquals(expected, uri.getPath());
   }
-
 }

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -671,14 +671,14 @@ public class WebSocketTest extends VertxTestBase {
 
   private void testWSWriteStream(WebsocketVersion version) throws Exception {
 
-    String host = DEFAULT_HTTP_HOST + ":" + DEFAULT_HTTP_PORT;
     String scheme = "http";
     String path = "/some/path";
     String query = "handshake=bar&wibble=eek";
     String uri = path + "?" + query;
 
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).webSocketHandler(ws -> {
-      assertEquals(host, ws.host());
+      assertEquals(DEFAULT_HTTP_HOST, ws.authority().host());
+      assertEquals(DEFAULT_HTTP_PORT, ws.authority().port());
       assertEquals(scheme, ws.scheme());
       assertEquals(uri, ws.uri());
       assertEquals(path, ws.path());
@@ -721,7 +721,6 @@ public class WebSocketTest extends VertxTestBase {
   }
 
   private void testWSFrames(boolean binary, WebsocketVersion version) throws Exception {
-    String host = DEFAULT_HTTP_HOST + ":" + DEFAULT_HTTP_PORT;
     String scheme = "http";
     String path = "/some/path";
     String query = "handshake=bar&wibble=eek";
@@ -731,7 +730,8 @@ public class WebSocketTest extends VertxTestBase {
     int frames = version == WebsocketVersion.V00 ? 1: 10;
 
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).webSocketHandler(ws -> {
-      assertEquals(host, ws.host());
+      assertEquals(DEFAULT_HTTP_HOST, ws.authority().host());
+      assertEquals(DEFAULT_HTTP_PORT, ws.authority().port());
       assertEquals(scheme, ws.scheme());
       assertEquals(uri, ws.uri());
       assertEquals(path, ws.path());

--- a/src/test/java/io/vertx/core/net/impl/HostAndPortTest.java
+++ b/src/test/java/io/vertx/core/net/impl/HostAndPortTest.java
@@ -1,0 +1,70 @@
+package io.vertx.core.net.impl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HostAndPortTest {
+
+  @Test
+  public void testParseIPLiteral() {
+    assertEquals(-1, HostAndPortImpl.parseIPLiteral("", 0, 0));
+    assertEquals(-1, HostAndPortImpl.parseIPLiteral("[", 0, 1));
+    assertEquals(-1, HostAndPortImpl.parseIPLiteral("[]", 0, 2));
+    assertEquals(3, HostAndPortImpl.parseIPLiteral("[0]", 0, 3));
+    assertEquals(-1, HostAndPortImpl.parseIPLiteral("[0", 0, 2));
+  }
+
+  @Test
+  public void testParseDecOctet() {
+    assertEquals(-1, HostAndPortImpl.parseDecOctet("", 0, 0));
+    assertEquals(1, HostAndPortImpl.parseDecOctet("0", 0, 1));
+    assertEquals(1, HostAndPortImpl.parseDecOctet("9", 0, 1));
+    assertEquals(1, HostAndPortImpl.parseDecOctet("01", 0, 2));
+    assertEquals(2, HostAndPortImpl.parseDecOctet("19", 0, 2));
+    assertEquals(3, HostAndPortImpl.parseDecOctet("192", 0, 3));
+    assertEquals(3, HostAndPortImpl.parseDecOctet("1234", 0, 4));
+    assertEquals(-1, HostAndPortImpl.parseDecOctet("256", 0, 3));
+  }
+
+  @Test
+  public void testParseIPV4Address() {
+    assertEquals(-1, HostAndPortImpl.parseIPv4Address("0.0.0", 0, 5));
+    assertEquals(-1, HostAndPortImpl.parseIPv4Address("0.0.0#0", 0, 7));
+    assertEquals(7, HostAndPortImpl.parseIPv4Address("0.0.0.0", 0, 7));
+    assertEquals(11, HostAndPortImpl.parseIPv4Address("192.168.0.0", 0, 11));
+    assertEquals(-1, HostAndPortImpl.parseIPv4Address("011.168.0.0", 0, 11));
+  }
+
+  @Test
+  public void testParseRegName() {
+    assertEquals(5, HostAndPortImpl.parseRegName("abcdef", 0, 5));
+    assertEquals(5, HostAndPortImpl.parseRegName("abcdef:1234", 0, 5));
+    assertEquals(11, HostAndPortImpl.parseRegName("example.com", 0, 11));
+    assertEquals(14, HostAndPortImpl.parseRegName("example-fr.com", 0, 14));
+  }
+
+  @Test
+  public void testParseHost() {
+    assertEquals(14, HostAndPortImpl.parseHost("example-fr.com", 0, 14));
+    assertEquals(5, HostAndPortImpl.parseHost("[0::]", 0, 5));
+    assertEquals(7, HostAndPortImpl.parseHost("0.0.0.0", 0, 7));
+  }
+
+  @Test
+  public void testParseHostAndPort() {
+    assertHostAndPort("example.com", 8080, "example.com:8080");
+    assertHostAndPort("example.com", -1, "example.com");
+    assertHostAndPort("0.1.2.3", -1, "0.1.2.3");
+    assertHostAndPort("[0::]", -1, "[0::]");
+    assertNull(HostAndPortImpl.parseHostAndPort("", -1));
+    assertNull(HostAndPortImpl.parseHostAndPort("/", -1));
+  }
+
+  private void assertHostAndPort(String expectedHost, int expectedPort, String actual) {
+    HostAndPortImpl hostAndPort = HostAndPortImpl.parseHostAndPort(actual, -1);
+    assertNotNull(hostAndPort);
+    assertEquals(expectedHost, hostAndPort.host());
+    assertEquals(expectedPort, hostAndPort.port());
+  }
+}


### PR DESCRIPTION
The HttpClientRequest/HttpServerRequest exposes the HTTP request auth…ority using a host/port combination for the client request and a single host header for the server. In addition this terminology is also confusing with the server host and port.

Deprecate and provide the request host/port accessors, replaced by an authority property modelled as an HostAndPort object.

This also handle HTTP/2 server request whose host header differs from authority pseudo header when present to treat them as malformed requests.