### PR TITLE
A few HTTP stream writeXXX API are fluent and instead should return a future signaling the success or failure of the write operation

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -463,8 +463,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    * @param payload the frame payload
    * @return a reference to this, so the API can be used fluently
    */
-  @Fluent
-  HttpClientRequest writeCustomFrame(int type, int flags, Buffer payload);
+  Future<Void> writeCustomFrame(int type, int flags, Buffer payload);
 
   /**
    * @return the id of the stream of this response, {@literal -1} when it is not yet determined, i.e
@@ -479,8 +478,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    *
    * @param frame the frame to write
    */
-  @Fluent
-  default HttpClientRequest writeCustomFrame(HttpFrame frame) {
+  default Future<Void> writeCustomFrame(HttpFrame frame) {
     return writeCustomFrame(frame.type(), frame.flags(), frame.payload());
   }
 

--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -229,8 +229,7 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    * Must only be used if the request contains an "Expect:100-Continue" header
    * @return a reference to this, so the API can be used fluently
    */
-  @Fluent
-  HttpServerResponse writeContinue();
+  Future<Void> writeContinue();
 
   /**
    * Used to write an interim 103 Early Hints response to return some HTTP headers before the final HTTP message.
@@ -504,16 +503,14 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    * @param payload the frame payload
    * @return a reference to this, so the API can be used fluently
    */
-  @Fluent
-  HttpServerResponse writeCustomFrame(int type, int flags, Buffer payload);
+  Future<Void> writeCustomFrame(int type, int flags, Buffer payload);
 
   /**
    * Like {@link #writeCustomFrame(int, int, Buffer)} but with an {@link HttpFrame}.
    *
    * @param frame the frame to write
    */
-  @Fluent
-  default HttpServerResponse writeCustomFrame(HttpFrame frame) {
+  default Future<Void> writeCustomFrame(HttpFrame frame) {
     return writeCustomFrame(frame.type(), frame.flags(), frame.payload());
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -624,7 +624,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     }
 
     @Override
-    public void writeFrame(int type, int flags, ByteBuf payload) {
+    public Future<Void> writeFrame(int type, int flags, ByteBuf payload) {
       throw new IllegalStateException("Cannot write an HTTP/2 frame over an HTTP/1.x connection");
     }
 

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -37,6 +37,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.FutureListener;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -455,8 +456,9 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
     context.execute(writable, handler);
   }
 
-  void write100Continue() {
-    chctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE));
+  void write100Continue(FutureListener<Void> listener) {
+    ChannelPromise promise = listener == null ? chctx.voidPromise() : chctx.newPromise().addListener(listener);
+    chctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE), promise);
   }
 
   void write103EarlyHints(HttpHeaders headers, PromiseInternal<Void> promise) {

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -186,7 +186,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
 
   private void check100() {
     if (HttpUtil.is100ContinueExpected(request)) {
-      conn.write100Continue();
+      conn.write100Continue(null);
     }
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.concurrent.FutureListener;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -341,9 +342,10 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public HttpServerResponse writeContinue() {
-    conn.write100Continue();
-    return this;
+  public Future<Void> writeContinue() {
+    Promise<Void> promise = context.promise();
+    conn.write100Continue((FutureListener<Void>) promise);
+    return promise.future();
   }
 
   @Override
@@ -745,8 +747,8 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public HttpServerResponse writeCustomFrame(int type, int flags, Buffer payload) {
-    return this;
+  public Future<Void> writeCustomFrame(int type, int flags, Buffer payload) {
+    return context.failedFuture("HTTP/1 does not support custom frames");
   }
 
   CookieJar cookies() {

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -314,12 +314,13 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public HttpServerResponse writeContinue() {
+  public Future<Void> writeContinue() {
+    Promise<Void> promise = stream.context.promise();
     synchronized (conn) {
       checkHeadWritten();
-      stream.writeHeaders(new DefaultHttp2Headers().status(HttpResponseStatus.CONTINUE.codeAsText()), false, null);
-      return this;
+      stream.writeHeaders(new DefaultHttp2Headers().status(HttpResponseStatus.CONTINUE.codeAsText()), false, promise);
     }
+    return promise.future();
   }
 
   @Override
@@ -482,14 +483,15 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public HttpServerResponse writeCustomFrame(int type, int flags, Buffer payload) {
+  public Future<Void> writeCustomFrame(int type, int flags, Buffer payload) {
+    Promise<Void> promise = stream.context.promise();
     synchronized (conn) {
       checkValid();
       checkSendHeaders(false);
-      stream.writeFrame(type, flags, payload.getByteBuf());
+      stream.writeFrame(type, flags, payload.getByteBuf(), promise);
       ctx.flush();
-      return this;
     }
+    return promise.future();
   }
 
   private void checkValid() {

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -154,8 +154,8 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
     }
 
     @Override
-    public void writeFrame(int type, int flags, ByteBuf payload) {
-      delegate.writeFrame(type, flags, payload);
+    public Future<Void> writeFrame(int type, int flags, ByteBuf payload) {
+      return delegate.writeFrame(type, flags, payload);
     }
 
     @Override
@@ -699,11 +699,11 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
     }
 
     @Override
-    public void writeFrame(int type, int flags, ByteBuf payload) {
+    public Future<Void> writeFrame(int type, int flags, ByteBuf payload) {
       if (upgradedStream != null) {
-        upgradedStream.writeFrame(type, flags, payload);
+        return upgradedStream.writeFrame(type, flags, payload);
       } else {
-        upgradingStream.writeFrame(type, flags, payload);
+        return upgradingStream.writeFrame(type, flags, payload);
       }
     }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -263,12 +263,11 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   }
 
   @Override
-  public HttpClientRequest writeCustomFrame(int type, int flags, Buffer payload) {
+  public Future<Void> writeCustomFrame(int type, int flags, Buffer payload) {
     synchronized (this) {
       checkEnded();
     }
-    stream.writeFrame(type, flags, payload.getByteBuf());
-    return this;
+    return stream.writeFrame(type, flags, payload.getByteBuf());
   }
 
   private void handleDrained(Void v) {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -190,7 +190,7 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
-  public HttpClientRequest writeCustomFrame(int type, int flags, Buffer payload) {
+  public Future<Void> writeCustomFrame(int type, int flags, Buffer payload) {
     throw new UnsupportedOperationException("Cannot write frame with HTTP/1.x ");
   }
 }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -48,7 +48,7 @@ public interface HttpClientStream extends WriteStream<Buffer> {
 
   Future<Void> writeHead(HttpRequestHead request, boolean chunked, ByteBuf buf, boolean end, StreamPriority priority, boolean connect);
   Future<Void> writeBuffer(ByteBuf buf, boolean end);
-  void writeFrame(int type, int flags, ByteBuf payload);
+  Future<Void> writeFrame(int type, int flags, ByteBuf payload);
 
   void continueHandler(Handler<Void> handler);
   void earlyHintsHandler(Handler<MultiMap> handler);

--- a/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
@@ -93,8 +93,8 @@ class StatisticsGatheringHttpClientStream<S, M> implements HttpClientStream {
   }
 
   @Override
-  public void writeFrame(int type, int flags, ByteBuf payload) {
-    delegate.writeFrame(type, flags, payload);
+  public Future<Void> writeFrame(int type, int flags, ByteBuf payload) {
+    return delegate.writeFrame(type, flags, payload);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
@@ -278,8 +278,9 @@ class VertxHttp2ConnectionHandler<C extends Http2ConnectionBase> extends Http2Co
     }
   }
 
-  void writeFrame(Http2Stream stream, byte type, short flags, ByteBuf payload) {
-    encoder().writeFrame(chctx, type, stream.id(), new Http2Flags(flags), payload, chctx.newPromise());
+  void writeFrame(Http2Stream stream, byte type, short flags, ByteBuf payload, FutureListener<Void> listener) {
+    ChannelPromise promise = listener == null ? chctx.voidPromise() : chctx.newPromise().addListener(listener);
+    encoder().writeFrame(chctx, type, stream.id(), new Http2Flags(flags), payload, promise);
     checkFlush();
   }
 

--- a/src/test/java/io/vertx/core/http/Http2ClientTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientTest.java
@@ -1597,7 +1597,9 @@ public class Http2ClientTest extends Http2TestBase {
         assertEquals(10, frame.type());
         assertEquals(253, frame.flags());
         assertEquals(expectedSend, frame.payload());
-        req.response().writeCustomFrame(12, 134, expectedRecv).end();
+        HttpServerResponse resp = req.response();
+        resp.writeCustomFrame(12, 134, expectedRecv);
+        resp.end();
       });
     });
     startServer(testAddress);

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -2529,7 +2529,9 @@ public class Http2ServerTest extends Http2TestBase {
         assertEquals(10, frame.type());
         assertEquals(253, frame.flags());
         assertEquals(expectedSend, frame.payload());
-        req.response().writeCustomFrame(12, 134, expectedRecv).end();
+        HttpServerResponse resp = req.response();
+        resp.writeCustomFrame(12, 134, expectedRecv);
+        resp.end();
       });
     });
     startServer(ctx);

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -4328,7 +4328,7 @@ public abstract class HttpTest extends HttpTestBase {
       public boolean reset(long code) { return false; }
       public boolean reset(long code, Throwable cause) { return false; }
       public HttpConnection connection() { throw new UnsupportedOperationException(); }
-      public HttpClientRequest writeCustomFrame(int type, int flags, Buffer payload) { throw new UnsupportedOperationException(); }
+      public Future<Void> writeCustomFrame(int type, int flags, Buffer payload) { throw new UnsupportedOperationException(); }
       public boolean writeQueueFull() { throw new UnsupportedOperationException(); }
       public StreamPriority getStreamPriority() { return null; }
       public HttpClientRequest onComplete(Handler<AsyncResult<HttpClientResponse>> handler) { throw new UnsupportedOperationException(); }


### PR DESCRIPTION
Update the API (breaking change with fluent return) and the implementation to expose future results.
