### PR TITLE
Deprecate HttpServerResponse close method

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -464,7 +464,10 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
 
   /**
    * Close the underlying TCP connection corresponding to the request.
+   *
+   * @deprecated instead use {@link HttpConnection#close()} or {@link #reset(long)}, this method is removed in Vert.x 5
    */
+  @Deprecated
   void close();
 
   /**


### PR DESCRIPTION
The `HttpServerResponse` close method closes the HTTP connection, it can be misleading as there are better API to interact with the current request/connection lifecycle which are `HttpServerResponse#reset` and `HttpConnection#close`.