### PR TITLE
Buffer adding support for float le and double le

### DIFF
--- a/src/main/java/io/vertx/core/buffer/Buffer.java
+++ b/src/main/java/io/vertx/core/buffer/Buffer.java
@@ -191,11 +191,25 @@ public interface Buffer extends ClusterSerializable, Shareable {
   double getDouble(int pos);
 
   /**
+   * Gets a double at the specified absolute {@code index} in this buffer in Little Endian Byte Order.
+   *
+   * @throws IndexOutOfBoundsException if the specified {@code pos} is less than {@code 0} or {@code pos + 8} is greater than the length of the Buffer.
+   */
+  double getDoubleLE(int pos);
+
+  /**
    * Returns the {@code float} at position {@code pos} in the Buffer.
    *
    * @throws IndexOutOfBoundsException if the specified {@code pos} is less than {@code 0} or {@code pos + 4} is greater than the length of the Buffer.
    */
   float getFloat(int pos);
+
+  /**
+   * Gets a float at the specified absolute {@code index} in this buffer in Little Endian Byte Order.
+   *
+   * @throws IndexOutOfBoundsException if the specified {@code pos} is less than {@code 0} or {@code pos + 4} is greater than the length of the Buffer.
+   */
+  float getFloatLE(int pos);
 
   /**
    * Returns the {@code short} at position {@code pos} in the Buffer.
@@ -465,11 +479,25 @@ public interface Buffer extends ClusterSerializable, Shareable {
   Buffer appendFloat(float f);
 
   /**
+   * Appends the specified unsigned {@code float} to the end of the Buffer in the Little Endian Byte Order.The buffer will expand as necessary to accommodate any bytes written.<p>
+   * Returns a reference to {@code this} so multiple operations can be appended together.
+   */
+  @Fluent
+  Buffer appendFloatLE(float f);
+
+  /**
    * Appends the specified {@code double} to the end of the Buffer. The buffer will expand as necessary to accommodate any bytes written.<p>
    * Returns a reference to {@code this} so multiple operations can be appended together.
    */
   @Fluent
   Buffer appendDouble(double d);
+
+  /**
+   * Appends the specified unsigned {@code double} to the end of the Buffer in the Little Endian Byte Order.The buffer will expand as necessary to accommodate any bytes written.<p>
+   * Returns a reference to {@code this} so multiple operations can be appended together.
+   */
+  @Fluent
+  Buffer appendDoubleLE(double d);
 
   /**
    * Appends the specified {@code String} to the end of the Buffer with the encoding as specified by {@code enc}.<p>
@@ -565,11 +593,25 @@ public interface Buffer extends ClusterSerializable, Shareable {
   Buffer setDouble(int pos, double d);
 
   /**
+   * Sets the {@code double} at position {@code pos} in the Buffer to the value {@code d} in the Little Endian Byte Order.<p>
+   * The buffer will expand as necessary to accommodate any value written.
+   */
+  @Fluent
+  Buffer setDoubleLE(int pos, double d);
+
+  /**
    * Sets the {@code float} at position {@code pos} in the Buffer to the value {@code f}.<p>
    * The buffer will expand as necessary to accommodate any value written.
    */
   @Fluent
   Buffer setFloat(int pos, float f);
+
+  /**
+   * Sets the {@code float} at position {@code pos} in the Buffer to the value {@code f} in the Little Endian Byte Order.<p>
+   * The buffer will expand as necessary to accommodate any value written.
+   */
+  @Fluent
+  Buffer setFloatLE(int pos, float f);
 
   /**
    * Sets the {@code short} at position {@code pos} in the Buffer to the value {@code s}.<p>

--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -349,7 +349,7 @@ public class BufferImpl implements BufferInternal {
   }
 
   @Override
-  public Buffer appendFloatLE(float f) {
+  public BufferImpl appendFloatLE(float f) {
     buffer.writeFloatLE(f);
     return this;
   }
@@ -360,7 +360,7 @@ public class BufferImpl implements BufferInternal {
   }
 
   @Override
-  public Buffer appendDoubleLE(double d) {
+  public BufferImpl appendDoubleLE(double d) {
     buffer.writeDoubleLE(d);
     return this;
   }
@@ -440,7 +440,7 @@ public class BufferImpl implements BufferInternal {
   }
 
   @Override
-  public Buffer setDoubleLE(int pos, double d) {
+  public BufferImpl setDoubleLE(int pos, double d) {
     ensureLength(pos + 8);
     buffer.setDoubleLE(pos, d);
     return this;
@@ -453,7 +453,7 @@ public class BufferImpl implements BufferInternal {
   }
 
   @Override
-  public Buffer setFloatLE(int pos, float f) {
+  public BufferImpl setFloatLE(int pos, float f) {
     ensureLength(pos + 4);
     buffer.setFloatLE(pos, f);
     return this;

--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -137,7 +137,7 @@ public class BufferImpl implements BufferInternal {
   }
 
   public double getDoubleLE(int pos) {
-    checkUpperBound(pos, 4);
+    checkUpperBound(pos, 8);
     return buffer.getDoubleLE(pos);
   }
 

--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -136,9 +136,19 @@ public class BufferImpl implements BufferInternal {
     return buffer.getDouble(pos);
   }
 
+  public double getDoubleLE(int pos) {
+    checkUpperBound(pos, 4);
+    return buffer.getDoubleLE(pos);
+  }
+
   public float getFloat(int pos) {
     checkUpperBound(pos, 4);
     return buffer.getFloat(pos);
+  }
+
+  public float getFloatLE(int pos) {
+    checkUpperBound(pos, 4);
+    return buffer.getFloatLE(pos);
   }
 
   public short getShort(int pos) {
@@ -338,8 +348,20 @@ public class BufferImpl implements BufferInternal {
     return this;
   }
 
+  @Override
+  public Buffer appendFloatLE(float f) {
+    buffer.writeFloatLE(f);
+    return this;
+  }
+
   public BufferImpl appendDouble(double d) {
     buffer.writeDouble(d);
+    return this;
+  }
+
+  @Override
+  public Buffer appendDoubleLE(double d) {
+    buffer.writeDoubleLE(d);
     return this;
   }
 
@@ -417,9 +439,23 @@ public class BufferImpl implements BufferInternal {
     return this;
   }
 
+  @Override
+  public Buffer setDoubleLE(int pos, double d) {
+    ensureLength(pos + 8);
+    buffer.setDoubleLE(pos, d);
+    return this;
+  }
+
   public BufferImpl setFloat(int pos, float f) {
     ensureLength(pos + 4);
     buffer.setFloat(pos, f);
+    return this;
+  }
+
+  @Override
+  public Buffer setFloatLE(int pos, float f) {
+    ensureLength(pos + 4);
+    buffer.setFloatLE(pos, f);
     return this;
   }
 

--- a/src/main/java/io/vertx/core/buffer/impl/BufferInternal.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferInternal.java
@@ -108,7 +108,13 @@ public interface BufferInternal extends Buffer {
   BufferInternal appendFloat(float f);
 
   @Override
+  Buffer appendFloatLE(float f);
+
+  @Override
   BufferInternal appendDouble(double d);
+
+  @Override
+  Buffer appendDoubleLE(double d);
 
   @Override
   BufferInternal appendString(String str, String enc);
@@ -150,7 +156,13 @@ public interface BufferInternal extends Buffer {
   BufferInternal setDouble(int pos, double d);
 
   @Override
+  Buffer setDoubleLE(int pos, double d);
+
+  @Override
   BufferInternal setFloat(int pos, float f);
+
+  @Override
+  Buffer setFloatLE(int pos, float f);
 
   @Override
   BufferInternal setShort(int pos, short s);

--- a/src/main/java/io/vertx/core/buffer/impl/BufferInternal.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferInternal.java
@@ -108,13 +108,13 @@ public interface BufferInternal extends Buffer {
   BufferInternal appendFloat(float f);
 
   @Override
-  Buffer appendFloatLE(float f);
+  BufferInternal appendFloatLE(float f);
 
   @Override
   BufferInternal appendDouble(double d);
 
   @Override
-  Buffer appendDoubleLE(double d);
+  BufferInternal appendDoubleLE(double d);
 
   @Override
   BufferInternal appendString(String str, String enc);
@@ -156,13 +156,13 @@ public interface BufferInternal extends Buffer {
   BufferInternal setDouble(int pos, double d);
 
   @Override
-  Buffer setDoubleLE(int pos, double d);
+  BufferInternal setDoubleLE(int pos, double d);
 
   @Override
   BufferInternal setFloat(int pos, float f);
 
   @Override
-  Buffer setFloatLE(int pos, float f);
+  BufferInternal setFloatLE(int pos, float f);
 
   @Override
   BufferInternal setShort(int pos, short s);

--- a/src/test/java/io/vertx/core/buffer/BufferTest.java
+++ b/src/test/java/io/vertx/core/buffer/BufferTest.java
@@ -277,6 +277,8 @@ public class BufferTest {
     checkBEAndLE(4, Buffer.buffer().appendInt(Integer.MAX_VALUE), Buffer.buffer().appendIntLE(Integer.MAX_VALUE));
     checkBEAndLE(4, Buffer.buffer().appendUnsignedInt(Integer.MAX_VALUE), Buffer.buffer().appendUnsignedIntLE(Integer.MAX_VALUE));
     checkBEAndLE(8, Buffer.buffer().appendLong(Long.MAX_VALUE), Buffer.buffer().appendLongLE(Long.MAX_VALUE));
+    checkBEAndLE(4, Buffer.buffer().appendFloat(Float.MAX_VALUE), Buffer.buffer().appendFloatLE(Float.MAX_VALUE));
+    checkBEAndLE(8, Buffer.buffer().appendDouble(Double.MAX_VALUE), Buffer.buffer().appendDoubleLE(Double.MAX_VALUE));
   }
 
   private void checkBEAndLE(int size, Buffer big, Buffer little) {
@@ -529,30 +531,65 @@ public class BufferTest {
     testGetSetLong(true);
   }
 
-  @Test
-  public void testGetFloat() throws Exception {
+  public void testGetFloat(boolean isLE) throws Exception {
     int numFloats = 100;
     Buffer b = Buffer.buffer(numFloats * 4);
     for (int i = 0; i < numFloats; i++) {
-      b.setFloat(i * 4, i);
+      if (isLE) {
+        b.setFloatLE(i * 4, i);
+      } else {
+        b.setFloat(i * 4, i);
+      }
+
     }
 
     for (int i = 0; i < numFloats; i++) {
-      assertEquals((float) i, b.getFloat(i * 4), 0);
+      if (isLE) {
+        assertEquals((float) i, b.getFloatLE(i * 4), 0);
+      } else {
+        assertEquals((float) i, b.getFloat(i * 4), 0);
+      }
+    }
+  }
+
+  @Test
+  public void testGetFloat() throws Exception {
+    testGetFloat(false);
+  }
+
+  @Test
+  public void testGetFloatLE() throws Exception {
+    testGetFloat(true);
+  }
+
+  public void testGetDouble(boolean isLE) throws Exception {
+    int numDoubles = 100;
+    Buffer b = Buffer.buffer(numDoubles * 8);
+    for (int i = 0; i < numDoubles; i++) {
+      if (isLE) {
+        b.setDoubleLE(i * 8, i);
+      } else {
+        b.setDouble(i * 8, i);
+      }
+    }
+
+    for (int i = 0; i < numDoubles; i++) {
+      if (isLE) {
+        assertEquals((double) i, b.getDoubleLE(i * 8), 0);
+      } else {
+        assertEquals((double) i, b.getDouble(i * 8), 0);
+      }
     }
   }
 
   @Test
   public void testGetDouble() throws Exception {
-    int numDoubles = 100;
-    Buffer b = Buffer.buffer(numDoubles * 8);
-    for (int i = 0; i < numDoubles; i++) {
-      b.setDouble(i * 8, i);
-    }
+    testGetDouble(false);
+  }
 
-    for (int i = 0; i < numDoubles; i++) {
-      assertEquals((double) i, b.getDouble(i * 8), 0);
-    }
+  @Test
+  public void testGetDoubleLE() throws Exception {
+    testGetDouble(true);
   }
 
   private void testGetSetShort(boolean isLE) throws Exception {

--- a/src/test/java/io/vertx/core/buffer/impl/VertxBufferTest.java
+++ b/src/test/java/io/vertx/core/buffer/impl/VertxBufferTest.java
@@ -73,4 +73,5 @@ public class VertxBufferTest {
     assertEquals(3, duplicate.readerIndex());
     assertEquals(0, byteBuf.readerIndex());
   }
+
 }


### PR DESCRIPTION
**Title:** Add Little Endian Support for Floats and Doubles in Buffer Class

**Body:**

This pull request aims to add support for Little Endian representation in floats and doubles within the `Buffer` class.

**New Methods:**

In `Buffer`:
- `double getDoubleLE(int pos);`
- `float getFloatLE(int pos);`
- `Buffer appendFloatLE(float f);`
- `Buffer appendDoubleLE(double d);`
- `Buffer setDoubleLE(int pos, double d);`
- `Buffer setFloatLE(int pos, float f);`

Corresponding changes have been made to the `BufferInternal`, `BufferImpl` classes, and `BufferTest` to accommodate these new methods.

---