### PR TITLE
avoid using e.g. in javadoc to not cut short the line

### DIFF
--- a/src/main/java/io/vertx/core/net/ProxyOptions.java
+++ b/src/main/java/io/vertx/core/net/ProxyOptions.java
@@ -32,7 +32,7 @@ public class ProxyOptions {
   /**
    * The default port for proxy connect = 3128
    *
-   * 3128 is the default port for e.g. Squid
+   * 3128 is the default port for Squid
    */
   public static final int DEFAULT_PORT = 3128;
 


### PR DESCRIPTION
Motivation:

Javadoc cuts lines with a dot short as it consider that the end of the first sentence, so using e.g. does not work as expected
the result was "3128 is the default port for e.g."

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
