### PR TITLE
Event bus internal improvements

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -329,14 +329,14 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   }
 
   protected <T> void sendOrPub(ContextInternal ctx, MessageImpl<?, T> message, DeliveryOptions options, Promise<Void> writePromise) {
-    sendLocally(message, options, writePromise);
+    sendLocally(message, writePromise);
   }
 
   protected <T> void sendOrPub(OutboundDeliveryContext<T> sendContext) {
     sendOrPub(sendContext.ctx, sendContext.message, sendContext.options, sendContext);
   }
 
-  protected <T> void sendLocally(MessageImpl<?, T> message, DeliveryOptions options, Promise<Void> writePromise) {
+  protected <T> void sendLocally(MessageImpl<?, T> message, Promise<Void> writePromise) {
     ReplyException failure = deliverMessageLocally(message);
     if (failure != null) {
       writePromise.tryFail(failure);

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -258,9 +258,9 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     return msg;
   }
 
-  protected <T> Consumer<Promise<Void>> addRegistration(String address, HandlerRegistration<T> registration, boolean replyHandler, boolean localOnly, Promise<Void> promise) {
+  protected <T> Consumer<Promise<Void>> addRegistration(String address, HandlerRegistration<T> registration, boolean broadcast, boolean localOnly, Promise<Void> promise) {
     HandlerHolder<T> holder = addLocalRegistration(address, registration, localOnly);
-    if (!replyHandler) {
+    if (broadcast) {
       onLocalRegistration(holder, promise);
     } else {
       if (promise != null) {
@@ -268,7 +268,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
       }
     }
     return p -> {
-      removeRegistration(holder, replyHandler, p);
+      removeRegistration(holder, broadcast, p);
     };
   }
 
@@ -303,9 +303,9 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     return new HandlerHolder<>(registration, localOnly, context);
   }
 
-  protected <T> void removeRegistration(HandlerHolder<T> handlerHolder, boolean replyHandler, Promise<Void> promise) {
+  protected <T> void removeRegistration(HandlerHolder<T> handlerHolder, boolean broadcast, Promise<Void> promise) {
     removeLocalRegistration(handlerHolder);
-    if (!replyHandler) {
+    if (broadcast) {
       onLocalUnregistration(handlerHolder, promise);
     } else {
       promise.complete();

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -257,10 +258,12 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     return msg;
   }
 
-  protected <T> HandlerHolder<T> addRegistration(String address, HandlerRegistration<T> registration, boolean replyHandler, boolean localOnly, Promise<Void> promise) {
+  protected <T> Consumer<Promise<Void>> addRegistration(String address, HandlerRegistration<T> registration, boolean replyHandler, boolean localOnly, Promise<Void> promise) {
     HandlerHolder<T> holder = addLocalRegistration(address, registration, replyHandler, localOnly);
     onLocalRegistration(holder, promise);
-    return holder;
+    return p -> {
+      removeRegistration(holder, p);
+    };
   }
 
   protected <T> void onLocalRegistration(HandlerHolder<T> handlerHolder, Promise<Void> promise) {

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerHolder.java
@@ -22,14 +22,12 @@ public class HandlerHolder<T> {
 
   public final ContextInternal context;
   public final HandlerRegistration<T> handler;
-  public final boolean replyHandler;
   public final boolean localOnly;
   private boolean removed;
 
-  public HandlerHolder(HandlerRegistration<T> handler, boolean replyHandler, boolean localOnly, ContextInternal context) {
+  public HandlerHolder(HandlerRegistration<T> handler, boolean localOnly, ContextInternal context) {
     this.context = context;
     this.handler = handler;
-    this.replyHandler = replyHandler;
     this.localOnly = localOnly;
   }
 
@@ -74,10 +72,6 @@ public class HandlerHolder<T> {
 
   public HandlerRegistration<T> getHandler() {
     return handler;
-  }
-
-  public boolean isReplyHandler() {
-    return replyHandler;
   }
 
   public boolean isLocalOnly() {

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -58,13 +58,13 @@ public abstract class HandlerRegistration<T> implements Closeable {
 
   protected abstract void dispatch(Message<T> msg, ContextInternal context, Handler<Message<T>> handler);
 
-  synchronized void register(String repliedAddress, boolean localOnly, Promise<Void> promise) {
+  synchronized void register(boolean broadcast, boolean localOnly, Promise<Void> promise) {
     if (registered != null) {
       throw new IllegalStateException();
     }
-    registered = bus.addRegistration(address, this, repliedAddress != null, localOnly, promise);
+    registered = bus.addRegistration(address, this, broadcast, localOnly, promise);
     if (bus.metrics != null) {
-      metric = bus.metrics.handlerRegistered(address, repliedAddress);
+      metric = bus.metrics.handlerRegistered(address, null /* regression */);
     }
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -20,13 +20,15 @@ import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingPolicy;
 
+import java.util.function.Consumer;
+
 public abstract class HandlerRegistration<T> implements Closeable {
 
   public final ContextInternal context;
   public final EventBusImpl bus;
   public final String address;
   public final boolean src;
-  private HandlerHolder<T> registered;
+  private Consumer<Promise<Void>> registered;
   private Object metric;
 
   HandlerRegistration(ContextInternal context,
@@ -74,7 +76,7 @@ public abstract class HandlerRegistration<T> implements Closeable {
     Promise<Void> promise = context.promise();
     synchronized (this) {
       if (registered != null) {
-        bus.removeRegistration(registered, promise);
+        registered.accept(promise);
         registered = null;
         if (bus.metrics != null) {
           bus.metrics.handlerUnregistered(metric);

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -64,7 +64,7 @@ public abstract class HandlerRegistration<T> implements Closeable {
     }
     registered = bus.addRegistration(address, this, broadcast, localOnly, promise);
     if (bus.metrics != null) {
-      metric = bus.metrics.handlerRegistered(address, null /* regression */);
+      metric = bus.metrics.handlerRegistered(address);
     }
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
@@ -216,7 +216,7 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
           registered = true;
           Promise<Void> p = result;
           Promise<Void> registration = context.promise();
-          register(null, localOnly, registration);
+          register(true, localOnly, registration);
           registration.future().onComplete(ar -> {
             if (ar.succeeded()) {
               p.tryComplete();

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
@@ -45,14 +45,8 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
 
   @Override
   public Future<Void> write(T body) {
-    Promise<Void> promise = ((VertxInternal)vertx).getOrCreateContext().promise();
-    write(body, promise);
-    return promise.future();
-  }
-
-  private void write(T data, Promise<Void> handler) {
-    MessageImpl msg = bus.createMessage(send, address, options.getHeaders(), data, options.getCodecName());
-    bus.sendOrPubInternal(msg, options, null, handler);
+    MessageImpl msg = bus.createMessage(send, address, options.getHeaders(), body, options.getCodecName());
+    return bus.sendOrPubInternal(msg, options, null);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
@@ -83,7 +83,7 @@ class ReplyHandler<T> extends HandlerRegistration<T> implements Handler<Long> {
   }
 
   void register() {
-    register(repliedAddress, true, null);
+    register(repliedAddress, false, null);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
@@ -83,7 +83,7 @@ class ReplyHandler<T> extends HandlerRegistration<T> implements Handler<Long> {
   }
 
   void register() {
-    register(repliedAddress, false, null);
+    register(false, false, null);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -25,7 +25,6 @@ import io.vertx.core.eventbus.impl.MessageImpl;
 import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.impl.utils.ConcurrentCyclicSequence;
@@ -192,9 +191,9 @@ public class ClusteredEventBus extends EventBusImpl {
   @Override
   protected <T> void sendOrPub(ContextInternal ctx, MessageImpl<?, T> message, DeliveryOptions options, Promise<Void> writePromise) {
     if (((ClusteredMessage) message).getRepliedTo() != null) {
-      clusteredSendReply(message, options, writePromise, ((ClusteredMessage) message).getRepliedTo());
+      clusteredSendReply(message, writePromise, ((ClusteredMessage) message).getRepliedTo());
     } else if (options.isLocalOnly()) {
-      super.sendOrPub(ctx, message, options, writePromise);
+      sendLocally(message, writePromise);
     } else {
       Serializer serializer = Serializer.get(ctx);
       if (message.isSend()) {
@@ -202,7 +201,7 @@ public class ClusteredEventBus extends EventBusImpl {
         serializer.queue(message, nodeSelector::selectForSend, promise);
         promise.future().onComplete(ar -> {
           if (ar.succeeded()) {
-            sendToNode(ar.result(), message, options, writePromise);
+            sendToNode(ar.result(), message, writePromise);
           } else {
             sendOrPublishFailed(writePromise, ar.cause());
           }
@@ -212,7 +211,7 @@ public class ClusteredEventBus extends EventBusImpl {
         serializer.queue(message, nodeSelector::selectForPublish, promise);
         promise.future().onComplete(ar -> {
           if (ar.succeeded()) {
-            sendToNodes(ar.result(), message, options, writePromise);
+            sendToNodes(ar.result(), message, writePromise);
           } else {
             sendOrPublishFailed(writePromise, ar.cause());
           }
@@ -326,15 +325,15 @@ public class ClusteredEventBus extends EventBusImpl {
     };
   }
 
-  private <T> void sendToNode(String nodeId, MessageImpl<?, T> message, DeliveryOptions options, Promise<Void> writePromise) {
+  private <T> void sendToNode(String nodeId, MessageImpl<?, T> message, Promise<Void> writePromise) {
     if (nodeId != null && !nodeId.equals(this.nodeId)) {
-      sendRemote(nodeId, message, options, writePromise);
+      sendRemote(nodeId, message, writePromise);
     } else {
-      super.sendOrPub(ebContext, message, options, writePromise);
+      sendLocally(message, writePromise);
     }
   }
 
-  private <T> void sendToNodes(Iterable<String> nodeIds, MessageImpl<?, T> message, DeliveryOptions options, Promise<Void> writePromise) {
+  private <T> void sendToNodes(Iterable<String> nodeIds, MessageImpl<?, T> message, Promise<Void> writePromise) {
     boolean sentRemote = false;
     if (nodeIds != null) {
       for (String nid : nodeIds) {
@@ -342,23 +341,23 @@ public class ClusteredEventBus extends EventBusImpl {
           sentRemote = true;
         }
         // Write promise might be completed several times!!!!
-        sendToNode(nid, message, options, writePromise);
+        sendToNode(nid, message, writePromise);
       }
     }
     if (!sentRemote) {
-      super.sendOrPub(ebContext, message, options, writePromise);
+      sendLocally(message, writePromise);
     }
   }
 
-  private <T> void clusteredSendReply(MessageImpl<?, T> message, DeliveryOptions options, Promise<Void> writePromise, String replyDest) {
+  private <T> void clusteredSendReply(MessageImpl<?, T> message, Promise<Void> writePromise, String replyDest) {
     if (!replyDest.equals(nodeId)) {
-      sendRemote(replyDest, message, options, writePromise);
+      sendRemote(replyDest, message, writePromise);
     } else {
-      super.sendOrPub(ebContext, message, options, writePromise);
+      sendLocally(message, writePromise);
     }
   }
 
-  private void sendRemote(String remoteNodeId, MessageImpl<?, ?> message, DeliveryOptions options, Promise<Void> writePromise) {
+  private void sendRemote(String remoteNodeId, MessageImpl<?, ?> message, Promise<Void> writePromise) {
     // We need to deal with the fact that connecting can take some time and is async, and we cannot
     // block to wait for it. So we add any sends to a pending list if not connected yet.
     // Once we connect we send them.

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -11,12 +11,10 @@
 
 package io.vertx.core.eventbus.impl.clustered;
 
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.Promise;
-import io.vertx.core.VertxOptions;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.AddressHelper;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBusOptions;
 import io.vertx.core.eventbus.MessageCodec;
 import io.vertx.core.eventbus.impl.CodecManager;
@@ -24,10 +22,10 @@ import io.vertx.core.eventbus.impl.EventBusImpl;
 import io.vertx.core.eventbus.impl.HandlerHolder;
 import io.vertx.core.eventbus.impl.HandlerRegistration;
 import io.vertx.core.eventbus.impl.MessageImpl;
-import io.vertx.core.eventbus.impl.OutboundDeliveryContext;
 import io.vertx.core.impl.CloseFuture;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.impl.utils.ConcurrentCyclicSequence;
@@ -192,42 +190,42 @@ public class ClusteredEventBus extends EventBusImpl {
   }
 
   @Override
-  protected <T> void sendOrPub(OutboundDeliveryContext<T> sendContext) {
-    if (((ClusteredMessage) sendContext.message).getRepliedTo() != null) {
-      clusteredSendReply(((ClusteredMessage) sendContext.message).getRepliedTo(), sendContext);
-    } else if (sendContext.options.isLocalOnly()) {
-      super.sendOrPub(sendContext);
+  protected <T> void sendOrPub(ContextInternal ctx, MessageImpl<?, T> message, DeliveryOptions options, Promise<Void> writePromise) {
+    if (((ClusteredMessage) message).getRepliedTo() != null) {
+      clusteredSendReply(message, options, writePromise, ((ClusteredMessage) message).getRepliedTo());
+    } else if (options.isLocalOnly()) {
+      super.sendOrPub(ctx, message, options, writePromise);
     } else {
-      Serializer serializer = Serializer.get(sendContext.ctx);
-      if (sendContext.message.isSend()) {
-        Promise<String> promise = sendContext.ctx.promise();
-        serializer.queue(sendContext.message, nodeSelector::selectForSend, promise);
+      Serializer serializer = Serializer.get(ctx);
+      if (message.isSend()) {
+        Promise<String> promise = Promise.promise();
+        serializer.queue(message, nodeSelector::selectForSend, promise);
         promise.future().onComplete(ar -> {
           if (ar.succeeded()) {
-            sendToNode(sendContext, ar.result());
+            sendToNode(ar.result(), message, options, writePromise);
           } else {
-            sendOrPublishFailed(sendContext, ar.cause());
+            sendOrPublishFailed(writePromise, ar.cause());
           }
         });
       } else {
-        Promise<Iterable<String>> promise = sendContext.ctx.promise();
-        serializer.queue(sendContext.message, nodeSelector::selectForPublish, promise);
+        Promise<Iterable<String>> promise = Promise.promise();
+        serializer.queue(message, nodeSelector::selectForPublish, promise);
         promise.future().onComplete(ar -> {
           if (ar.succeeded()) {
-            sendToNodes(sendContext, ar.result());
+            sendToNodes(ar.result(), message, options, writePromise);
           } else {
-            sendOrPublishFailed(sendContext, ar.cause());
+            sendOrPublishFailed(writePromise, ar.cause());
           }
         });
       }
     }
   }
 
-  private void sendOrPublishFailed(OutboundDeliveryContext<?> sendContext, Throwable cause) {
+  private void sendOrPublishFailed(Promise<Void> promise, Throwable cause) {
     if (log.isDebugEnabled()) {
       log.error("Failed to send message", cause);
     }
-    sendContext.written(cause);
+    promise.tryFail(cause);
   }
 
   @Override
@@ -328,39 +326,39 @@ public class ClusteredEventBus extends EventBusImpl {
     };
   }
 
-  private <T> void sendToNode(OutboundDeliveryContext<T> sendContext, String nodeId) {
+  private <T> void sendToNode(String nodeId, MessageImpl<?, T> message, DeliveryOptions options, Promise<Void> writePromise) {
     if (nodeId != null && !nodeId.equals(this.nodeId)) {
-      sendRemote(sendContext, nodeId, sendContext.message);
+      sendRemote(nodeId, message, options, writePromise);
     } else {
-      super.sendOrPub(sendContext);
+      super.sendOrPub(ebContext, message, options, writePromise);
     }
   }
 
-  private <T> void sendToNodes(OutboundDeliveryContext<T> sendContext, Iterable<String> nodeIds) {
+  private <T> void sendToNodes(Iterable<String> nodeIds, MessageImpl<?, T> message, DeliveryOptions options, Promise<Void> writePromise) {
     boolean sentRemote = false;
     if (nodeIds != null) {
       for (String nid : nodeIds) {
         if (!sentRemote) {
           sentRemote = true;
         }
-        sendToNode(sendContext, nid);
+        // Write promise might be completed several times!!!!
+        sendToNode(nid, message, options, writePromise);
       }
     }
     if (!sentRemote) {
-      super.sendOrPub(sendContext);
+      super.sendOrPub(ebContext, message, options, writePromise);
     }
   }
 
-  private <T> void clusteredSendReply(String replyDest, OutboundDeliveryContext<T> sendContext) {
-    MessageImpl message = sendContext.message;
+  private <T> void clusteredSendReply(MessageImpl<?, T> message, DeliveryOptions options, Promise<Void> writePromise, String replyDest) {
     if (!replyDest.equals(nodeId)) {
-      sendRemote(sendContext, replyDest, message);
+      sendRemote(replyDest, message, options, writePromise);
     } else {
-      super.sendOrPub(sendContext);
+      super.sendOrPub(ebContext, message, options, writePromise);
     }
   }
 
-  private void sendRemote(OutboundDeliveryContext<?> sendContext, String remoteNodeId, MessageImpl message) {
+  private void sendRemote(String remoteNodeId, MessageImpl<?, ?> message, DeliveryOptions options, Promise<Void> writePromise) {
     // We need to deal with the fact that connecting can take some time and is async, and we cannot
     // block to wait for it. So we add any sends to a pending list if not connected yet.
     // Once we connect we send them.
@@ -379,7 +377,7 @@ public class ClusteredEventBus extends EventBusImpl {
         holder.connect();
       }
     }
-    holder.writeMessage(sendContext);
+    holder.writeMessage(message, writePromise);
   }
 
   ConcurrentMap<String, ConnectionHolder> connections() {

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -155,37 +155,29 @@ public class ClusteredEventBus extends EventBusImpl {
 
   @Override
   protected <T> void onLocalRegistration(HandlerHolder<T> handlerHolder, Promise<Void> promise) {
-    if (!handlerHolder.isReplyHandler()) {
-      RegistrationInfo registrationInfo = new RegistrationInfo(
-        nodeId,
-        handlerHolder.getSeq(),
-        handlerHolder.isLocalOnly()
-      );
-      clusterManager.addRegistration(handlerHolder.getHandler().address, registrationInfo, Objects.requireNonNull(promise));
-    } else if (promise != null) {
-      promise.complete();
-    }
+    RegistrationInfo registrationInfo = new RegistrationInfo(
+      nodeId,
+      handlerHolder.getSeq(),
+      handlerHolder.isLocalOnly()
+    );
+    clusterManager.addRegistration(handlerHolder.getHandler().address, registrationInfo, Objects.requireNonNull(promise));
   }
 
   @Override
-  protected <T> HandlerHolder<T> createHandlerHolder(HandlerRegistration<T> registration, boolean replyHandler, boolean localOnly, ContextInternal context) {
-    return new ClusteredHandlerHolder<>(registration, replyHandler, localOnly, context, handlerSequence.getAndIncrement());
+  protected <T> HandlerHolder<T> createHandlerHolder(HandlerRegistration<T> registration, boolean localOnly, ContextInternal context) {
+    return new ClusteredHandlerHolder<>(registration, localOnly, context, handlerSequence.getAndIncrement());
   }
 
   @Override
   protected <T> void onLocalUnregistration(HandlerHolder<T> handlerHolder, Promise<Void> completionHandler) {
-    if (!handlerHolder.isReplyHandler()) {
-      RegistrationInfo registrationInfo = new RegistrationInfo(
-        nodeId,
-        handlerHolder.getSeq(),
-        handlerHolder.isLocalOnly()
-      );
-      Promise<Void> promise = Promise.promise();
-      clusterManager.removeRegistration(handlerHolder.getHandler().address, registrationInfo, promise);
-      promise.future().onComplete(completionHandler);
-    } else {
-      completionHandler.complete();
-    }
+    RegistrationInfo registrationInfo = new RegistrationInfo(
+      nodeId,
+      handlerHolder.getSeq(),
+      handlerHolder.isLocalOnly()
+    );
+    Promise<Void> promise = Promise.promise();
+    clusterManager.removeRegistration(handlerHolder.getHandler().address, registrationInfo, promise);
+    promise.future().onComplete(completionHandler);
   }
 
   @Override
@@ -248,7 +240,7 @@ public class ClusteredEventBus extends EventBusImpl {
       Iterator<HandlerHolder> iterator = handlers.iterator(false);
       while (iterator.hasNext()) {
         HandlerHolder next = iterator.next();
-        if (next.isReplyHandler() || !next.isLocalOnly()) {
+        if (!next.isLocalOnly()) {
           handlerHolder = next;
           break;
         }

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -189,7 +189,7 @@ public class ClusteredEventBus extends EventBusImpl {
     } else {
       Serializer serializer = Serializer.get(ctx);
       if (message.isSend()) {
-        Promise<String> promise = Promise.promise();
+        Promise<String> promise = ctx.promise();
         serializer.queue(message, nodeSelector::selectForSend, promise);
         promise.future().onComplete(ar -> {
           if (ar.succeeded()) {
@@ -199,7 +199,7 @@ public class ClusteredEventBus extends EventBusImpl {
           }
         });
       } else {
-        Promise<Iterable<String>> promise = Promise.promise();
+        Promise<Iterable<String>> promise = ctx.promise();
         serializer.queue(message, nodeSelector::selectForPublish, promise);
         promise.future().onComplete(ar -> {
           if (ar.succeeded()) {

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredHandlerHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredHandlerHolder.java
@@ -19,8 +19,8 @@ public class ClusteredHandlerHolder<T> extends HandlerHolder<T> {
 
   private final long seq;
 
-  public ClusteredHandlerHolder(HandlerRegistration<T> handler, boolean replyHandler, boolean localOnly, ContextInternal context, long seq) {
-    super(handler, replyHandler, localOnly, context);
+  public ClusteredHandlerHolder(HandlerRegistration<T> handler, boolean localOnly, ContextInternal context, long seq) {
+    super(handler, localOnly, context);
     this.seq = seq;
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
@@ -14,7 +14,7 @@ package io.vertx.core.eventbus.impl.clustered;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBusOptions;
-import io.vertx.core.eventbus.impl.OutboundDeliveryContext;
+import io.vertx.core.eventbus.impl.MessageImpl;
 import io.vertx.core.eventbus.impl.codecs.PingMessageCodec;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.logging.Logger;
@@ -41,11 +41,20 @@ class ConnectionHolder {
   private final VertxInternal vertx;
   private final EventBusMetrics metrics;
 
-  private Queue<OutboundDeliveryContext<?>> pending;
+  private Queue<SomeTask> pending;
   private NetSocket socket;
   private boolean connected;
   private long timeoutID = -1;
   private long pingTimeoutID = -1;
+
+  private static class SomeTask {
+    final MessageImpl<?, ?> message;
+    final Promise<Void> writePromise;
+    SomeTask(MessageImpl<?, ?> message, Promise<Void> writePromise) {
+      this.message = message;
+      this.writePromise = writePromise;
+    }
+  }
 
   ConnectionHolder(ClusteredEventBus eventBus, String remoteNodeId) {
     this.eventBus = eventBus;
@@ -70,13 +79,13 @@ class ConnectionHolder {
   }
 
   // TODO optimise this (contention on monitor)
-  synchronized void writeMessage(OutboundDeliveryContext<?> ctx) {
+  synchronized void writeMessage(MessageImpl<?, ?> message, Promise<Void> writePromise) {
     if (connected) {
-      Buffer data = ((ClusteredMessage) ctx.message).encodeToWire();
+      Buffer data = ((ClusteredMessage) message).encodeToWire();
       if (metrics != null) {
-        metrics.messageWritten(ctx.message.address(), data.length());
+        metrics.messageWritten(message.address(), data.length());
       }
-      socket.write(data).onComplete(ctx);
+      socket.write(data).onComplete(writePromise);
     } else {
       if (pending == null) {
         if (log.isDebugEnabled()) {
@@ -84,7 +93,7 @@ class ConnectionHolder {
         }
         pending = new ArrayDeque<>();
       }
-      pending.add(ctx);
+      pending.add(new SomeTask(message, writePromise));
     }
   }
 
@@ -100,10 +109,10 @@ class ConnectionHolder {
       vertx.cancelTimer(pingTimeoutID);
     }
     synchronized (this) {
-      OutboundDeliveryContext<?> msg;
+      SomeTask msg;
       if (pending != null) {
         while ((msg = pending.poll()) != null) {
-          msg.written(cause);
+          msg.writePromise.tryFail(cause);
         }
       }
     }
@@ -150,12 +159,12 @@ class ConnectionHolder {
       if (log.isDebugEnabled()) {
         log.debug("Draining the queue for server " + remoteNodeId);
       }
-      for (OutboundDeliveryContext<?> ctx : pending) {
+      for (SomeTask ctx : pending) {
         Buffer data = ((ClusteredMessage<?, ?>)ctx.message).encodeToWire();
         if (metrics != null) {
           metrics.messageWritten(ctx.message.address(), data.length());
         }
-        socket.write(data).onComplete(ctx);
+        socket.write(data).onComplete(ctx.writePromise);
       }
     }
     pending = null;

--- a/src/main/java/io/vertx/core/spi/cluster/NodeSelector.java
+++ b/src/main/java/io/vertx/core/spi/cluster/NodeSelector.java
@@ -13,7 +13,6 @@ package io.vertx.core.spi.cluster;
 
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.Message;
 import io.vertx.core.impl.VertxBuilder;
 import io.vertx.core.spi.VertxServiceProvider;
 
@@ -47,20 +46,16 @@ public interface NodeSelector extends VertxServiceProvider {
    *
    * <p> The provided {@code promise} needs to be completed with {@link Promise#tryComplete} and {@link Promise#tryFail}
    * as it might completed outside the selector.
-   *
-   * @throws IllegalArgumentException if {@link Message#isSend()} returns {@code false}
    */
-  void selectForSend(Message<?> message, Promise<String> promise);
+  void selectForSend(String address, Promise<String> promise);
 
   /**
    * Select a node for publishing the given {@code message}.
    *
    * <p> The provided {@code promise} needs to be completed with {@link Promise#tryComplete} and {@link Promise#tryFail}
    * as it might completed outside the selector.
-   *
-   * @throws IllegalArgumentException if {@link Message#isSend()} returns {@code true}
    */
-  void selectForPublish(Message<?> message, Promise<Iterable<String>> promise);
+  void selectForPublish(String address, Promise<Iterable<String>> promise);
 
   /**
    * Invoked by the {@link ClusterManager} when messaging handler registrations are added or removed.

--- a/src/main/java/io/vertx/core/spi/cluster/impl/DefaultNodeSelector.java
+++ b/src/main/java/io/vertx/core/spi/cluster/impl/DefaultNodeSelector.java
@@ -13,8 +13,6 @@ package io.vertx.core.spi.cluster.impl;
 
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.Message;
-import io.vertx.core.impl.Arguments;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.cluster.NodeSelector;
 import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
@@ -37,17 +35,15 @@ public class DefaultNodeSelector implements NodeSelector {
   }
 
   @Override
-  public void selectForSend(Message<?> message, Promise<String> promise) {
-    Arguments.require(message.isSend(), "selectForSend used for publishing");
-    selectors.withSelector(message, promise, (prom, selector) -> {
+  public void selectForSend(String address, Promise<String> promise) {
+    selectors.withSelector(address, promise, (prom, selector) -> {
       prom.tryComplete(selector.selectForSend());
     });
   }
 
   @Override
-  public void selectForPublish(Message<?> message, Promise<Iterable<String>> promise) {
-    Arguments.require(!message.isSend(), "selectForPublish used for sending");
-    selectors.withSelector(message, promise, (prom, selector) -> {
+  public void selectForPublish(String address, Promise<Iterable<String>> promise) {
+    selectors.withSelector(address, promise, (prom, selector) -> {
       prom.tryComplete(selector.selectForPublish());
     });
   }

--- a/src/main/java/io/vertx/core/spi/cluster/impl/selector/Selectors.java
+++ b/src/main/java/io/vertx/core/spi/cluster/impl/selector/Selectors.java
@@ -35,8 +35,7 @@ public class Selectors {
     this.clusterManager = clusterManager;
   }
 
-  public <T> void withSelector(Message<?> message, Promise<T> promise, BiConsumer<Promise<T>, RoundRobinSelector> task) {
-    String address = message.address();
+  public <T> void withSelector(String address, Promise<T> promise, BiConsumer<Promise<T>, RoundRobinSelector> task) {
     SelectorEntry entry = map.compute(address, (addr, curr) -> {
       return curr == null ? new SelectorEntry() : (curr.isNotReady() ? curr.increment() : curr);
     });

--- a/src/main/java/io/vertx/core/spi/metrics/EventBusMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/EventBusMetrics.java
@@ -23,13 +23,12 @@ public interface EventBusMetrics<H> extends Metrics {
 
   /**
    * Called when a handler is registered on the event bus.<p/>
-   *
+   * <p>
    * No specific thread and context can be expected when this method is called.
    *
    * @param address the address used to register the handler
-   * @param repliedAddress null when the handler is not a reply handler, otherwise the address this handler is replying to
    */
-  default H handlerRegistered(String address, String repliedAddress) {
+  default H handlerRegistered(String address) {
     return null;
   }
 

--- a/src/test/java/io/vertx/core/eventbus/CustomNodeSelectorTest.java
+++ b/src/test/java/io/vertx/core/eventbus/CustomNodeSelectorTest.java
@@ -105,12 +105,12 @@ public class CustomNodeSelectorTest extends VertxTestBase {
     }
 
     @Override
-    public void selectForSend(Message<?> message, Promise<String> promise) {
+    public void selectForSend(String address, Promise<String> promise) {
       promise.fail("Not implemented");
     }
 
     @Override
-    public void selectForPublish(Message<?> message, Promise<Iterable<String>> promise) {
+    public void selectForPublish(String address, Promise<Iterable<String>> promise) {
       List<String> nodes = clusterManager.getNodes();
       CompositeFuture future = nodes.stream()
         .map(nodeId -> {

--- a/src/test/java/io/vertx/core/eventbus/MessageQueueOnWorkerThreadTest.java
+++ b/src/test/java/io/vertx/core/eventbus/MessageQueueOnWorkerThreadTest.java
@@ -89,7 +89,7 @@ public class MessageQueueOnWorkerThreadTest extends VertxTestBase {
     }
 
     @Override
-    public void selectForSend(Message<?> message, Promise<String> promise) {
+    public void selectForSend(String address, Promise<String> promise) {
       try {
         NANOSECONDS.sleep(150);
       } catch (InterruptedException e) {
@@ -99,7 +99,7 @@ public class MessageQueueOnWorkerThreadTest extends VertxTestBase {
     }
 
     @Override
-    public void selectForPublish(Message<?> message, Promise<Iterable<String>> promise) {
+    public void selectForPublish(String address, Promise<Iterable<String>> promise) {
       throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/io/vertx/core/eventbus/WriteHandlerLookupFailureTest.java
+++ b/src/test/java/io/vertx/core/eventbus/WriteHandlerLookupFailureTest.java
@@ -38,12 +38,12 @@ public final class WriteHandlerLookupFailureTest extends VertxTestBase {
       .setPort(0);
     NodeSelector nodeSelector = new DefaultNodeSelector() {
       @Override
-      public void selectForSend(Message<?> message, Promise<String> promise) {
+      public void selectForSend(String address, Promise<String> promise) {
         promise.fail(cause);
       }
 
       @Override
-      public void selectForPublish(Message<?> message, Promise<Iterable<String>> promise) {
+      public void selectForPublish(String address, Promise<Iterable<String>> promise) {
         promise.fail("Not implemented");
       }
     };

--- a/src/test/java/io/vertx/core/spi/cluster/WrappedNodeSelector.java
+++ b/src/test/java/io/vertx/core/spi/cluster/WrappedNodeSelector.java
@@ -34,13 +34,13 @@ public class WrappedNodeSelector implements NodeSelector {
   }
 
   @Override
-  public void selectForSend(Message<?> message, Promise<String> promise) {
-    delegate.selectForSend(message, promise);
+  public void selectForSend(String address, Promise<String> promise) {
+    delegate.selectForSend(address, promise);
   }
 
   @Override
-  public void selectForPublish(Message<?> message, Promise<Iterable<String>> promise) {
-    delegate.selectForPublish(message, promise);
+  public void selectForPublish(String address, Promise<Iterable<String>> promise) {
+    delegate.selectForPublish(address, promise);
   }
 
   @Override

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
@@ -827,13 +827,12 @@ public class MetricsContextTest extends VertxTestBase {
     AtomicReference<Thread> deliveredThread = new AtomicReference<>();
     AtomicBoolean registeredCalled = new AtomicBoolean();
     AtomicBoolean unregisteredCalled = new AtomicBoolean();
-    AtomicBoolean messageDelivered = new AtomicBoolean();
     VertxMetricsFactory factory = (options) -> new DummyVertxMetrics() {
       @Override
       public EventBusMetrics createEventBusMetrics() {
         return new DummyEventBusMetrics() {
           @Override
-          public Void handlerRegistered(String address, String repliedAddress) {
+          public Void handlerRegistered(String address) {
             registeredCalled.set(true);
             return null;
           }

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -342,7 +342,6 @@ public class MetricsTest extends VertxTestBase {
     assertEquals(1, metrics.getRegistrations().size());
     HandlerMetric registration = metrics.getRegistrations().get(0);
     assertEquals(ADDRESS1, registration.address);
-    assertEquals(null, registration.repliedAddress);
     consumer.unregister().onComplete(onSuccess(v1 -> {
       assertEquals(0, metrics.getRegistrations().size());
       consumer.unregister().onComplete(onSuccess(v2 -> {
@@ -397,7 +396,6 @@ public class MetricsTest extends VertxTestBase {
       to.eventBus().consumer(ADDRESS1, msg -> {
         HandlerMetric registration = assertRegistration(metrics);
         assertEquals(ADDRESS1, registration.address);
-        assertEquals(null, registration.repliedAddress);
         assertEquals(1, registration.scheduleCount.get());
         assertEquals(expectedLocalCount, registration.localScheduleCount.get());
         assertEquals(1, registration.deliveredCount.get());
@@ -416,7 +414,6 @@ public class MetricsTest extends VertxTestBase {
     }
     HandlerMetric registration = assertRegistration(metrics);
     assertEquals(ADDRESS1, registration.address);
-    assertEquals(null, registration.repliedAddress);
     from.eventBus().request(ADDRESS1, "ping").onComplete(onSuccess(reply -> {
       assertEquals(1, registration.scheduleCount.get());
       // This might take a little time
@@ -438,7 +435,6 @@ public class MetricsTest extends VertxTestBase {
       assertEquals(ADDRESS1, metrics.getRegistrations().get(0).address);
       assertWaitUntil(() -> metrics.getRegistrations().size() == 2);
       HandlerMetric registration = metrics.getRegistrations().get(1);
-      assertEquals(null, registration.repliedAddress); // new behavior
       assertEquals(0, registration.scheduleCount.get());
       assertEquals(0, registration.deliveredCount.get());
       assertEquals(0, registration.localDeliveredCount.get());
@@ -452,13 +448,11 @@ public class MetricsTest extends VertxTestBase {
     vertx.eventBus().request(ADDRESS1, "ping").onComplete(onSuccess(reply -> {
       assertEquals(ADDRESS1, metrics.getRegistrations().get(0).address);
       HandlerMetric registration = replyRegistration.get();
-      assertEquals(null, registration.repliedAddress);
       assertEquals(1, registration.scheduleCount.get());
       assertEquals(1, registration.deliveredCount.get());
       assertEquals(1, registration.localDeliveredCount.get());
       vertx.runOnContext(v -> {
         assertEquals(ADDRESS1, metrics.getRegistrations().get(0).address);
-        assertEquals(null, registration.repliedAddress);
         assertEquals(1, registration.scheduleCount.get());
         assertEquals(1, registration.deliveredCount.get());
         assertEquals(1, registration.localDeliveredCount.get());

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -438,7 +438,7 @@ public class MetricsTest extends VertxTestBase {
       assertEquals(ADDRESS1, metrics.getRegistrations().get(0).address);
       assertWaitUntil(() -> metrics.getRegistrations().size() == 2);
       HandlerMetric registration = metrics.getRegistrations().get(1);
-      assertEquals(ADDRESS1, registration.repliedAddress);
+      assertEquals(null, registration.repliedAddress); // new behavior
       assertEquals(0, registration.scheduleCount.get());
       assertEquals(0, registration.deliveredCount.get());
       assertEquals(0, registration.localDeliveredCount.get());
@@ -452,13 +452,13 @@ public class MetricsTest extends VertxTestBase {
     vertx.eventBus().request(ADDRESS1, "ping").onComplete(onSuccess(reply -> {
       assertEquals(ADDRESS1, metrics.getRegistrations().get(0).address);
       HandlerMetric registration = replyRegistration.get();
-      assertEquals(ADDRESS1, registration.repliedAddress);
+      assertEquals(null, registration.repliedAddress);
       assertEquals(1, registration.scheduleCount.get());
       assertEquals(1, registration.deliveredCount.get());
       assertEquals(1, registration.localDeliveredCount.get());
       vertx.runOnContext(v -> {
         assertEquals(ADDRESS1, metrics.getRegistrations().get(0).address);
-        assertEquals(ADDRESS1, registration.repliedAddress);
+        assertEquals(null, registration.repliedAddress);
         assertEquals(1, registration.scheduleCount.get());
         assertEquals(1, registration.deliveredCount.get());
         assertEquals(1, registration.localDeliveredCount.get());

--- a/src/test/java/io/vertx/test/fakemetrics/FakeEventBusMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeEventBusMetrics.java
@@ -76,8 +76,8 @@ public class FakeEventBusMetrics extends FakeMetricsBase implements EventBusMetr
   }
 
   @Override
-  public HandlerMetric handlerRegistered(String address, String repliedAddress) {
-    HandlerMetric registration = new HandlerMetric(address, repliedAddress);
+  public HandlerMetric handlerRegistered(String address) {
+    HandlerMetric registration = new HandlerMetric(address);
     registrations.add(registration);
     return registration;
   }

--- a/src/test/java/io/vertx/test/fakemetrics/HandlerMetric.java
+++ b/src/test/java/io/vertx/test/fakemetrics/HandlerMetric.java
@@ -19,21 +19,19 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class HandlerMetric {
 
   public final String address;
-  public final String repliedAddress;
   public final AtomicInteger scheduleCount = new AtomicInteger();
   public final AtomicInteger localScheduleCount = new AtomicInteger();
   public final AtomicInteger discardCount = new AtomicInteger();
   public final AtomicInteger deliveredCount = new AtomicInteger();
   public final AtomicInteger localDeliveredCount = new AtomicInteger();
 
-  public HandlerMetric(String address, String repliedAddress) {
+  public HandlerMetric(String address) {
     this.address = address;
-    this.repliedAddress = repliedAddress;
   }
 
   @Override
   public String toString() {
-    return "HandlerRegistration[address=" + address + ",repliedAddress=" + repliedAddress +
+    return "HandlerRegistration[address=" + address +
         ",deliveredCount=" + deliveredCount.get() + ",discardCount="  + discardCount + ",localCount=" + localDeliveredCount.get() + "]";
   }
 }


### PR DESCRIPTION
See also https://github.com/eclipse-vertx/vert.x/pull/4712

# Decouple message emission from the interceptor chain

EventBus streaming requires to send messages that does not go through the interceptor chain, e.g. establishing a stream requires to send such messages. The sendOrPub method and the downstream chain of calls (sendLocally, sendOrPublishFailed, sendToNode, sendToNodes) are coupled to OutboundDeliveryContext by convenience. The EventBus#sendOrPub is refactored to carry the messages and the delivery options instead of the OutboundDeliveryContext.

Main changes

- `EventBusImpl#sendOrPub(OutboundDeliveryContext) -> EventBusimpl#sendOrPub(ContextInternal,MessageImpl,DeliveryOptions,Promise)`
- same for `sendLocally`, `sendOrPublishFailed`, `sendToNode`, `sendToNodes`

# Decouple the RegistrationHandler from the repliedAddress knowledge

The clustered event bus is aware of the nature of the `HandlerHolder`: when a `HandlerHolder` is registered it does broadcast the registration when the `HandlerHolder` is a reply handler. The `HandlerHolder#isReplyHandler()` method is removed, instead `EventBusImpl#addRegistration` replaces the `replyHandler` boolean by a `broadcast` boolean, when `broadcast` is set to false the `onLocalRegistration` method is not called avoiding the clustered event bus to perform the check.

Main changes:

- `HandlerRegistration#register(String repliedAddress, boolean localOnly, Promise<Void> promise)` -> `HandlerRegistration#register(boolean broadcast, boolean localOnly, Promise<Void> promise)`
- `HandlerHolder` does not carry anymore the `replyHandler` boolean
- `MessageConsumerImpl` calls register with `broadcast` = true
- `ReplyHandler` calls register with `broadcast` = false
- `ClusteredEventBus` processes a local registration whatsoever as it is not called for reply handlers

# NodeSelector cleanup

The `NodeSelector` SPI is coupled to event-bus message API, instead it should only care about the message address, this simplifies the API and decouple the `NodeSelector` SPI from the message.

Main changes:

- `NodeSelector#selectForSend(Message, Promise<String>)` -> `NodeSelector#selectForSend(String, Promise<String>)`
- etc...