### PR TITLE
HTTP2 timeout exception

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -77,6 +77,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
 
   @Override
   void handleException(Throwable t) {
+    t = mapException(t);
     super.handleException(t);
     if (endPromise.tryFail(t)) {
       Handler<Throwable> handler = exceptionHandler();

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -3200,9 +3200,7 @@ public abstract class HttpTest extends HttpTestBase {
           AtomicInteger count = new AtomicInteger();
           resp.exceptionHandler(t -> {
             if (count.getAndIncrement() == 0) {
-              assertTrue(
-                t instanceof TimeoutException || /* HTTP/1 */
-                  t instanceof VertxException /* HTTP/2: connection closed */);
+              assertTrue(t instanceof TimeoutException);
               assertEquals(expected, received);
               complete();
             }
@@ -3222,9 +3220,7 @@ public abstract class HttpTest extends HttpTestBase {
         AtomicInteger count = new AtomicInteger();
         req.exceptionHandler(t -> {
           if (count.getAndIncrement() == 0) {
-            assertTrue(
-              t instanceof TimeoutException || /* HTTP/1 */
-                t instanceof VertxException /* HTTP/2: connection closed */);
+            assertTrue(t instanceof TimeoutException);
             assertEquals(expected, received);
             complete();
           }


### PR DESCRIPTION
When an HTTP client request timeout fires, the corresponding stream is reset with a cancel code, the application cannot be aware of the cancellation because the netty stream reset will simply notify the stream to be closed.

We can keep track of the timeout in the HttpClientRequest and replace the HTTP closed exception with the timeout exception when this happens to better inform the application.
