### PR TITLE
DnsClient can now be closed

### DIFF
--- a/src/main/asciidoc/dns.adoc
+++ b/src/main/asciidoc/dns.adoc
@@ -26,6 +26,8 @@ for non blocking address resolution.
 {@link examples.DNSExamples#example1__}
 ----
 
+A client uses a single event loop for querying purposes, it can safely be used from any thread, including non Vert.x thread.
+
 === lookup
 
 Try to lookup the A (ipv4) or AAAA (ipv6) record for a given name. The first which is returned will be used,

--- a/src/main/java/io/vertx/core/dns/DnsClient.java
+++ b/src/main/java/io/vertx/core/dns/DnsClient.java
@@ -21,6 +21,8 @@ import java.util.List;
  * Provides a way to asynchronously lookup information from DNS servers.
  * <p>
  * Please consult the documentation for more information on DNS clients.
+ * <p>
+ * The client is thread safe and can be used from any thread.
  *
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
@@ -138,4 +140,12 @@ public interface DnsClient {
    *                 get notified with {@code null}. If an error occurs it will get failed.
    */
   Future<@Nullable String> reverseLookup(String ipaddress);
+
+  /**
+   * Close the client.
+   *
+   * @return the future completed when the client resources have been released
+   */
+  Future<Void> close();
+
 }

--- a/src/test/java/io/vertx/test/fakedns/FakeDNSServer.java
+++ b/src/test/java/io/vertx/test/fakedns/FakeDNSServer.java
@@ -93,6 +93,10 @@ public final class FakeDNSServer extends DnsServer {
   public FakeDNSServer() {
   }
 
+  public RecordStore store() {
+    return store;
+  }
+
   public FakeDNSServer store(RecordStore store) {
     this.store = store;
     return this;


### PR DESCRIPTION
The DnsClient does not have a close method to release the underlying networking resources.

Add a close method to the client that closes the datagram channel, inflight queries are failed.
