### PR TITLE
Execute blocking uses callable 4.x

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -603,8 +603,8 @@ blocking APIs safely within a Vert.x application.
 As discussed before, you can't call blocking operations directly from an event loop, as that would prevent it
 from doing any other useful work. So how can you do this?
 
-It's done by calling {@link io.vertx.core.Vertx#executeBlocking} specifying both the blocking code to execute and a
-result handler to be called back asynchronous when the blocking code has been executed.
+It's done by calling {@link io.vertx.core.Vertx#executeBlocking} with blocking code to execute, as return you get a
+future completed with the result of the blocking code execution.
 
 [source,$lang]
 ----
@@ -621,7 +621,7 @@ which can interact with verticles using the event-bus or {@link io.vertx.core.Co
 By default, if executeBlocking is called several times from the same context (e.g. the same verticle instance) then
 the different executeBlocking are executed _serially_ (i.e. one after another).
 
-If you don't care about ordering you can call {@link io.vertx.core.Vertx#executeBlocking(io.vertx.core.Handler,boolean,io.vertx.core.Handler)}
+If you don't care about ordering you can call {@link io.vertx.core.Vertx#executeBlocking(java.util.concurrent.Callable,boolean)}
 specifying `false` as the argument to `ordered`. In this case any executeBlocking may be executed in parallel
 on the worker pool.
 

--- a/src/main/java/examples/CoreExamples.java
+++ b/src/main/java/examples/CoreExamples.java
@@ -67,10 +67,9 @@ public class CoreExamples {
   }
 
   public void example7(Vertx vertx) {
-    vertx.executeBlocking(promise -> {
+    vertx.executeBlocking(() -> {
       // Call some blocking API that takes a significant amount of time to return
-      String result = someAPI.blockingMethod("hello");
-      promise.complete(result);
+      return someAPI.blockingMethod("hello");
     }).onComplete(res -> {
       System.out.println("The result is: " + res.result());
     });
@@ -78,10 +77,9 @@ public class CoreExamples {
 
   public void workerExecutor1(Vertx vertx) {
     WorkerExecutor executor = vertx.createSharedWorkerExecutor("my-worker-pool");
-    executor.executeBlocking(promise -> {
+    executor.executeBlocking(() -> {
       // Call some blocking API that takes a significant amount of time to return
-      String result = someAPI.blockingMethod("hello");
-      promise.complete(result);
+      return someAPI.blockingMethod("hello");
     }).onComplete(res -> {
       System.out.println("The result is: " + res.result());
     });

--- a/src/main/java/io/vertx/core/Context.java
+++ b/src/main/java/io/vertx/core/Context.java
@@ -20,6 +20,7 @@ import io.vertx.core.impl.launcher.VertxCommandLauncher;
 import io.vertx.core.json.JsonObject;
 
 import java.util.List;
+import java.util.concurrent.Callable;
 
 /**
  * The execution context of a {@link io.vertx.core.Handler} execution.
@@ -105,8 +106,8 @@ public interface Context {
    * <p>
    * Executes the blocking code in the handler {@code blockingCodeHandler} using a thread from the worker pool.
    * <p>
-   * When the code is complete the handler {@code resultHandler} will be called with the result on the original context
-   * (e.g. on the original event loop of the caller).
+   * The returned future will be completed with the result on the original context (i.e. on the original event loop of the caller)
+   * or failed when the handler throws an exception.
    * <p>
    * A {@code Future} instance is passed into {@code blockingCodeHandler}. When the blocking code successfully completes,
    * the handler should call the {@link Promise#complete} or {@link Promise#complete(Object)} method, or the {@link Promise#fail}
@@ -131,6 +132,33 @@ public interface Context {
   <T> void executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<@Nullable T>> resultHandler);
 
   /**
+   * Safely execute some blocking code.
+   * <p>
+   * Executes the blocking code in the handler {@code blockingCodeHandler} using a thread from the worker pool.
+   * <p>
+   * The returned future will be completed with the result on the original context (i.e. on the original event loop of the caller)
+   * or failed when the handler throws an exception.
+   * <p>
+   * The blocking code should block for a reasonable amount of time (i.e no more than a few seconds). Long blocking operations
+   * or polling operations (i.e a thread that spin in a loop polling events in a blocking fashion) are precluded.
+   * <p>
+   * When the blocking operation lasts more than the 10 seconds, a message will be printed on the console by the
+   * blocked thread checker.
+   * <p>
+   * Long blocking operations should use a dedicated thread managed by the application, which can interact with
+   * verticles using the event-bus or {@link Context#runOnContext(Handler)}
+   *
+   * @param blockingCodeHandler  handler representing the blocking code to run
+   * @param ordered  if true then if executeBlocking is called several times on the same context, the executions
+   *                 for that context will be executed serially, not in parallel. if false then they will be no ordering
+   *                 guarantees
+   * @param <T> the type of the result
+   * @return a future completed when the blocking code is complete
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  <T> Future<@Nullable T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered);
+
+  /**
    * Invoke {@link #executeBlocking(Handler, boolean, Handler)} with order = true.
    * @param blockingCodeHandler  handler representing the blocking code to run
    * @param resultHandler  handler that will be called when the blocking code is complete
@@ -148,7 +176,18 @@ public interface Context {
   /**
    * Same as {@link #executeBlocking(Handler, Handler)} but with an {@code handler} called when the operation completes
    */
-  default <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler) {
+  default <T> Future<@Nullable T> executeBlocking(Handler<Promise<T>> blockingCodeHandler) {
+    return executeBlocking(blockingCodeHandler, true);
+  }
+
+  /**
+   * Invoke {@link #executeBlocking(Callable, boolean)} with order = true.
+   * @param blockingCodeHandler  handler representing the blocking code to run
+   * @param <T> the type of the result
+   * @return a future completed when the blocking code is complete
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default <T> Future<@Nullable T> executeBlocking(Callable<T> blockingCodeHandler) {
     return executeBlocking(blockingCodeHandler, true);
   }
 
@@ -177,7 +216,7 @@ public interface Context {
   /**
    * Is the current context an event loop context?
    * <p>
-   * NOTE! when running blocking code using {@link io.vertx.core.Vertx#executeBlocking(Handler, Handler)} from a
+   * NOTE! when running blocking code using {@link io.vertx.core.Vertx#executeBlocking(Callable)} from a
    * standard (not worker) verticle, the context will still an event loop context and this {@link this#isEventLoopContext()}
    * will return true.
    *
@@ -188,7 +227,7 @@ public interface Context {
   /**
    * Is the current context a worker context?
    * <p>
-   * NOTE! when running blocking code using {@link io.vertx.core.Vertx#executeBlocking(Handler, Handler)} from a
+   * NOTE! when running blocking code using {@link io.vertx.core.Vertx#executeBlocking(Callable)} from a
    * standard (not worker) verticle, the context will still an event loop context and this {@link this#isWorkerContext()}
    * will return false.
    *

--- a/src/main/java/io/vertx/core/Context.java
+++ b/src/main/java/io/vertx/core/Context.java
@@ -128,7 +128,9 @@ public interface Context {
    *                 for that context will be executed serially, not in parallel. if false then they will be no ordering
    *                 guarantees
    * @param <T> the type of the result
+   * @deprecated instead use {@link #executeBlocking(Callable, boolean)}
    */
+  @Deprecated
   <T> void executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<@Nullable T>> resultHandler);
 
   /**
@@ -163,19 +165,27 @@ public interface Context {
    * @param blockingCodeHandler  handler representing the blocking code to run
    * @param resultHandler  handler that will be called when the blocking code is complete
    * @param <T> the type of the result
+   * @deprecated instead use {@link #executeBlocking(Callable)}
    */
+  @Deprecated
   default <T> void executeBlocking(Handler<Promise<T>> blockingCodeHandler, Handler<AsyncResult<@Nullable T>> resultHandler) {
     executeBlocking(blockingCodeHandler, true, resultHandler);
   }
 
   /**
    * Same as {@link #executeBlocking(Handler, boolean, Handler)} but with an {@code handler} called when the operation completes
+   *
+   * @deprecated instead use {@link #executeBlocking(Callable, boolean)}
    */
+  @Deprecated
   <T> Future<@Nullable T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered);
 
   /**
    * Same as {@link #executeBlocking(Handler, Handler)} but with an {@code handler} called when the operation completes
+   *
+   * @deprecated instead use {@link #executeBlocking(Callable)}
    */
+  @Deprecated
   default <T> Future<@Nullable T> executeBlocking(Handler<Promise<T>> blockingCodeHandler) {
     return executeBlocking(blockingCodeHandler, true);
   }

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -592,7 +592,9 @@ public interface Vertx extends Measured {
    *                 for that context will be executed serially, not in parallel. if false then they will be no ordering
    *                 guarantees
    * @param <T> the type of the result
+   * @deprecated use instead {@link #executeBlocking(Callable, boolean)}
    */
+  @Deprecated
   default <T> void executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<@Nullable T>> resultHandler) {
     Context context = getOrCreateContext();
     context.executeBlocking(blockingCodeHandler, ordered, resultHandler);
@@ -600,14 +602,20 @@ public interface Vertx extends Measured {
 
   /**
    * Like {@link #executeBlocking(Handler, boolean, Handler)} called with ordered = true.
+   *
+   * @deprecated instead use {@link #executeBlocking(Callable)}
    */
+  @Deprecated
   default <T> void executeBlocking(Handler<Promise<T>> blockingCodeHandler, Handler<AsyncResult<@Nullable T>> resultHandler) {
     executeBlocking(blockingCodeHandler, true, resultHandler);
   }
 
   /**
    * Same as {@link #executeBlocking(Handler, boolean, Handler)} but with an {@code handler} called when the operation completes
+   *
+   * @deprecated instead use {@link #executeBlocking(Callable, boolean)}
    */
+  @Deprecated
   default <T> Future<@Nullable T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered) {
     Context context = getOrCreateContext();
     return context.executeBlocking(blockingCodeHandler, ordered);
@@ -648,7 +656,10 @@ public interface Vertx extends Measured {
 
   /**
    * Same as {@link #executeBlocking(Handler, Handler)} but with an {@code handler} called when the operation completes
+   *
+   * @deprecated instead use {@link #executeBlocking(Callable)}
    */
+  @Deprecated
   default <T> Future<@Nullable T> executeBlocking(Handler<Promise<T>> blockingCodeHandler) {
     return executeBlocking(blockingCodeHandler, true);
   }

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -36,6 +36,7 @@ import io.vertx.core.spi.VerticleFactory;
 import io.vertx.core.streams.ReadStream;
 
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -566,15 +567,15 @@ public interface Vertx extends Measured {
    * <p>
    * Executes the blocking code in the handler {@code blockingCodeHandler} using a thread from the worker pool.
    * <p>
-   * When the code is complete the handler {@code resultHandler} will be called with the result on the original context
-   * (e.g. on the original event loop of the caller).
+   * The returned future will be completed with the result on the original context (i.e. on the original event loop of the caller)
+   * or failed when the handler throws an exception.
    * <p>
    * A {@code Future} instance is passed into {@code blockingCodeHandler}. When the blocking code successfully completes,
    * the handler should call the {@link Promise#complete} or {@link Promise#complete(Object)} method, or the {@link Promise#fail}
    * method if it failed.
    * <p>
    * In the {@code blockingCodeHandler} the current context remains the original context and therefore any task
-   * scheduled in the {@code blockingCodeHandler} will be executed on the this context and not on the worker thread.
+   * scheduled in the {@code blockingCodeHandler} will be executed on this context and not on the worker thread.
    * <p>
    * The blocking code should block for a reasonable amount of time (i.e no more than a few seconds). Long blocking operations
    * or polling operations (i.e a thread that spin in a loop polling events in a blocking fashion) are precluded.
@@ -613,9 +614,50 @@ public interface Vertx extends Measured {
   }
 
   /**
+   * Safely execute some blocking code.
+   * <p>
+   * Executes the blocking code in the handler {@code blockingCodeHandler} using a thread from the worker pool.
+   * <p>
+   * The returned future will be completed with the result on the original context (i.e. on the original event loop of the caller)
+   * or failed when the handler throws an exception.
+   * <p>
+   * In the {@code blockingCodeHandler} the current context remains the original context and therefore any task
+   * scheduled in the {@code blockingCodeHandler} will be executed on this context and not on the worker thread.
+   * <p>
+   * The blocking code should block for a reasonable amount of time (i.e no more than a few seconds). Long blocking operations
+   * or polling operations (i.e a thread that spin in a loop polling events in a blocking fashion) are precluded.
+   * <p>
+   * When the blocking operation lasts more than the 10 seconds, a message will be printed on the console by the
+   * blocked thread checker.
+   * <p>
+   * Long blocking operations should use a dedicated thread managed by the application, which can interact with
+   * verticles using the event-bus or {@link Context#runOnContext(Handler)}
+   *
+   * @param blockingCodeHandler  handler representing the blocking code to run
+   * @param ordered  if true then if executeBlocking is called several times on the same context, the executions
+   *                 for that context will be executed serially, not in parallel. if false then they will be no ordering
+   *                 guarantees
+   * @param <T> the type of the result
+   * @return a future completed when the blocking code is complete
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default <T> Future<@Nullable T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
+    Context context = getOrCreateContext();
+    return context.executeBlocking(blockingCodeHandler, ordered);
+  }
+
+  /**
    * Same as {@link #executeBlocking(Handler, Handler)} but with an {@code handler} called when the operation completes
    */
-  default <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler) {
+  default <T> Future<@Nullable T> executeBlocking(Handler<Promise<T>> blockingCodeHandler) {
+    return executeBlocking(blockingCodeHandler, true);
+  }
+
+  /**
+   * Like {@link #executeBlocking(Callable, boolean)} called with ordered = true.
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default <T> Future<@Nullable T> executeBlocking(Callable<T> blockingCodeHandler) {
     return executeBlocking(blockingCodeHandler, true);
   }
 

--- a/src/main/java/io/vertx/core/WorkerExecutor.java
+++ b/src/main/java/io/vertx/core/WorkerExecutor.java
@@ -50,19 +50,27 @@ public interface WorkerExecutor extends Measured {
    *                 for that context will be executed serially, not in parallel. if false then they will be no ordering
    *                 guarantees
    * @param <T> the type of the result
+   * @deprecated instead use {@link #executeBlocking(Callable, boolean)}
    */
+  @Deprecated
   <T> void executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<@Nullable T>> resultHandler);
 
   /**
    * Like {@link #executeBlocking(Handler, boolean, Handler)} called with ordered = true.
+   *
+   * @deprecated instead use {@link #executeBlocking(Callable)}
    */
+  @Deprecated
   default <T> void executeBlocking(Handler<Promise<T>> blockingCodeHandler, Handler<AsyncResult<@Nullable T>> resultHandler) {
     executeBlocking(blockingCodeHandler, true, resultHandler);
   }
 
   /**
    * Same as {@link #executeBlocking(Handler, boolean, Handler)} but with an {@code handler} called when the operation completes
+   *
+   * @deprecated instead use {@link #executeBlocking(Callable, boolean)}
    */
+  @Deprecated
   <T> Future<@Nullable T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered);
 
   /**
@@ -88,7 +96,10 @@ public interface WorkerExecutor extends Measured {
 
   /**
    * Like {@link #executeBlocking(Handler, boolean, Handler)} called with ordered = true.
+   *
+   * @deprecated instead use {@link #executeBlocking(Callable)}
    */
+  @Deprecated
   default <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler) {
     return executeBlocking(blockingCodeHandler, true);
   }

--- a/src/main/java/io/vertx/core/WorkerExecutor.java
+++ b/src/main/java/io/vertx/core/WorkerExecutor.java
@@ -11,9 +11,12 @@
 
 package io.vertx.core;
 
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.metrics.Measured;
+
+import java.util.concurrent.Callable;
 
 /**
  * An executor for executing blocking code in Vert.x .<p>
@@ -31,15 +34,15 @@ public interface WorkerExecutor extends Measured {
    * <p>
    * Executes the blocking code in the handler {@code blockingCodeHandler} using a thread from the worker pool.
    * <p>
-   * When the code is complete the handler {@code resultHandler} will be called with the result on the original context
-   * (i.e. on the original event loop of the caller).
+   * The returned future will be completed with the result on the original context (i.e. on the original event loop of the caller)
+   * or failed when the handler throws an exception.
    * <p>
    * A {@code Future} instance is passed into {@code blockingCodeHandler}. When the blocking code successfully completes,
    * the handler should call the {@link Promise#complete} or {@link Promise#complete(Object)} method, or the {@link Promise#fail}
    * method if it failed.
    * <p>
    * In the {@code blockingCodeHandler} the current context remains the original context and therefore any task
-   * scheduled in the {@code blockingCodeHandler} will be executed on the this context and not on the worker thread.
+   * scheduled in the {@code blockingCodeHandler} will be executed on this context and not on the worker thread.
    *
    * @param blockingCodeHandler  handler representing the blocking code to run
    * @param resultHandler  handler that will be called when the blocking code is complete
@@ -63,9 +66,38 @@ public interface WorkerExecutor extends Measured {
   <T> Future<@Nullable T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered);
 
   /**
+   * Safely execute some blocking code.
+   * <p>
+   * Executes the blocking code in the handler {@code blockingCodeHandler} using a thread from the worker pool.
+   * <p>
+   * The returned future will be completed with the result on the original context (i.e. on the original event loop of the caller)
+   * or failed when the handler throws an exception.
+   * <p>
+   * In the {@code blockingCodeHandler} the current context remains the original context and therefore any task
+   * scheduled in the {@code blockingCodeHandler} will be executed on this context and not on the worker thread.
+   *
+   * @param blockingCodeHandler  handler representing the blocking code to run
+   * @param ordered  if true then if executeBlocking is called several times on the same context, the executions
+   *                 for that context will be executed serially, not in parallel. if false then they will be no ordering
+   *                 guarantees
+   * @param <T> the type of the result
+   * @return a future notified with the result
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  <T> Future<@Nullable T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered);
+
+  /**
    * Like {@link #executeBlocking(Handler, boolean, Handler)} called with ordered = true.
    */
   default <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler) {
+    return executeBlocking(blockingCodeHandler, true);
+  }
+
+  /**
+   * Like {@link #executeBlocking(Callable, boolean)} called with ordered = true.
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler) {
     return executeBlocking(blockingCodeHandler, true);
   }
 

--- a/src/main/java/io/vertx/core/impl/ContextBase.java
+++ b/src/main/java/io/vertx/core/impl/ContextBase.java
@@ -12,17 +12,16 @@
 package io.vertx.core.impl;
 
 import io.netty.channel.EventLoop;
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.*;
+import io.vertx.core.Future;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.*;
 
 /**
  * A base class for {@link Context} implementations.
@@ -106,7 +105,17 @@ public abstract class ContextBase implements ContextInternal {
   }
 
   @Override
+  public <T> Future<T> executeBlockingInternal(Callable<T> action) {
+    return executeBlocking(this, action, internalWorkerPool, internalOrderedTasks);
+  }
+
+  @Override
   public <T> Future<T> executeBlockingInternal(Handler<Promise<T>> action, boolean ordered) {
+    return executeBlocking(this, action, internalWorkerPool, ordered ? internalOrderedTasks : null);
+  }
+
+  @Override
+  public <T> Future<T> executeBlockingInternal(Callable<T> action, boolean ordered) {
     return executeBlocking(this, action, internalWorkerPool, ordered ? internalOrderedTasks : null);
   }
 
@@ -116,11 +125,66 @@ public abstract class ContextBase implements ContextInternal {
   }
 
   @Override
+  public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
+    return executeBlocking(this, blockingCodeHandler, workerPool, ordered ? orderedTasks : null);
+  }
+
+  @Override
+  public boolean isEventLoopContext() {
+    return false;
+  }
+
+  @Override
+  public boolean isWorkerContext() {
+    return false;
+  }
+
+  @Override
+  public Executor executor() {
+    return null;
+  }
+
+  @Override
+  public boolean inThread() {
+    return false;
+  }
+
+  @Override
   public <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, TaskQueue queue) {
     return executeBlocking(this, blockingCodeHandler, workerPool, queue);
   }
 
+  @Override
+  public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, TaskQueue queue) {
+    return executeBlocking(this, blockingCodeHandler, workerPool, queue);
+  }
+
+  static <T> Future<T> executeBlocking(ContextInternal context, Callable<T> blockingCodeHandler,
+                                       WorkerPool workerPool, TaskQueue queue) {
+    return internalExecuteBlocking(context, promise -> {
+      T result;
+      try {
+        result = blockingCodeHandler.call();
+      } catch (Throwable e) {
+        promise.fail(e);
+        return;
+      }
+      promise.complete(result);
+    }, workerPool, queue);
+  }
+
   static <T> Future<T> executeBlocking(ContextInternal context, Handler<Promise<T>> blockingCodeHandler,
+                                       WorkerPool workerPool, TaskQueue queue) {
+    return internalExecuteBlocking(context, promise -> {
+      try {
+        blockingCodeHandler.handle(promise);
+      } catch (Throwable e) {
+        promise.tryFail(e);
+      }
+    }, workerPool, queue);
+  }
+
+  private static <T> Future<T> internalExecuteBlocking(ContextInternal context, Handler<Promise<T>> blockingCodeHandler,
       WorkerPool workerPool, TaskQueue queue) {
     PoolMetrics metrics = workerPool.metrics();
     Object queueMetric = metrics != null ? metrics.submitted() : null;
@@ -132,13 +196,7 @@ public abstract class ContextBase implements ContextInternal {
         if (metrics != null) {
           execMetric = metrics.begin(queueMetric);
         }
-        context.dispatch(promise, f -> {
-          try {
-            blockingCodeHandler.handle(promise);
-          } catch (Throwable e) {
-            promise.tryFail(e);
-          }
-        });
+        context.dispatch(promise, blockingCodeHandler);
         if (metrics != null) {
           metrics.end(execMetric, fut.succeeded());
         }

--- a/src/main/java/io/vertx/core/impl/ContextInternal.java
+++ b/src/main/java/io/vertx/core/impl/ContextInternal.java
@@ -124,7 +124,10 @@ public interface ContextInternal extends Context {
   /**
    * Like {@link #executeBlocking(Handler, boolean, Handler)} but uses the {@code queue} to order the tasks instead
    * of the internal queue of this context.
+   *
+   * @deprecated instead use {@link #executeBlocking(Callable, TaskQueue)}
    */
+  @Deprecated
   default <T> void executeBlocking(Handler<Promise<T>> blockingCodeHandler, TaskQueue queue, Handler<AsyncResult<T>> resultHandler) {
     Future<T> fut = executeBlocking(blockingCodeHandler, queue);
     setResultHandler(this, fut, resultHandler);
@@ -134,6 +137,7 @@ public interface ContextInternal extends Context {
    * Like {@link #executeBlocking(Handler, boolean)} but uses the {@code queue} to order the tasks instead
    * of the internal queue of this context.
    */
+  @Deprecated
   <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, TaskQueue queue);
 
   <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, TaskQueue queue);
@@ -141,11 +145,13 @@ public interface ContextInternal extends Context {
   /**
    * Execute an internal task on the internal blocking ordered executor.
    */
+  @Deprecated
   default <T> void executeBlockingInternal(Handler<Promise<T>> action, Handler<AsyncResult<T>> resultHandler) {
     Future<T> fut = executeBlockingInternal(action);
     setResultHandler(this, fut, resultHandler);
   }
 
+  @Deprecated
   default <T> void executeBlockingInternal(Handler<Promise<T>> action, boolean ordered, Handler<AsyncResult<T>> resultHandler) {
     Future<T> fut = executeBlockingInternal(action, ordered);
     setResultHandler(this, fut, resultHandler);

--- a/src/main/java/io/vertx/core/impl/ContextInternal.java
+++ b/src/main/java/io/vertx/core/impl/ContextInternal.java
@@ -20,6 +20,7 @@ import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.impl.future.SucceededFuture;
 import io.vertx.core.spi.tracing.VertxTracer;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -135,6 +136,8 @@ public interface ContextInternal extends Context {
    */
   <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, TaskQueue queue);
 
+  <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, TaskQueue queue);
+
   /**
    * Execute an internal task on the internal blocking ordered executor.
    */
@@ -159,10 +162,14 @@ public interface ContextInternal extends Context {
    */
   <T> Future<T> executeBlockingInternal(Handler<Promise<T>> action);
 
+  <T> Future<T> executeBlockingInternal(Callable<T> action);
+
   /**
    * Like {@link #executeBlockingInternal(Handler, boolean, Handler)} but returns a {@code Future} of the asynchronous result
    */
   <T> Future<T> executeBlockingInternal(Handler<Promise<T>> action, boolean ordered);
+
+  <T> Future<T> executeBlockingInternal(Callable<T> action, boolean ordered);
 
   /**
    * @return the deployment associated with this context or {@code null}

--- a/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -18,6 +18,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tracing.VertxTracer;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -129,7 +130,17 @@ class DuplicatedContext implements ContextInternal {
   }
 
   @Override
+  public <T> Future<T> executeBlockingInternal(Callable<T> action) {
+    return ContextBase.executeBlocking(this, action, delegate.internalWorkerPool, delegate.internalOrderedTasks);
+  }
+
+  @Override
   public final <T> Future<T> executeBlockingInternal(Handler<Promise<T>> action, boolean ordered) {
+    return ContextBase.executeBlocking(this, action, delegate.internalWorkerPool, ordered ? delegate.internalOrderedTasks : null);
+  }
+
+  @Override
+  public <T> Future<T> executeBlockingInternal(Callable<T> action, boolean ordered) {
     return ContextBase.executeBlocking(this, action, delegate.internalWorkerPool, ordered ? delegate.internalOrderedTasks : null);
   }
 
@@ -139,7 +150,17 @@ class DuplicatedContext implements ContextInternal {
   }
 
   @Override
+  public final <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
+    return ContextBase.executeBlocking(this, blockingCodeHandler, delegate.workerPool, ordered ? delegate.orderedTasks : null);
+  }
+
+  @Override
   public final <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, TaskQueue queue) {
+    return ContextBase.executeBlocking(this, blockingCodeHandler, delegate.workerPool, queue);
+  }
+
+  @Override
+  public final <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, TaskQueue queue) {
     return ContextBase.executeBlocking(this, blockingCodeHandler, delegate.workerPool, queue);
   }
 

--- a/src/main/java/io/vertx/core/impl/NoStackTraceException.java
+++ b/src/main/java/io/vertx/core/impl/NoStackTraceException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.impl;
+
+import io.vertx.core.VertxException;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class NoStackTraceException extends VertxException {
+
+  public NoStackTraceException(String message) {
+    super(message, null, true);
+  }
+
+  public NoStackTraceException(Throwable cause) {
+    super(cause, true);
+  }
+}

--- a/src/main/java/io/vertx/core/impl/VertxInternal.java
+++ b/src/main/java/io/vertx/core/impl/VertxInternal.java
@@ -148,6 +148,7 @@ public interface VertxInternal extends Vertx {
   /**
    * Like {@link #executeBlocking(Handler, Handler)} but using the internal worker thread pool.
    */
+  @Deprecated
   default <T> void executeBlockingInternal(Handler<Promise<T>> blockingCodeHandler, Handler<AsyncResult<T>> resultHandler) {
     ContextInternal context = getOrCreateContext();
     context.executeBlockingInternal(blockingCodeHandler, resultHandler);
@@ -158,6 +159,7 @@ public interface VertxInternal extends Vertx {
     return context.executeBlockingInternal(blockingCodeHandler);
   }
 
+  @Deprecated
   default <T> void executeBlockingInternal(Handler<Promise<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> resultHandler) {
     ContextInternal context = getOrCreateContext();
     context.executeBlockingInternal(blockingCodeHandler, ordered, resultHandler);

--- a/src/main/java/io/vertx/core/impl/VertxInternal.java
+++ b/src/main/java/io/vertx/core/impl/VertxInternal.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -152,9 +153,19 @@ public interface VertxInternal extends Vertx {
     context.executeBlockingInternal(blockingCodeHandler, resultHandler);
   }
 
+  default <T> Future<T> executeBlockingInternal(Callable<T> blockingCodeHandler) {
+    ContextInternal context = getOrCreateContext();
+    return context.executeBlockingInternal(blockingCodeHandler);
+  }
+
   default <T> void executeBlockingInternal(Handler<Promise<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> resultHandler) {
     ContextInternal context = getOrCreateContext();
     context.executeBlockingInternal(blockingCodeHandler, ordered, resultHandler);
+  }
+
+  default <T> Future<T> executeBlockingInternal(Callable<T> blockingCodeHandler, boolean ordered) {
+    ContextInternal context = getOrCreateContext();
+    return context.executeBlockingInternal(blockingCodeHandler, ordered);
   }
 
   ClusterManager getClusterManager();

--- a/src/main/java/io/vertx/core/impl/VertxWrapper.java
+++ b/src/main/java/io/vertx/core/impl/VertxWrapper.java
@@ -55,6 +55,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -320,8 +321,18 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
+  public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
+    return delegate.executeBlockingInternal(blockingCodeHandler, ordered);
+  }
+
+  @Override
   public <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler) {
     return delegate.executeBlocking(blockingCodeHandler);
+  }
+
+  @Override
+  public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler) {
+    return delegate.executeBlockingInternal(blockingCodeHandler);
   }
 
   @Override
@@ -515,8 +526,18 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
+  public <T> Future<T> executeBlockingInternal(Callable<T> blockingCodeHandler) {
+    return delegate.executeBlockingInternal(blockingCodeHandler);
+  }
+
+  @Override
   public <T> void executeBlockingInternal(Handler<Promise<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> asyncResultHandler) {
     delegate.executeBlockingInternal(blockingCodeHandler, ordered, asyncResultHandler);
+  }
+
+  @Override
+  public <T> Future<T> executeBlockingInternal(Callable<T> blockingCodeHandler, boolean ordered) {
+    return delegate.executeBlockingInternal(blockingCodeHandler, ordered);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
+++ b/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
@@ -18,6 +18,8 @@ import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.metrics.PoolMetrics;
 
+import java.util.concurrent.Callable;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -63,6 +65,13 @@ class WorkerExecutorImpl implements MetricsProvider, WorkerExecutorInternal {
       }
     }
     ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
+    ContextBase impl = context instanceof DuplicatedContext ? ((DuplicatedContext)context).delegate : (ContextBase) context;
+    return ContextBase.executeBlocking(context, blockingCodeHandler, pool, ordered ? impl.orderedTasks : null);
+  }
+
+  @Override
+  public <T> Future<@Nullable T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
+    ContextInternal context = vertx.getOrCreateContext();
     ContextBase impl = context instanceof DuplicatedContext ? ((DuplicatedContext)context).delegate : (ContextBase) context;
     return ContextBase.executeBlocking(context, blockingCodeHandler, pool, ordered ? impl.orderedTasks : null);
   }

--- a/src/test/java/io/vertx/core/FakeContext.java
+++ b/src/test/java/io/vertx/core/FakeContext.java
@@ -12,6 +12,7 @@ import io.vertx.core.impl.WorkerPool;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tracing.VertxTracer;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 
@@ -44,6 +45,11 @@ class FakeContext implements ContextInternal {
 
   @Override
   public <T> Future<@Nullable T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered) {
+    return null;
+  }
+
+  @Override
+  public <T> Future<@Nullable T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
     return null;
   }
 
@@ -93,12 +99,27 @@ class FakeContext implements ContextInternal {
   }
 
   @Override
+  public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, TaskQueue queue) {
+    return null;
+  }
+
+  @Override
   public <T> Future<T> executeBlockingInternal(Handler<Promise<T>> action) {
     return null;
   }
 
   @Override
+  public <T> Future<T> executeBlockingInternal(Callable<T> action) {
+    return null;
+  }
+
+  @Override
   public <T> Future<T> executeBlockingInternal(Handler<Promise<T>> action, boolean ordered) {
+    return null;
+  }
+
+  @Override
+  public <T> Future<T> executeBlockingInternal(Callable<T> action, boolean ordered) {
     return null;
   }
 


### PR DESCRIPTION
The Vert.x API for executing blocking actions uses a pattern with handler completing or failing a promise, instead this can be replaced with `java.util.concurrent.Callable` that returns the same value or throws an exception.

```java
// Deprecated
Future<String> fut = vertx.executeBlocking(promise -> promise.complete("result"));

// Instead use
Future<String> fut = vertx.executeBlocking(() -> "result");
```

This existing API is deprecated for removal in Vert.x 5.

There should be no ambiguity with existing lambda usage of such methods as new methods uses a callable that has no arguments.

See https://github.com/eclipse-vertx/vert.x/pull/4782