### PR TITLE
Fix SSLOptions equals method to use sslHandshakeTimeout from argument

### DIFF
--- a/src/main/java/io/vertx/core/net/SSLOptions.java
+++ b/src/main/java/io/vertx/core/net/SSLOptions.java
@@ -331,7 +331,7 @@ public class SSLOptions {
     }
     if (obj instanceof SSLOptions) {
       SSLOptions that = (SSLOptions) obj;
-      return sslHandshakeTimeoutUnit.toNanos(sslHandshakeTimeout) == that.sslHandshakeTimeoutUnit.toNanos(sslHandshakeTimeout) &&
+      return sslHandshakeTimeoutUnit.toNanos(sslHandshakeTimeout) == that.sslHandshakeTimeoutUnit.toNanos(that.sslHandshakeTimeout) &&
          Objects.equals(keyCertOptions, that.keyCertOptions) &&
          Objects.equals(trustOptions, that.trustOptions) &&
          Objects.equals(enabledCipherSuites, that.enabledCipherSuites) &&


### PR DESCRIPTION
Motivation:

As explained in https://github.com/eclipse-vertx/vert.x/issues/4787, I am interested in updating the keystore used by an `HttpServer` object. However, the keystore at the path given in the `JksOptions` doesn't change; the keystore itself changes. So when attempting to call `updateSSLOptions(SSLOptions)` on the `HttpServer` object, vert.x thinks that the options have not changed, and thus wont reread the certificate. I was hoping to force vertx to reread the keystore by changing the `sslHandshakeTimeout` variable, as that is really the only one that can be modified without security concerns. However, in doing so, I noticed that the `equals()` method on the `SSLOptions` class incorrectly returned `true` when the SSL handshake timeout was different.