### PR TITLE
HTTP/1.1 upgrade to H2C cannot process fully request entity with a size greater than the initial window size

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
@@ -409,9 +409,6 @@ class VertxHttp2ConnectionHandler<C extends Http2ConnectionBase> extends Http2Co
         connection.onHeadersRead(ctx, 1, frame.headers(), frame.padding(), frame.isEndStream());
       } else if (msg instanceof Http2DataFrame) {
         Http2DataFrame frame = (Http2DataFrame) msg;
-        Http2LocalFlowController controller = decoder().flowController();
-        Http2Stream stream = decoder().connection().stream(1);
-        controller.receiveFlowControlledFrame(stream, frame.content(), frame.padding(), frame.isEndStream());
         connection.onDataRead(ctx, 1, frame.content(), frame.padding(), frame.isEndStream());
       }
     } else {

--- a/src/test/java/io/vertx/core/http/Http2WithUpgradeServerFileUploadTest.java
+++ b/src/test/java/io/vertx/core/http/Http2WithUpgradeServerFileUploadTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+/**
+ */
+public class Http2WithUpgradeServerFileUploadTest extends HttpServerFileUploadTest {
+
+  @Override
+  protected HttpClientOptions createBaseClientOptions() {
+    return new HttpClientOptions()
+      .setProtocolVersion(HttpVersion.HTTP_2)
+      .setHttp2ClearTextUpgrade(true);
+  }
+
+}

--- a/src/test/java/io/vertx/core/http/HttpServerFileUploadTest.java
+++ b/src/test/java/io/vertx/core/http/HttpServerFileUploadTest.java
@@ -331,16 +331,12 @@ public abstract class HttpServerFileUploadTest extends HttpTestBase {
             "\r\n";
           req.headers().set("content-length", "" + (pro + contentStr + epi).length());
           req.headers().set("content-type", "multipart/form-data; boundary=" + boundary);
-          if (abortClient || cancelStream) {
-            Future<Void> fut = req.write(pro + contentStr.substring(0, contentStr.length() / 2));
-            if (abortClient) {
-              fut.onComplete(onSuccess(v -> {
-                clientConn.set(req.connection());
-                checkClose.run();
-              }));
-            }
-          } else {
-            req.end(pro + contentStr + epi);
+          Future<Void> fut = req.end(pro + contentStr + epi);
+          if (abortClient) {
+            fut.onComplete(onSuccess(v -> {
+              clientConn.set(req.connection());
+              checkClose.run();
+            }));
           }
           if (abortClient) {
             req.response(onFailure(err -> complete()));


### PR DESCRIPTION
When the server upgrades an HTTP/1.1 connection to H2C, it forwards inbound HTTP messages to the H2 encoder and updates the frame controller with the received amount of bytes. Actually such messages are not taken in account by the H2 flow controller and therefore when the window size becomes zero, it will not process message anymore.

This impacts HTTP/1.1 upgrades to H2C sending messages payload greater than the flow control window size.
