### PR TITLE
Deprecate Netty 4 API exposure in Vert.x API

### DIFF
--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -676,8 +676,10 @@ public interface Vertx extends Measured {
    * Return the Netty EventLoopGroup used by Vert.x
    *
    * @return the EventLoopGroup
+   * @deprecated removed from public API in Vert.x 5
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Deprecated
   EventLoopGroup nettyEventLoopGroup();
 
   /**

--- a/src/main/java/io/vertx/core/buffer/Buffer.java
+++ b/src/main/java/io/vertx/core/buffer/Buffer.java
@@ -110,7 +110,9 @@ public interface Buffer extends ClusterSerializable, Shareable {
    *
    * @param byteBuf the Netty ByteBuf
    * @return the buffer
+   * @deprecated removed from public API in Vert.x 5
    */
+  @Deprecated
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static Buffer buffer(ByteBuf byteBuf) {
     Objects.requireNonNull(byteBuf);
@@ -705,7 +707,10 @@ public interface Buffer extends ClusterSerializable, Shareable {
    * Returns the Buffer as a Netty {@code ByteBuf}.
    *
    * <p> The returned buffer is a duplicate that maintain its own indices.
+   *
+   * @deprecated removed from public API in Vert.x 5
    */
+  @Deprecated
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   ByteBuf getByteBuf();
 

--- a/src/main/java/io/vertx/core/impl/VertxInternal.java
+++ b/src/main/java/io/vertx/core/impl/VertxInternal.java
@@ -15,6 +15,7 @@ package io.vertx.core.impl;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.resolver.AddressResolverGroup;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.*;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;

--- a/src/test/java/io/vertx/core/dns/HostnameResolutionTest.java
+++ b/src/test/java/io/vertx/core/dns/HostnameResolutionTest.java
@@ -327,7 +327,7 @@ public class HostnameResolutionTest extends VertxTestBase {
       CountDownLatch connectLatch = new CountDownLatch(1);
       Bootstrap bootstrap = new Bootstrap();
       bootstrap.channelFactory(((VertxInternal)vertx).transport().channelFactory(false));
-      bootstrap.group(vertx.nettyEventLoopGroup());
+      bootstrap.group(((VertxInternal) vertx).getEventLoopGroup());
       bootstrap.resolver(((VertxInternal) vertx).nettyAddressResolverGroup());
       bootstrap.handler(new ChannelInitializer<Channel>() {
         @Override


### PR DESCRIPTION
 The Vert.x API exposes the Netty API in its public API, allowing interactions with the Netty API. Since Netty is evolving toward Netty 5, we should remove Netty API from the Vert.x public API in Vert.x 5 to have the opportunity to change the underlying Netty version used by Vert.x without worrying about the version of the Netty version.
    
Such API continues to exist in Vert.x 5 but is moved to internal API which more easily change, therefore experimented users of this API can continue to use it granted that the version of Vert.x 5 uses Netty 4.
    
In practice most users should not use this API, and the deprecation should be seen also as a signal toward users of this API.
