### PR TITLE
Pool evict/acquire race fix

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/pool/CombinerExecutor.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/CombinerExecutor.java
@@ -54,11 +54,14 @@ public class CombinerExecutor<S> implements Executor<S> {
           if (a == null) {
             break;
           }
-          Task task = a.execute(state);
+          final Task task = a.execute(state);
           if (task != null) {
             if (head == null) {
               assert tail == null;
               tail = task;
+              for (Task next = tail.next();next != null;next = tail.next()) {
+                tail = tail.next();
+              }
               head = task;
             } else {
               tail = tail.next(task);

--- a/src/main/java/io/vertx/core/net/impl/pool/SemaphoreExecutor.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/SemaphoreExecutor.java
@@ -30,8 +30,9 @@ public class SemaphoreExecutor<S> implements Executor<S> {
       post = action.execute(state);
     } finally {
       lock.unlock();
-      if (post != null) {
+      while (post != null) {
         post.run();
+        post = post.next();
       }
     }
   }

--- a/src/main/java/io/vertx/core/net/impl/pool/Task.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/Task.java
@@ -20,6 +20,10 @@ public abstract class Task {
     return oldNext;
   }
 
+  public Task next() {
+    return next;
+  }
+
   public Task next(Task next) {
     this.next = next;
     return next;

--- a/src/test/java/io/vertx/core/net/impl/pool/ConnectionPoolTest.java
+++ b/src/test/java/io/vertx/core/net/impl/pool/ConnectionPoolTest.java
@@ -445,6 +445,40 @@ public class ConnectionPoolTest extends VertxTestBase {
   }
 
   @Test
+  public void testSynchronousEviction() throws Exception {
+    ConnectionManager mgr = new ConnectionManager();
+    ConnectionPool<Connection> pool = ConnectionPool.pool(mgr, new int[] { 1 }, 1);
+    EventLoopContext ctx = vertx.createEventLoopContext();
+    CountDownLatch latch1 = new CountDownLatch(1);
+    CountDownLatch latch2 = new CountDownLatch(1);
+    CountDownLatch latch3 = new CountDownLatch(1);
+    pool.acquire(ctx, 0, onSuccess(lease -> {
+      lease.recycle();
+      latch1.countDown();
+    }));
+    ConnectionRequest request = mgr.assertRequest();
+    Connection conn1 = new Connection();
+    request.connect(conn1, 0);
+    awaitLatch(latch1);
+    Connection conn2 = new Connection();
+    pool.evict(candidate -> {
+      assertSame(candidate, conn1);
+      pool.acquire(ctx, 0, onSuccess(lease -> {
+        Connection c2 = lease.get();
+        assertSame(conn2, c2);
+        latch3.countDown();
+      }));
+      return true;
+    }, onSuccess(list -> {
+      latch2.countDown();
+    }));
+    awaitLatch(latch2);
+    request = mgr.assertRequest();
+    request.connect(conn2, 0);
+    awaitLatch(latch3);
+  }
+
+  @Test
   public void testConnectionInProgressShouldNotBeEvicted() {
     ConnectionManager mgr = new ConnectionManager();
     ConnectionPool<Connection> pool = ConnectionPool.pool(mgr, new int[] { 1 }, 5);


### PR DESCRIPTION
The pool asynchronously removes connection slots when they are identified as removable. This create races, e.g a connection can be evicted from the pool and then acquired before the removal happens.

Connection slots are now removed synchronously when the pool identifies connections to be removed immediately within the pool logic. The post action removal are now enqueued in the main post action (when there is one), the combiner executor has been modified to take in account the fact that a post action might next actions to execute.
