### PR TITLE
Replace Future eventually function argument by a supplier argument

### DIFF
--- a/src/main/java/examples/FileSystemExamples.java
+++ b/src/main/java/examples/FileSystemExamples.java
@@ -165,7 +165,7 @@ public class FileSystemExamples {
       .open("target/classes/les_miserables.txt", new OpenOptions())
       .compose(file -> file
         .pipeTo(output)
-        .eventually(v -> file.close()))
+        .eventually(() -> file.close()))
       .onComplete(result -> {
         if (result.succeeded()) {
           System.out.println("Copy done");

--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Represents the result of an action that may, or may not, have occurred yet.
@@ -417,7 +418,7 @@ public interface Future<T> extends AsyncResult<T> {
    * @param mapper the function returning the future.
    * @return the composed future
    */
-  <U> Future<T> eventually(Function<Void, Future<U>> mapper);
+  <U> Future<T> eventually(Supplier<Future<U>> mapper);
 
   /**
    * Apply a {@code mapper} function on this future.<p>

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -555,7 +555,7 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
         checkSendHeaders(false);
         return file
           .pipeTo(this)
-          .eventually(v -> file.close());
+          .eventually(() -> file.close());
     });
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
@@ -200,7 +200,7 @@ class HttpNetSocket implements NetSocket {
         .pipe()
         .endOnComplete(false)
         .to(this)
-        .eventually(v -> file.close())
+        .eventually(file::close)
       );
   }
 

--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -337,7 +337,7 @@ public class DeploymentManager {
             Promise<Void> stopPromise = undeployingContext.promise();
             Future<Void> stopFuture = stopPromise.future();
             stopFuture
-              .eventually(v2 -> {
+              .eventually(() -> {
                 deployments.remove(deploymentID);
                 return verticleHolder
                   .close()

--- a/src/main/java/io/vertx/core/impl/future/Eventually.java
+++ b/src/main/java/io/vertx/core/impl/future/Eventually.java
@@ -14,6 +14,7 @@ import io.vertx.core.Future;
 import io.vertx.core.impl.ContextInternal;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Eventually operation.
@@ -22,18 +23,18 @@ import java.util.function.Function;
  */
 class Eventually<T, U> extends Operation<T> implements Listener<T> {
 
-  private final Function<Void, Future<U>> mapper;
+  private final Supplier<Future<U>> supplier;
 
-  Eventually(ContextInternal context, Function<Void, Future<U>> mapper) {
+  Eventually(ContextInternal context, Supplier<Future<U>> supplier) {
     super(context);
-    this.mapper = mapper;
+    this.supplier = supplier;
   }
 
   @Override
   public void onSuccess(T value) {
     FutureInternal<U> future;
     try {
-      future = (FutureInternal<U>) mapper.apply(null);
+      future = (FutureInternal<U>) supplier.get();
     } catch (Throwable e) {
       tryFail(e);
       return;
@@ -54,7 +55,7 @@ class Eventually<T, U> extends Operation<T> implements Listener<T> {
   public void onFailure(Throwable failure) {
     FutureInternal<U> future;
     try {
-      future = (FutureInternal<U>) mapper.apply(null);
+      future = (FutureInternal<U>) supplier.get();
     } catch (Throwable e) {
       tryFail(e);
       return;

--- a/src/main/java/io/vertx/core/impl/future/FutureBase.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureBase.java
@@ -18,6 +18,7 @@ import io.vertx.core.impl.ContextInternal;
 
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Future base implementation.
@@ -94,9 +95,9 @@ public abstract class FutureBase<T> implements FutureInternal<T> {
   }
 
   @Override
-  public <U> Future<T> eventually(Function<Void, Future<U>> mapper) {
-    Objects.requireNonNull(mapper, "No null mapper accepted");
-    Eventually<T, U> operation = new Eventually<>(context, mapper);
+  public <U> Future<T> eventually(Supplier<Future<U>> supplier) {
+    Objects.requireNonNull(supplier, "No null supplier accepted");
+    Eventually<T, U> operation = new Eventually<>(context, supplier);
     addListener(operation);
     return operation;
   }

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -396,7 +397,7 @@ public class FutureTest extends FutureTestBase {
     Future<Integer> c = p.future();
     Promise<String> p3 = Promise.promise();
     Future<String> f3 = p3.future();
-    Future<String> f4 = f3.eventually(v -> {
+    Future<String> f4 = f3.eventually(() -> {
       cnt.incrementAndGet();
       return c;
     });
@@ -425,7 +426,7 @@ public class FutureTest extends FutureTestBase {
     Future<Integer> c = p.future();
     Promise<String> p3 = Promise.promise();
     Future<String> f3 = p3.future();
-    Future<String> f4 = f3.eventually(v -> {
+    Future<String> f4 = f3.eventually(() -> {
       cnt.incrementAndGet();
       return c;
     });
@@ -823,7 +824,7 @@ public class FutureTest extends FutureTestBase {
       public boolean failed() { throw new UnsupportedOperationException(); }
       public <U> Future<U> compose(Function<T, Future<U>> successMapper, Function<Throwable, Future<U>> failureMapper) { throw new UnsupportedOperationException(); }
       public <U> Future<U> transform(Function<AsyncResult<T>, Future<U>> mapper) { throw new UnsupportedOperationException(); }
-      public <U> Future<T> eventually(Function<Void, Future<U>> mapper) { throw new UnsupportedOperationException(); }
+      public <U> Future<T> eventually(Supplier<Future<U>> mapper) { throw new UnsupportedOperationException(); }
       public <U> Future<U> map(Function<T, U> mapper) { throw new UnsupportedOperationException(); }
       public <V> Future<V> map(V value) { throw new UnsupportedOperationException(); }
       public Future<T> otherwise(Function<Throwable, T> mapper) { throw new UnsupportedOperationException(); }

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -3609,7 +3609,7 @@ public class WebSocketTest extends VertxTestBase {
       assertNull(ws.binaryHandlerID());
       ws.binaryMessageHandler(data -> {
         assertEquals(hello, data);
-        ws.writeBinaryMessage(bye).eventually(v -> ws.close());
+        ws.writeBinaryMessage(bye).eventually(ws::close);
       });
     });
 


### PR DESCRIPTION
The` Future#eventually` should use a `Supplier<Future<T>>` instead of a function, the new method was added in Vert.x 4 and the function version has been deprecated.

Replace `Future#eventually(Function<Void, Future<T>>)` by `Future#eventually(Supplier<Future<T>>)`.
