### PR TITLE
Dns address resolver hosts configuration refresh period.

### DIFF
--- a/src/main/generated/io/vertx/core/dns/AddressResolverOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/dns/AddressResolverOptionsConverter.java
@@ -40,6 +40,11 @@ public class AddressResolverOptionsConverter {
             obj.setHostsPath((String)member.getValue());
           }
           break;
+        case "hostsRefreshPeriod":
+          if (member.getValue() instanceof Number) {
+            obj.setHostsRefreshPeriod(((Number)member.getValue()).intValue());
+          }
+          break;
         case "hostsValue":
           if (member.getValue() instanceof String) {
             obj.setHostsValue(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)member.getValue())));
@@ -115,6 +120,7 @@ public class AddressResolverOptionsConverter {
     if (obj.getHostsPath() != null) {
       json.put("hostsPath", obj.getHostsPath());
     }
+    json.put("hostsRefreshPeriod", obj.getHostsRefreshPeriod());
     if (obj.getHostsValue() != null) {
       json.put("hostsValue", BASE64_ENCODER.encodeToString(obj.getHostsValue().getBytes()));
     }

--- a/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
+++ b/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
@@ -59,6 +59,11 @@ public class AddressResolverOptions {
   public static final int DEFAULT_QUERY_TIMEOUT = 5000;
 
   /**
+   * The default value for the hosts refresh value in millis = 0 (disabled)
+   */
+  public static final int DEFAULT_HOSTS_REFRESH_PERIOD = 0;
+
+  /**
    * The default value for the max dns queries per query = 4
    */
   public static final int DEFAULT_MAX_QUERIES = 4;
@@ -90,6 +95,7 @@ public class AddressResolverOptions {
 
   private String hostsPath;
   private Buffer hostsValue;
+  private int hostsRefreshPeriod;
   private List<String> servers;
   private boolean optResourceEnabled;
   private int cacheMinTimeToLive;
@@ -116,11 +122,13 @@ public class AddressResolverOptions {
     ndots = DEFAULT_NDOTS;
     rotateServers = DEFAULT_ROTATE_SERVERS;
     roundRobinInetAddress = DEFAULT_ROUND_ROBIN_INET_ADDRESS;
+    hostsRefreshPeriod = DEFAULT_HOSTS_REFRESH_PERIOD;
   }
 
   public AddressResolverOptions(AddressResolverOptions other) {
     this.hostsPath = other.hostsPath;
     this.hostsValue = other.hostsValue != null ? other.hostsValue.copy() : null;
+    this.hostsRefreshPeriod = other.hostsRefreshPeriod;
     this.servers = other.servers != null ? new ArrayList<>(other.servers) : null;
     this.optResourceEnabled = other.optResourceEnabled;
     this.cacheMinTimeToLive = other.cacheMinTimeToLive;
@@ -179,6 +187,30 @@ public class AddressResolverOptions {
    */
   public AddressResolverOptions setHostsValue(Buffer hostsValue) {
     this.hostsValue = hostsValue;
+    return this;
+  }
+
+  /**
+   * @return the hosts configuration refresh period in millis
+   */
+  public int getHostsRefreshPeriod() {
+    return hostsRefreshPeriod;
+  }
+
+  /**
+   * Set the hosts configuration refresh period in millis, {@code 0} disables it.
+   * <p/>
+   * The resolver caches the hosts configuration {@link #hostsPath file} after it has read it. When
+   * the content of this file can change, setting a positive refresh period will load the configuration
+   * file again when necessary.
+   *
+   * @param hostsRefreshPeriod the hosts configuration refresh period
+   */
+  public AddressResolverOptions setHostsRefreshPeriod(int hostsRefreshPeriod) {
+    if (hostsRefreshPeriod < 0) {
+      throw new IllegalArgumentException("hostsRefreshPeriod must be >= 0");
+    }
+    this.hostsRefreshPeriod = hostsRefreshPeriod;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/impl/AddressResolver.java
+++ b/src/main/java/io/vertx/core/impl/AddressResolver.java
@@ -21,6 +21,7 @@ import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.impl.launcher.commands.ExecUtils;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.impl.resolver.DnsResolverProvider;
 import io.vertx.core.spi.resolver.ResolverProvider;
 
 import java.io.File;

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -529,7 +529,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     String host = options.getHost();
     int port = options.getPort();
     if (host == null || port < 0) {
-      DnsResolverProvider provider = new DnsResolverProvider(this, addressResolverOptions);
+      DnsResolverProvider provider = DnsResolverProvider.create(this, addressResolverOptions);
       InetSocketAddress address = provider.nameServerAddresses().get(0);
       // provide the host and port
       options = new DnsClientOptions(options)

--- a/src/main/java/io/vertx/core/impl/resolver/DnsResolverProvider.java
+++ b/src/main/java/io/vertx/core/impl/resolver/DnsResolverProvider.java
@@ -11,21 +11,17 @@
 
 package io.vertx.core.impl.resolver;
 
-import io.netty.channel.ChannelFactory;
 import io.netty.channel.EventLoop;
-import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.resolver.*;
 import io.netty.resolver.dns.*;
 import io.netty.util.NetUtil;
-import io.netty.util.concurrent.EventExecutor;
-import io.vertx.core.Context;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxException;
+import io.vertx.core.*;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.impl.AddressResolver;
-import io.vertx.core.impl.VertxImpl;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.spi.resolver.ResolverProvider;
 
 import java.io.File;
@@ -34,27 +30,32 @@ import java.io.StringReader;
 import java.net.*;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static io.netty.util.internal.ObjectUtil.intValue;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class DnsResolverProvider implements ResolverProvider {
+public class DnsResolverProvider implements ResolverProvider, HostsFileEntriesResolver {
 
-  private final Vertx vertx;
+  public static DnsResolverProvider create(VertxInternal vertx, AddressResolverOptions options) {
+    DnsResolverProvider provider = new DnsResolverProvider(vertx, options);
+    provider.refresh();
+    return provider;
+  }
+
+  private final VertxInternal vertx;
   private final List<ResolverRegistration> resolvers = Collections.synchronizedList(new ArrayList<>());
   private AddressResolverGroup<InetSocketAddress> resolverGroup;
   private final List<InetSocketAddress> serverList = new ArrayList<>();
+  private final String hostsPath;
+  private final Buffer hostsValue;
+  private final AtomicLong refreshTimestamp = new AtomicLong();
+  private final long hostsRefreshPeriodNanos;
+  private volatile HostsFileEntries parsedHostsFile = new HostsFileEntries(Collections.emptyMap(), Collections.emptyMap());
 
-  /**
-   * @return a list of DNS servers available to use
-   */
-  public List<InetSocketAddress> nameServerAddresses() {
-    return serverList;
-  }
-
-  public DnsResolverProvider(VertxImpl vertx, AddressResolverOptions options) {
+  private DnsResolverProvider(VertxInternal vertx, AddressResolverOptions options) {
     List<String> dnsServers = options.getServers();
     if (dnsServers != null && dnsServers.size() > 0) {
       for (String dnsServer : dnsServers) {
@@ -87,30 +88,8 @@ public class DnsResolverProvider implements ResolverProvider {
       }
     }
     DnsServerAddresses nameServerAddresses = options.isRotateServers() ? DnsServerAddresses.rotational(serverList) : DnsServerAddresses.sequential(serverList);
-    DnsServerAddressStreamProvider nameServerAddressProvider = hostname -> {
-      return nameServerAddresses.stream();
-    };
+    DnsServerAddressStreamProvider nameServerAddressProvider = hostname -> nameServerAddresses.stream();
 
-    HostsFileEntries entries;
-    if (options.getHostsPath() != null) {
-      File file = vertx.resolveFile(options.getHostsPath()).getAbsoluteFile();
-      try {
-        if (!file.exists() || !file.isFile()) {
-          throw new IOException();
-        }
-        entries = HostsFileParser.parse(file);
-      } catch (IOException e) {
-        throw new VertxException("Cannot read hosts file " + file.getAbsolutePath());
-      }
-    } else if (options.getHostsValue() != null) {
-      try {
-        entries = HostsFileParser.parse(new StringReader(options.getHostsValue().toString()));
-      } catch (IOException e) {
-        throw new VertxException("Cannot read hosts config ", e);
-      }
-    } else {
-      entries = HostsFileParser.parseSilently();
-    }
 
     int minTtl = intValue(options.getCacheMinTimeToLive(), 0);
     int maxTtl = intValue(options.getCacheMaxTimeToLive(), Integer.MAX_VALUE);
@@ -119,38 +98,12 @@ public class DnsResolverProvider implements ResolverProvider {
     DnsCache authoritativeDnsServerCache = new DefaultDnsCache(minTtl, maxTtl, negativeTtl);
 
     this.vertx = vertx;
-
+    this.hostsPath = options.getHostsPath();
+    this.hostsValue = options.getHostsValue();
+    this.hostsRefreshPeriodNanos = options.getHostsRefreshPeriod();
 
     DnsNameResolverBuilder builder = new DnsNameResolverBuilder();
-    builder.hostsFileEntriesResolver(new HostsFileEntriesResolver() {
-      @Override
-      public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
-        if (inetHost.endsWith(".")) {
-          inetHost = inetHost.substring(0, inetHost.length() - 1);
-        }
-        InetAddress address = lookup(inetHost, resolvedAddressTypes);
-        if (address == null) {
-          address = lookup(inetHost.toLowerCase(Locale.ENGLISH), resolvedAddressTypes);
-        }
-        return address;
-      }
-      InetAddress lookup(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
-        switch (resolvedAddressTypes) {
-          case IPV4_ONLY:
-            return entries.inet4Entries().get(inetHost);
-          case IPV6_ONLY:
-            return entries.inet6Entries().get(inetHost);
-          case IPV4_PREFERRED:
-            Inet4Address inet4Address = entries.inet4Entries().get(inetHost);
-            return inet4Address != null? inet4Address : entries.inet6Entries().get(inetHost);
-          case IPV6_PREFERRED:
-            Inet6Address inet6Address = entries.inet6Entries().get(inetHost);
-            return inet6Address != null? inet6Address : entries.inet4Entries().get(inetHost);
-          default:
-            throw new IllegalArgumentException("Unknown ResolvedAddressTypes " + resolvedAddressTypes);
-        }
-      }
-    });
+    builder.hostsFileEntriesResolver(this);
     builder.channelFactory(() -> vertx.transport().datagramChannel());
     builder.socketChannelFactory(() -> (SocketChannel) vertx.transport().channelFactory(false).newChannel());
     builder.nameServerProvider(nameServerAddressProvider);
@@ -184,13 +137,42 @@ public class DnsResolverProvider implements ResolverProvider {
     };
   }
 
-  private static class ResolverRegistration {
-    private final io.netty.resolver.AddressResolver<InetSocketAddress> resolver;
-    private final EventLoop executor;
-    ResolverRegistration(io.netty.resolver.AddressResolver<InetSocketAddress> resolver, EventLoop executor) {
-      this.resolver = resolver;
-      this.executor = executor;
+  @Override
+  public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
+    if (inetHost.endsWith(".")) {
+      inetHost = inetHost.substring(0, inetHost.length() - 1);
     }
+    if (hostsRefreshPeriodNanos > 0) {
+      ensureHostsFileFresh(hostsRefreshPeriodNanos);
+    }
+    InetAddress address = lookup(inetHost, resolvedAddressTypes);
+    if (address == null) {
+      address = lookup(inetHost.toLowerCase(Locale.ENGLISH), resolvedAddressTypes);
+    }
+    return address;
+  }
+  InetAddress lookup(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
+    switch (resolvedAddressTypes) {
+      case IPV4_ONLY:
+        return parsedHostsFile.inet4Entries().get(inetHost);
+      case IPV6_ONLY:
+        return parsedHostsFile.inet6Entries().get(inetHost);
+      case IPV4_PREFERRED:
+        Inet4Address inet4Address = parsedHostsFile.inet4Entries().get(inetHost);
+        return inet4Address != null? inet4Address : parsedHostsFile.inet6Entries().get(inetHost);
+      case IPV6_PREFERRED:
+        Inet6Address inet6Address = parsedHostsFile.inet6Entries().get(inetHost);
+        return inet6Address != null? inet6Address : parsedHostsFile.inet4Entries().get(inetHost);
+      default:
+        throw new IllegalArgumentException("Unknown ResolvedAddressTypes " + resolvedAddressTypes);
+    }
+  }
+
+  /**
+   * @return a list of DNS servers available to use
+   */
+  public List<InetSocketAddress> nameServerAddresses() {
+    return serverList;
   }
 
   @Override
@@ -200,7 +182,7 @@ public class DnsResolverProvider implements ResolverProvider {
 
   @Override
   public void close(Handler<Void> doneHandler) {
-    Context context = vertx.getOrCreateContext();
+    ContextInternal context = vertx.getOrCreateContext();
     ResolverRegistration[] registrations = this.resolvers.toArray(new ResolverRegistration[0]);
     if (registrations.length == 0) {
       context.runOnContext(doneHandler);
@@ -219,6 +201,51 @@ public class DnsResolverProvider implements ResolverProvider {
       } else {
         registration.executor.execute(task);
       }
+    }
+  }
+
+  public void refresh() {
+    ensureHostsFileFresh(0);
+  }
+
+  private void ensureHostsFileFresh(long refreshPeriodNanos) {
+    long prev = refreshTimestamp.get();
+    long now = System.nanoTime();
+    if ((now - prev) >= refreshPeriodNanos && refreshTimestamp.compareAndSet(prev, now)) {
+      refreshHostsFile();
+    }
+  }
+
+  private void refreshHostsFile() {
+    HostsFileEntries entries;
+    if (hostsPath != null) {
+      File file = vertx.resolveFile(hostsPath).getAbsoluteFile();
+      try {
+        if (!file.exists() || !file.isFile()) {
+          throw new IOException();
+        }
+        entries = HostsFileParser.parse(file);
+      } catch (IOException e) {
+        throw new VertxException("Cannot read hosts file " + file.getAbsolutePath());
+      }
+    } else if (hostsValue != null) {
+      try {
+        entries = HostsFileParser.parse(new StringReader(hostsValue.toString()));
+      } catch (IOException e) {
+        throw new VertxException("Cannot read hosts config ", e);
+      }
+    } else {
+      entries = HostsFileParser.parseSilently();
+    }
+    parsedHostsFile = entries;
+  }
+
+  private static class ResolverRegistration {
+    private final io.netty.resolver.AddressResolver<InetSocketAddress> resolver;
+    private final EventLoop executor;
+    ResolverRegistration(io.netty.resolver.AddressResolver<InetSocketAddress> resolver, EventLoop executor) {
+      this.resolver = resolver;
+      this.executor = executor;
     }
   }
 }

--- a/src/main/java/io/vertx/core/spi/resolver/ResolverProvider.java
+++ b/src/main/java/io/vertx/core/spi/resolver/ResolverProvider.java
@@ -17,6 +17,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
 import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.impl.VertxImpl;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.resolver.DnsResolverProvider;
 import io.vertx.core.impl.resolver.DefaultResolverProvider;
 import io.vertx.core.impl.logging.Logger;
@@ -36,7 +37,7 @@ public interface ResolverProvider {
     // that use an unstable API and fallback on the default (blocking) provider
     try {
       if (!Boolean.getBoolean(DISABLE_DNS_RESOLVER_PROP_NAME)) {
-        return new DnsResolverProvider((VertxImpl) vertx, options);
+        return DnsResolverProvider.create((VertxInternal) vertx, options);
       }
     } catch (Throwable e) {
       if (e instanceof VertxException) {


### PR DESCRIPTION
The Vert.x DNS address resolver can load an hosts configuration file and cache the content forever. Sometimes the content of the file can change and the cached content becomes stale.

Add a new AddressResolverOptions hostsRefreshPeriod property to let the resolver refresh the hosts file when its cached content is older than the last read + refresh period.