### PR TITLE
feat: onComplete method new signature

### DIFF
--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -268,6 +268,26 @@ public interface Future<T> extends AsyncResult<T> {
   Future<T> onComplete(Handler<AsyncResult<T>> handler);
 
   /**
+   * Add handlers to be notified on succeeded result and failed result.
+   * <p>
+   * <em><strong>WARNING</strong></em>: this is a terminal operation.
+   * If several {@code handler}s are registered, there is no guarantee that they will be invoked in order of registration.
+   *
+   * @param successHandler the handler that will be called with the succeeded result
+   * @param failureHandler the handler that will be called with the failed result
+   * @return a reference to this, so it can be used fluently
+   */
+  default Future<T> onComplete(Handler<T> successHandler, Handler<Throwable> failureHandler) {
+      return onComplete(ar -> {
+        if (successHandler != null && ar.succeeded()) {
+          successHandler.handle(ar.result());
+        } else if (failureHandler != null && ar.failed()) {
+          failureHandler.handle(ar.cause());
+        }
+      });
+  }
+
+  /**
    * Add a handler to be notified of the succeeded result.
    * <p>
    * <em><strong>WARNING</strong></em>: this is a terminal operation.
@@ -278,11 +298,7 @@ public interface Future<T> extends AsyncResult<T> {
    */
   @Fluent
   default Future<T> onSuccess(Handler<T> handler) {
-    return onComplete(ar -> {
-      if (ar.succeeded()) {
-        handler.handle(ar.result());
-      }
-    });
+    return onComplete(handler, null);
   }
 
   /**
@@ -296,11 +312,7 @@ public interface Future<T> extends AsyncResult<T> {
    */
   @Fluent
   default Future<T> onFailure(Handler<Throwable> handler) {
-    return onComplete(ar -> {
-      if (ar.failed()) {
-        handler.handle(ar.cause());
-      }
-    });
+    return onComplete(null, handler);
   }
 
   /**

--- a/src/main/java/io/vertx/core/impl/future/FutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureImpl.java
@@ -128,6 +128,41 @@ class FutureImpl<T> extends FutureBase<T> {
   }
 
   @Override
+  public Future<T> onComplete(Handler<T> successHandler, Handler<Throwable> failureHandler) {
+    addListener(new Listener<T>() {
+      @Override
+      public void onSuccess(T value) {
+        try {
+          if (successHandler != null) {
+            successHandler.handle(value);
+          }
+        } catch (Throwable t) {
+          if (context != null) {
+            context.reportException(t);
+          } else {
+            throw t;
+          }
+        }
+      }
+      @Override
+      public void onFailure(Throwable failure) {
+        try {
+          if (failureHandler != null) {
+            failureHandler.handle(failure);
+          }
+        } catch (Throwable t) {
+          if (context != null) {
+            context.reportException(t);
+          } else {
+            throw t;
+          }
+        }
+      }
+    });
+    return this;
+  }
+
+  @Override
   public Future<T> onComplete(Handler<AsyncResult<T>> handler) {
     Objects.requireNonNull(handler, "No null handler accepted");
     Listener<T> listener;

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -1311,13 +1311,20 @@ public class FutureTest extends FutureTestBase {
 
   @Test
   public void testSuccessNotification() {
-    waitFor(2);
+    waitFor(3);
     Promise<String> promise = Promise.promise();
     Future<String> fut = promise.future();
     fut.onComplete(onSuccess(res -> {
       assertEquals("foo", res);
       complete();
     }));
+    fut.onComplete(
+      res -> {
+        assertEquals("foo", res);
+        complete();
+      },
+      err -> fail()
+    );
     fut.onSuccess(res -> {
       assertEquals("foo", res);
       complete();
@@ -1331,7 +1338,7 @@ public class FutureTest extends FutureTestBase {
 
   @Test
   public void testFailureNotification() {
-    waitFor(2);
+    waitFor(3);
     Promise<String> promise = Promise.promise();
     Future<String> fut = promise.future();
     Throwable failure = new Throwable();
@@ -1339,6 +1346,13 @@ public class FutureTest extends FutureTestBase {
       assertEquals(failure, err);
       complete();
     }));
+    fut.onComplete(
+      res -> fail(),
+      err -> {
+        assertEquals(failure, err);
+        complete();
+      }
+    );
     fut.onSuccess(res -> {
       fail();
     });


### PR DESCRIPTION
Add Future implementation
Add FutureImpl implementations
Refactor to re-use new code for onSuccess and onFailure

Motivation:

Add onComplete method to Future class with onSuccess and onFailure mappers
Closes https://github.com/eclipse-vertx/vert.x/issues/4829
Cherry-pick of #4830 
