### PR TITLE
Fix HTTP/1.1 server connection close header processing that close the connection too early

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -155,11 +155,11 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
     }
   }
 
-  void handleBegin(boolean writable) {
+  void handleBegin(boolean writable, boolean keepAlive) {
     if (METRICS_ENABLED) {
       reportRequestBegin();
     }
-    response = new Http1xServerResponse((VertxInternal) conn.vertx(), context, conn, request, metric, writable);
+    response = new Http1xServerResponse((VertxInternal) conn.vertx(), context, conn, request, metric, writable, keepAlive);
     if (conn.handle100ContinueAutomatically) {
       check100();
     }

--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -960,4 +960,11 @@ public final class HttpUtils {
   static boolean isConnectOrUpgrade(io.vertx.core.http.HttpMethod method, MultiMap headers) {
     return method == io.vertx.core.http.HttpMethod.CONNECT || (method == io.vertx.core.http.HttpMethod.GET && headers.contains(io.vertx.core.http.HttpHeaders.CONNECTION, io.vertx.core.http.HttpHeaders.UPGRADE, true));
   }
+
+  static boolean isKeepAlive(HttpRequest request) {
+    HttpVersion version = request.protocolVersion();
+    return (version == HttpVersion.HTTP_1_1 && !request.headers().contains(io.vertx.core.http.HttpHeaders.CONNECTION, io.vertx.core.http.HttpHeaders.CLOSE, true))
+      || (version == HttpVersion.HTTP_1_0 && request.headers().contains(io.vertx.core.http.HttpHeaders.CONNECTION, io.vertx.core.http.HttpHeaders.KEEP_ALIVE, true));
+  }
+
 }


### PR DESCRIPTION
The implementation of HTTP/1.x connection close immediately close the HTTP connection when the response has been sent regargless of the request status.

The responsibility of closing the connection has been moved from Http1xServerResponse to Http1xServerConnection which now computes and maintains the keep alive status of the connection and becomes responsible to close the connection when it should not be kept alive at the appropriate lifecycle of the connection (that is when the response has been sent and the corresponding request received).
