### PR TITLE
Simplified API for locks

### DIFF
--- a/src/main/asciidoc/shareddata.adoc
+++ b/src/main/asciidoc/shareddata.adoc
@@ -143,6 +143,16 @@ If your application doesn't need the lock to be shared with every other node, yo
 {@link examples.SharedDataExamples#localLock}
 ----
 
+Sometimes, you use the lock API to retrieve an asynchronous result and apply the acquire/release pattern around the asynchronous call. Vert.x provides a simplified lock API to simplify this pattern.
+
+[source,$lang]
+----
+{@link examples.SharedDataExamples#withLock}
+----
+
+The lock is acquired before calling the supplier and released when the future returned by the supplier
+completes.
+
 === Asynchronous counters
 
 It's often useful to maintain an atomic counter locally or across the different nodes of your application.

--- a/src/main/java/examples/SharedDataExamples.java
+++ b/src/main/java/examples/SharedDataExamples.java
@@ -11,6 +11,7 @@
 
 package examples;
 
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.*;
@@ -114,6 +115,21 @@ public class SharedDataExamples {
           // Something went wrong
         }
       });
+  }
+
+  private Future<String> getAsyncString() {
+    throw new UnsupportedOperationException();
+  }
+
+  public void withLock(Vertx vertx) {
+    SharedData sharedData = vertx.sharedData();
+
+    Future<String> res = sharedData.withLock("mylock", () -> {
+      // Obtained the lock!
+      Future<String> future = getAsyncString();
+      // It will be released upon completion of this future
+      return future;
+    });
   }
 
   public void lockWithTimeout(Vertx vertx) {

--- a/src/main/java/io/vertx/core/file/AsyncFile.java
+++ b/src/main/java/io/vertx/core/file/AsyncFile.java
@@ -17,9 +17,13 @@ import io.vertx.codegen.annotations.Unstable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Represents a file on the file-system which can be read from, or written to asynchronously.
@@ -171,7 +175,9 @@ public interface AsyncFile extends ReadStream<Buffer>, WriteStream<Buffer> {
    * @return the lock if it can be acquired immediately, otherwise {@code null}
    */
   @Unstable
-  @Nullable AsyncFileLock tryLock();
+  default @Nullable AsyncFileLock tryLock() {
+    return tryLock(0, Long.MAX_VALUE, false);
+  }
 
   /**
    * Try to acquire a lock on a portion of this file.
@@ -190,7 +196,9 @@ public interface AsyncFile extends ReadStream<Buffer>, WriteStream<Buffer> {
    * @return a future indicating the completion of this operation
    */
   @Unstable
-  Future<AsyncFileLock> lock();
+  default Future<AsyncFileLock> lock() {
+    return lock(0, Long.MAX_VALUE, false);
+  }
 
   /**
    * Acquire a lock on a portion of this file.
@@ -203,4 +211,48 @@ public interface AsyncFile extends ReadStream<Buffer>, WriteStream<Buffer> {
   @Unstable
   Future<AsyncFileLock> lock(long position, long size, boolean shared);
 
+  /**
+   * Acquire a non-shared lock on the entire file.
+   *
+   * <p>When the {@code block} is called, the lock is already acquired, it will be released when the
+   * {@code Future<T>} returned by the block completes.
+   *
+   * <p>When the {@code block} fails, the lock is released and the returned future is failed with the cause of the failure.
+   *
+   * @param block the code block called after lock acquisition
+   * @return the future returned by the {@code block}
+   */
+  @Unstable
+  default <T> Future<T> withLock(Supplier<Future<T>> block) {
+    return withLock(0, Long.MAX_VALUE, false, block);
+  }
+
+  /**
+   * Acquire a lock on a portion of this file.
+   *
+   * <p>When the {@code block} is called, the lock is already acquired , it will be released when the
+   * {@code Future<T>} returned by the block completes.
+   *
+   * <p>When the {@code block} fails, the lock is released and the returned future is failed with the cause of the failure.
+   *
+   * @param position where the region starts
+   * @param size the size of the region
+   * @param shared whether the lock should be shared
+   * @param block the code block called after lock acquisition
+   * @return the future returned by the {@code block}
+   */
+  @Unstable
+  default <T> Future<T> withLock(long position, long size, boolean shared, Supplier<Future<T>> block) {
+    return lock(position, size, shared)
+      .compose(lock -> {
+        Future<T> res;
+        try {
+          res = block.get();
+        } catch (Exception e) {
+          lock.release();
+          throw new VertxException(e);
+        }
+        return res.eventually(v -> lock.release());
+      });
+  }
 }

--- a/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -558,26 +558,12 @@ public class AsyncFileImpl implements AsyncFile {
   }
 
   @Override
-  public AsyncFileLock tryLock() {
-    try {
-      return new AsyncFileLockImpl(vertx, ch.tryLock());
-    } catch (IOException e) {
-      throw new FileSystemException(e);
-    }
-  }
-
-  @Override
   public AsyncFileLock tryLock(long position, long size, boolean shared) {
     try {
       return new AsyncFileLockImpl(vertx, ch.tryLock(position, size, shared));
     } catch (IOException e) {
       throw new FileSystemException(e);
     }
-  }
-
-  @Override
-  public Future<AsyncFileLock> lock() {
-    return lock(0, Long.MAX_VALUE, false);
   }
 
   private static CompletionHandler<FileLock, PromiseInternal<AsyncFileLock>> LOCK_COMPLETION = new CompletionHandler<FileLock, PromiseInternal<AsyncFileLock>>() {

--- a/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class SharedDataImpl implements SharedData {
 
-  private static final long DEFAULT_LOCK_TIMEOUT = 10 * 1000;
+  public static final long DEFAULT_LOCK_TIMEOUT = 10 * 1000;
 
   private final VertxInternal vertx;
   private final ClusterManager clusterManager;


### PR DESCRIPTION
Acquire/release asynchronous API can be modelled as a function returning a future that is called when the lock is available until the returned future commits.

```java
Future<T> fut = sharedData.lock("the-lock").compose(lock ->
  return getAsyncFalue().andThen(ar -> lock.release());
});
```

can be replaced with

```java
Future<T> fut = sharedLock.withLock("the-lock", v -> getAsyncValue());
```

This can be backported to Vert.x 4.x