### PR TITLE
EventBus impl - Remove duplicate fields and args, rename confusing field and method names

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -169,7 +169,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   public <T> MessageConsumer<T> consumer(String address) {
     checkStarted();
     Objects.requireNonNull(address, "address");
-    return new MessageConsumerImpl<>(vertx, vertx.getOrCreateContext(), this, address,  false);
+    return new MessageConsumerImpl<>(vertx.getOrCreateContext(), this, address,  false);
   }
 
   @Override
@@ -184,7 +184,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   public <T> MessageConsumer<T> localConsumer(String address) {
     checkStarted();
     Objects.requireNonNull(address, "address");
-    return new MessageConsumerImpl<>(vertx, vertx.getOrCreateContext(), this, address,  true);
+    return new MessageConsumerImpl<>(vertx.getOrCreateContext(), this, address,  true);
   }
 
   @Override
@@ -464,4 +464,3 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     }
   }
 }
-

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
@@ -22,23 +22,21 @@ import io.vertx.core.streams.ReadStream;
 
 import java.util.*;
 
-/*
- * This class is optimised for performance when used on the same event loop it was created on.
+/**
+ * This class is optimized for performance when used on the same event loop it was created on.
  * However it can be used safely from other threads.
  *
  * The internal state is protected using the synchronized keyword. If always used on the same event loop, then
  * we benefit from biased locking which makes the overhead of synchronized near zero.
+ * https://quarkus.io/blog/biased-locking-help/
+ * @see ReplyHandler
  */
 public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements MessageConsumer<T> {
 
   private static final Logger log = LoggerFactory.getLogger(MessageConsumerImpl.class);
 
-  private static final int DEFAULT_MAX_BUFFERED_MESSAGES = 1000;
+  public static final int DEFAULT_MAX_BUFFERED_MESSAGES = 1000;
 
-  private final Vertx vertx;
-  private final ContextInternal context;
-  private final EventBusImpl eventBus;
-  private final String address;
   private final boolean localOnly;
   private Handler<Message<T>> handler;
   private Handler<Void> endHandler;
@@ -49,12 +47,8 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
   private Promise<Void> result;
   private boolean registered;
 
-  MessageConsumerImpl(Vertx vertx, ContextInternal context, EventBusImpl eventBus, String address, boolean localOnly) {
+  MessageConsumerImpl (ContextInternal context, EventBusImpl eventBus, String address, boolean localOnly) {
     super(context, eventBus, address, false);
-    this.vertx = vertx;
-    this.context = context;
-    this.eventBus = eventBus;
-    this.address = address;
     this.localOnly = localOnly;
     this.result = context.promise();
   }
@@ -93,6 +87,10 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
     return maxBufferedMessages;
   }
 
+  public synchronized int getPendingQueueSize() {
+    return pending.size();
+  }
+
   @Override
   public String address() {
     return address;
@@ -112,7 +110,7 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
     if (pending.size() > 0) {
       Queue<Message<T>> discarded = pending;
       Handler<Message<T>> handler = discardHandler;
-      pending = new ArrayDeque<>();
+      pending = new ArrayDeque<>(8);
       for (Message<T> msg : discarded) {
         discard(msg);
         if (handler != null) {
@@ -126,11 +124,12 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
       registered = false;
       Promise<Void> res = result; // Alias reference because result can become null when the onComplete callback executes
       fut.onComplete(ar -> res.tryFail("Consumer unregistered before registration completed"));
-      result = context.promise();
+      result = context.promise();// old result is-Complete or will be-Complete shortly
     }
     return fut;
   }
 
+  @Override
   protected boolean doReceive(Message<T> message) {
     Handler<Message<T>> theHandler;
     synchronized (this) {
@@ -167,16 +166,14 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
 
   @Override
   protected void dispatch(Message<T> msg, ContextInternal context, Handler<Message<T>> handler) {
-    if (handler == null) {
-      throw new NullPointerException();
-    }
+    Objects.requireNonNull(handler, "dispatch: handler cannot be null");
     context.dispatch(msg, handler);
   }
 
   private void deliver(Handler<Message<T>> theHandler, Message<T> message) {
     // Handle the message outside the sync block
     // https://bugs.eclipse.org/bugs/show_bug.cgi?id=473714
-    dispatch(theHandler, message, context.duplicate());
+    dispatchUsingInboundDeliveryContext(theHandler, message, context.duplicate());
     checkNextTick();
   }
 
@@ -250,9 +247,7 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
 
   @Override
   public synchronized MessageConsumer<T> fetch(long amount) {
-    if (amount < 0) {
-      throw new IllegalArgumentException();
-    }
+    Arguments.require(amount >= 0, "fetch(amount) must be positive, but: "+amount);
     demand += amount;
     if (demand < 0L) {
       demand = Long.MAX_VALUE;
@@ -267,7 +262,7 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
   public synchronized MessageConsumer<T> endHandler(Handler<Void> endHandler) {
     if (endHandler != null) {
       // We should use the HandlerHolder context to properly do this (needs small refactoring)
-      Context endCtx = vertx.getOrCreateContext();
+      Context endCtx = vertx().getOrCreateContext();
       this.endHandler = v1 -> endCtx.runOnContext(v2 -> endHandler.handle(null));
     } else {
       this.endHandler = null;


### PR DESCRIPTION
Issue: https://github.com/eclipse-vertx/vert.x/issues/4836

1) Remove duplicate fields (in subclasses) and ctor arguments 
2) better Javadoc and comments, spelling
3) better inheritance
4) better field and method names
5) utility functions to remove long boilerplate code 
6) bug fixes
7) better, informative exceptions messages

"The Best Code is No Code At All"

The code is compact, clear, and very easy to understand now!