### PR TITLE
HttpServerResponse close removal

### DIFF
--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -491,9 +491,9 @@ calling write with a string or buffer followed by calling end with no arguments.
 {@link examples.HTTPExamples#example20}
 ----
 
-==== Closing the underlying connection
+==== Closing the underlying TCP connection
 
-You can close the underlying TCP connection with {@link io.vertx.core.http.HttpServerResponse#close}.
+You can close the underlying TCP connection with {@link io.vertx.core.http.HttpConnection#close}.
 
 Non keep-alive connections will be automatically closed by Vert.x when the response is ended.
 

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -74,7 +74,7 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
     }
     HttpServerResponse response = request.response();
     response.setStatusCode(status.code()).end();
-    response.close();
+    request.connection().close();
   };
 
   @Override

--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -12,7 +12,6 @@
 package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.*;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -357,11 +356,6 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    * @return a future completed with the body result
    */
   Future<Void> sendFile(String filename, long offset, long length);
-
-  /**
-   * Close the underlying TCP connection corresponding to the request.
-   */
-  void close();
 
   /**
    * @return has the response already ended?

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -457,7 +457,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
           failed[0] = true;
           // Request Entity Too Large
           response.setStatusCode(413).end();
-          response.close();
+          conn.close();
         }
       }
     });

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequestHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequestHandler.java
@@ -62,7 +62,7 @@ public class Http1xServerRequestHandler implements Handler<HttpServerRequest> {
     } else if (req.version() == null) {
       // Invalid HTTP version, i.e not HTTP/1.1 or HTTP/1.0
       req.response().setStatusCode(501).end();
-      req.response().close();
+      req.connection().close();
     } else {
       reqHandler.handle(req);
     }

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -427,20 +427,6 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public void close() {
-    synchronized (conn) {
-      if (!closed) {
-        if (headWritten) {
-          closeConnAfterWrite();
-        } else {
-          conn.close();
-        }
-        closed = true;
-      }
-    }
-  }
-
-  @Override
   public Future<Void> end() {
     return end(EMPTY_BUFFER);
   }
@@ -553,12 +539,6 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
       this.bodyEndHandler = handler;
       return this;
     }
-  }
-
-  private void closeConnAfterWrite() {
-    ChannelPromise channelFuture = conn.channelFuture();
-    conn.writeToChannel(Unpooled.EMPTY_BUFFER, channelFuture);
-    channelFuture.addListener(fut -> conn.close());
   }
 
   void handleWritabilityChanged(boolean writable) {
@@ -727,7 +707,7 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
         return false;
       }
     }
-    close();
+    conn.close();
     return true;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -560,11 +560,6 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public void close() {
-    conn.close();
-  }
-
-  @Override
   public boolean ended() {
     synchronized (conn) {
       return ended;

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -1217,7 +1217,7 @@ public class Http1xTest extends HttpTest {
     int n = 5;
     server.requestHandler(req -> {
       vertx.setTimer(100, id -> {
-        req.response().close();
+        req.connection().close();
       });
     });
     startServer(testAddress);
@@ -1249,7 +1249,7 @@ public class Http1xTest extends HttpTest {
     server.requestHandler(req -> {
       if (first.compareAndSet(true, false)) {
         latch.whenComplete((v, err) -> {
-          req.response().close();
+          req.connection().close();
         });
       } else {
         req.response().end();
@@ -1410,7 +1410,7 @@ public class Http1xTest extends HttpTest {
         HttpServerResponse resp = req.response();
         resp.end();
         if (count[0] == n) {
-          resp.close();
+          req.connection().close();
         }
       });
     });
@@ -2091,7 +2091,7 @@ public class Http1xTest extends HttpTest {
   public void testRequestExceptionHandlerContext() throws Exception {
     waitFor(2);
     server.requestHandler(req -> {
-      req.response().close();
+      req.connection().close();
     });
     startServer(testAddress);
     Context clientCtx = vertx.getOrCreateContext();
@@ -4741,7 +4741,7 @@ public class Http1xTest extends HttpTest {
   public void testHttpClientRequestShouldCallExceptionHandlerWhenTheClosedHandlerIsCalled() throws Exception {
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).requestHandler(req -> {
       vertx.setTimer(1000, id -> {
-        req.response().close();
+        req.connection().close();
       });
     });
     startServer(testAddress);

--- a/src/test/java/io/vertx/core/http/HttpClientConnectionTest.java
+++ b/src/test/java/io/vertx/core/http/HttpClientConnectionTest.java
@@ -75,7 +75,7 @@ public abstract class HttpClientConnectionTest extends HttpTestBase {
   public void testConnectionClose() throws Exception {
     waitFor(2);
     server.requestHandler(req -> {
-      req.response().close();
+      req.connection().close();
     });
     startServer(testAddress);
     client.connect(testAddress, peerAddress).onComplete(onSuccess(conn -> {

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -1406,7 +1406,7 @@ public abstract class HttpTest extends HttpTestBase {
     int numReqs = 10;
     waitFor(numReqs);
     server.requestHandler(request -> {
-      request.response().close();
+      request.connection().close();
     });
     startServer(testAddress);
     // Exception handler should be called for any requests in the pipeline if connection is closed
@@ -1424,7 +1424,7 @@ public abstract class HttpTest extends HttpTestBase {
       //Write partial response then close connection before completing it
       HttpServerResponse resp = request.response().setChunked(true);
       resp.write("foo");
-      resp.close();
+      request.connection().close();
     });
     startServer(testAddress);
     // Exception handler should be called for any requests in the pipeline if connection is closed
@@ -4036,7 +4036,7 @@ public abstract class HttpTest extends HttpTestBase {
             if (expectFail) {
               resp.setChunked(true).write("whatever");
               vertx.runOnContext(v -> {
-                resp.close();
+                req.connection().close();
               });
             } else {
               resp.end();

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
@@ -140,7 +140,7 @@ public class MetricsContextTest extends VertxTestBase {
       HttpServer server = vertx.createHttpServer().requestHandler(req -> {
         HttpServerResponse response = req.response();
         response.setStatusCode(200).setChunked(true).end("bye");
-        response.close();
+        req.connection().close();
       });
       server.listen(8080, "localhost").onComplete(onSuccess(s -> {
         expectedThread.set(Thread.currentThread());
@@ -434,7 +434,7 @@ public class MetricsContextTest extends VertxTestBase {
       req.endHandler(buf -> {
         HttpServerResponse resp = req.response();
         resp.setChunked(true).end(Buffer.buffer("bye"));
-        resp.close();
+        req.connection().close();
       });
     });
     awaitFuture(server.listen(8080, "localhost"));


### PR DESCRIPTION
The HttpServerResponse close method closes the HTTP connection, it can be misleading as there are better API to interact with the current request/connection lifecycle which are HttpServerResponse#reset and HttpConnection#close.

This commits removes the close method of HtttpServerResponse.
