### PR TITLE
Dns address resolver hosts configuration refresh period.

### DIFF
--- a/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
+++ b/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
@@ -59,6 +59,11 @@ public class AddressResolverOptions {
   public static final int DEFAULT_QUERY_TIMEOUT = 5000;
 
   /**
+   * The default value for the hosts refresh value in millis = 0 (disabled)
+   */
+  public static final int DEFAULT_HOSTS_REFRESH_PERIOD = 0;
+
+  /**
    * The default value for the max dns queries per query = 4
    */
   public static final int DEFAULT_MAX_QUERIES = 4;
@@ -90,6 +95,7 @@ public class AddressResolverOptions {
 
   private String hostsPath;
   private Buffer hostsValue;
+  private int hostsRefreshPeriod;
   private List<String> servers;
   private boolean optResourceEnabled;
   private int cacheMinTimeToLive;
@@ -116,11 +122,13 @@ public class AddressResolverOptions {
     ndots = DEFAULT_NDOTS;
     rotateServers = DEFAULT_ROTATE_SERVERS;
     roundRobinInetAddress = DEFAULT_ROUND_ROBIN_INET_ADDRESS;
+    hostsRefreshPeriod = DEFAULT_HOSTS_REFRESH_PERIOD;
   }
 
   public AddressResolverOptions(AddressResolverOptions other) {
     this.hostsPath = other.hostsPath;
     this.hostsValue = other.hostsValue != null ? other.hostsValue.copy() : null;
+    this.hostsRefreshPeriod = other.hostsRefreshPeriod;
     this.servers = other.servers != null ? new ArrayList<>(other.servers) : null;
     this.optResourceEnabled = other.optResourceEnabled;
     this.cacheMinTimeToLive = other.cacheMinTimeToLive;
@@ -179,6 +187,30 @@ public class AddressResolverOptions {
    */
   public AddressResolverOptions setHostsValue(Buffer hostsValue) {
     this.hostsValue = hostsValue;
+    return this;
+  }
+
+  /**
+   * @return the hosts configuration refresh period in millis
+   */
+  public int getHostsRefreshPeriod() {
+    return hostsRefreshPeriod;
+  }
+
+  /**
+   * Set the hosts configuration refresh period in millis, {@code 0} disables it.
+   * <p/>
+   * The resolver caches the hosts configuration {@link #hostsPath file} after it has read it. When
+   * the content of this file can change, setting a positive refresh period will load the configuration
+   * file again when necessary.
+   *
+   * @param hostsRefreshPeriod the hosts configuration refresh period
+   */
+  public AddressResolverOptions setHostsRefreshPeriod(int hostsRefreshPeriod) {
+    if (hostsRefreshPeriod < 0) {
+      throw new IllegalArgumentException("hostsRefreshPeriod must be >= 0");
+    }
+    this.hostsRefreshPeriod = hostsRefreshPeriod;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/impl/AddressResolver.java
+++ b/src/main/java/io/vertx/core/impl/AddressResolver.java
@@ -21,6 +21,7 @@ import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.impl.resolver.DnsResolverProvider;
 import io.vertx.core.spi.resolver.ResolverProvider;
 
 import java.io.File;

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -518,7 +518,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     String host = options.getHost();
     int port = options.getPort();
     if (host == null || port < 0) {
-      DnsResolverProvider provider = new DnsResolverProvider(this, addressResolverOptions);
+      DnsResolverProvider provider = DnsResolverProvider.create(this, addressResolverOptions);
       InetSocketAddress address = provider.nameServerAddresses().get(0);
       // provide the host and port
       options = new DnsClientOptions(options)

--- a/src/main/java/io/vertx/core/spi/resolver/ResolverProvider.java
+++ b/src/main/java/io/vertx/core/spi/resolver/ResolverProvider.java
@@ -18,6 +18,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
 import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.impl.VertxImpl;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.resolver.DnsResolverProvider;
 import io.vertx.core.impl.resolver.DefaultResolverProvider;
 import io.vertx.core.impl.logging.Logger;
@@ -37,7 +38,7 @@ public interface ResolverProvider {
     // that use an unstable API and fallback on the default (blocking) provider
     try {
       if (!Boolean.getBoolean(DISABLE_DNS_RESOLVER_PROP_NAME)) {
-        return new DnsResolverProvider((VertxImpl) vertx, options);
+        return DnsResolverProvider.create((VertxInternal) vertx, options);
       }
     } catch (Throwable e) {
       if (e instanceof VertxException) {


### PR DESCRIPTION
The Vert.x DNS address resolver can load an hosts configuration file and cache the content forever. Sometimes the content of the file can change and the cached content becomes stale.

Add a new AddressResolverOptions hostsRefreshPeriod property to let the resolver refresh the hosts file when its cached content is older than the last read + refresh period.
