### PR TITLE
HTTP client improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
             <configuration>
               <processors>
                 <processor>io.vertx.codegen.CodeGenProcessor</processor>
-<!--                <processor>io.vertx.docgen.JavaDocGenProcessor</processor>-->
+                <processor>io.vertx.docgen.JavaDocGenProcessor</processor>
               </processors>
               <optionMap>
                 <codegen.output>${project.basedir}/src/main</codegen.output>

--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
             <configuration>
               <processors>
                 <processor>io.vertx.codegen.CodeGenProcessor</processor>
-                <processor>io.vertx.docgen.JavaDocGenProcessor</processor>
+<!--                <processor>io.vertx.docgen.JavaDocGenProcessor</processor>-->
               </processors>
               <optionMap>
                 <codegen.output>${project.basedir}/src/main</codegen.output>

--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -805,7 +805,7 @@ You can configure compressors according to your needs
 
 === Creating an HTTP client
 
-Youu create an {@link io.vertx.core.http.HttpClientPool} instance with default options as follows:
+You create an {@link io.vertx.core.http.HttpClientPool} instance with default options as follows:
 
 [source,$lang]
 ----

--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -805,7 +805,7 @@ You can configure compressors according to your needs
 
 === Creating an HTTP client
 
-u create an {@link io.vertx.core.http.HttpClientPool} instance with default options as follows:
+Youu create an {@link io.vertx.core.http.HttpClientPool} instance with default options as follows:
 
 [source,$lang]
 ----

--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -805,7 +805,7 @@ You can configure compressors according to your needs
 
 === Creating an HTTP client
 
-You create an {@link io.vertx.core.http.HttpClient} instance with default options as follows:
+u create an {@link io.vertx.core.http.HttpClientPool} instance with default options as follows:
 
 [source,$lang]
 ----
@@ -849,6 +849,26 @@ with {@link io.vertx.core.http.HttpClientResponse#version()} when the response a
 When a clients connects to an HTTP/2 server, it sends to the server its {@link io.vertx.core.http.HttpClientOptions#getInitialSettings initial settings}.
 The settings define how the server can use the connection, the default initial settings for a client are the default
 values defined by the HTTP/2 RFC.
+
+=== Pool configuration
+
+ For performance purpose, the client uses connection pooling when interacting with HTTP/1.1 servers. The pool creates up
+ to 5 connections per server. You can override the pool configuration like this:
+
+ [source,$lang]
+ ----
+ {@link examples.HTTPExamples#examplePoolConfiguration}
+ ----
+
+ You can configure various pool {@link io.vertx.core.http.PoolOptions options} as follows
+
+- {@link io.vertx.core.http.PoolOptions options#setHttp1MaxSize} the maximum number of opened per HTTP/1.x server (5 by default)
+- {@link io.vertx.core.http.PoolOptions options#setHttp2MaxSize} the maximum number of opened per HTTP/2 server (1 by default), you *should* not change this value since a single HTTP/2 connection is capable of delivering the same performance level than multiple HTTP/1.x connections
+- {@link io.vertx.core.http.PoolOptions options#setCleanerPeriod} the period in milliseconds at which the pool checks expired connections (1 second by default)
+- {@link io.vertx.core.http.PoolOptions options#setEventLoopSize} sets the number of event loops the pool use (0 by default)
+- a value of 0 configures the pool to use the event loop of the caller
+- a positive value configures the pool load balance the creation of connection over a list of event loops determined by the value
+- {@link io.vertx.core.http.PoolOptions options#setMaxWaitQueueSize} the maximum number of HTTP requests waiting until a connection is available, when the queue is full, the request is rejected
 
 === Logging network client activity
 
@@ -1413,7 +1433,7 @@ When keep alive is enabled. Vert.x will add a `Connection: Keep-Alive` header to
 When keep alive is disabled. Vert.x will add a `Connection: Close` header to each HTTP/1.1 request sent to signal
 that the connection will be closed after completion of the response.
 
-The maximum number of connections to pool *for each server* is configured using {@link io.vertx.core.http.HttpClientOptions#setMaxPoolSize(int)}
+The maximum number of connections to pool *for each server* is configured using {@link io.vertx.core.http.PoolOptions#setHttp1MaxSize(int)}
 
 When making a request with pooling enabled, Vert.x will create a new connection if there are less than the maximum number of
 connections already created for that server, otherwise it will add the request to a queue.
@@ -1449,7 +1469,7 @@ fairness of the distribution of the client requests over the connections to the 
 HTTP/2 advocates to use a single connection to a server, by default the http client uses a single
 connection for each server, all the streams to the same server are multiplexed over the same connection.
 
-When the clients needs to use more than a single connection and use pooling, the {@link io.vertx.core.http.HttpClientOptions#setHttp2MaxPoolSize(int)}
+When the clients needs to use more than a single connection and use pooling, the {@link io.vertx.core.http.PoolOptions#setHttp2MaxSize(int)}
 shall be used.
 
 When it is desirable to limit the number of multiplexed streams per connection and use a connection
@@ -1798,17 +1818,23 @@ The {@link io.vertx.core.http.ServerWebSocket} instance enables you to retrieve 
 
 ==== WebSockets on the client
 
-The Vert.x {@link io.vertx.core.http.HttpClient} supports WebSockets.
+e Vert.x {@link io.vertx.core.http.WebSocketClient} supports WebSockets.
 
-You can connect a WebSocket to a server using one of the {@link io.vertx.core.http.HttpClient#webSocket} operations and
-providing a handler.
+ You can connect a WebSocket to a server using one of the {@link io.vertx.core.http.WebSocketClient#connect} operations.
 
-The handler will be called with an instance of {@link io.vertx.core.http.WebSocket} when the connection has been made:
-
+ The returned future will be completed with an instance of {@link io.vertx.core.http.WebSocket} when the connection has been made:
 [source,$lang]
 ----
 {@link examples.HTTPExamples#example54}
 ----
+
+en connecting from a non Vert.x thread, you can create a {@link io.vertx.core.http.ClientWebSocket}, configure its handlers and
+then connect to the server:
+
+ [source,$lang]
+ ----
+ {@link examples.HTTPExamples#example54_bis}
+ ----
 
 By default, the client sets the `origin` header to the server host, e.g http://www.example.com. Some servers will refuse
 such request, you can configure the client to not set this header.
@@ -1839,7 +1865,7 @@ If you wish to write a single WebSocket message to the WebSocket you can do this
 ----
 
 If the WebSocket message is larger than the maximum WebSocket frame size as configured with
-{@link io.vertx.core.http.HttpClientOptions#setMaxWebSocketFrameSize(int)}
+{@link io.vertx.core.http.WebSocketClientOptions#setMaxFrameSize(int)}
 then Vert.x will split it into multiple WebSocket frames before sending it on the wire.
 
 ==== Writing frames to WebSockets

--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -75,26 +75,6 @@ public class HttpClientOptionsConverter {
             obj.setTryUseCompression((Boolean)member.getValue());
           }
           break;
-        case "sendUnmaskedFrames":
-          if (member.getValue() instanceof Boolean) {
-            obj.setSendUnmaskedFrames((Boolean)member.getValue());
-          }
-          break;
-        case "maxWebSocketFrameSize":
-          if (member.getValue() instanceof Number) {
-            obj.setMaxWebSocketFrameSize(((Number)member.getValue()).intValue());
-          }
-          break;
-        case "maxWebSocketMessageSize":
-          if (member.getValue() instanceof Number) {
-            obj.setMaxWebSocketMessageSize(((Number)member.getValue()).intValue());
-          }
-          break;
-        case "maxWebSockets":
-          if (member.getValue() instanceof Number) {
-            obj.setMaxWebSockets(((Number)member.getValue()).intValue());
-          }
-          break;
         case "defaultHost":
           if (member.getValue() instanceof String) {
             obj.setDefaultHost((String)member.getValue());
@@ -165,38 +145,6 @@ public class HttpClientOptionsConverter {
             obj.setForceSni((Boolean)member.getValue());
           }
           break;
-        case "tryUsePerFrameWebSocketCompression":
-          if (member.getValue() instanceof Boolean) {
-            obj.setTryUsePerFrameWebSocketCompression((Boolean)member.getValue());
-          }
-          break;
-        case "tryWebSocketDeflateFrameCompression":
-          break;
-        case "tryUsePerMessageWebSocketCompression":
-          if (member.getValue() instanceof Boolean) {
-            obj.setTryUsePerMessageWebSocketCompression((Boolean)member.getValue());
-          }
-          break;
-        case "webSocketCompressionLevel":
-          if (member.getValue() instanceof Number) {
-            obj.setWebSocketCompressionLevel(((Number)member.getValue()).intValue());
-          }
-          break;
-        case "webSocketCompressionAllowClientNoContext":
-          if (member.getValue() instanceof Boolean) {
-            obj.setWebSocketCompressionAllowClientNoContext((Boolean)member.getValue());
-          }
-          break;
-        case "webSocketCompressionRequestServerNoContext":
-          if (member.getValue() instanceof Boolean) {
-            obj.setWebSocketCompressionRequestServerNoContext((Boolean)member.getValue());
-          }
-          break;
-        case "webSocketClosingTimeout":
-          if (member.getValue() instanceof Number) {
-            obj.setWebSocketClosingTimeout(((Number)member.getValue()).intValue());
-          }
-          break;
         case "decoderInitialBufferSize":
           if (member.getValue() instanceof Number) {
             obj.setDecoderInitialBufferSize(((Number)member.getValue()).intValue());
@@ -247,10 +195,6 @@ public class HttpClientOptionsConverter {
     json.put("pipeliningLimit", obj.getPipeliningLimit());
     json.put("verifyHost", obj.isVerifyHost());
     json.put("tryUseCompression", obj.isTryUseCompression());
-    json.put("sendUnmaskedFrames", obj.isSendUnmaskedFrames());
-    json.put("maxWebSocketFrameSize", obj.getMaxWebSocketFrameSize());
-    json.put("maxWebSocketMessageSize", obj.getMaxWebSocketMessageSize());
-    json.put("maxWebSockets", obj.getMaxWebSockets());
     if (obj.getDefaultHost() != null) {
       json.put("defaultHost", obj.getDefaultHost());
     }
@@ -274,12 +218,6 @@ public class HttpClientOptionsConverter {
     json.put("http2ClearTextUpgradeWithPreflightRequest", obj.isHttp2ClearTextUpgradeWithPreflightRequest());
     json.put("maxRedirects", obj.getMaxRedirects());
     json.put("forceSni", obj.isForceSni());
-    json.put("tryWebSocketDeflateFrameCompression", obj.getTryWebSocketDeflateFrameCompression());
-    json.put("tryUsePerMessageWebSocketCompression", obj.getTryUsePerMessageWebSocketCompression());
-    json.put("webSocketCompressionLevel", obj.getWebSocketCompressionLevel());
-    json.put("webSocketCompressionAllowClientNoContext", obj.getWebSocketCompressionAllowClientNoContext());
-    json.put("webSocketCompressionRequestServerNoContext", obj.getWebSocketCompressionRequestServerNoContext());
-    json.put("webSocketClosingTimeout", obj.getWebSocketClosingTimeout());
     json.put("decoderInitialBufferSize", obj.getDecoderInitialBufferSize());
     json.put("poolCleanerPeriod", obj.getPoolCleanerPeriod());
     json.put("poolEventLoopSize", obj.getPoolEventLoopSize());

--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -20,19 +20,9 @@ public class HttpClientOptionsConverter {
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, HttpClientOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "maxPoolSize":
-          if (member.getValue() instanceof Number) {
-            obj.setMaxPoolSize(((Number)member.getValue()).intValue());
-          }
-          break;
         case "http2MultiplexingLimit":
           if (member.getValue() instanceof Number) {
             obj.setHttp2MultiplexingLimit(((Number)member.getValue()).intValue());
-          }
-          break;
-        case "http2MaxPoolSize":
-          if (member.getValue() instanceof Number) {
-            obj.setHttp2MaxPoolSize(((Number)member.getValue()).intValue());
           }
           break;
         case "http2ConnectionWindowSize":
@@ -105,11 +95,6 @@ public class HttpClientOptionsConverter {
             obj.setMaxHeaderSize(((Number)member.getValue()).intValue());
           }
           break;
-        case "maxWaitQueueSize":
-          if (member.getValue() instanceof Number) {
-            obj.setMaxWaitQueueSize(((Number)member.getValue()).intValue());
-          }
-          break;
         case "initialSettings":
           if (member.getValue() instanceof JsonObject) {
             obj.setInitialSettings(new io.vertx.core.http.Http2Settings((io.vertx.core.json.JsonObject)member.getValue()));
@@ -150,16 +135,6 @@ public class HttpClientOptionsConverter {
             obj.setDecoderInitialBufferSize(((Number)member.getValue()).intValue());
           }
           break;
-        case "poolCleanerPeriod":
-          if (member.getValue() instanceof Number) {
-            obj.setPoolCleanerPeriod(((Number)member.getValue()).intValue());
-          }
-          break;
-        case "poolEventLoopSize":
-          if (member.getValue() instanceof Number) {
-            obj.setPoolEventLoopSize(((Number)member.getValue()).intValue());
-          }
-          break;
         case "tracingPolicy":
           if (member.getValue() instanceof String) {
             obj.setTracingPolicy(io.vertx.core.tracing.TracingPolicy.valueOf((String)member.getValue()));
@@ -184,9 +159,7 @@ public class HttpClientOptionsConverter {
   }
 
    static void toJson(HttpClientOptions obj, java.util.Map<String, Object> json) {
-    json.put("maxPoolSize", obj.getMaxPoolSize());
     json.put("http2MultiplexingLimit", obj.getHttp2MultiplexingLimit());
-    json.put("http2MaxPoolSize", obj.getHttp2MaxPoolSize());
     json.put("http2ConnectionWindowSize", obj.getHttp2ConnectionWindowSize());
     json.put("http2KeepAliveTimeout", obj.getHttp2KeepAliveTimeout());
     json.put("keepAlive", obj.isKeepAlive());
@@ -205,7 +178,6 @@ public class HttpClientOptionsConverter {
     json.put("maxChunkSize", obj.getMaxChunkSize());
     json.put("maxInitialLineLength", obj.getMaxInitialLineLength());
     json.put("maxHeaderSize", obj.getMaxHeaderSize());
-    json.put("maxWaitQueueSize", obj.getMaxWaitQueueSize());
     if (obj.getInitialSettings() != null) {
       json.put("initialSettings", obj.getInitialSettings().toJson());
     }
@@ -219,8 +191,6 @@ public class HttpClientOptionsConverter {
     json.put("maxRedirects", obj.getMaxRedirects());
     json.put("forceSni", obj.isForceSni());
     json.put("decoderInitialBufferSize", obj.getDecoderInitialBufferSize());
-    json.put("poolCleanerPeriod", obj.getPoolCleanerPeriod());
-    json.put("poolEventLoopSize", obj.getPoolEventLoopSize());
     if (obj.getTracingPolicy() != null) {
       json.put("tracingPolicy", obj.getTracingPolicy().name());
     }

--- a/src/main/generated/io/vertx/core/http/PoolOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/PoolOptionsConverter.java
@@ -1,0 +1,63 @@
+package io.vertx.core.http;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.core.http.PoolOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.core.http.PoolOptions} original class using Vert.x codegen.
+ */
+public class PoolOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+   static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, PoolOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "http1MaxSize":
+          if (member.getValue() instanceof Number) {
+            obj.setHttp1MaxSize(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "http2MaxSize":
+          if (member.getValue() instanceof Number) {
+            obj.setHttp2MaxSize(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "cleanerPeriod":
+          if (member.getValue() instanceof Number) {
+            obj.setCleanerPeriod(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "eventLoopSize":
+          if (member.getValue() instanceof Number) {
+            obj.setEventLoopSize(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "maxWaitQueueSize":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxWaitQueueSize(((Number)member.getValue()).intValue());
+          }
+          break;
+      }
+    }
+  }
+
+   static void toJson(PoolOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+   static void toJson(PoolOptions obj, java.util.Map<String, Object> json) {
+    json.put("http1MaxSize", obj.getHttp1MaxSize());
+    json.put("http2MaxSize", obj.getHttp2MaxSize());
+    json.put("cleanerPeriod", obj.getCleanerPeriod());
+    json.put("eventLoopSize", obj.getEventLoopSize());
+    json.put("maxWaitQueueSize", obj.getMaxWaitQueueSize());
+  }
+}

--- a/src/main/generated/io/vertx/core/http/WebSocketClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/WebSocketClientOptionsConverter.java
@@ -1,0 +1,113 @@
+package io.vertx.core.http;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.core.http.WebSocketClientOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.core.http.WebSocketClientOptions} original class using Vert.x codegen.
+ */
+public class WebSocketClientOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+   static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, WebSocketClientOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "verifyHost":
+          if (member.getValue() instanceof Boolean) {
+            obj.setVerifyHost((Boolean)member.getValue());
+          }
+          break;
+        case "sendUnmaskedFrames":
+          if (member.getValue() instanceof Boolean) {
+            obj.setSendUnmaskedFrames((Boolean)member.getValue());
+          }
+          break;
+        case "maxFrameSize":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxFrameSize(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "maxMessageSize":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxMessageSize(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "maxConnections":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxConnections(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "tryUsePerFrameCompression":
+          if (member.getValue() instanceof Boolean) {
+            obj.setTryUsePerFrameCompression((Boolean)member.getValue());
+          }
+          break;
+        case "tryUsePerMessageCompression":
+          if (member.getValue() instanceof Boolean) {
+            obj.setTryUsePerMessageCompression((Boolean)member.getValue());
+          }
+          break;
+        case "compressionLevel":
+          if (member.getValue() instanceof Number) {
+            obj.setCompressionLevel(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "compressionAllowClientNoContext":
+          if (member.getValue() instanceof Boolean) {
+            obj.setCompressionAllowClientNoContext((Boolean)member.getValue());
+          }
+          break;
+        case "compressionRequestServerNoContext":
+          if (member.getValue() instanceof Boolean) {
+            obj.setCompressionRequestServerNoContext((Boolean)member.getValue());
+          }
+          break;
+        case "closingTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setClosingTimeout(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "shared":
+          if (member.getValue() instanceof Boolean) {
+            obj.setShared((Boolean)member.getValue());
+          }
+          break;
+        case "name":
+          if (member.getValue() instanceof String) {
+            obj.setName((String)member.getValue());
+          }
+          break;
+      }
+    }
+  }
+
+   static void toJson(WebSocketClientOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+   static void toJson(WebSocketClientOptions obj, java.util.Map<String, Object> json) {
+    json.put("verifyHost", obj.isVerifyHost());
+    json.put("sendUnmaskedFrames", obj.isSendUnmaskedFrames());
+    json.put("maxFrameSize", obj.getMaxFrameSize());
+    json.put("maxMessageSize", obj.getMaxMessageSize());
+    json.put("maxConnections", obj.getMaxConnections());
+    json.put("tryUsePerFrameCompression", obj.getTryUsePerFrameCompression());
+    json.put("tryUsePerMessageCompression", obj.getTryUsePerMessageCompression());
+    json.put("compressionLevel", obj.getCompressionLevel());
+    json.put("compressionAllowClientNoContext", obj.getCompressionAllowClientNoContext());
+    json.put("compressionRequestServerNoContext", obj.getCompressionRequestServerNoContext());
+    json.put("closingTimeout", obj.getClosingTimeout());
+    json.put("shared", obj.isShared());
+    if (obj.getName() != null) {
+      json.put("name", obj.getName());
+    }
+  }
+}

--- a/src/main/java/examples/HTTP2Examples.java
+++ b/src/main/java/examples/HTTP2Examples.java
@@ -209,7 +209,7 @@ public class HTTP2Examples {
     HttpConnection connection = request.connection();
   }
 
-  public void example19(HttpClient client) {
+  public void example19(HttpClientPool client) {
     client.connectionHandler(connection -> {
       System.out.println("Connected to the server");
     });

--- a/src/main/java/examples/HTTP2Examples.java
+++ b/src/main/java/examples/HTTP2Examples.java
@@ -13,19 +13,7 @@ package examples;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.Http2Settings;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpConnection;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServer;
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.http.HttpVersion;
-import io.vertx.core.http.StreamResetException;
+import io.vertx.core.http.*;
 import io.vertx.core.net.JksOptions;
 
 /**
@@ -284,11 +272,10 @@ public class HTTP2Examples {
 
   public void useMaxStreams(Vertx vertx) {
 
-    HttpClientOptions clientOptions = new HttpClientOptions().
-        setHttp2MultiplexingLimit(10).
-        setHttp2MaxPoolSize(3);
-
     // Uses up to 3 connections and up to 10 streams per connection
-    HttpClient client = vertx.createHttpClient(clientOptions);
+    HttpClient client = vertx.createHttpClient(
+      new HttpClientOptions().setHttp2MultiplexingLimit(10),
+      new PoolOptions().setHttp2MaxSize(3)
+    );
   }
 }

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -329,6 +329,11 @@ public class HTTPExamples {
     HttpClient client = vertx.createHttpClient(options);
   }
 
+  public void examplePoolConfiguration(Vertx vertx) {
+    PoolOptions options = new PoolOptions().setHttp1MaxSize(10);
+    HttpClient client = vertx.createHttpClient(options);
+  }
+
   public void exampleClientLogging(Vertx vertx) {
     HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
     HttpClient client = vertx.createHttpClient(options);
@@ -965,13 +970,35 @@ public class HTTPExamples {
     });
   }
 
-  public void example54(WebSocketClient client, int port, String host) {
+
+  public void example54(Vertx vertx) {
+    WebSocketClient client = vertx.createWebSocketClient();
+
     client
-      .connect(port, host, "/some-uri")
+      .connect(80, "example.com", "/some-uri")
       .onComplete(res -> {
         if (res.succeeded()) {
           WebSocket ws = res.result();
+          ws.textMessageHandler(msg -> {
+            // Handle msg
+          });
           System.out.println("Connected!");
+        }
+      });
+  }
+
+  public void example54_bis(Vertx vertx) {
+    WebSocketClient client = vertx.createWebSocketClient();
+
+    client
+      .webSocket()
+      .textMessageHandler(msg -> {
+        // Handle msg
+      })
+      .connect(80, "example.com", "/some-uri")
+      .onComplete(res -> {
+        if (res.succeeded()) {
+          WebSocket ws = res.result();
         }
       });
   }

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -965,9 +965,9 @@ public class HTTPExamples {
     });
   }
 
-  public void example54(HttpClient client) {
+  public void example54(WebSocketClient client, int port, String host) {
     client
-      .webSocket("/some-uri")
+      .connect(port, host, "/some-uri")
       .onComplete(res -> {
         if (res.succeeded()) {
           WebSocket ws = res.result();
@@ -976,14 +976,14 @@ public class HTTPExamples {
       });
   }
 
-  public void exampleWebSocketDisableOriginHeader(HttpClient client, String host, int port, String requestUri) {
+  public void exampleWebSocketDisableOriginHeader(WebSocketClient client, String host, int port, String requestUri) {
     WebSocketConnectOptions options = new WebSocketConnectOptions()
       .setHost(host)
       .setPort(port)
       .setURI(requestUri)
       .setAllowOriginHeader(false);
     client
-      .webSocket(options)
+      .connect(options)
       .onComplete(res -> {
         if (res.succeeded()) {
           WebSocket ws = res.result();
@@ -992,14 +992,14 @@ public class HTTPExamples {
       });
   }
 
-  public void exampleWebSocketSetOriginHeader(HttpClient client, String host, int port, String requestUri, String origin) {
+  public void exampleWebSocketSetOriginHeader(WebSocketClient client, String host, int port, String requestUri, String origin) {
     WebSocketConnectOptions options = new WebSocketConnectOptions()
       .setHost(host)
       .setPort(port)
       .setURI(requestUri)
       .addHeader(HttpHeaders.ORIGIN, origin);
     client
-      .webSocket(options)
+      .connect(options)
       .onComplete(res -> {
         if (res.succeeded()) {
           WebSocket ws = res.result();

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -799,7 +799,7 @@ public class HTTPExamples {
     throw new UnsupportedOperationException();
   }
 
-  public void exampleFollowRedirect03(HttpClient client) {
+  public void exampleFollowRedirect03(HttpClientPool client) {
 
     client.redirectHandler(response -> {
 

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -1242,7 +1242,7 @@ public class HTTPExamples {
       @Override
       public void start() {
         // The client creates and use two event-loops for 4 instances
-        client = vertx.createHttpClient(new HttpClientOptions().setPoolEventLoopSize(2).setShared(true).setName("my-client"));
+        client = vertx.createHttpClient(new HttpClientOptions().setShared(true).setName("my-client"), new PoolOptions().setEventLoopSize(2));
       }
     }, new DeploymentOptions().setInstances(4));
   }

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -18,12 +18,7 @@ import io.vertx.core.dns.DnsClient;
 import io.vertx.core.dns.DnsClientOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.file.FileSystem;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.WebSocketClient;
-import io.vertx.core.http.WebSocketClientOptions;
-import io.vertx.core.http.HttpServer;
-import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.*;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxBuilder;
 import io.vertx.core.dns.impl.DnsAddressResolverProvider;
@@ -192,6 +187,22 @@ public interface Vertx extends Measured {
    * @return the client
    */
   HttpClient createHttpClient(HttpClientOptions options);
+
+  /**
+   * Create a HTTP/HTTPS client using the specified options
+   *
+   * @param options  the options to use
+   * @return the client
+   */
+  HttpClient createHttpClient(HttpClientOptions options, PoolOptions poolOptions);
+
+  /**
+   * Create a HTTP/HTTPS client using the specified options
+   *
+   * @param poolOptions  the pool options to use
+   * @return the client
+   */
+  HttpClient createHttpClient(PoolOptions poolOptions);
 
   /**
    * Create a HTTP/HTTPS client using default options

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -186,7 +186,7 @@ public interface Vertx extends Measured {
    * @param options  the options to use
    * @return the client
    */
-  HttpClient createHttpClient(HttpClientOptions options);
+  HttpClientPool createHttpClient(HttpClientOptions options);
 
   /**
    * Create a HTTP/HTTPS client using the specified options
@@ -194,7 +194,7 @@ public interface Vertx extends Measured {
    * @param options  the options to use
    * @return the client
    */
-  HttpClient createHttpClient(HttpClientOptions options, PoolOptions poolOptions);
+  HttpClientPool createHttpClient(HttpClientOptions options, PoolOptions poolOptions);
 
   /**
    * Create a HTTP/HTTPS client using the specified options
@@ -202,14 +202,14 @@ public interface Vertx extends Measured {
    * @param poolOptions  the pool options to use
    * @return the client
    */
-  HttpClient createHttpClient(PoolOptions poolOptions);
+  HttpClientPool createHttpClient(PoolOptions poolOptions);
 
   /**
    * Create a HTTP/HTTPS client using default options
    *
    * @return the client
    */
-  default HttpClient createHttpClient() {
+  default HttpClientPool createHttpClient() {
     return createHttpClient(new HttpClientOptions());
   }
 

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -20,6 +20,8 @@ import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.WebSocketClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.impl.ContextInternal;
@@ -164,6 +166,24 @@ public interface Vertx extends Measured {
   default HttpServer createHttpServer() {
     return createHttpServer(new HttpServerOptions());
   }
+
+
+  /**
+   * Create a WebSocket client using default options
+   *
+   * @return the client
+   */
+  default WebSocketClient createWebSocketClient() {
+    return createWebSocketClient(new WebSocketClientOptions());
+  }
+
+  /**
+   * Create a WebSocket client using the specified options
+   *
+   * @param options  the options to use
+   * @return the client
+   */
+  WebSocketClient createWebSocketClient(WebSocketClientOptions options);
 
   /**
    * Create a HTTP/HTTPS client using the specified options

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -181,28 +181,33 @@ public interface Vertx extends Measured {
   WebSocketClient createWebSocketClient(WebSocketClientOptions options);
 
   /**
-   * Create a HTTP/HTTPS client using the specified options
+   * Create a HTTP/HTTPS client using the specified client and pool options
    *
-   * @param options  the options to use
+   * @param clientOptions  the client options to use
+   * @param poolOptions  the pool options to use
    * @return the client
    */
-  HttpClientPool createHttpClient(HttpClientOptions options);
+  HttpClientPool createHttpClient(HttpClientOptions clientOptions, PoolOptions poolOptions);
 
   /**
-   * Create a HTTP/HTTPS client using the specified options
+   * Create a HTTP/HTTPS client using the specified client options
    *
-   * @param options  the options to use
+   * @param clientOptions  the options to use
    * @return the client
    */
-  HttpClientPool createHttpClient(HttpClientOptions options, PoolOptions poolOptions);
+  default HttpClientPool createHttpClient(HttpClientOptions clientOptions) {
+    return createHttpClient(clientOptions, new PoolOptions());
+  }
 
   /**
-   * Create a HTTP/HTTPS client using the specified options
+   * Create a HTTP/HTTPS client using the specified pool options
    *
    * @param poolOptions  the pool options to use
    * @return the client
    */
-  HttpClientPool createHttpClient(PoolOptions poolOptions);
+  default HttpClientPool createHttpClient(PoolOptions poolOptions) {
+    return createHttpClient(new HttpClientOptions(), poolOptions);
+  }
 
   /**
    * Create a HTTP/HTTPS client using default options
@@ -210,9 +215,8 @@ public interface Vertx extends Measured {
    * @return the client
    */
   default HttpClientPool createHttpClient() {
-    return createHttpClient(new HttpClientOptions());
+    return createHttpClient(new HttpClientOptions(), new PoolOptions());
   }
-
   /**
    * Create a datagram socket using the specified options
    *

--- a/src/main/java/io/vertx/core/http/ClientWebSocket.java
+++ b/src/main/java/io/vertx/core/http/ClientWebSocket.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+
+import java.util.List;
+
+/**
+ * Represents a client-side WebSocket.
+ *
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+@VertxGen
+public interface ClientWebSocket extends WebSocket {
+
+  /**
+   * Connect this WebSocket with the specified options.
+   *
+   * @param options  the request options
+   * @return a future notified when the WebSocket when connected
+   */
+  Future<WebSocket> connect(WebSocketConnectOptions options);
+
+  /**
+   * Connect this WebSocket to the specified port, host and relative request URI.
+   *
+   * @param port  the port
+   * @param host  the host
+   * @param requestURI  the relative URI
+   * @return a future notified when the WebSocket when connected
+   */
+  default Future<WebSocket> connect(int port, String host, String requestURI) {
+    return connect(new WebSocketConnectOptions().setURI(requestURI).setHost(host).setPort(port));
+  }
+
+  /**
+   * Connect this WebSocket to the host and relative request URI and default port.
+   *
+   * @param host  the host
+   * @param requestURI  the relative URI
+   * @return a future notified when the WebSocket when connected
+   */
+  Future<WebSocket> connect(String host, String requestURI);
+
+  /**
+   * Connect this WebSocket at the relative request URI using the default host and port.
+   *
+   * @param requestURI  the relative URI
+   * @return a future notified when the WebSocket when connected
+   */
+  Future<WebSocket> connect(String requestURI);
+
+  /**
+   * Connect this WebSocket with the specified absolute url, with the specified headers, using
+   * the specified version of WebSockets, and the specified WebSocket sub protocols.
+   *
+   * @param url            the absolute url
+   * @param headers        the headers
+   * @param version        the WebSocket version
+   * @param subProtocols   the subprotocols to use
+   * @return a future notified when the WebSocket when connected
+   */
+  Future<WebSocket> connect(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols);
+
+  @Override
+  ClientWebSocket handler(Handler<Buffer> handler);
+
+  @Override
+  ClientWebSocket endHandler(Handler<Void> endHandler);
+
+  @Override
+  ClientWebSocket drainHandler(Handler<Void> handler);
+
+  @Override
+  ClientWebSocket closeHandler(Handler<Void> handler);
+
+  @Override
+  ClientWebSocket frameHandler(Handler<WebSocketFrame> handler);
+
+  @Override
+  ClientWebSocket textMessageHandler(@Nullable Handler<String> handler);
+
+  @Override
+  ClientWebSocket binaryMessageHandler(@Nullable Handler<Buffer> handler);
+
+  @Override
+  ClientWebSocket pongHandler(@Nullable Handler<Buffer> handler);
+
+  @Override
+  ClientWebSocket exceptionHandler(Handler<Throwable> handler);
+
+}

--- a/src/main/java/io/vertx/core/http/ClientWebSocket.java
+++ b/src/main/java/io/vertx/core/http/ClientWebSocket.java
@@ -47,34 +47,34 @@ public interface ClientWebSocket extends WebSocket {
     return connect(new WebSocketConnectOptions().setURI(requestURI).setHost(host).setPort(port));
   }
 
-  /**
-   * Connect this WebSocket to the host and relative request URI and default port.
-   *
-   * @param host  the host
-   * @param requestURI  the relative URI
-   * @return a future notified when the WebSocket when connected
-   */
-  Future<WebSocket> connect(String host, String requestURI);
+//  /**
+//   * Connect this WebSocket to the host and relative request URI and default port.
+//   *
+//   * @param host  the host
+//   * @param requestURI  the relative URI
+//   * @return a future notified when the WebSocket when connected
+//   */
+//  Future<WebSocket> connect(String host, String requestURI);
+//
+//  /**
+//   * Connect this WebSocket at the relative request URI using the default host and port.
+//   *
+//   * @param requestURI  the relative URI
+//   * @return a future notified when the WebSocket when connected
+//   */
+//  Future<WebSocket> connect(String requestURI);
 
-  /**
-   * Connect this WebSocket at the relative request URI using the default host and port.
-   *
-   * @param requestURI  the relative URI
-   * @return a future notified when the WebSocket when connected
-   */
-  Future<WebSocket> connect(String requestURI);
-
-  /**
-   * Connect this WebSocket with the specified absolute url, with the specified headers, using
-   * the specified version of WebSockets, and the specified WebSocket sub protocols.
-   *
-   * @param url            the absolute url
-   * @param headers        the headers
-   * @param version        the WebSocket version
-   * @param subProtocols   the subprotocols to use
-   * @return a future notified when the WebSocket when connected
-   */
-  Future<WebSocket> connect(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols);
+//  /**
+//   * Connect this WebSocket with the specified absolute url, with the specified headers, using
+//   * the specified version of WebSockets, and the specified WebSocket sub protocols.
+//   *
+//   * @param url            the absolute url
+//   * @param headers        the headers
+//   * @param version        the WebSocket version
+//   * @param subProtocols   the subprotocols to use
+//   * @return a future notified when the WebSocket when connected
+//   */
+//  Future<WebSocket> connect(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols);
 
   @Override
   ClientWebSocket handler(Handler<Buffer> handler);

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -94,6 +94,13 @@ public interface HttpClient extends Measured {
   Future<HttpClientRequest> request(HttpMethod method, String requestURI);
 
   /**
+   * Create a WebSocket that is not yet connected to the server.
+   *
+   * @return the client WebSocket
+   */
+  ClientWebSocket webSocket();
+
+  /**
    * Connect a WebSocket to the specified port, host and relative request URI.
    *
    * @param port  the port
@@ -101,7 +108,9 @@ public interface HttpClient extends Measured {
    * @param requestURI  the relative URI
    * @return a future notified when the WebSocket when connected
    */
-  Future<WebSocket> webSocket(int port, String host, String requestURI);
+  default Future<WebSocket> webSocket(int port, String host, String requestURI) {
+    return webSocket(new WebSocketConnectOptions().setURI(requestURI).setHost(host).setPort(port));
+  }
 
   /**
    * Connect a WebSocket to the host and relative request URI and default port.

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -51,7 +51,7 @@ import java.util.function.Function;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
-public interface HttpClient extends Measured {
+public interface HttpClient {
 
   /**
    * Create an HTTP request to send to the server.
@@ -90,52 +90,6 @@ public interface HttpClient extends Measured {
    * @return a future notified when the request is ready to be sent
    */
   Future<HttpClientRequest> request(HttpMethod method, String requestURI);
-
-  /**
-   * Update the client SSL options.
-   *
-   * Update only happens if the SSL options is valid.
-   *
-   * @param options the new SSL options
-   * @return a future signaling the update success
-   */
-  Future<Void> updateSSLOptions(ClientSSLOptions options);
-
-  /**
-   * Set a connection handler for the client. This handler is called when a new connection is established.
-   *
-   * @return a reference to this, so the API can be used fluently
-   */
-  @Fluent
-  HttpClient connectionHandler(Handler<HttpConnection> handler);
-
-  /**
-   * Set a redirect handler for the http client.
-   * <p>
-   * The redirect handler is called when a {@code 3xx} response is received and the request is configured to
-   * follow redirects with {@link HttpClientRequest#setFollowRedirects(boolean)}.
-   * <p>
-   * The redirect handler is passed the {@link HttpClientResponse}, it can return an {@link HttpClientRequest} or {@code null}.
-   * <ul>
-   *   <li>when null is returned, the original response is processed by the original request response handler</li>
-   *   <li>when a new {@code Future<HttpClientRequest>} is returned, the client will send this new request</li>
-   * </ul>
-   * The new request will get a copy of the previous request headers unless headers are set. In this case,
-   * the client assumes that the redirect handler exclusively managers the headers of the new request.
-   * <p>
-   * The handler must return a {@code Future<HttpClientRequest>} unsent so the client can further configure it and send it.
-   *
-   * @param handler the new redirect handler
-   * @return a reference to this, so the API can be used fluently
-   */
-  @Fluent
-  HttpClient redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler);
-
-  /**
-   * @return the current redirect handler.
-   */
-  @GenIgnore
-  Function<HttpClientResponse, Future<RequestOptions>> redirectHandler();
 
   /**
    * Close the client immediately ({@code close(0, TimeUnit.SECONDS}).

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -11,16 +11,10 @@
 
 package io.vertx.core.http;
 
-import io.vertx.codegen.annotations.Fluent;
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.metrics.Measured;
-import io.vertx.core.net.ClientSSLOptions;
 
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 /**
  * An asynchronous HTTP client.
@@ -97,7 +91,16 @@ public interface HttpClient {
    * @return a future notified when the client is closed
    */
   default Future<Void> close() {
-    return close(0, TimeUnit.SECONDS);
+    return shutdown(0, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Initiate the close sequence with a 30 seconds timeout.
+   *
+   * see {@link #shutdown(long, TimeUnit)}
+   */
+  default Future<Void> shutdown() {
+    return shutdown(30, TimeUnit.SECONDS);
   }
 
   /**
@@ -114,6 +117,6 @@ public interface HttpClient {
    *
    * @return a future notified when the client is closed
    */
-  Future<Void> close(long timeout, TimeUnit timeUnit);
+  Future<Void> shutdown(long timeout, TimeUnit timeUnit);
 
 }

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -16,11 +16,9 @@ import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
 import io.vertx.core.metrics.Measured;
 import io.vertx.core.net.ClientSSLOptions;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -92,62 +90,6 @@ public interface HttpClient extends Measured {
    * @return a future notified when the request is ready to be sent
    */
   Future<HttpClientRequest> request(HttpMethod method, String requestURI);
-
-  /**
-   * Create a WebSocket that is not yet connected to the server.
-   *
-   * @return the client WebSocket
-   */
-  ClientWebSocket webSocket();
-
-  /**
-   * Connect a WebSocket to the specified port, host and relative request URI.
-   *
-   * @param port  the port
-   * @param host  the host
-   * @param requestURI  the relative URI
-   * @return a future notified when the WebSocket when connected
-   */
-  default Future<WebSocket> webSocket(int port, String host, String requestURI) {
-    return webSocket(new WebSocketConnectOptions().setURI(requestURI).setHost(host).setPort(port));
-  }
-
-  /**
-   * Connect a WebSocket to the host and relative request URI and default port.
-   *
-   * @param host  the host
-   * @param requestURI  the relative URI
-   * @return a future notified when the WebSocket when connected
-   */
-  Future<WebSocket> webSocket(String host, String requestURI);
-
-  /**
-   * Connect a WebSocket at the relative request URI using the default host and port.
-   *
-   * @param requestURI  the relative URI
-   * @return a future notified when the WebSocket when connected
-   */
-  Future<WebSocket> webSocket(String requestURI);
-
-  /**
-   * Connect a WebSocket with the specified options.
-   *
-   * @param options  the request options
-   * @return a future notified when the WebSocket when connected
-   */
-  Future<WebSocket> webSocket(WebSocketConnectOptions options);
-
-  /**
-   * Connect a WebSocket with the specified absolute url, with the specified headers, using
-   * the specified version of WebSockets, and the specified WebSocket sub protocols.
-   *
-   * @param url            the absolute url
-   * @param headers        the headers
-   * @param version        the WebSocket version
-   * @param subProtocols   the subprotocols to use
-   * @return a future notified when the WebSocket when connected
-   */
-  Future<WebSocket> webSocketAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols);
 
   /**
    * Update the client SSL options.

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -35,16 +35,6 @@ import java.util.concurrent.TimeUnit;
 public class HttpClientOptions extends ClientOptionsBase {
 
   /**
-   * The default maximum number of HTTP/1 connections a client will pool = 5
-   */
-  public static final int DEFAULT_MAX_POOL_SIZE = 5;
-
-  /**
-   * The default maximum number of connections an HTTP/2 client will pool = 1
-   */
-  public static final int DEFAULT_HTTP2_MAX_POOL_SIZE = 1;
-
-  /**
    * The default maximum number of concurrent streams per connection for HTTP/2 = -1
    */
   public static final int DEFAULT_HTTP2_MULTIPLEXING_LIMIT = -1;
@@ -120,11 +110,6 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final int DEFAULT_MAX_HEADER_SIZE = 8192;
 
   /**
-   * Default max wait queue size = -1 (unbounded)
-   */
-  public static final int DEFAULT_MAX_WAIT_QUEUE_SIZE = -1;
-
-  /**
    * Default Application-Layer Protocol Negotiation versions = [] (automatic according to protocol version)
    */
   public static final List<HttpVersion> DEFAULT_ALPN_VERSIONS = Collections.emptyList();
@@ -155,16 +140,6 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final int DEFAULT_DECODER_INITIAL_BUFFER_SIZE = 128;
 
   /**
-   * Default pool cleaner period = 1000 ms (1 second)
-   */
-  public static final int DEFAULT_POOL_CLEANER_PERIOD = 1000;
-
-  /**
-   * Default pool event loop size = 0 (reuse current event-loop)
-   */
-  public static final int DEFAULT_POOL_EVENT_LOOP_SIZE = 0;
-
-  /**
    * Default tracing control = {@link TracingPolicy#PROPAGATE}
    */
   public static final TracingPolicy DEFAULT_TRACING_POLICY = TracingPolicy.PROPAGATE;
@@ -180,17 +155,13 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final String DEFAULT_NAME = "__vertx.DEFAULT";
 
   private boolean verifyHost = true;
-  private int maxPoolSize;
   private boolean keepAlive;
   private int keepAliveTimeout;
   private int pipeliningLimit;
   private boolean pipelining;
-  private int http2MaxPoolSize;
   private int http2MultiplexingLimit;
   private int http2ConnectionWindowSize;
   private int http2KeepAliveTimeout;
-  private int poolCleanerPeriod;
-  private int poolEventLoopSize;
 
   private boolean tryUseCompression;
   private String defaultHost;
@@ -199,7 +170,6 @@ public class HttpClientOptions extends ClientOptionsBase {
   private int maxChunkSize;
   private int maxInitialLineLength;
   private int maxHeaderSize;
-  private int maxWaitQueueSize;
   private Http2Settings initialSettings;
   private List<HttpVersion> alpnVersions;
   private boolean http2ClearTextUpgrade;
@@ -239,12 +209,10 @@ public class HttpClientOptions extends ClientOptionsBase {
   public HttpClientOptions(HttpClientOptions other) {
     super(other);
     this.verifyHost = other.isVerifyHost();
-    this.maxPoolSize = other.getMaxPoolSize();
     this.keepAlive = other.isKeepAlive();
     this.keepAliveTimeout = other.getKeepAliveTimeout();
     this.pipelining = other.isPipelining();
     this.pipeliningLimit = other.getPipeliningLimit();
-    this.http2MaxPoolSize = other.getHttp2MaxPoolSize();
     this.http2MultiplexingLimit = other.http2MultiplexingLimit;
     this.http2ConnectionWindowSize = other.http2ConnectionWindowSize;
     this.http2KeepAliveTimeout = other.getHttp2KeepAliveTimeout();
@@ -255,7 +223,6 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.maxChunkSize = other.maxChunkSize;
     this.maxInitialLineLength = other.getMaxInitialLineLength();
     this.maxHeaderSize = other.getMaxHeaderSize();
-    this.maxWaitQueueSize = other.maxWaitQueueSize;
     this.initialSettings = other.initialSettings != null ? new Http2Settings(other.initialSettings) : null;
     this.alpnVersions = other.alpnVersions != null ? new ArrayList<>(other.alpnVersions) : null;
     this.http2ClearTextUpgrade = other.http2ClearTextUpgrade;
@@ -263,8 +230,6 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.maxRedirects = other.maxRedirects;
     this.forceSni = other.forceSni;
     this.decoderInitialBufferSize = other.getDecoderInitialBufferSize();
-    this.poolCleanerPeriod = other.getPoolCleanerPeriod();
-    this.poolEventLoopSize = other.getPoolEventLoopSize();
     this.tracingPolicy = other.tracingPolicy;
     this.shared = other.shared;
     this.name = other.name;
@@ -294,13 +259,11 @@ public class HttpClientOptions extends ClientOptionsBase {
 
   private void init() {
     verifyHost = DEFAULT_VERIFY_HOST;
-    maxPoolSize = DEFAULT_MAX_POOL_SIZE;
     keepAlive = DEFAULT_KEEP_ALIVE;
     keepAliveTimeout = DEFAULT_KEEP_ALIVE_TIMEOUT;
     pipelining = DEFAULT_PIPELINING;
     pipeliningLimit = DEFAULT_PIPELINING_LIMIT;
     http2MultiplexingLimit = DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
-    http2MaxPoolSize = DEFAULT_HTTP2_MAX_POOL_SIZE;
     http2ConnectionWindowSize = DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE;
     http2KeepAliveTimeout = DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT;
     tryUseCompression = DEFAULT_TRY_USE_COMPRESSION;
@@ -310,7 +273,6 @@ public class HttpClientOptions extends ClientOptionsBase {
     maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
     maxInitialLineLength = DEFAULT_MAX_INITIAL_LINE_LENGTH;
     maxHeaderSize = DEFAULT_MAX_HEADER_SIZE;
-    maxWaitQueueSize = DEFAULT_MAX_WAIT_QUEUE_SIZE;
     initialSettings = new Http2Settings();
     alpnVersions = new ArrayList<>(DEFAULT_ALPN_VERSIONS);
     http2ClearTextUpgrade = DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE;
@@ -318,8 +280,6 @@ public class HttpClientOptions extends ClientOptionsBase {
     maxRedirects = DEFAULT_MAX_REDIRECTS;
     forceSni = DEFAULT_FORCE_SNI;
     decoderInitialBufferSize = DEFAULT_DECODER_INITIAL_BUFFER_SIZE;
-    poolCleanerPeriod = DEFAULT_POOL_CLEANER_PERIOD;
-    poolEventLoopSize = DEFAULT_POOL_EVENT_LOOP_SIZE;
     tracingPolicy = DEFAULT_TRACING_POLICY;
     shared = DEFAULT_SHARED;
     name = DEFAULT_NAME;
@@ -531,29 +491,6 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   /**
-   * Get the maximum pool size for connections
-   *
-   * @return  the maximum pool size
-   */
-  public int getMaxPoolSize() {
-    return maxPoolSize;
-  }
-
-  /**
-   * Set the maximum pool size for connections
-   *
-   * @param maxPoolSize  the maximum pool size
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setMaxPoolSize(int maxPoolSize) {
-    if (maxPoolSize < 1) {
-      throw new IllegalArgumentException("maxPoolSize must be > 0");
-    }
-    this.maxPoolSize = maxPoolSize;
-    return this;
-  }
-
-  /**
    * @return the maximum number of concurrent streams for an HTTP/2 connection, {@code -1} means
    * the value sent by the server
    */
@@ -577,29 +514,6 @@ public class HttpClientOptions extends ClientOptionsBase {
       throw new IllegalArgumentException("maxPoolSize must be > 0 or -1 (disabled)");
     }
     this.http2MultiplexingLimit = limit;
-    return this;
-  }
-
-  /**
-   * Get the maximum pool size for HTTP/2 connections
-   *
-   * @return  the maximum pool size
-   */
-  public int getHttp2MaxPoolSize() {
-    return http2MaxPoolSize;
-  }
-
-  /**
-   * Set the maximum pool size for HTTP/2 connections
-   *
-   * @param max  the maximum pool size
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setHttp2MaxPoolSize(int max) {
-    if (max < 1) {
-      throw new IllegalArgumentException("http2MaxPoolSize must be > 0");
-    }
-    this.http2MaxPoolSize = max;
     return this;
   }
 
@@ -892,25 +806,6 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   /**
-   * Set the maximum requests allowed in the wait queue, any requests beyond the max size will result in
-   * a ConnectionPoolTooBusyException.  If the value is set to a negative number then the queue will be unbounded.
-   * @param maxWaitQueueSize the maximum number of waiting requests
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setMaxWaitQueueSize(int maxWaitQueueSize) {
-    this.maxWaitQueueSize = maxWaitQueueSize;
-    return this;
-  }
-
-  /**
-   * Returns the maximum wait queue size
-   * @return the maximum wait queue size
-   */
-  public int getMaxWaitQueueSize() {
-    return maxWaitQueueSize;
-  }
-
-  /**
    * @return the initial HTTP/2 connection settings
    */
   public Http2Settings getInitialSettings() {
@@ -1096,52 +991,6 @@ public class HttpClientOptions extends ClientOptionsBase {
   public HttpClientOptions setDecoderInitialBufferSize(int decoderInitialBufferSize) {
     Arguments.require(decoderInitialBufferSize > 0, "initialBufferSizeHttpDecoder must be > 0");
     this.decoderInitialBufferSize = decoderInitialBufferSize;
-    return this;
-  }
-
-  /**
-   * @return the connection pool cleaner period in ms.
-   */
-  public int getPoolCleanerPeriod() {
-    return poolCleanerPeriod;
-  }
-
-  /**
-   * Set the connection pool cleaner period in milli seconds, a non positive value disables expiration checks and connections
-   * will remain in the pool until they are closed.
-   *
-   * @param poolCleanerPeriod the pool cleaner period
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setPoolCleanerPeriod(int poolCleanerPeriod) {
-    this.poolCleanerPeriod = poolCleanerPeriod;
-    return this;
-  }
-
-  /**
-   * @return the max number of event-loop a pool will use, the default value is {@code 0} which implies
-   * to reuse the current event-loop
-   */
-  public int getPoolEventLoopSize() {
-    return poolEventLoopSize;
-  }
-
-  /**
-   * Set the number of event-loop the pool use.
-   *
-   * <ul>
-   *   <li>when the size is {@code 0}, the client pool will use the current event-loop</li>
-   *   <li>otherwise the client will create and use its own event loop</li>
-   * </ul>
-   *
-   * The default size is {@code 0}.
-   *
-   * @param poolEventLoopSize  the new size
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setPoolEventLoopSize(int poolEventLoopSize) {
-    Arguments.require(poolEventLoopSize >= 0, "poolEventLoopSize must be >= 0");
-    this.poolEventLoopSize = poolEventLoopSize;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -90,22 +90,6 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final boolean DEFAULT_VERIFY_HOST = true;
 
   /**
-   * The default value for maximum WebSocket frame size = 65536 bytes
-   */
-  public static final int DEFAULT_MAX_WEBSOCKET_FRAME_SIZE = 65536;
-
-  /**
-   * The default value for maximum WebSocket messages (could be assembled from multiple frames) is 4 full frames
-   * worth of data
-   */
-  public static final int DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE = 65536 * 4;
-
-  /**
-   * The default value for the maximum number of WebSocket = 50
-   */
-  public static final int DEFAULT_MAX_WEBSOCKETS = 50;
-
-  /**
    * The default value for host name = "localhost"
    */
   public static final String DEFAULT_DEFAULT_HOST = "localhost";
@@ -155,11 +139,6 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public static final boolean DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE_WITH_PREFLIGHT_REQUEST = false;
 
-  /**
-   * Default WebSocket masked bit is true as depicted by RFC = {@code false}
-   */
-  public static final boolean DEFAULT_SEND_UNMASKED_FRAMES = false;
-
   /*
    * Default max redirect = 16
    */
@@ -176,31 +155,6 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final int DEFAULT_DECODER_INITIAL_BUFFER_SIZE = 128;
 
   /**
-   * Default offer WebSocket per-frame deflate compression extension = {@code false}
-   */
-  public static final boolean DEFAULT_TRY_USE_PER_FRAME_WEBSOCKET_COMPRESSION = false;
-
-  /**
-   * Default offer WebSocket per-message deflate compression extension = {@code false}
-   */
-  public static final boolean DEFAULT_TRY_USE_PER_MESSAGE_WEBSOCKET_COMPRESSION = false;
-
-  /**
-   * Default WebSocket deflate compression level = 6
-   */
-  public static final int DEFAULT_WEBSOCKET_COMPRESSION_LEVEL = 6;
-
-  /**
-   * Default offering of the {@code server_no_context_takeover} WebSocket parameter deflate compression extension = {@code false}
-   */
-  public static final boolean DEFAULT_WEBSOCKET_ALLOW_CLIENT_NO_CONTEXT = false;
-
-  /**
-   * Default offering of the {@code client_no_context_takeover} WebSocket parameter deflate compression extension = {@code false}
-   */
-  public static final boolean DEFAULT_WEBSOCKET_REQUEST_SERVER_NO_CONTEXT = false;
-
-  /**
    * Default pool cleaner period = 1000 ms (1 second)
    */
   public static final int DEFAULT_POOL_CLEANER_PERIOD = 1000;
@@ -209,11 +163,6 @@ public class HttpClientOptions extends ClientOptionsBase {
    * Default pool event loop size = 0 (reuse current event-loop)
    */
   public static final int DEFAULT_POOL_EVENT_LOOP_SIZE = 0;
-
-  /**
-   * Default WebSocket closing timeout = 10 second
-   */
-  public static final int DEFAULT_WEBSOCKET_CLOSING_TIMEOUT = 10;
 
   /**
    * Default tracing control = {@link TracingPolicy#PROPAGATE}
@@ -244,9 +193,6 @@ public class HttpClientOptions extends ClientOptionsBase {
   private int poolEventLoopSize;
 
   private boolean tryUseCompression;
-  private int maxWebSocketFrameSize;
-  private int maxWebSocketMessageSize;
-  private int maxWebSockets;
   private String defaultHost;
   private int defaultPort;
   private HttpVersion protocolVersion;
@@ -258,17 +204,9 @@ public class HttpClientOptions extends ClientOptionsBase {
   private List<HttpVersion> alpnVersions;
   private boolean http2ClearTextUpgrade;
   private boolean http2ClearTextUpgradeWithPreflightRequest;
-  private boolean sendUnmaskedFrames;
   private int maxRedirects;
   private boolean forceSni;
   private int decoderInitialBufferSize;
-
-  private boolean tryUsePerFrameWebSocketCompression;
-  private boolean tryUsePerMessageWebSocketCompression;
-  private int webSocketCompressionLevel;
-  private boolean webSocketAllowClientNoContext;
-  private boolean webSocketRequestServerNoContext;
-  private int webSocketClosingTimeout;
 
   private TracingPolicy tracingPolicy;
 
@@ -280,6 +218,16 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public HttpClientOptions() {
     super();
+    init();
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param other  the options to copy
+   */
+  public HttpClientOptions(ClientOptionsBase other) {
+    super(other);
     init();
   }
 
@@ -301,9 +249,6 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.http2ConnectionWindowSize = other.http2ConnectionWindowSize;
     this.http2KeepAliveTimeout = other.getHttp2KeepAliveTimeout();
     this.tryUseCompression = other.isTryUseCompression();
-    this.maxWebSocketFrameSize = other.maxWebSocketFrameSize;
-    this.maxWebSocketMessageSize = other.maxWebSocketMessageSize;
-    this.maxWebSockets = other.maxWebSockets;
     this.defaultHost = other.defaultHost;
     this.defaultPort = other.defaultPort;
     this.protocolVersion = other.protocolVersion;
@@ -315,18 +260,11 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.alpnVersions = other.alpnVersions != null ? new ArrayList<>(other.alpnVersions) : null;
     this.http2ClearTextUpgrade = other.http2ClearTextUpgrade;
     this.http2ClearTextUpgradeWithPreflightRequest = other.http2ClearTextUpgradeWithPreflightRequest;
-    this.sendUnmaskedFrames = other.isSendUnmaskedFrames();
     this.maxRedirects = other.maxRedirects;
     this.forceSni = other.forceSni;
     this.decoderInitialBufferSize = other.getDecoderInitialBufferSize();
     this.poolCleanerPeriod = other.getPoolCleanerPeriod();
     this.poolEventLoopSize = other.getPoolEventLoopSize();
-    this.tryUsePerFrameWebSocketCompression = other.tryUsePerFrameWebSocketCompression;
-    this.tryUsePerMessageWebSocketCompression = other.tryUsePerMessageWebSocketCompression;
-    this.webSocketAllowClientNoContext = other.webSocketAllowClientNoContext;
-    this.webSocketCompressionLevel = other.webSocketCompressionLevel;
-    this.webSocketRequestServerNoContext = other.webSocketRequestServerNoContext;
-    this.webSocketClosingTimeout = other.webSocketClosingTimeout;
     this.tracingPolicy = other.tracingPolicy;
     this.shared = other.shared;
     this.name = other.name;
@@ -366,9 +304,6 @@ public class HttpClientOptions extends ClientOptionsBase {
     http2ConnectionWindowSize = DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE;
     http2KeepAliveTimeout = DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT;
     tryUseCompression = DEFAULT_TRY_USE_COMPRESSION;
-    maxWebSocketFrameSize = DEFAULT_MAX_WEBSOCKET_FRAME_SIZE;
-    maxWebSocketMessageSize = DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE;
-    maxWebSockets = DEFAULT_MAX_WEBSOCKETS;
     defaultHost = DEFAULT_DEFAULT_HOST;
     defaultPort = DEFAULT_DEFAULT_PORT;
     protocolVersion = DEFAULT_PROTOCOL_VERSION;
@@ -380,16 +315,9 @@ public class HttpClientOptions extends ClientOptionsBase {
     alpnVersions = new ArrayList<>(DEFAULT_ALPN_VERSIONS);
     http2ClearTextUpgrade = DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE;
     http2ClearTextUpgradeWithPreflightRequest = DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE_WITH_PREFLIGHT_REQUEST;
-    sendUnmaskedFrames = DEFAULT_SEND_UNMASKED_FRAMES;
     maxRedirects = DEFAULT_MAX_REDIRECTS;
     forceSni = DEFAULT_FORCE_SNI;
     decoderInitialBufferSize = DEFAULT_DECODER_INITIAL_BUFFER_SIZE;
-    tryUsePerFrameWebSocketCompression = DEFAULT_TRY_USE_PER_FRAME_WEBSOCKET_COMPRESSION;
-    tryUsePerMessageWebSocketCompression = DEFAULT_TRY_USE_PER_MESSAGE_WEBSOCKET_COMPRESSION;
-    webSocketCompressionLevel = DEFAULT_WEBSOCKET_COMPRESSION_LEVEL;
-    webSocketAllowClientNoContext = DEFAULT_WEBSOCKET_ALLOW_CLIENT_NO_CONTEXT;
-    webSocketRequestServerNoContext = DEFAULT_WEBSOCKET_REQUEST_SERVER_NO_CONTEXT;
-    webSocketClosingTimeout = DEFAULT_WEBSOCKET_CLOSING_TIMEOUT;
     poolCleanerPeriod = DEFAULT_POOL_CLEANER_PERIOD;
     poolEventLoopSize = DEFAULT_POOL_EVENT_LOOP_SIZE;
     tracingPolicy = DEFAULT_TRACING_POLICY;
@@ -848,93 +776,6 @@ public class HttpClientOptions extends ClientOptionsBase {
     return this;
   }
 
-
-  /**
-  * @return {@code true} when frame masking is skipped
-  */
-  public boolean isSendUnmaskedFrames() {
-    return sendUnmaskedFrames;
-  }
-
-  /**
-   * Set {@code true} when the client wants to skip frame masking.
-   * <p>
-   * You may want to set it {@code true} on server by server WebSocket communication: in this case you are by passing
-   * RFC6455 protocol.
-   * <p>
-   * It's {@code false} as default.
-   *
-   * @param sendUnmaskedFrames  true if enabled
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setSendUnmaskedFrames(boolean sendUnmaskedFrames) {
-    this.sendUnmaskedFrames = sendUnmaskedFrames;
-    return this;
-  }
-
-  /**
-   * Get the maximum WebSocket frame size to use
-   *
-   * @return  the max WebSocket frame size
-   */
-  public int getMaxWebSocketFrameSize() {
-    return maxWebSocketFrameSize;
-  }
-
-  /**
-   * Set the max WebSocket frame size
-   *
-   * @param maxWebSocketFrameSize  the max frame size, in bytes
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setMaxWebSocketFrameSize(int maxWebSocketFrameSize) {
-    this.maxWebSocketFrameSize = maxWebSocketFrameSize;
-    return this;
-  }
-
-  /**
-   * Get the maximum WebSocket message size to use
-   *
-   * @return  the max WebSocket message size
-   */
-  public int getMaxWebSocketMessageSize() {
-    return maxWebSocketMessageSize;
-  }
-
-  /**
-   * Set the max WebSocket message size
-   *
-   * @param maxWebSocketMessageSize  the max message size, in bytes
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setMaxWebSocketMessageSize(int maxWebSocketMessageSize) {
-    this.maxWebSocketMessageSize = maxWebSocketMessageSize;
-    return this;
-  }
-
-  /**
-   * Get the maximum of WebSockets per endpoint.
-   *
-   * @return  the max number of WebSockets
-   */
-  public int getMaxWebSockets() {
-    return maxWebSockets;
-  }
-
-  /**
-   * Set the max number of WebSockets per endpoint.
-   *
-   * @param maxWebSockets  the max value
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setMaxWebSockets(int maxWebSockets) {
-    if (maxWebSockets == 0 || maxWebSockets < -1) {
-      throw new IllegalArgumentException("maxWebSockets must be > 0 or -1 (disabled)");
-    }
-    this.maxWebSockets = maxWebSockets;
-    return this;
-  }
-
   /**
    * Get the default host name to be used by this client in requests if none is provided when making the request.
    *
@@ -1239,125 +1080,6 @@ public class HttpClientOptions extends ClientOptionsBase {
   @Override
   public HttpClientOptions setActivityLogDataFormat(ByteBufFormat activityLogDataFormat) {
     return (HttpClientOptions) super.setActivityLogDataFormat(activityLogDataFormat);
-  }
-
-  /**
-   * Set whether the client will offer the WebSocket per-frame deflate compression extension.
-   *
-   * @param offer {@code true} to offer the per-frame deflate compression extension
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setTryUsePerFrameWebSocketCompression(boolean offer) {
-    this.tryUsePerFrameWebSocketCompression = offer;
-    return this;
-  }
-
-  /**
-   * @return {@code true} when the WebSocket per-frame deflate compression extension will be offered
-   */
-  public boolean getTryWebSocketDeflateFrameCompression() {
-    return this.tryUsePerFrameWebSocketCompression;
-  }
-
-  /**
-   * Set whether the client will offer the WebSocket per-message deflate compression extension.
-   *
-   * @param offer {@code true} to offer the per-message deflate compression extension
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setTryUsePerMessageWebSocketCompression(boolean offer) {
-    this.tryUsePerMessageWebSocketCompression = offer;
-    return this;
-  }
-
-  /**
-   * @return {@code true} when the WebSocket per-message deflate compression extension will be offered
-   */
-  public boolean getTryUsePerMessageWebSocketCompression() {
-    return this.tryUsePerMessageWebSocketCompression;
-  }
-
-  /**
-   * Set the WebSocket deflate compression level.
-   *
-   * @param compressionLevel the WebSocket deflate compression level
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setWebSocketCompressionLevel(int compressionLevel) {
-    this.webSocketCompressionLevel = compressionLevel;
-    return this;
-  }
-
-  /**
-   * @return the WebSocket deflate compression level
-   */
-  public int getWebSocketCompressionLevel() {
-    return this.webSocketCompressionLevel;
-  }
-
-  /**
-   * Set whether the {@code client_no_context_takeover} parameter of the WebSocket per-message
-   * deflate compression extension will be offered.
-   *
-   * @param offer {@code true} to offer the {@code client_no_context_takeover} parameter
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setWebSocketCompressionAllowClientNoContext(boolean offer) {
-    this.webSocketAllowClientNoContext = offer;
-    return this;
-  }
-
-  /**
-   * @return {@code true} when the {@code client_no_context_takeover} parameter for the WebSocket per-message
-   * deflate compression extension will be offered
-   */
-  public boolean getWebSocketCompressionAllowClientNoContext() {
-    return this.webSocketAllowClientNoContext;
-  }
-
-  /**
-   * Set whether the {@code server_no_context_takeover} parameter of the WebSocket per-message
-   * deflate compression extension will be offered.
-   *
-   * @param offer {@code true} to offer the {@code server_no_context_takeover} parameter
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setWebSocketCompressionRequestServerNoContext(boolean offer) {
-    this.webSocketRequestServerNoContext = offer;
-    return this;
-  }
-
-  /**
-   * @return {@code true} when the {@code server_no_context_takeover} parameter for the WebSocket per-message
-   * deflate compression extension will be offered
-   */
-  public boolean getWebSocketCompressionRequestServerNoContext() {
-    return this.webSocketRequestServerNoContext;
-  }
-
-  /**
-   * @return the amount of time (in seconds) a client WebSocket will wait until it closes TCP connection after receiving a close frame
-   */
-  public int getWebSocketClosingTimeout() {
-    return webSocketClosingTimeout;
-  }
-
-  /**
-   * Set the amount of time a client WebSocket will wait until it closes the TCP connection after receiving a close frame.
-   *
-   * <p> When a WebSocket is closed, the server should close the TCP connection. This timeout will close
-   * the TCP connection on the client when it expires.
-   *
-   * <p> Set to {@code 0L} closes the TCP connection immediately after receiving the close frame.
-   *
-   * <p> Set to a negative value to disable it.
-   *
-   * @param webSocketClosingTimeout the timeout is seconds
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpClientOptions setWebSocketClosingTimeout(int webSocketClosingTimeout) {
-    this.webSocketClosingTimeout = webSocketClosingTimeout;
-    return this;
   }
 
   /**

--- a/src/main/java/io/vertx/core/http/HttpClientPool.java
+++ b/src/main/java/io/vertx/core/http/HttpClientPool.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.net.ClientSSLOptions;
+import io.vertx.core.net.SSLOptions;
+
+import java.util.function.Function;
+
+@VertxGen
+public interface HttpClientPool extends HttpClient, io.vertx.core.metrics.Measured {
+
+  /**
+   * Update the client SSL options.
+   *
+   * Update only happens if the SSL options is valid.
+   *
+   * @param options the new SSL options
+   * @return a future signaling the update success
+   */
+  Future<Void> updateSSLOptions(ClientSSLOptions options);
+
+  /**
+   * Set a connection handler for the client. This handler is called when a new connection is established.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpClientPool connectionHandler(Handler<HttpConnection> handler);
+
+  /**
+   * Set a redirect handler for the http client.
+   * <p>
+   * The redirect handler is called when a {@code 3xx} response is received and the request is configured to
+   * follow redirects with {@link HttpClientRequest#setFollowRedirects(boolean)}.
+   * <p>
+   * The redirect handler is passed the {@link HttpClientResponse}, it can return an {@link HttpClientRequest} or {@code null}.
+   * <ul>
+   *   <li>when null is returned, the original response is processed by the original request response handler</li>
+   *   <li>when a new {@code Future<HttpClientRequest>} is returned, the client will send this new request</li>
+   * </ul>
+   * The new request will get a copy of the previous request headers unless headers are set. In this case,
+   * the client assumes that the redirect handler exclusively managers the headers of the new request.
+   * <p>
+   * The handler must return a {@code Future<HttpClientRequest>} unsent so the client can further configure it and send it.
+   *
+   * @param handler the new redirect handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpClientPool redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler);
+
+  /**
+   * @return the current redirect handler.
+   */
+  @GenIgnore
+  Function<HttpClientResponse, Future<RequestOptions>> redirectHandler();
+
+}

--- a/src/main/java/io/vertx/core/http/PoolOptions.java
+++ b/src/main/java/io/vertx/core/http/PoolOptions.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.impl.Arguments;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Options configuring a {@link HttpClient} pool.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@DataObject(generateConverter = true, publicConverter = false)
+public class PoolOptions {
+
+  /**
+   * The default maximum number of HTTP/1 connections a client will pool = 5
+   */
+  public static final int DEFAULT_MAX_POOL_SIZE = 5;
+
+  /**
+   * The default maximum number of connections an HTTP/2 client will pool = 1
+   */
+  public static final int DEFAULT_HTTP2_MAX_POOL_SIZE = 1;
+
+  /**
+   * Default max wait queue size = -1 (unbounded)
+   */
+  public static final int DEFAULT_MAX_WAIT_QUEUE_SIZE = -1;
+
+  /**
+   * Default pool cleaner period = 1000 ms (1 second)
+   */
+  public static final int DEFAULT_POOL_CLEANER_PERIOD = 1000;
+
+  /**
+   * Default pool event loop size = 0 (reuse current event-loop)
+   */
+  public static final int DEFAULT_POOL_EVENT_LOOP_SIZE = 0;
+
+  private int http1MaxSize;
+  private int http2MaxSize;
+  private int cleanerPeriod;
+  private int eventLoopSize;
+  private int maxWaitQueueSize;
+
+  /**
+   * Default constructor
+   */
+  public PoolOptions() {
+    http1MaxSize = DEFAULT_MAX_POOL_SIZE;
+    http2MaxSize = DEFAULT_HTTP2_MAX_POOL_SIZE;
+    cleanerPeriod = DEFAULT_POOL_CLEANER_PERIOD;
+    eventLoopSize = DEFAULT_POOL_EVENT_LOOP_SIZE;
+    maxWaitQueueSize = DEFAULT_MAX_WAIT_QUEUE_SIZE;
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param other  the options to copy
+   */
+  public PoolOptions(PoolOptions other) {
+    this.http1MaxSize = other.http1MaxSize;
+    this.http2MaxSize = other.http2MaxSize;
+    this.cleanerPeriod = other.cleanerPeriod;
+    this.eventLoopSize = other.eventLoopSize;
+    this.maxWaitQueueSize = other.maxWaitQueueSize;
+  }
+
+  /**
+   * Constructor to create an options from JSON
+   *
+   * @param json  the JSON
+   */
+  public PoolOptions(JsonObject json) {
+    PoolOptionsConverter.fromJson(json, this);
+  }
+
+  /**
+   * Get the maximum pool size for HTTP/1.x connections
+   *
+   * @return  the maximum pool size
+   */
+  public int getHttp1MaxSize() {
+    return http1MaxSize;
+  }
+
+  /**
+   * Set the maximum pool size for HTTP/1.x connections
+   *
+   * @param http1MaxSize  the maximum pool size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public PoolOptions setHttp1MaxSize(int http1MaxSize) {
+    if (http1MaxSize < 1) {
+      throw new IllegalArgumentException("maxPoolSize must be > 0");
+    }
+    this.http1MaxSize = http1MaxSize;
+    return this;
+  }
+
+  /**
+   * Get the maximum pool size for HTTP/2 connections
+   *
+   * @return  the maximum pool size
+   */
+  public int getHttp2MaxSize() {
+    return http2MaxSize;
+  }
+
+  /**
+   * Set the maximum pool size for HTTP/2 connections
+   *
+   * @param max  the maximum pool size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public PoolOptions setHttp2MaxSize(int max) {
+    if (max < 1) {
+      throw new IllegalArgumentException("http2MaxPoolSize must be > 0");
+    }
+    this.http2MaxSize = max;
+    return this;
+  }
+
+  /**
+   * @return the connection pool cleaner period in ms.
+   */
+  public int getCleanerPeriod() {
+    return cleanerPeriod;
+  }
+
+  /**
+   * Set the connection pool cleaner period in milli seconds, a non positive value disables expiration checks and connections
+   * will remain in the pool until they are closed.
+   *
+   * @param cleanerPeriod the pool cleaner period
+   * @return a reference to this, so the API can be used fluently
+   */
+  public PoolOptions setCleanerPeriod(int cleanerPeriod) {
+    this.cleanerPeriod = cleanerPeriod;
+    return this;
+  }
+
+  /**
+   * @return the max number of event-loop a pool will use, the default value is {@code 0} which implies
+   * to reuse the current event-loop
+   */
+  public int getEventLoopSize() {
+    return eventLoopSize;
+  }
+
+  /**
+   * Set the number of event-loop the pool use.
+   *
+   * <ul>
+   *   <li>when the size is {@code 0}, the client pool will use the current event-loop</li>
+   *   <li>otherwise the client will create and use its own event loop</li>
+   * </ul>
+   *
+   * The default size is {@code 0}.
+   *
+   * @param eventLoopSize  the new size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public PoolOptions setEventLoopSize(int eventLoopSize) {
+    Arguments.require(eventLoopSize >= 0, "poolEventLoopSize must be >= 0");
+    this.eventLoopSize = eventLoopSize;
+    return this;
+  }
+
+  /**
+   * Set the maximum requests allowed in the wait queue, any requests beyond the max size will result in
+   * a ConnectionPoolTooBusyException.  If the value is set to a negative number then the queue will be unbounded.
+   * @param maxWaitQueueSize the maximum number of waiting requests
+   * @return a reference to this, so the API can be used fluently
+   */
+  public PoolOptions setMaxWaitQueueSize(int maxWaitQueueSize) {
+    this.maxWaitQueueSize = maxWaitQueueSize;
+    return this;
+  }
+
+  /**
+   * Returns the maximum wait queue size
+   * @return the maximum wait queue size
+   */
+  public int getMaxWaitQueueSize() {
+    return maxWaitQueueSize;
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    PoolOptionsConverter.toJson(this, json);
+    return json;
+  }
+}

--- a/src/main/java/io/vertx/core/http/ServerWebSocket.java
+++ b/src/main/java/io/vertx/core/http/ServerWebSocket.java
@@ -31,7 +31,7 @@ import javax.net.ssl.SSLSession;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
-public interface ServerWebSocket extends WebSocketBase {
+public interface ServerWebSocket extends WebSocket {
 
   @Override
   ServerWebSocket exceptionHandler(Handler<Throwable> handler);

--- a/src/main/java/io/vertx/core/http/WebSocket.java
+++ b/src/main/java/io/vertx/core/http/WebSocket.java
@@ -11,12 +11,18 @@
 
 package io.vertx.core.http;
 
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
 
 /**
- * Represents a client-side WebSocket.
+ * Common WebSocket implementation.
+ * <p>
+ * It implements both {@link ReadStream} and {@link WriteStream} so it can be used with
+ * {@link io.vertx.core.streams.Pipe} to pipe data with flow control.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -52,4 +58,14 @@ public interface WebSocket extends WebSocketBase {
 
   @Override
   WebSocket frameHandler(Handler<WebSocketFrame> handler);
+
+  @Override
+  WebSocket textMessageHandler(@Nullable Handler<String> handler);
+
+  @Override
+  WebSocket binaryMessageHandler(@Nullable Handler<Buffer> handler);
+
+  @Override
+  WebSocket pongHandler(@Nullable Handler<Buffer> handler);
+
 }

--- a/src/main/java/io/vertx/core/http/WebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/WebSocketClient.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.metrics.Measured;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An asynchronous WebSocket client.
+ * <p>
+ * It allows you to open WebSockets to servers.
+ * <p>
+ *
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+@VertxGen
+public interface WebSocketClient extends Measured {
+
+  /**
+   * Create a WebSocket that is not yet connected to the server.
+   *
+   * @return the client WebSocket
+   */
+  ClientWebSocket webSocket();
+
+  /**
+   * Connect a WebSocket to the specified port, host and relative request URI.
+   *
+   * @param port  the port
+   * @param host  the host
+   * @param requestURI  the relative URI
+   * @return a future notified when the WebSocket when connected
+   */
+  default Future<WebSocket> connect(int port, String host, String requestURI) {
+    return connect(new WebSocketConnectOptions().setURI(requestURI).setHost(host).setPort(port));
+  }
+
+  /**
+   * Connect a WebSocket with the specified options.
+   *
+   * @param options  the request options
+   * @return a future notified when the WebSocket when connected
+   */
+  Future<WebSocket> connect(WebSocketConnectOptions options);
+
+  /**
+   * Close the client immediately ({@code close(0, TimeUnit.SECONDS}).
+   *
+   * @return a future notified when the client is closed
+   */
+  default Future<Void> close() {
+    return close(0, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Initiate the client close sequence.
+   *
+   * <p> Connections are taken out of service and closed when all inflight requests are processed, client connection are
+   * immediately removed from the pool. When all connections are closed the client is closed. When the timeout
+   * expires, all unclosed connections are immediately closed.
+   *
+   * <ul>
+   *   <li>HTTP/2 connections will send a go away frame immediately to signal the other side the connection will close</li>
+   *   <li>HTTP/1.x client connection will be closed after the current response is received</li>
+   * </ul>
+   *
+   * @return a future notified when the client is closed
+   */
+  Future<Void> close(long timeout, TimeUnit timeUnit);
+
+}

--- a/src/main/java/io/vertx/core/http/WebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/WebSocketClient.java
@@ -60,7 +60,16 @@ public interface WebSocketClient extends Measured {
    * @return a future notified when the client is closed
    */
   default Future<Void> close() {
-    return close(0, TimeUnit.SECONDS);
+    return shutdown(0, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Initiate the close sequence with a 30 seconds timeout.
+   *
+   * see {@link #shutdown(long, TimeUnit)}
+   */
+  default Future<Void> shutdown() {
+    return shutdown(30, TimeUnit.SECONDS);
   }
 
   /**
@@ -77,6 +86,6 @@ public interface WebSocketClient extends Measured {
    *
    * @return a future notified when the client is closed
    */
-  Future<Void> close(long timeout, TimeUnit timeUnit);
+  Future<Void> shutdown(long timeout, TimeUnit timeUnit);
 
 }

--- a/src/main/java/io/vertx/core/http/WebSocketClientOptions.java
+++ b/src/main/java/io/vertx/core/http/WebSocketClientOptions.java
@@ -1,0 +1,656 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.netty.handler.logging.ByteBufFormat;
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.*;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static io.vertx.core.http.HttpClientOptions.DEFAULT_NAME;
+import static io.vertx.core.http.HttpClientOptions.DEFAULT_SHARED;
+
+@DataObject(generateConverter = true, publicConverter = false)
+public class WebSocketClientOptions extends ClientOptionsBase {
+
+  /**
+   * The default value for maximum WebSocket messages (could be assembled from multiple frames) is 4 full frames
+   * worth of data
+   */
+  public static final int DEFAULT_MAX_MESSAGE_SIZE = 65536 * 4;
+
+  /**
+   * The default value for the maximum number of WebSocket = 50
+   */
+  public static final int DEFAULT_MAX_CONNECTIONS = 50;
+
+  /**
+   * Default WebSocket masked bit is true as depicted by RFC = {@code false}
+   */
+  public static final boolean DEFAULT_SEND_UNMASKED_FRAMES = false;
+
+  /**
+   * Default offer WebSocket per-frame deflate compression extension = {@code false}
+   */
+  public static final boolean DEFAULT_TRY_USE_PER_FRAME_COMPRESSION = false;
+
+  /**
+   * Default offer WebSocket per-message deflate compression extension = {@code false}
+   */
+  public static final boolean DEFAULT_TRY_USE_PER_MESSAGE_COMPRESSION = false;
+
+  /**
+   * Default WebSocket deflate compression level = 6
+   */
+  public static final int DEFAULT_COMPRESSION_LEVEL = 6;
+
+  /**
+   * Default offering of the {@code server_no_context_takeover} WebSocket parameter deflate compression extension = {@code false}
+   */
+  public static final boolean DEFAULT_ALLOW_CLIENT_NO_CONTEXT = false;
+
+  /**
+   * Default offering of the {@code client_no_context_takeover} WebSocket parameter deflate compression extension = {@code false}
+   */
+  public static final boolean DEFAULT_REQUEST_SERVER_NO_CONTEXT = false;
+
+  /**
+   * Default WebSocket closing timeout = 10 second
+   */
+  public static final int DEFAULT_CLOSING_TIMEOUT = 10;
+
+  /**
+   * The default value for maximum WebSocket frame size = 65536 bytes
+   */
+  public static final int DEFAULT_MAX_FRAME_SIZE = 65536;
+
+  private boolean verifyHost;
+  private int maxFrameSize;
+  private int maxMessageSize;
+  private int maxConnections;
+  private boolean sendUnmaskedFrames;
+  private boolean tryUsePerFrameCompression;
+  private boolean tryUsePerMessageCompression;
+  private int compressionLevel;
+  private boolean allowClientNoContext;
+  private boolean requestServerNoContext;
+  private int closingTimeout;
+  private boolean shared;
+  private String name;
+
+  /**
+   * Default constructor
+   */
+  public WebSocketClientOptions() {
+    init();
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param other  the options to copy
+   */
+  public WebSocketClientOptions(WebSocketClientOptions other) {
+    super(other);
+
+    this.verifyHost = other.verifyHost;
+    this.maxFrameSize = other.maxFrameSize;
+    this.maxMessageSize = other.maxMessageSize;
+    this.maxConnections = other.maxConnections;
+    this.sendUnmaskedFrames = other.sendUnmaskedFrames;
+    this.tryUsePerFrameCompression = other.tryUsePerFrameCompression;
+    this.tryUsePerMessageCompression = other.tryUsePerMessageCompression;
+    this.allowClientNoContext = other.allowClientNoContext;
+    this.compressionLevel = other.compressionLevel;
+    this.requestServerNoContext = other.requestServerNoContext;
+    this.closingTimeout = other.closingTimeout;
+    this.shared = other.shared;
+    this.name = other.name;
+  }
+
+  /**
+   * Constructor to create an options from JSON
+   *
+   * @param json  the JSON
+   */
+  public WebSocketClientOptions(JsonObject json) {
+    super(json);
+    init();
+    WebSocketClientOptionsConverter.fromJson(json, this);
+  }
+
+  private void init() {
+    verifyHost = true;
+    maxFrameSize = DEFAULT_MAX_FRAME_SIZE;
+    maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
+    maxConnections = DEFAULT_MAX_CONNECTIONS;
+    sendUnmaskedFrames = DEFAULT_SEND_UNMASKED_FRAMES;
+    tryUsePerFrameCompression = DEFAULT_TRY_USE_PER_FRAME_COMPRESSION;
+    tryUsePerMessageCompression = DEFAULT_TRY_USE_PER_MESSAGE_COMPRESSION;
+    compressionLevel = DEFAULT_COMPRESSION_LEVEL;
+    allowClientNoContext = DEFAULT_ALLOW_CLIENT_NO_CONTEXT;
+    requestServerNoContext = DEFAULT_REQUEST_SERVER_NO_CONTEXT;
+    closingTimeout = DEFAULT_CLOSING_TIMEOUT;
+    shared = DEFAULT_SHARED;
+    name = DEFAULT_NAME;
+  }
+
+  /**
+   * Is hostname verification (for SSL/TLS) enabled?
+   *
+   * @return {@code true} if enabled
+   */
+  public boolean isVerifyHost() {
+    return verifyHost;
+  }
+
+  /**
+   * Set whether hostname verification is enabled
+   *
+   * @param verifyHost {@code true} if enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setVerifyHost(boolean verifyHost) {
+    this.verifyHost = verifyHost;
+    return this;
+  }
+
+  /**
+   * @return {@code true} when frame masking is skipped
+   */
+  public boolean isSendUnmaskedFrames() {
+    return sendUnmaskedFrames;
+  }
+
+  /**
+   * Set {@code true} when the client wants to skip frame masking.
+   * <p>
+   * You may want to set it {@code true} on server by server WebSocket communication: in this case you are by passing
+   * RFC6455 protocol.
+   * <p>
+   * It's {@code false} as default.
+   *
+   * @param sendUnmaskedFrames  true if enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setSendUnmaskedFrames(boolean sendUnmaskedFrames) {
+    this.sendUnmaskedFrames = sendUnmaskedFrames;
+    return this;
+  }
+
+  /**
+   * Get the maximum WebSocket frame size to use
+   *
+   * @return  the max WebSocket frame size
+   */
+  public int getMaxFrameSize() {
+    return maxFrameSize;
+  }
+
+  /**
+   * Set the max WebSocket frame size
+   *
+   * @param maxFrameSize  the max frame size, in bytes
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setMaxFrameSize(int maxFrameSize) {
+    this.maxFrameSize = maxFrameSize;
+    return this;
+  }
+
+  /**
+   * Get the maximum WebSocket message size to use
+   *
+   * @return  the max WebSocket message size
+   */
+  public int getMaxMessageSize() {
+    return maxMessageSize;
+  }
+
+  /**
+   * Set the max WebSocket message size
+   *
+   * @param maxMessageSize  the max message size, in bytes
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setMaxMessageSize(int maxMessageSize) {
+    this.maxMessageSize = maxMessageSize;
+    return this;
+  }
+
+  /**
+   * Get the maximum of WebSockets per endpoint.
+   *
+   * @return  the max number of WebSockets
+   */
+  public int getMaxConnections() {
+    return maxConnections;
+  }
+
+  /**
+   * Set the max number of WebSockets per endpoint.
+   *
+   * @param maxConnections  the max value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setMaxConnections(int maxConnections) {
+    if (maxConnections == 0 || maxConnections < -1) {
+      throw new IllegalArgumentException("maxWebSockets must be > 0 or -1 (disabled)");
+    }
+    this.maxConnections = maxConnections;
+    return this;
+  }
+
+  /**
+   * Set whether the client will offer the WebSocket per-frame deflate compression extension.
+   *
+   * @param offer {@code true} to offer the per-frame deflate compression extension
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setTryUsePerFrameCompression(boolean offer) {
+    this.tryUsePerFrameCompression = offer;
+    return this;
+  }
+
+  /**
+   * @return {@code true} when the WebSocket per-frame deflate compression extension will be offered
+   */
+  public boolean getTryUsePerFrameCompression() {
+    return this.tryUsePerFrameCompression;
+  }
+
+  /**
+   * Set whether the client will offer the WebSocket per-message deflate compression extension.
+   *
+   * @param offer {@code true} to offer the per-message deflate compression extension
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setTryUsePerMessageCompression(boolean offer) {
+    this.tryUsePerMessageCompression = offer;
+    return this;
+  }
+
+  /**
+   * @return {@code true} when the WebSocket per-message deflate compression extension will be offered
+   */
+  public boolean getTryUsePerMessageCompression() {
+    return this.tryUsePerMessageCompression;
+  }
+
+  /**
+   * Set the WebSocket deflate compression level.
+   *
+   * @param compressionLevel the WebSocket deflate compression level
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setCompressionLevel(int compressionLevel) {
+    this.compressionLevel = compressionLevel;
+    return this;
+  }
+
+  /**
+   * @return the WebSocket deflate compression level
+   */
+  public int getCompressionLevel() {
+    return this.compressionLevel;
+  }
+
+  /**
+   * Set whether the {@code client_no_context_takeover} parameter of the WebSocket per-message
+   * deflate compression extension will be offered.
+   *
+   * @param offer {@code true} to offer the {@code client_no_context_takeover} parameter
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setCompressionAllowClientNoContext(boolean offer) {
+    this.allowClientNoContext = offer;
+    return this;
+  }
+
+  /**
+   * @return {@code true} when the {@code client_no_context_takeover} parameter for the WebSocket per-message
+   * deflate compression extension will be offered
+   */
+  public boolean getCompressionAllowClientNoContext() {
+    return this.allowClientNoContext;
+  }
+
+  /**
+   * Set whether the {@code server_no_context_takeover} parameter of the WebSocket per-message
+   * deflate compression extension will be offered.
+   *
+   * @param offer {@code true} to offer the {@code server_no_context_takeover} parameter
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setCompressionRequestServerNoContext(boolean offer) {
+    this.requestServerNoContext = offer;
+    return this;
+  }
+
+  /**
+   * @return {@code true} when the {@code server_no_context_takeover} parameter for the WebSocket per-message
+   * deflate compression extension will be offered
+   */
+  public boolean getCompressionRequestServerNoContext() {
+    return this.requestServerNoContext;
+  }
+
+  /**
+   * @return the amount of time (in seconds) a client WebSocket will wait until it closes TCP connection after receiving a close frame
+   */
+  public int getClosingTimeout() {
+    return closingTimeout;
+  }
+
+  /**
+   * Set the amount of time a client WebSocket will wait until it closes the TCP connection after receiving a close frame.
+   *
+   * <p> When a WebSocket is closed, the server should close the TCP connection. This timeout will close
+   * the TCP connection on the client when it expires.
+   *
+   * <p> Set to {@code 0L} closes the TCP connection immediately after receiving the close frame.
+   *
+   * <p> Set to a negative value to disable it.
+   *
+   * @param closingTimeout the timeout is seconds
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setClosingTimeout(int closingTimeout) {
+    this.closingTimeout = closingTimeout;
+    return this;
+  }
+
+  /**
+   * @return whether the pool is shared
+   */
+  public boolean isShared() {
+    return shared;
+  }
+
+  /**
+   * Set to {@code true} to share the client.
+   *
+   * <p> There can be multiple shared clients distinguished by {@link #getName()}, when no specific
+   * name is set, the {@link HttpClientOptions#DEFAULT_NAME} is used.
+   *
+   * @param shared {@code true} to use a shared client
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setShared(boolean shared) {
+    this.shared = shared;
+    return this;
+  }
+
+  /**
+   * @return the client name used for sharing
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Set the client name, used when the client is shared, otherwise ignored.
+   * @param name the new name
+   * @return a reference to this, so the API can be used fluently
+   */
+  public WebSocketClientOptions setName(String name) {
+    Objects.requireNonNull(name, "Client name cannot be null");
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Convert to JSON
+   *
+   * @return the JSON
+   */
+  public JsonObject toJson() {
+    JsonObject json = super.toJson();
+    WebSocketClientOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  @Override
+  public WebSocketClientOptions setTrustAll(boolean trustAll) {
+    return (WebSocketClientOptions)super.setTrustAll(trustAll);
+  }
+
+  @Override
+  public WebSocketClientOptions setConnectTimeout(int connectTimeout) {
+    return (WebSocketClientOptions)super.setConnectTimeout(connectTimeout);
+  }
+
+  @Override
+  public WebSocketClientOptions setMetricsName(String metricsName) {
+    return (WebSocketClientOptions)super.setMetricsName(metricsName);
+  }
+
+  @Override
+  public WebSocketClientOptions setProxyOptions(ProxyOptions proxyOptions) {
+    return (WebSocketClientOptions)super.setProxyOptions(proxyOptions);
+  }
+
+  @Override
+  public WebSocketClientOptions setNonProxyHosts(List<String> nonProxyHosts) {
+    return (WebSocketClientOptions)super.setNonProxyHosts(nonProxyHosts);
+  }
+
+  @Override
+  public WebSocketClientOptions setLocalAddress(String localAddress) {
+    return (WebSocketClientOptions)super.setLocalAddress(localAddress);
+  }
+
+  @Override
+  public WebSocketClientOptions setLogActivity(boolean logEnabled) {
+    return (WebSocketClientOptions)super.setLogActivity(logEnabled);
+  }
+
+  @Override
+  public WebSocketClientOptions setActivityLogDataFormat(ByteBufFormat activityLogDataFormat) {
+    return (WebSocketClientOptions)super.setActivityLogDataFormat(activityLogDataFormat);
+  }
+
+  @Override
+  public WebSocketClientOptions setTcpNoDelay(boolean tcpNoDelay) {
+    return (WebSocketClientOptions)super.setTcpNoDelay(tcpNoDelay);
+  }
+
+  @Override
+  public WebSocketClientOptions setTcpKeepAlive(boolean tcpKeepAlive) {
+    return (WebSocketClientOptions)super.setTcpKeepAlive(tcpKeepAlive);
+  }
+
+  @Override
+  public WebSocketClientOptions setSoLinger(int soLinger) {
+    return (WebSocketClientOptions)super.setSoLinger(soLinger);
+  }
+
+  @Override
+  public WebSocketClientOptions setIdleTimeout(int idleTimeout) {
+    return (WebSocketClientOptions)super.setIdleTimeout(idleTimeout);
+  }
+
+  @Override
+  public WebSocketClientOptions setReadIdleTimeout(int idleTimeout) {
+    return (WebSocketClientOptions)super.setReadIdleTimeout(idleTimeout);
+  }
+
+  @Override
+  public WebSocketClientOptions setWriteIdleTimeout(int idleTimeout) {
+    return (WebSocketClientOptions)super.setWriteIdleTimeout(idleTimeout);
+  }
+
+  @Override
+  public WebSocketClientOptions setIdleTimeoutUnit(TimeUnit idleTimeoutUnit) {
+    return (WebSocketClientOptions)super.setIdleTimeoutUnit(idleTimeoutUnit);
+  }
+
+  @Override
+  public WebSocketClientOptions setSsl(boolean ssl) {
+    return (WebSocketClientOptions)super.setSsl(ssl);
+  }
+
+  @Override
+  public WebSocketClientOptions setKeyCertOptions(KeyCertOptions options) {
+    return (WebSocketClientOptions)super.setKeyCertOptions(options);
+  }
+
+  @Override
+  public WebSocketClientOptions setKeyStoreOptions(JksOptions options) {
+    return (WebSocketClientOptions)super.setKeyStoreOptions(options);
+  }
+
+  @Override
+  public WebSocketClientOptions setPfxKeyCertOptions(PfxOptions options) {
+    return (WebSocketClientOptions)super.setPfxKeyCertOptions(options);
+  }
+
+  @Override
+  public WebSocketClientOptions setPemKeyCertOptions(PemKeyCertOptions options) {
+    return (WebSocketClientOptions)super.setPemKeyCertOptions(options);
+  }
+
+  @Override
+  public WebSocketClientOptions setTrustOptions(TrustOptions options) {
+    return (WebSocketClientOptions)super.setTrustOptions(options);
+  }
+
+  @Override
+  public WebSocketClientOptions setTrustStoreOptions(JksOptions options) {
+    return (WebSocketClientOptions)super.setTrustStoreOptions(options);
+  }
+
+  @Override
+  public WebSocketClientOptions setPfxTrustOptions(PfxOptions options) {
+    return (WebSocketClientOptions)super.setPfxTrustOptions(options);
+  }
+
+  @Override
+  public WebSocketClientOptions setPemTrustOptions(PemTrustOptions options) {
+    return (WebSocketClientOptions)super.setPemTrustOptions(options);
+  }
+
+  @Override
+  public WebSocketClientOptions setUseAlpn(boolean useAlpn) {
+    return (WebSocketClientOptions)super.setUseAlpn(useAlpn);
+  }
+
+  @Override
+  public WebSocketClientOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
+    return (WebSocketClientOptions)super.setSslEngineOptions(sslEngineOptions);
+  }
+
+  @Override
+  public WebSocketClientOptions setJdkSslEngineOptions(JdkSSLEngineOptions sslEngineOptions) {
+    return (WebSocketClientOptions)super.setJdkSslEngineOptions(sslEngineOptions);
+  }
+
+  @Override
+  public WebSocketClientOptions setOpenSslEngineOptions(OpenSSLEngineOptions sslEngineOptions) {
+    return (WebSocketClientOptions)super.setOpenSslEngineOptions(sslEngineOptions);
+  }
+
+  @Override
+  public WebSocketClientOptions setSendBufferSize(int sendBufferSize) {
+    return (WebSocketClientOptions)super.setSendBufferSize(sendBufferSize);
+  }
+
+  @Override
+  public WebSocketClientOptions setReceiveBufferSize(int receiveBufferSize) {
+    return (WebSocketClientOptions)super.setReceiveBufferSize(receiveBufferSize);
+  }
+
+  @Override
+  public WebSocketClientOptions setReuseAddress(boolean reuseAddress) {
+    return (WebSocketClientOptions)super.setReuseAddress(reuseAddress);
+  }
+
+  @Override
+  public WebSocketClientOptions setReusePort(boolean reusePort) {
+    return (WebSocketClientOptions)super.setReusePort(reusePort);
+  }
+
+  @Override
+  public WebSocketClientOptions setTrafficClass(int trafficClass) {
+    return (WebSocketClientOptions)super.setTrafficClass(trafficClass);
+  }
+
+  @Override
+  public WebSocketClientOptions setTcpFastOpen(boolean tcpFastOpen) {
+    return (WebSocketClientOptions)super.setTcpFastOpen(tcpFastOpen);
+  }
+
+  @Override
+  public WebSocketClientOptions setTcpCork(boolean tcpCork) {
+    return (WebSocketClientOptions)super.setTcpCork(tcpCork);
+  }
+
+  @Override
+  public WebSocketClientOptions setTcpQuickAck(boolean tcpQuickAck) {
+    return (WebSocketClientOptions)super.setTcpQuickAck(tcpQuickAck);
+  }
+
+  @Override
+  public WebSocketClientOptions setTcpUserTimeout(int tcpUserTimeout) {
+    return (WebSocketClientOptions)super.setTcpUserTimeout(tcpUserTimeout);
+  }
+
+  @Override
+  public WebSocketClientOptions setEnabledSecureTransportProtocols(Set<String> enabledSecureTransportProtocols) {
+    return (WebSocketClientOptions)super.setEnabledSecureTransportProtocols(enabledSecureTransportProtocols);
+  }
+
+  @Override
+  public WebSocketClientOptions setSslHandshakeTimeout(long sslHandshakeTimeout) {
+    return (WebSocketClientOptions)super.setSslHandshakeTimeout(sslHandshakeTimeout);
+  }
+
+  @Override
+  public WebSocketClientOptions setSslHandshakeTimeoutUnit(TimeUnit sslHandshakeTimeoutUnit) {
+    return (WebSocketClientOptions)super.setSslHandshakeTimeoutUnit(sslHandshakeTimeoutUnit);
+  }
+
+  @Override
+  public WebSocketClientOptions addNonProxyHost(String host) {
+    return (WebSocketClientOptions)super.addNonProxyHost(host);
+  }
+
+  @Override
+  public WebSocketClientOptions addEnabledCipherSuite(String suite) {
+    return (WebSocketClientOptions)super.addEnabledCipherSuite(suite);
+  }
+
+  @Override
+  public WebSocketClientOptions removeEnabledCipherSuite(String suite) {
+    return (WebSocketClientOptions)super.removeEnabledCipherSuite(suite);
+  }
+
+  @Override
+  public WebSocketClientOptions addCrlPath(String crlPath) throws NullPointerException {
+    return (WebSocketClientOptions)super.addCrlPath(crlPath);
+  }
+
+  @Override
+  public WebSocketClientOptions addCrlValue(Buffer crlValue) throws NullPointerException {
+    return (WebSocketClientOptions)super.addCrlValue(crlValue);
+  }
+
+  @Override
+  public WebSocketClientOptions addEnabledSecureTransportProtocol(String protocol) {
+    return (WebSocketClientOptions)super.addEnabledSecureTransportProtocol(protocol);
+  }
+}

--- a/src/main/java/io/vertx/core/http/WebSocketConnectOptions.java
+++ b/src/main/java/io/vertx/core/http/WebSocketConnectOptions.java
@@ -16,9 +16,14 @@ import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.SocketAddress;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+
+import java.net.URL;
 
 /**
  * Options describing how an {@link HttpClient} connect a {@link WebSocket}.
@@ -235,6 +240,76 @@ public class WebSocketConnectOptions extends RequestOptions {
   @Override
   public WebSocketConnectOptions setHeaders(MultiMap headers) {
     return (WebSocketConnectOptions) super.setHeaders(headers);
+  }
+
+  @Override
+  public WebSocketConnectOptions setServer(SocketAddress server) {
+    return (WebSocketConnectOptions) super.setServer(server);
+  }
+
+  @Override
+  public WebSocketConnectOptions setMethod(HttpMethod method) {
+    return (WebSocketConnectOptions) super.setMethod(method);
+  }
+
+  @Override
+  public WebSocketConnectOptions setFollowRedirects(Boolean followRedirects) {
+    return (WebSocketConnectOptions) super.setFollowRedirects(followRedirects);
+  }
+
+  @Override
+  public WebSocketConnectOptions setAbsoluteURI(String absoluteURI) {
+    URI uri;
+    try {
+      uri = new URI(absoluteURI);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+    setAbsoluteURI(uri);
+    return this;
+  }
+
+  @Override
+  public WebSocketConnectOptions setAbsoluteURI(URL url) {
+    URI uri;
+    try {
+      uri = url.toURI();
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+    setAbsoluteURI(uri);
+    return this;
+  }
+
+  private void setAbsoluteURI(URI uri) {
+    String scheme = uri.getScheme();
+    if (!"ws".equals(scheme) && !"wss".equals(scheme)) {
+      throw new IllegalArgumentException("Scheme: " + scheme);
+    }
+    boolean ssl = scheme.length() == 3;
+    int port = uri.getPort();
+    if (port == -1) {
+      port = ssl ? 443 : 80;
+    };
+    StringBuilder relativeUri = new StringBuilder();
+    if (uri.getRawPath() != null) {
+      relativeUri.append(uri.getRawPath());
+    }
+    if (uri.getRawQuery() != null) {
+      relativeUri.append('?').append(uri.getRawQuery());
+    }
+    if (uri.getRawFragment() != null) {
+      relativeUri.append('#').append(uri.getRawFragment());
+    }
+    setHost(uri.getHost());
+    setPort(port);
+    setSsl(ssl);
+    setURI(relativeUri.toString());
+  }
+
+  @Override
+  public WebSocketConnectOptions setTraceOperation(String op) {
+    return (WebSocketConnectOptions) super.setTraceOperation(op);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -83,11 +83,6 @@ public class CleanableHttpClient implements HttpClientInternal {
   }
 
   @Override
-  public Future<WebSocket> webSocket(int port, String host, String requestURI) {
-    return delegate.webSocket(port, host, requestURI);
-  }
-
-  @Override
   public Future<WebSocket> webSocket(String host, String requestURI) {
     return delegate.webSocket(host, requestURI);
   }
@@ -105,6 +100,11 @@ public class CleanableHttpClient implements HttpClientInternal {
   @Override
   public Future<WebSocket> webSocketAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
     return delegate.webSocketAbs(url, headers, version, subProtocols);
+  }
+
+  @Override
+  public ClientWebSocket webSocket() {
+    return delegate.webSocket();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -106,7 +106,7 @@ public class CleanableHttpClient implements HttpClientInternal {
   }
 
   @Override
-  public Future<Void> close(long timeout, TimeUnit timeUnit) {
+  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
     if (timeout < 0L) {
       throw new IllegalArgumentException();
     }

--- a/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -83,31 +83,6 @@ public class CleanableHttpClient implements HttpClientInternal {
   }
 
   @Override
-  public Future<WebSocket> webSocket(String host, String requestURI) {
-    return delegate.webSocket(host, requestURI);
-  }
-
-  @Override
-  public Future<WebSocket> webSocket(String requestURI) {
-    return delegate.webSocket(requestURI);
-  }
-
-  @Override
-  public Future<WebSocket> webSocket(WebSocketConnectOptions options) {
-    return delegate.webSocket(options);
-  }
-
-  @Override
-  public Future<WebSocket> webSocketAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
-    return delegate.webSocketAbs(url, headers, version, subProtocols);
-  }
-
-  @Override
-  public ClientWebSocket webSocket() {
-    return delegate.webSocket();
-  }
-
-  @Override
   public Future<Void> updateSSLOptions(ClientSSLOptions options) {
     return delegate.updateSSLOptions(options);
   }
@@ -188,6 +163,5 @@ public class CleanableHttpClient implements HttpClientInternal {
   public void close(Promise<Void> completion) {
     delegate.close(completion);
   }
-
 
 }

--- a/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -89,13 +89,13 @@ public class CleanableHttpClient implements HttpClientInternal {
 
   @Override
   @Fluent
-  public HttpClient connectionHandler(Handler<HttpConnection> handler) {
+  public HttpClientPool connectionHandler(Handler<HttpConnection> handler) {
     return delegate.connectionHandler(handler);
   }
 
   @Override
   @Fluent
-  public HttpClient redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
+  public HttpClientPool redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
     return delegate.redirectHandler(handler);
   }
 

--- a/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.vertx.core.Closeable;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.http.*;
+import io.vertx.core.spi.metrics.Metrics;
+import io.vertx.core.spi.metrics.MetricsProvider;
+
+import java.lang.ref.Cleaner;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+
+/**
+ * A lightweight proxy of Vert.x {@link HttpClient} that can be collected by the garbage collector and release
+ * the resources when it happens with a {@code 30} seconds grace period.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class CleanableWebSocketClient implements WebSocketClient, MetricsProvider, Closeable {
+
+  static class Action implements Runnable {
+    private final BiFunction<Long, TimeUnit, Future<Void>> dispose;
+    private long timeout = 30L;
+    private TimeUnit timeUnit = TimeUnit.SECONDS;
+    private Future<Void> closeFuture;
+    private Action(BiFunction<Long, TimeUnit, Future<Void>> dispose) {
+      this.dispose = dispose;
+    }
+    @Override
+    public void run() {
+      closeFuture = dispose.apply(timeout, timeUnit);
+    }
+  }
+
+  public final WebSocketClient delegate;
+  private final Cleaner.Cleanable cleanable;
+  private final Action action;
+
+  public CleanableWebSocketClient(WebSocketClient delegate, Cleaner cleaner, BiFunction<Long, TimeUnit, Future<Void>> dispose) {
+    this.action = new Action(dispose);
+    this.delegate = delegate;
+    this.cleanable = cleaner.register(this, action);
+  }
+
+  @Override
+  public ClientWebSocket webSocket() {
+    return delegate.webSocket();
+  }
+
+  public Future<WebSocket> connect(WebSocketConnectOptions options) {
+    return delegate.connect(options);
+  }
+
+  @Override
+  public Future<Void> close(long timeout, TimeUnit timeUnit) {
+    if (timeout < 0L) {
+      throw new IllegalArgumentException();
+    }
+    if (timeUnit == null) {
+      throw new IllegalArgumentException();
+    }
+    action.timeout = timeout;
+    action.timeUnit = timeUnit;
+    cleanable.clean();
+    return action.closeFuture;
+  }
+
+  @Override
+  public void close(Promise<Void> completion) {
+    ((Closeable)delegate).close(completion);
+  }
+
+  @Override
+  public Metrics getMetrics() {
+    return ((MetricsProvider)delegate).getMetrics();
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
@@ -63,7 +63,7 @@ public class CleanableWebSocketClient implements WebSocketClient, MetricsProvide
   }
 
   @Override
-  public Future<Void> close(long timeout, TimeUnit timeUnit) {
+  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
     if (timeout < 0L) {
       throw new IllegalArgumentException();
     }

--- a/src/main/java/io/vertx/core/http/impl/ClientWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientWebSocketImpl.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class ClientWebSocketImpl implements ClientWebSocket {
 
-  private HttpClientImpl client;
+  private WebSocketClientImpl client;
   private final AtomicReference<Promise<WebSocket>> connect = new AtomicReference<>();
   private volatile WebSocket ws;
   private Handler<Throwable> exceptionHandler;
@@ -43,7 +43,7 @@ public class ClientWebSocketImpl implements ClientWebSocket {
   private Handler<Buffer> binaryMessageHandler;
   private Handler<Buffer> pongHandler;
 
-  ClientWebSocketImpl(HttpClientImpl client) {
+  ClientWebSocketImpl(WebSocketClientImpl client) {
     this.client = client;
   }
 
@@ -75,20 +75,20 @@ public class ClientWebSocketImpl implements ClientWebSocket {
       }).mapEmpty();
   }
 
-  @Override
-  public Future<WebSocket> connect(String host, String requestURI) {
-    return connect(client.options.getDefaultPort(), host, requestURI);
-  }
-
-  @Override
-  public Future<WebSocket> connect(String requestURI) {
-    return connect(client.options.getDefaultPort(), client.options.getDefaultHost(), requestURI);
-  }
-
-  @Override
-  public Future<WebSocket> connect(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
-    return connect(HttpClientImpl.webSocketConnectOptionsAbs(url, headers, version, subProtocols));
-  }
+//  @Override
+//  public Future<WebSocket> connect(String host, String requestURI) {
+//    return connect(client.options.getDefaultPort(), host, requestURI);
+//  }
+//
+//  @Override
+//  public Future<WebSocket> connect(String requestURI) {
+//    return connect(client.options.getDefaultPort(), client.options.getDefaultHost(), requestURI);
+//  }
+//
+//  @Override
+//  public Future<WebSocket> connect(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
+//    return connect(HttpClientImpl.webSocketConnectOptionsAbs(url, headers, version, subProtocols));
+//  }
 
   @Override
   public ClientWebSocket exceptionHandler(Handler<Throwable> handler) {

--- a/src/main/java/io/vertx/core/http/impl/ClientWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientWebSocketImpl.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2011-2034 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.*;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.SocketAddress;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.cert.X509Certificate;
+import java.security.cert.Certificate;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Client WebSocket implementation
+ */
+public class ClientWebSocketImpl implements ClientWebSocket {
+
+  private HttpClientImpl client;
+  private final AtomicReference<Promise<WebSocket>> connect = new AtomicReference<>();
+  private volatile WebSocket ws;
+  private Handler<Throwable> exceptionHandler;
+  private Handler<Buffer> dataHandler;
+  private Handler<Void> endHandler;
+  private Handler<Void> closeHandler;
+  private Handler<Void> drainHandler;
+  private Handler<WebSocketFrame> frameHandler;
+  private Handler<String> textMessageHandler;
+  private Handler<Buffer> binaryMessageHandler;
+  private Handler<Buffer> pongHandler;
+
+  ClientWebSocketImpl(HttpClientImpl client) {
+    this.client = client;
+  }
+
+  @Override
+  public Future<WebSocket> connect(WebSocketConnectOptions options) {
+    ContextInternal ctx = client.vertx().getOrCreateContext();
+    Promise<WebSocket> promise = ctx.promise();
+    if (!connect.compareAndSet(null, promise)) {
+      return ctx.failedFuture("Already connecting");
+    }
+    client.webSocket(ctx, options, promise);
+    return promise
+      .future()
+      .andThen(ar -> {
+        if (ar.succeeded()) {
+          WebSocket w = ar.result();
+          ws = w;
+          w.handler(dataHandler);
+          w.binaryMessageHandler(binaryMessageHandler);
+          w.textMessageHandler(textMessageHandler);
+          w.endHandler(endHandler);
+          w.closeHandler(closeHandler);
+          w.exceptionHandler(exceptionHandler);
+          w.drainHandler(drainHandler);
+          w.frameHandler(frameHandler);
+          w.pongHandler(pongHandler);
+          w.resume();
+        }
+      }).mapEmpty();
+  }
+
+  @Override
+  public Future<WebSocket> connect(String host, String requestURI) {
+    return connect(client.options.getDefaultPort(), host, requestURI);
+  }
+
+  @Override
+  public Future<WebSocket> connect(String requestURI) {
+    return connect(client.options.getDefaultPort(), client.options.getDefaultHost(), requestURI);
+  }
+
+  @Override
+  public Future<WebSocket> connect(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
+    return connect(HttpClientImpl.webSocketConnectOptionsAbs(url, headers, version, subProtocols));
+  }
+
+  @Override
+  public ClientWebSocket exceptionHandler(Handler<Throwable> handler) {
+    exceptionHandler = handler;
+    WebSocket w = ws;
+    if (w != null) {
+      w.exceptionHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public ClientWebSocket handler(Handler<Buffer> handler) {
+    dataHandler = handler;
+    WebSocket w = ws;
+    if (w != null) {
+      w.handler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public WebSocket pause() {
+    delegate().pause();
+    return this;
+  }
+
+  @Override
+  public WebSocket resume() {
+    delegate().resume();
+    return this;
+  }
+
+  @Override
+  public WebSocket fetch(long amount) {
+    delegate().fetch(amount);
+    return this;
+  }
+
+  @Override
+  public ClientWebSocket endHandler(Handler<Void> handler) {
+    endHandler = handler;
+    WebSocket w = ws;
+    if (w != null) {
+      w.endHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public WebSocket setWriteQueueMaxSize(int maxSize) {
+    delegate().setWriteQueueMaxSize(maxSize);
+    return this;
+  }
+
+  @Override
+  public ClientWebSocket drainHandler(Handler<Void> handler) {
+    drainHandler = handler;
+    WebSocket w = ws;
+    if (w != null) {
+      w.drainHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public ClientWebSocket closeHandler(Handler<Void> handler) {
+    closeHandler = handler;
+    WebSocket w = ws;
+    if (w != null) {
+      w.closeHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public ClientWebSocket frameHandler(Handler<WebSocketFrame> handler) {
+    frameHandler = handler;
+    WebSocket w = ws;
+    if (w != null) {
+      w.frameHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public String binaryHandlerID() {
+    return delegate().binaryHandlerID();
+  }
+
+  @Override
+  public String textHandlerID() {
+    return delegate().textHandlerID();
+  }
+
+  @Override
+  public String subProtocol() {
+    return delegate().subProtocol();
+  }
+
+  @Override
+  public Short closeStatusCode() {
+    return delegate().closeStatusCode();
+  }
+
+  @Override
+  public String closeReason() {
+    return delegate().closeReason();
+  }
+
+  @Override
+  public MultiMap headers() {
+    return delegate().headers();
+  }
+
+  @Override
+  public Future<Void> writeFrame(WebSocketFrame frame) {
+    return delegate().writeFrame(frame);
+  }
+
+  @Override
+  public Future<Void> writeFinalTextFrame(String text) {
+    return delegate().writeFinalTextFrame(text);
+  }
+
+  @Override
+  public Future<Void> writeFinalBinaryFrame(Buffer data) {
+    return delegate().writeFinalBinaryFrame(data);
+  }
+
+  @Override
+  public Future<Void> writeBinaryMessage(Buffer data) {
+    return delegate().writeBinaryMessage(data);
+  }
+
+  @Override
+  public Future<Void> writeTextMessage(String text) {
+    return delegate().writeTextMessage(text);
+  }
+
+  @Override
+  public Future<Void> writePing(Buffer data) {
+    return delegate().writePing(data);
+  }
+
+  @Override
+  public Future<Void> writePong(Buffer data) {
+    return delegate().writePong(data);
+  }
+
+  @Override
+  public ClientWebSocket textMessageHandler(@Nullable Handler<String> handler) {
+    textMessageHandler = handler;
+    WebSocket w = ws;
+    if (w != null) {
+      w.textMessageHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public ClientWebSocket binaryMessageHandler(@Nullable Handler<Buffer> handler) {
+    binaryMessageHandler = handler;
+    WebSocket w = ws;
+    if (w != null) {
+      w.binaryMessageHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public ClientWebSocket pongHandler(@Nullable Handler<Buffer> handler) {
+    pongHandler = handler;
+    WebSocket w = ws;
+    if (w != null) {
+      w.pongHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public Future<Void> end() {
+    return delegate().end();
+  }
+
+  @Override
+  public Future<Void> close() {
+    return delegate().close();
+  }
+
+  @Override
+  public Future<Void> close(short statusCode) {
+    return delegate().close(statusCode);
+  }
+
+  @Override
+  public Future<Void> close(short statusCode, @Nullable String reason) {
+    return delegate().close(statusCode, reason);
+  }
+
+  @Override
+  public SocketAddress remoteAddress() {
+    return delegate().remoteAddress();
+  }
+
+  @Override
+  public SocketAddress localAddress() {
+    return delegate().localAddress();
+  }
+
+  @Override
+  public boolean isSsl() {
+    return delegate().isSsl();
+  }
+
+  @Override
+  public boolean isClosed() {
+    return delegate().isClosed();
+  }
+
+  @Override
+  public SSLSession sslSession() {
+    return delegate().sslSession();
+  }
+
+  @Override
+  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+    return delegate().peerCertificateChain();
+  }
+
+  @Override
+  public List<Certificate> peerCertificates() throws SSLPeerUnverifiedException {
+    return delegate().peerCertificates();
+  }
+
+  @Override
+  public Future<Void> write(Buffer data) {
+    return delegate().write(data);
+  }
+
+  @Override
+  public boolean writeQueueFull() {
+    return delegate().writeQueueFull();
+  }
+
+  private WebSocket delegate() {
+    WebSocket w = ws;
+    if (w == null) {
+      throw new IllegalStateException("Not connected");
+    }
+    return w;
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -43,14 +43,14 @@ import java.util.function.BiConsumer;
  */
 class Http2ClientConnection extends Http2ConnectionBase implements HttpClientConnection {
 
-  private final HttpClientImpl client;
+  private final HttpClientBase client;
   private final ClientMetrics metrics;
   private Handler<Void> evictionHandler = DEFAULT_EVICTION_HANDLER;
   private Handler<Long> concurrencyChangeHandler = DEFAULT_CONCURRENCY_CHANGE_HANDLER;
   private long expirationTimestamp;
   private boolean evicted;
 
-  Http2ClientConnection(HttpClientImpl client,
+  Http2ClientConnection(HttpClientBase client,
                         EventLoopContext context,
                         VertxHttp2ConnectionHandler connHandler,
                         ClientMetrics metrics) {
@@ -665,7 +665,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
   }
 
   public static VertxHttp2ConnectionHandler<Http2ClientConnection> createHttp2ConnectionHandler(
-    HttpClientImpl client,
+    HttpClientBase client,
     ClientMetrics metrics,
     EventLoopContext context,
     boolean upgrade,

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -51,7 +51,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
 
   private static final Logger log = LoggerFactory.getLogger(Http2UpgradeClientConnection.class);
 
-  private HttpClientImpl client;
+  private HttpClientBase client;
   private HttpClientConnection current;
   private boolean upgradeProcessed;
 
@@ -64,7 +64,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
   private Handler<Long> concurrencyChangeHandler;
   private Handler<Http2Settings> remoteSettingsHandler;
 
-  Http2UpgradeClientConnection(HttpClientImpl client, Http1xClientConnection connection) {
+  Http2UpgradeClientConnection(HttpClientBase client, Http1xClientConnection connection) {
     this.client = client;
     this.current = connection;
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
@@ -46,7 +46,7 @@ import static io.vertx.core.http.HttpMethod.OPTIONS;
  */
 public class HttpChannelConnector {
 
-  private final HttpClientImpl client;
+  private final HttpClientBase client;
   private final NetClientInternal netClient;
   private final HttpClientOptions options;
   private final ProxyOptions proxyOptions;
@@ -57,7 +57,7 @@ public class HttpChannelConnector {
   private final SocketAddress peerAddress;
   private final SocketAddress server;
 
-  public HttpChannelConnector(HttpClientImpl client,
+  public HttpChannelConnector(HttpClientBase client,
                               NetClientInternal netClient,
                               ProxyOptions proxyOptions,
                               ClientMetrics metrics,

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.http.impl;
+
+import io.vertx.core.*;
+import io.vertx.core.http.*;
+import io.vertx.core.impl.CloseSequence;
+import io.vertx.core.impl.EventLoopContext;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.*;
+import io.vertx.core.net.impl.NetClientBuilder;
+import io.vertx.core.net.impl.NetClientInternal;
+import io.vertx.core.net.impl.ProxyFilter;
+import io.vertx.core.spi.metrics.HttpClientMetrics;
+import io.vertx.core.spi.metrics.Metrics;
+import io.vertx.core.spi.metrics.MetricsProvider;
+import io.vertx.core.spi.resolver.AddressResolver;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * This class is thread-safe.
+ *
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public class HttpClientBase implements MetricsProvider, Closeable {
+
+  protected final VertxInternal vertx;
+  final HttpClientOptions options;
+  protected final NetClientInternal netClient;
+  protected final HttpClientMetrics metrics;
+  protected final CloseSequence closeSequence;
+  volatile ClientSSLOptions sslOptions;
+  private long closeTimeout = 0L;
+  private TimeUnit closeTimeoutUnit = TimeUnit.SECONDS;
+  private Predicate<SocketAddress> proxyFilter;
+
+  public HttpClientBase(VertxInternal vertx, HttpClientOptions options) {
+    this.vertx = vertx;
+    this.metrics = vertx.metricsSPI() != null ? vertx.metricsSPI().createHttpClientMetrics(options) : null;
+    this.options = new HttpClientOptions(options);
+    this.closeSequence = new CloseSequence(this::doClose, this::doShutdown);
+    List<HttpVersion> alpnVersions = options.getAlpnVersions();
+    if (alpnVersions == null || alpnVersions.isEmpty()) {
+      switch (options.getProtocolVersion()) {
+        case HTTP_2:
+          alpnVersions = Arrays.asList(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1);
+          break;
+        default:
+          alpnVersions = Collections.singletonList(options.getProtocolVersion());
+          break;
+      }
+    }
+    if (!options.isKeepAlive() && options.isPipelining()) {
+      throw new IllegalStateException("Cannot have pipelining with no keep alive");
+    }
+    this.proxyFilter = options.getNonProxyHosts() != null ? ProxyFilter.nonProxyHosts(options.getNonProxyHosts()) : ProxyFilter.DEFAULT_PROXY_FILTER;
+    this.netClient = new NetClientBuilder(vertx, new NetClientOptions(options)
+      .setHostnameVerificationAlgorithm(options.isVerifyHost() ? "HTTPS": "")
+      .setProxyOptions(null)
+      .setApplicationLayerProtocols(alpnVersions
+        .stream()
+        .map(HttpVersion::alpnName)
+        .collect(Collectors.toList())))
+      .metrics(metrics)
+      .build();
+  }
+
+  public NetClientInternal netClient() {
+    return netClient;
+  }
+
+  public Future<Void> closeFuture() {
+    return closeSequence.future();
+  }
+
+  public void close(Promise<Void> completion) {
+    closeSequence.close(completion);
+  }
+
+  protected int getPort(RequestOptions request) {
+    Integer port = request.getPort();
+    if (port != null) {
+      return port;
+    }
+    SocketAddress server = request.getServer();
+    if (server != null && server.isInetSocket()) {
+      return server.port();
+    }
+    return options.getDefaultPort();
+  }
+
+  private ProxyOptions getProxyOptions(ProxyOptions proxyOptions) {
+    if (proxyOptions == null) {
+      proxyOptions = options.getProxyOptions();
+    }
+    return proxyOptions;
+  }
+
+  protected String getHost(RequestOptions request) {
+    String host = request.getHost();
+    if (host != null) {
+      return host;
+    }
+    SocketAddress server = request.getServer();
+    if (server != null && server.isInetSocket()) {
+      return server.host();
+    }
+    return options.getDefaultHost();
+  }
+
+  protected ProxyOptions computeProxyOptions(ProxyOptions proxyOptions, SocketAddress addr) {
+    proxyOptions = getProxyOptions(proxyOptions);
+    if (proxyFilter != null) {
+      if (!proxyFilter.test(addr)) {
+        proxyOptions = null;
+      }
+    }
+    return proxyOptions;
+  }
+
+  HttpClientMetrics metrics() {
+    return metrics;
+  }
+
+  /**
+   * Connect to a server.
+   */
+  public Future<HttpClientConnection> connect(SocketAddress server) {
+    return connect(server, null);
+  }
+
+  /**
+   * Connect to a server.
+   */
+  public Future<HttpClientConnection> connect(SocketAddress server, SocketAddress peer) {
+    EventLoopContext context = (EventLoopContext) vertx.getOrCreateContext();
+    HttpChannelConnector connector = new HttpChannelConnector(this, netClient, null, null, options.getProtocolVersion(), options.isSsl(), options.isUseAlpn(), peer, server);
+    return connector.httpConnect(context);
+  }
+
+
+  protected void doShutdown(Promise<Void> p) {
+    netClient.shutdown(closeTimeout, closeTimeoutUnit).onComplete(p);
+  }
+
+  protected void doClose(Promise<Void> p) {
+    netClient.close().onComplete(p);
+  }
+
+  public Future<Void> close(long timeout, TimeUnit timeUnit) {
+    this.closeTimeout = timeout;
+    this.closeTimeoutUnit = timeUnit;
+    return closeSequence.close();
+  }
+
+  @Override
+  public boolean isMetricsEnabled() {
+    return getMetrics() != null;
+  }
+
+  @Override
+  public Metrics getMetrics() {
+    return metrics;
+  }
+
+  public Future<Void> updateSSLOptions(ClientSSLOptions options) {
+    return netClient.updateSSLOptions(options);
+  }
+
+  public HttpClient connectionHandler(Handler<HttpConnection> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  public HttpClient redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  public Function<HttpClientResponse, Future<RequestOptions>> redirectHandler() {
+    throw new UnsupportedOperationException();
+  }
+
+  public HttpClientBase proxyFilter(Predicate<SocketAddress> filter) {
+    proxyFilter = filter;
+    return this;
+  }
+
+  public HttpClientOptions options() {
+    return options;
+  }
+
+  public VertxInternal vertx() {
+    return vertx;
+  }
+
+  public void addressResolver(AddressResolver<?, ?, ?> addressResolver) {
+    throw new UnsupportedOperationException();
+  }
+
+  protected void checkClosed() {
+    if (closeSequence.started()) {
+      throw new IllegalStateException("Client is closed");
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -161,7 +161,7 @@ public class HttpClientBase implements MetricsProvider, Closeable {
     netClient.close().onComplete(p);
   }
 
-  public Future<Void> close(long timeout, TimeUnit timeUnit) {
+  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
     this.closeTimeout = timeout;
     this.closeTimeoutUnit = timeUnit;
     return closeSequence.close();

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -23,11 +23,9 @@ import io.vertx.core.net.impl.ProxyFilter;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
-import io.vertx.core.spi.resolver.AddressResolver;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -189,18 +187,6 @@ public class HttpClientBase implements MetricsProvider, Closeable {
       .setApplicationLayerProtocols(alpnVersions.stream().map(HttpVersion::alpnName).collect(Collectors.toList()));;    return Future.succeededFuture();
   }
 
-  public HttpClient connectionHandler(Handler<HttpConnection> handler) {
-    throw new UnsupportedOperationException();
-  }
-
-  public HttpClient redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
-    throw new UnsupportedOperationException();
-  }
-
-  public Function<HttpClientResponse, Future<RequestOptions>> redirectHandler() {
-    throw new UnsupportedOperationException();
-  }
-
   public HttpClientBase proxyFilter(Predicate<SocketAddress> filter) {
     proxyFilter = filter;
     return this;
@@ -212,10 +198,6 @@ public class HttpClientBase implements MetricsProvider, Closeable {
 
   public VertxInternal vertx() {
     return vertx;
-  }
-
-  public void addressResolver(AddressResolver<?, ?, ?> addressResolver) {
-    throw new UnsupportedOperationException();
   }
 
   protected void checkClosed() {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -108,7 +108,6 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   private final PoolOptions poolOptions;
   private final EndpointProvider<EndpointKey, Lease<HttpClientConnection>> httpEndpointProvider;
   private final ConnectionManager<EndpointKey, Lease<HttpClientConnection>> httpCM;
-  private final List<HttpVersion> alpnVersions;
   private EndpointResolver<?, EndpointKey, Lease<HttpClientConnection>, ?> endpointResolver;
   private volatile Function<HttpClientResponse, Future<RequestOptions>> redirectHandler = DEFAULT_HANDLER;
   private long timerID;
@@ -117,20 +116,6 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
 
   public HttpClientImpl(VertxInternal vertx, HttpClientOptions options, PoolOptions poolOptions) {
     super(vertx, options);
-    List<HttpVersion> alpnVersions = options.getAlpnVersions();
-    if (alpnVersions == null || alpnVersions.isEmpty()) {
-      switch (options.getProtocolVersion()) {
-        case HTTP_2:
-          this.alpnVersions = Arrays.asList(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1);
-          break;
-        default:
-          this.alpnVersions = Collections.singletonList(options.getProtocolVersion());
-          break;
-      }
-    } else {
-      this.alpnVersions = alpnVersions;
-    }
-
     this.poolOptions = poolOptions;
     httpEndpointProvider = httpEndpointProvider();
     httpCM = new ConnectionManager<>(httpEndpointProvider);

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -47,7 +47,7 @@ import static io.vertx.core.http.HttpHeaders.*;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
+public class HttpClientImpl extends HttpClientBase implements HttpClientInternal, MetricsProvider {
 
   // Pattern to check we are not dealing with an absoluate URI
   private static final Pattern ABS_URI_START_PATTERN = Pattern.compile("^\\p{Alpha}[\\p{Alpha}\\p{Digit}+.\\-]*:");
@@ -105,64 +105,32 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
     }
   };
 
-  private final VertxInternal vertx;
-  final HttpClientOptions options;
   private final EndpointProvider<EndpointKey, Lease<HttpClientConnection>> httpEndpointProvider;
-  private final ConnectionManager<EndpointKey, HttpClientConnection> webSocketCM;
   private final ConnectionManager<EndpointKey, Lease<HttpClientConnection>> httpCM;
-  private final NetClientInternal netClient;
-  private final HttpClientMetrics metrics;
-  private final boolean keepAlive;
-  private final boolean pipelining;
   private final List<HttpVersion> alpnVersions;
-  private final CloseSequence closeSequence;
-  volatile ClientSSLOptions sslOptions;
   private EndpointResolver<?, EndpointKey, Lease<HttpClientConnection>, ?> endpointResolver;
-  private long closeTimeout = 0L;
-  private TimeUnit closeTimeoutUnit = TimeUnit.SECONDS;
-  private long timerID;
-  private Predicate<SocketAddress> proxyFilter;
-  private volatile Handler<HttpConnection> connectionHandler;
   private volatile Function<HttpClientResponse, Future<RequestOptions>> redirectHandler = DEFAULT_HANDLER;
+  private long timerID;
+  private volatile Handler<HttpConnection> connectionHandler;
   private final Function<ContextInternal, EventLoopContext> contextProvider;
 
   public HttpClientImpl(VertxInternal vertx, HttpClientOptions options) {
-    this.vertx = vertx;
-    this.metrics = vertx.metricsSPI() != null ? vertx.metricsSPI().createHttpClientMetrics(options) : null;
-    this.options = new HttpClientOptions(options);
-    this.closeSequence = new CloseSequence(this::doClose, this::doShutdown);
+    super(vertx, options);
     List<HttpVersion> alpnVersions = options.getAlpnVersions();
     if (alpnVersions == null || alpnVersions.isEmpty()) {
       switch (options.getProtocolVersion()) {
         case HTTP_2:
-          alpnVersions = Arrays.asList(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1);
+          this.alpnVersions = Arrays.asList(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1);
           break;
         default:
-          alpnVersions = Collections.singletonList(options.getProtocolVersion());
+          this.alpnVersions = Collections.singletonList(options.getProtocolVersion());
           break;
       }
+    } else {
+      this.alpnVersions = alpnVersions;
     }
-    this.alpnVersions = alpnVersions;
-    this.keepAlive = options.isKeepAlive();
-    this.pipelining = options.isPipelining();
-    if (!keepAlive && pipelining) {
-      throw new IllegalStateException("Cannot have pipelining with no keep alive");
-    }
-    this.proxyFilter = options.getNonProxyHosts() != null ? ProxyFilter.nonProxyHosts(options.getNonProxyHosts()) : ProxyFilter.DEFAULT_PROXY_FILTER;
-    ClientSSLOptions sslOptions = options
-      .getSslOptions();
-    if (sslOptions != null) {
-      sslOptions = sslOptions.copy();
-      sslOptions
-        .setHostnameVerificationAlgorithm(this.options.isVerifyHost() ? "HTTPS" : "")
-        .setApplicationLayerProtocols(alpnVersions.stream().map(HttpVersion::alpnName).collect(Collectors.toList()));
-    }
-    this.sslOptions = sslOptions;
-    this.netClient = new NetClientBuilder(vertx, new NetClientOptions(options).setProxyOptions(null))
-      .metrics(metrics)
-      .build();
+
     httpEndpointProvider = httpEndpointProvider();
-    webSocketCM = webSocketConnectionManager();
     httpCM = new ConnectionManager<>(httpEndpointProvider);
     endpointResolver = null;
     if (options.getPoolCleanerPeriod() > 0 && (options.getKeepAliveTimeout() > 0L || options.getHttp2KeepAliveTimeout() > 0L)) {
@@ -186,18 +154,8 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
     }
   }
 
-  public NetClientInternal netClient() {
-    return netClient;
-  }
-
-  @Override
-  public Future<Void> closeFuture() {
-    return closeSequence.future();
-  }
-
-  @Override
-  public void close(Promise<Void> completion) {
-    closeSequence.close(completion);
+  Function<ContextInternal, EventLoopContext> contextProvider() {
+    return contextProvider;
   }
 
   /**
@@ -220,15 +178,15 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
     }
   }
 
-  private void checkExpired(Handler<Long> checker) {
-    httpCM.checkExpired();
-    if (endpointResolver != null) {
-      endpointResolver.checkExpired();
-    }
+  protected void checkExpired(Handler<Long> checker) {
     synchronized (this) {
       if (!closeSequence.started()) {
         timerID = vertx.setTimer(options.getPoolCleanerPeriod(), checker);
       }
+    }
+    httpCM.checkExpired();
+    if (endpointResolver != null) {
+      endpointResolver.checkExpired();
     }
   }
 
@@ -254,181 +212,70 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
     };
   }
 
-  private ConnectionManager<EndpointKey, HttpClientConnection> webSocketConnectionManager() {
-    EndpointProvider<EndpointKey, HttpClientConnection> provider = (key, dispose) -> {
-      int maxPoolSize = options.getMaxWebSockets();
-      ClientMetrics metrics = HttpClientImpl.this.metrics != null ? HttpClientImpl.this.metrics.createEndpointMetrics(key.serverAddr, maxPoolSize) : null;
-      HttpChannelConnector connector = new HttpChannelConnector(HttpClientImpl.this, netClient, key.proxyOptions, metrics, HttpVersion.HTTP_1_1, key.ssl, false, key.peerAddr, key.serverAddr);
-      return new WebSocketEndpoint(null, maxPoolSize, connector, dispose);
-    };
-    return new ConnectionManager<>(provider);
-  }
-
-  Function<ContextInternal, EventLoopContext> contextProvider() {
-    return contextProvider;
-  }
-
-  private int getPort(RequestOptions request) {
-    Integer port = request.getPort();
-    if (port != null) {
-      return port;
-    }
-    SocketAddress server = request.getServer();
-    if (server != null && server.isInetSocket()) {
-      return server.port();
-    }
-    return options.getDefaultPort();
-  }
-
-  private ProxyOptions getProxyOptions(ProxyOptions proxyOptions) {
-    if (proxyOptions == null) {
-      proxyOptions = options.getProxyOptions();
-    }
-    return proxyOptions;
-  }
-
-  private String getHost(RequestOptions request) {
-    String host = request.getHost();
-    if (host != null) {
-      return host;
-    }
-    SocketAddress server = request.getServer();
-    if (server != null && server.isInetSocket()) {
-      return server.host();
-    }
-    return options.getDefaultHost();
-  }
-
-  private ProxyOptions computeProxyOptions(ProxyOptions proxyOptions, SocketAddress addr) {
-    proxyOptions = getProxyOptions(proxyOptions);
-    if (proxyFilter != null) {
-      if (!proxyFilter.test(addr)) {
-        proxyOptions = null;
+  @Override
+  protected void doShutdown(Promise<Void> p) {
+    synchronized (this) {
+      if (timerID >= 0) {
+        vertx.cancelTimer(timerID);
+        timerID = -1;
       }
     }
-    return proxyOptions;
-  }
-
-  HttpClientMetrics metrics() {
-    return metrics;
-  }
-
-  /**
-   * Connect to a server.
-   */
-  public Future<HttpClientConnection> connect(SocketAddress server) {
-    return connect(server, null);
-  }
-
-  /**
-   * Connect to a server.
-   */
-  public Future<HttpClientConnection> connect(SocketAddress server, SocketAddress peer) {
-    EventLoopContext context = (EventLoopContext) vertx.getOrCreateContext();
-    HttpChannelConnector connector = new HttpChannelConnector(this, netClient, null, null, options.getProtocolVersion(), options.isSsl(), options.isUseAlpn(), peer, server);
-    return connector.httpConnect(context);
+    httpCM.shutdown();
+    super.doShutdown(p);
   }
 
   @Override
-  public ClientWebSocket webSocket() {
-    return new ClientWebSocketImpl(this);
+  protected void doClose(Promise<Void> p) {
+    httpCM.close();
+    super.doClose(p);
   }
 
-  Future<WebSocket> webSocket(ContextInternal ctx, WebSocketConnectOptions connectOptions) {
-    PromiseInternal<WebSocket> promise = ctx.promise();
-    webSocket(ctx, connectOptions, promise);
-    return promise.andThen(ar -> {
-      if (ar.succeeded()) {
-        ar.result().resume();
-      }
-    });
-  }
-
-  void webSocket(ContextInternal ctx, WebSocketConnectOptions connectOptions, Promise<WebSocket> promise) {
-    int port = getPort(connectOptions);
-    String host = getHost(connectOptions);
-    SocketAddress addr = SocketAddress.inetSocketAddress(port, host);
-    ProxyOptions proxyOptions = computeProxyOptions(connectOptions.getProxyOptions(), addr);
-    EndpointKey key = new EndpointKey(connectOptions.isSsl() != null ? connectOptions.isSsl() : options.isSsl(), proxyOptions, addr, addr);
-    EventLoopContext eventLoopContext;
-    if (ctx instanceof EventLoopContext) {
-      eventLoopContext = (EventLoopContext) ctx;
+  public void addressResolver(AddressResolver<?, ?, ?> addressResolver) {
+    if (addressResolver != null) {
+      this.endpointResolver = new EndpointResolver<>(httpEndpointProvider, addressResolver,
+        (key, addr) -> new EndpointKey(key.ssl, key.proxyOptions, addr, addr));
     } else {
-      eventLoopContext = vertx.createEventLoopContext(ctx.nettyEventLoop(), ctx.workerPool(), ctx.classLoader());
+      this.endpointResolver = null;
     }
-    webSocketCM
-      .getConnection(eventLoopContext, key)
-      .onComplete(c -> {
-        if (c.succeeded()) {
-          Http1xClientConnection conn = (Http1xClientConnection) c.result();
-          conn.toWebSocket(
-            ctx,
-            connectOptions.getURI(),
-            connectOptions.getHeaders(),
-            connectOptions.getAllowOriginHeader(),
-            connectOptions.getVersion(),
-            connectOptions.getSubProtocols(),
-            connectOptions.getTimeout(),
-            connectOptions.isRegisterWriteHandlers(),
-            HttpClientImpl.this.options.getMaxWebSocketFrameSize(),
-            promise);
-        } else {
-          promise.fail(c.cause());
-        }
-    });
   }
 
   @Override
-  public Future<WebSocket> webSocket(String host, String requestURI) {
-    return webSocket(options.getDefaultPort(), host, requestURI);
+  public HttpClient redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
+    if (handler == null) {
+      handler = DEFAULT_HANDLER;
+    }
+    redirectHandler = handler;
+    return this;
   }
 
   @Override
-  public Future<WebSocket> webSocket(String requestURI) {
-    return webSocket(options.getDefaultPort(), options.getDefaultHost(), requestURI);
+  public Function<HttpClientResponse, Future<RequestOptions>> redirectHandler() {
+    return redirectHandler;
   }
 
   @Override
-  public Future<WebSocket> webSocket(WebSocketConnectOptions options) {
-    return webSocket(vertx.getOrCreateContext(), options);
+  public HttpClient connectionHandler(Handler<HttpConnection> handler) {
+    connectionHandler = handler;
+    return this;
   }
 
-  static WebSocketConnectOptions webSocketConnectOptionsAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
-    URI uri;
-    try {
-      uri = new URI(url);
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException(e);
-    }
-    String scheme = uri.getScheme();
-    if (!"ws".equals(scheme) && !"wss".equals(scheme)) {
-      throw new IllegalArgumentException("Scheme: " + scheme);
-    }
-    boolean ssl = scheme.length() == 3;
-    int port = uri.getPort();
-    if (port == -1) port = ssl ? 443 : 80;
-    StringBuilder relativeUri = new StringBuilder();
-    if (uri.getRawPath() != null) {
-      relativeUri.append(uri.getRawPath());
-    }
-    if (uri.getRawQuery() != null) {
-      relativeUri.append('?').append(uri.getRawQuery());
-    }
-    if (uri.getRawFragment() != null) {
-      relativeUri.append('#').append(uri.getRawFragment());
-    }
-    return new WebSocketConnectOptions()
-      .setHost(uri.getHost())
-      .setPort(port).setSsl(ssl)
-      .setURI(relativeUri.toString())
-      .setHeaders(headers)
-      .setVersion(version)
-      .setSubProtocols(subProtocols);
+  Handler<HttpConnection> connectionHandler() {
+    return connectionHandler;
   }
 
   @Override
-  public Future<WebSocket> webSocketAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
-    return webSocket(webSocketConnectOptionsAbs(url, headers, version, subProtocols));
+  public Future<HttpClientRequest> request(HttpMethod method, int port, String host, String requestURI) {
+    return request(new RequestOptions().setMethod(method).setPort(port).setHost(host).setURI(requestURI));
+  }
+
+  @Override
+  public Future<HttpClientRequest> request(HttpMethod method, String host, String requestURI) {
+    return request(method, options.getDefaultPort(), host, requestURI);
+  }
+
+  @Override
+  public Future<HttpClientRequest> request(HttpMethod method, String requestURI) {
+    return request(method, options.getDefaultPort(), options.getDefaultHost(), requestURI);
   }
 
   @Override
@@ -457,115 +304,8 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
   }
 
   @Override
-  public Future<HttpClientRequest> request(HttpMethod method, int port, String host, String requestURI) {
-    return request(new RequestOptions().setMethod(method).setPort(port).setHost(host).setURI(requestURI));
-  }
-
-  @Override
   public Future<HttpClientRequest> request(Address address, HttpMethod method, int port, String host, String requestURI) {
     return doRequest(address, port, host, new RequestOptions().setMethod(method).setPort(port).setHost(host).setURI(requestURI));
-  }
-
-  @Override
-  public Future<HttpClientRequest> request(HttpMethod method, String host, String requestURI) {
-    return request(method, options.getDefaultPort(), host, requestURI);
-  }
-
-  @Override
-  public Future<HttpClientRequest> request(HttpMethod method, String requestURI) {
-    return request(method, options.getDefaultPort(), options.getDefaultHost(), requestURI);
-  }
-
-  private void doShutdown(Promise<Void> p) {
-    synchronized (this) {
-      if (timerID >= 0) {
-        vertx.cancelTimer(timerID);
-        timerID = -1;
-      }
-    }
-    httpCM.shutdown();
-    webSocketCM.shutdown();
-    netClient.shutdown(closeTimeout, closeTimeoutUnit).onComplete(p);
-  }
-
-  private void doClose(Promise<Void> p) {
-    httpCM.close();
-    webSocketCM.close();
-    netClient.close().onComplete(p);
-  }
-
-  @Override
-  public Future<Void> close(long timeout, TimeUnit timeUnit) {
-    this.closeTimeout = timeout;
-    this.closeTimeoutUnit = timeUnit;
-    return closeSequence.close();
-  }
-
-  @Override
-  public boolean isMetricsEnabled() {
-    return getMetrics() != null;
-  }
-
-  @Override
-  public Metrics getMetrics() {
-    return metrics;
-  }
-
-  @Override
-  public Future<Void> updateSSLOptions(ClientSSLOptions options) {
-    sslOptions = options
-      .copy()
-      .setHostnameVerificationAlgorithm(this.options.isVerifyHost() ? "HTTPS" : "")
-      .setApplicationLayerProtocols(alpnVersions.stream().map(HttpVersion::alpnName).collect(Collectors.toList()));;
-    return Future.succeededFuture();
-  }
-
-  @Override
-  public HttpClient connectionHandler(Handler<HttpConnection> handler) {
-    connectionHandler = handler;
-    return this;
-  }
-
-  Handler<HttpConnection> connectionHandler() {
-    return connectionHandler;
-  }
-
-  @Override
-  public HttpClient redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
-    if (handler == null) {
-      handler = DEFAULT_HANDLER;
-    }
-    redirectHandler = handler;
-    return this;
-  }
-
-  @Override
-  public Function<HttpClientResponse, Future<RequestOptions>> redirectHandler() {
-    return redirectHandler;
-  }
-
-  public HttpClient proxyFilter(Predicate<SocketAddress> filter) {
-    proxyFilter = filter;
-    return this;
-  }
-
-  @Override
-  public HttpClientOptions options() {
-    return options;
-  }
-
-  @Override
-  public VertxInternal vertx() {
-    return vertx;
-  }
-
-  public void addressResolver(AddressResolver<?, ?, ?> addressResolver) {
-    if (addressResolver != null) {
-      this.endpointResolver = new EndpointResolver<>(httpEndpointProvider, addressResolver,
-        (key, addr) -> new EndpointKey(key.ssl, key.proxyOptions, addr, addr));
-    } else {
-      this.endpointResolver = null;
-    }
   }
 
   private Future<HttpClientRequest> doRequest(Address server, int port, String host, RequestOptions request) {
@@ -705,12 +445,6 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
             return wrapped;
           });
       }));
-    }
-  }
-
-  private void checkClosed() {
-    if (closeSequence.started()) {
-      throw new IllegalStateException("Client is closed");
     }
   }
 }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -242,7 +242,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   }
 
   @Override
-  public HttpClient redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
+  public HttpClientPool redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
     if (handler == null) {
       handler = DEFAULT_HANDLER;
     }
@@ -256,7 +256,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   }
 
   @Override
-  public HttpClient connectionHandler(Handler<HttpConnection> handler) {
+  public HttpClientPool connectionHandler(Handler<HttpConnection> handler) {
     connectionHandler = handler;
     return this;
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -15,19 +15,9 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpConnection;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpVersion;
-import io.vertx.core.http.RequestOptions;
-import io.vertx.core.http.WebSocket;
-import io.vertx.core.http.WebSocketConnectOptions;
-import io.vertx.core.http.WebsocketVersion;
+import io.vertx.core.http.*;
 import io.vertx.core.impl.*;
+import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.net.*;
 import io.vertx.core.net.impl.NetClientBuilder;
 import io.vertx.core.net.impl.NetClientInternal;
@@ -116,7 +106,7 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
   };
 
   private final VertxInternal vertx;
-  private final HttpClientOptions options;
+  final HttpClientOptions options;
   private final EndpointProvider<EndpointKey, Lease<HttpClientConnection>> httpEndpointProvider;
   private final ConnectionManager<EndpointKey, HttpClientConnection> webSocketCM;
   private final ConnectionManager<EndpointKey, Lease<HttpClientConnection>> httpCM;
@@ -339,7 +329,22 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
     return connector.httpConnect(context);
   }
 
-  private Future<WebSocket> webSocket(ContextInternal ctx, WebSocketConnectOptions connectOptions) {
+  @Override
+  public ClientWebSocket webSocket() {
+    return new ClientWebSocketImpl(this);
+  }
+
+  Future<WebSocket> webSocket(ContextInternal ctx, WebSocketConnectOptions connectOptions) {
+    PromiseInternal<WebSocket> promise = ctx.promise();
+    webSocket(ctx, connectOptions, promise);
+    return promise.andThen(ar -> {
+      if (ar.succeeded()) {
+        ar.result().resume();
+      }
+    });
+  }
+
+  void webSocket(ContextInternal ctx, WebSocketConnectOptions connectOptions, Promise<WebSocket> promise) {
     int port = getPort(connectOptions);
     String host = getHost(connectOptions);
     SocketAddress addr = SocketAddress.inetSocketAddress(port, host);
@@ -351,28 +356,26 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
     } else {
       eventLoopContext = vertx.createEventLoopContext(ctx.nettyEventLoop(), ctx.workerPool(), ctx.classLoader());
     }
-    // Work around for workers
-    return ctx
-      .succeededFuture()
-      .compose(v -> webSocketCM.getConnection(eventLoopContext, key))
-      .compose(c -> {
-        Http1xClientConnection conn = (Http1xClientConnection) c;
-        return conn.toWebSocket(
-          ctx,
-          connectOptions.getURI(),
-          connectOptions.getHeaders(),
-          connectOptions.getAllowOriginHeader(),
-          connectOptions.getVersion(),
-          connectOptions.getSubProtocols(),
-          connectOptions.getTimeout(),
-          connectOptions.isRegisterWriteHandlers(),
-          HttpClientImpl.this.options.getMaxWebSocketFrameSize());
-      });
-  }
-
-  @Override
-  public Future<WebSocket> webSocket(int port, String host, String requestURI) {
-    return webSocket(new WebSocketConnectOptions().setURI(requestURI).setHost(host).setPort(port));
+    webSocketCM
+      .getConnection(eventLoopContext, key)
+      .onComplete(c -> {
+        if (c.succeeded()) {
+          Http1xClientConnection conn = (Http1xClientConnection) c.result();
+          conn.toWebSocket(
+            ctx,
+            connectOptions.getURI(),
+            connectOptions.getHeaders(),
+            connectOptions.getAllowOriginHeader(),
+            connectOptions.getVersion(),
+            connectOptions.getSubProtocols(),
+            connectOptions.getTimeout(),
+            connectOptions.isRegisterWriteHandlers(),
+            HttpClientImpl.this.options.getMaxWebSocketFrameSize(),
+            promise);
+        } else {
+          promise.fail(c.cause());
+        }
+    });
   }
 
   @Override
@@ -390,8 +393,7 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
     return webSocket(vertx.getOrCreateContext(), options);
   }
 
-  @Override
-  public Future<WebSocket> webSocketAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
+  static WebSocketConnectOptions webSocketConnectOptionsAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
     URI uri;
     try {
       uri = new URI(url);
@@ -415,14 +417,18 @@ public class HttpClientImpl implements HttpClientInternal, MetricsProvider {
     if (uri.getRawFragment() != null) {
       relativeUri.append('#').append(uri.getRawFragment());
     }
-    WebSocketConnectOptions options = new WebSocketConnectOptions()
+    return new WebSocketConnectOptions()
       .setHost(uri.getHost())
       .setPort(port).setSsl(ssl)
       .setURI(relativeUri.toString())
       .setHeaders(headers)
       .setVersion(version)
       .setSubProtocols(subProtocols);
-    return webSocket(options);
+  }
+
+  @Override
+  public Future<WebSocket> webSocketAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
+    return webSocket(webSocketConnectOptionsAbs(url, headers, version, subProtocols));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpClientInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientInternal.java
@@ -13,17 +13,14 @@ package io.vertx.core.http.impl;
 
 import io.vertx.core.Closeable;
 import io.vertx.core.Future;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.*;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.Address;
 import io.vertx.core.net.impl.NetClientInternal;
 import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.resolver.AddressResolver;
 
-public interface HttpClientInternal extends HttpClient, MetricsProvider, Closeable {
+public interface HttpClientInternal extends HttpClientPool, MetricsProvider, Closeable {
 
   /**
    * @return the vertx, for use in package related classes only.

--- a/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
+import io.vertx.core.http.*;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.EventLoopContext;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.impl.future.PromiseInternal;
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.impl.pool.ConnectionManager;
+import io.vertx.core.net.impl.pool.EndpointProvider;
+import io.vertx.core.spi.metrics.ClientMetrics;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+public class WebSocketClientImpl extends HttpClientBase implements WebSocketClient {
+
+  private final WebSocketClientOptions options;
+  private final ConnectionManager<EndpointKey, HttpClientConnection> webSocketCM;
+
+  public WebSocketClientImpl(VertxInternal vertx, HttpClientOptions options, WebSocketClientOptions wsOptions) {
+    super(vertx, options);
+
+    this.options = wsOptions;
+    this.webSocketCM = webSocketConnectionManager();
+  }
+
+  private ConnectionManager<EndpointKey, HttpClientConnection> webSocketConnectionManager() {
+    EndpointProvider<EndpointKey, HttpClientConnection> provider = (key, dispose) -> {
+      int maxPoolSize = options.getMaxConnections();
+      ClientMetrics metrics = WebSocketClientImpl.this.metrics != null ? WebSocketClientImpl.this.metrics.createEndpointMetrics(key.serverAddr, maxPoolSize) : null;
+      HttpChannelConnector connector = new HttpChannelConnector(WebSocketClientImpl.this, netClient, key.proxyOptions, metrics, HttpVersion.HTTP_1_1, key.ssl, false, key.peerAddr, key.serverAddr);
+      return new WebSocketEndpoint(null, maxPoolSize, connector, dispose);
+    };
+    return new ConnectionManager<>(provider);
+  }
+
+  protected void doShutdown(Promise<Void> p) {
+    webSocketCM.shutdown();
+    super.doShutdown(p);
+  }
+
+  protected void doClose(Promise<Void> p) {
+    webSocketCM.close();
+    super.doClose(p);
+  }
+
+  @Override
+  public Future<WebSocket> connect(WebSocketConnectOptions options) {
+    return webSocket(options);
+  }
+
+  void webSocket(ContextInternal ctx, WebSocketConnectOptions connectOptions, Promise<WebSocket> promise) {
+    int port = getPort(connectOptions);
+    String host = getHost(connectOptions);
+    SocketAddress addr = SocketAddress.inetSocketAddress(port, host);
+    ProxyOptions proxyOptions = computeProxyOptions(connectOptions.getProxyOptions(), addr);
+    EndpointKey key = new EndpointKey(connectOptions.isSsl() != null ? connectOptions.isSsl() : options.isSsl(), proxyOptions, addr, addr);
+    EventLoopContext eventLoopContext;
+    if (ctx instanceof EventLoopContext) {
+      eventLoopContext = (EventLoopContext) ctx;
+    } else {
+      eventLoopContext = vertx.createEventLoopContext(ctx.nettyEventLoop(), ctx.workerPool(), ctx.classLoader());
+    }
+    webSocketCM
+      .getConnection(eventLoopContext, key)
+      .onComplete(c -> {
+        if (c.succeeded()) {
+          Http1xClientConnection conn = (Http1xClientConnection) c.result();
+          conn.toWebSocket(
+            ctx,
+            connectOptions.getURI(),
+            connectOptions.getHeaders(),
+            connectOptions.getAllowOriginHeader(),
+            options,
+            connectOptions.getVersion(),
+            connectOptions.getSubProtocols(),
+            connectOptions.getTimeout(),
+            connectOptions.isRegisterWriteHandlers(),
+            WebSocketClientImpl.this.options.getMaxFrameSize(),
+            promise);
+        } else {
+          promise.fail(c.cause());
+        }
+      });
+  }
+
+  public Future<WebSocket> webSocket(int port, String host, String requestURI) {
+    return webSocket(new WebSocketConnectOptions().setURI(requestURI).setHost(host).setPort(port));
+  }
+
+  public Future<WebSocket> webSocket(WebSocketConnectOptions options) {
+    return webSocket(vertx.getOrCreateContext(), options);
+  }
+
+  static WebSocketConnectOptions webSocketConnectOptionsAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
+    URI uri;
+    try {
+      uri = new URI(url);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+    String scheme = uri.getScheme();
+    if (!"ws".equals(scheme) && !"wss".equals(scheme)) {
+      throw new IllegalArgumentException("Scheme: " + scheme);
+    }
+    boolean ssl = scheme.length() == 3;
+    int port = uri.getPort();
+    if (port == -1) port = ssl ? 443 : 80;
+    StringBuilder relativeUri = new StringBuilder();
+    if (uri.getRawPath() != null) {
+      relativeUri.append(uri.getRawPath());
+    }
+    if (uri.getRawQuery() != null) {
+      relativeUri.append('?').append(uri.getRawQuery());
+    }
+    if (uri.getRawFragment() != null) {
+      relativeUri.append('#').append(uri.getRawFragment());
+    }
+    return new WebSocketConnectOptions()
+      .setHost(uri.getHost())
+      .setPort(port).setSsl(ssl)
+      .setURI(relativeUri.toString())
+      .setHeaders(headers)
+      .setVersion(version)
+      .setSubProtocols(subProtocols);
+  }
+
+  public Future<WebSocket> webSocketAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols) {
+    return webSocket(webSocketConnectOptionsAbs(url, headers, version, subProtocols));
+  }
+
+  Future<WebSocket> webSocket(ContextInternal ctx, WebSocketConnectOptions connectOptions) {
+    PromiseInternal<WebSocket> promise = ctx.promise();
+    webSocket(ctx, connectOptions, promise);
+    return promise.andThen(ar -> {
+      if (ar.succeeded()) {
+        ar.result().resume();
+      }
+    });
+  }
+
+  public ClientWebSocket webSocket() {
+    return new ClientWebSocketImpl(this);
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -31,10 +31,7 @@ import io.vertx.core.buffer.impl.BufferInternal;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
-import io.vertx.core.http.HttpConnection;
-import io.vertx.core.http.WebSocketBase;
-import io.vertx.core.http.WebSocketFrame;
-import io.vertx.core.http.WebSocketFrameType;
+import io.vertx.core.http.*;
 import io.vertx.core.http.impl.ws.WebSocketFrameImpl;
 import io.vertx.core.http.impl.ws.WebSocketFrameInternal;
 import io.vertx.core.impl.ContextInternal;
@@ -60,7 +57,7 @@ import static io.vertx.core.net.impl.VertxHandler.*;
  * @author <a href="http://tfox.org">Tim Fox</a>
  * @param <S> self return type
  */
-public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebSocketInternal {
+public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocketInternal {
 
   private final boolean supportsContinuation;
   private final String textHandlerID;
@@ -590,7 +587,7 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
   }
 
   @Override
-  public WebSocketBase textMessageHandler(Handler<String> handler) {
+  public WebSocket textMessageHandler(Handler<String> handler) {
     synchronized (conn) {
       checkClosed();
       if (handler != null) {
@@ -636,7 +633,7 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
   }
 
   @Override
-  public WebSocketBase pongHandler(Handler<Buffer> handler) {
+  public WebSocket pongHandler(Handler<Buffer> handler) {
     synchronized (conn) {
       checkClosed();
       this.pongHandler = handler;

--- a/src/main/java/io/vertx/core/http/impl/WebSocketInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketInternal.java
@@ -12,9 +12,10 @@ package io.vertx.core.http.impl;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.WebSocket;
 import io.vertx.core.http.WebSocketBase;
 
-public interface WebSocketInternal extends WebSocketBase {
+public interface WebSocketInternal extends WebSocket {
 
   ChannelHandlerContext channelHandlerContext();
 

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -376,19 +376,19 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   @Override
-  public HttpClient createHttpClient(HttpClientOptions options) {
+  public HttpClientPool createHttpClient(HttpClientOptions options) {
     return createHttpClient(options, new PoolOptions());
   }
 
   @Override
-  public HttpClient createHttpClient(PoolOptions poolOptions) {
+  public HttpClientPool createHttpClient(PoolOptions poolOptions) {
     return createHttpClient(new HttpClientOptions(), poolOptions);
   }
 
   @Override
-  public HttpClient createHttpClient(HttpClientOptions options, PoolOptions poolOptions) {
+  public HttpClientPool createHttpClient(HttpClientOptions options, PoolOptions poolOptions) {
     CloseFuture cf = resolveCloseFuture();
-    HttpClient client;
+    HttpClientPool client;
     Closeable closeable;
     if (options.isShared()) {
       CloseFuture closeFuture = new CloseFuture();

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -369,7 +369,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     } else {
       WebSocketClientImpl impl = new WebSocketClientImpl(this, o, options);
       closeable = impl;
-      client = new CleanableWebSocketClient(impl, cleaner, impl::close);
+      client = new CleanableWebSocketClient(impl, cleaner, impl::shutdown);
     }
     cf.add(closeable);
     return client;
@@ -402,7 +402,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     } else {
       HttpClientImpl impl = new HttpClientImpl(this, options, poolOptions);
       closeable = impl;
-      client = new CleanableHttpClient(impl, cleaner, impl::close);
+      client = new CleanableHttpClient(impl, cleaner, impl::shutdown);
     }
     cf.add(closeable);
     return client;

--- a/src/main/java/io/vertx/core/impl/VertxWrapper.java
+++ b/src/main/java/io/vertx/core/impl/VertxWrapper.java
@@ -26,10 +26,7 @@ import io.vertx.core.dns.DnsClient;
 import io.vertx.core.dns.DnsClientOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.file.FileSystem;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpServer;
-import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.*;
 import io.vertx.core.http.impl.HttpServerImpl;
 import io.vertx.core.impl.btc.BlockedThreadChecker;
 import io.vertx.core.impl.future.PromiseInternal;
@@ -109,12 +106,12 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public HttpClient createHttpClient(HttpClientOptions options) {
+  public HttpClientPool createHttpClient(HttpClientOptions options) {
     return delegate.createHttpClient(options);
   }
 
   @Override
-  public HttpClient createHttpClient() {
+  public HttpClientPool createHttpClient() {
     return delegate.createHttpClient();
   }
 

--- a/src/test/java/io/vertx/core/VertxTest.java
+++ b/src/test/java/io/vertx/core/VertxTest.java
@@ -213,7 +213,7 @@ public class VertxTest extends AsyncTestBase {
         .listen(8080, "localhost")
         .onComplete(onSuccess(server -> latch.countDown()));
       awaitLatch(latch);
-      HttpClient client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(1));
+      HttpClient client = vertx.createHttpClient(new PoolOptions().setHttp1MaxSize(1));
       Future<HttpClientRequest> fut = client.request(HttpMethod.GET, 8080, "localhost", "/");
       assertWaitUntil(fut::succeeded);
       WeakReference<HttpClient> ref = new WeakReference<>(client);

--- a/src/test/java/io/vertx/core/http/Http1xProxyTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xProxyTest.java
@@ -432,7 +432,7 @@ public class Http1xProxyTest extends HttpTestBase {
     }
 
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(2).setKeepAlive(true));
+    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(true), new PoolOptions().setHttp2MaxSize(2));
 
     CompletableFuture<List<String>> ret = new CompletableFuture<>();
 

--- a/src/test/java/io/vertx/core/http/Http1xProxyTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xProxyTest.java
@@ -477,7 +477,7 @@ public class Http1xProxyTest extends HttpTestBase {
   public void testWssHttpProxy() throws Exception {
     startProxy(null, ProxyType.HTTP);
     testWebSocket(createBaseServerOptions().setSsl(true)
-      .setKeyCertOptions(Cert.SERVER_JKS.get()), new HttpClientOptions()
+      .setKeyCertOptions(Cert.SERVER_JKS.get()), new WebSocketClientOptions()
       .setSsl(true)
       .setTrustOptions(Cert.SERVER_JKS.get())
       .setProxyOptions(new ProxyOptions()
@@ -489,7 +489,7 @@ public class Http1xProxyTest extends HttpTestBase {
   @Test
   public void testWsHttpProxy() throws Exception {
     startProxy(null, ProxyType.HTTP);
-    testWebSocket(createBaseServerOptions(), new HttpClientOptions()
+    testWebSocket(createBaseServerOptions(), new WebSocketClientOptions()
       .setProxyOptions(new ProxyOptions()
         .setType(ProxyType.HTTP)
         .setHost(DEFAULT_HTTP_HOST)
@@ -500,7 +500,7 @@ public class Http1xProxyTest extends HttpTestBase {
   public void testWssSocks5Proxy() throws Exception {
     startProxy(null, ProxyType.SOCKS5);
     testWebSocket(createBaseServerOptions().setSsl(true)
-      .setKeyCertOptions(Cert.SERVER_JKS.get()), new HttpClientOptions()
+      .setKeyCertOptions(Cert.SERVER_JKS.get()), new WebSocketClientOptions()
       .setSsl(true)
       .setTrustOptions(Cert.SERVER_JKS.get())
       .setProxyOptions(new ProxyOptions()
@@ -512,7 +512,7 @@ public class Http1xProxyTest extends HttpTestBase {
   @Test
   public void testWsSocks5Proxy() throws Exception {
     startProxy(null, ProxyType.SOCKS5);
-    testWebSocket(createBaseServerOptions(), new HttpClientOptions()
+    testWebSocket(createBaseServerOptions(), new WebSocketClientOptions()
       .setProxyOptions(new ProxyOptions()
         .setType(ProxyType.SOCKS5)
         .setHost(DEFAULT_HTTP_HOST)
@@ -522,7 +522,7 @@ public class Http1xProxyTest extends HttpTestBase {
   @Test
   public void testWsNonProxyHosts() throws Exception {
     startProxy(null, ProxyType.HTTP);
-    testWebSocket(createBaseServerOptions(), new HttpClientOptions()
+    testWebSocket(createBaseServerOptions(), new WebSocketClientOptions()
       .addNonProxyHost("localhost")
       .setProxyOptions(new ProxyOptions()
         .setType(ProxyType.HTTP)
@@ -530,19 +530,18 @@ public class Http1xProxyTest extends HttpTestBase {
         .setPort(proxy.port())), false);
   }
 
-  private void testWebSocket(HttpServerOptions serverOptions, HttpClientOptions clientOptions, boolean proxied) throws Exception {
+  private void testWebSocket(HttpServerOptions serverOptions, WebSocketClientOptions clientOptions, boolean proxied) throws Exception {
     server.close();
     server = vertx.createHttpServer(serverOptions);
-    client.close();
-    client = vertx.createHttpClient(clientOptions);
     server.webSocketHandler(ws -> {
       ws.handler(buff -> {
         ws.write(buff);
         ws.close();
       });
     });
+    WebSocketClient client = vertx.createWebSocketClient(clientOptions);
     server.listen(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST).onSuccess(s -> {
-      client.webSocket(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onSuccess(ws -> {
+      client.connect(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onSuccess(ws -> {
         ws.handler(buff -> {
           ws.close().onComplete(onSuccess(v -> {
             if (proxied) {

--- a/src/test/java/io/vertx/core/http/Http1xTLSTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTLSTest.java
@@ -43,7 +43,7 @@ public class Http1xTLSTest extends HttpTLSTest {
   }
 
   @Override
-  HttpClient createHttpClient(HttpClientOptions options) {
+  HttpClientPool createHttpClient(HttpClientOptions options) {
     return vertx.createHttpClient(options);
   }
 

--- a/src/test/java/io/vertx/core/http/Http1xTLSTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTLSTest.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 

--- a/src/test/java/io/vertx/core/http/Http1xTLSTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTLSTest.java
@@ -202,11 +202,10 @@ public class Http1xTLSTest extends HttpTLSTest {
     List<String> expected = Arrays.asList("chunk-1", "chunk-2", "chunk-3");
     HttpClientOptions options = new HttpClientOptions()
       .setEnabledSecureTransportProtocols(Collections.singleton("TLSv1.2"))
-      .setMaxPoolSize(num)
       .setSsl(true)
       .setTrustAll(true);
     client.close();
-    client = vertx.createHttpClient(options);
+    client = vertx.createHttpClient(options, new PoolOptions().setHttp1MaxSize(num));
     AtomicInteger connCount = new AtomicInteger();
     List<String> sessionIds = Collections.synchronizedList(new ArrayList<>());
     client.connectionHandler(conn -> {

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -259,10 +259,6 @@ public class Http1xTest extends HttpTest {
     assertEquals(null, options.getLocalAddress());
 
 
-    assertEquals(false,options.isSendUnmaskedFrames());
-    assertEquals(options,options.setSendUnmaskedFrames(true));
-    assertEquals(true,options.isSendUnmaskedFrames());
-
     assertEquals(HttpClientOptions.DEFAULT_DECODER_INITIAL_BUFFER_SIZE, options.getDecoderInitialBufferSize());
     assertEquals(options, options.setDecoderInitialBufferSize(256));
     assertEquals(256, options.getDecoderInitialBufferSize());
@@ -504,7 +500,6 @@ public class Http1xTest extends HttpTest {
     options.setAlpnVersions(alpnVersions);
     options.setHttp2ClearTextUpgrade(h2cUpgrade);
     options.setLocalAddress(localAddress);
-    options.setSendUnmaskedFrames(sendUnmaskedFrame);
     options.setDecoderInitialBufferSize(decoderInitialBufferSize);
     options.setKeepAliveTimeout(keepAliveTimeout);
     options.setHttp2KeepAliveTimeout(http2KeepAliveTimeout);
@@ -1693,11 +1688,12 @@ public class Http1xTest extends HttpTest {
   public void testServerWebSocketIdleTimeout() {
     server.close();
     server = vertx.createHttpServer(createBaseServerOptions().setIdleTimeout(1).setPort(DEFAULT_HTTP_PORT).setHost(DEFAULT_HTTP_HOST));
+    WebSocketClient client = vertx.createWebSocketClient();
     server
       .webSocketHandler(ws -> {})
       .listen()
       .onComplete(onSuccess(v1 -> {
-        client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/")
+        client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/")
           .onComplete(onSuccess(ws -> {
             ws.closeHandler(v2 -> testComplete());
           }));
@@ -1708,12 +1704,11 @@ public class Http1xTest extends HttpTest {
 
   @Test
   public void testClientWebSocketIdleTimeout() {
-    client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setIdleTimeout(1));
+    WebSocketClient client = vertx.createWebSocketClient(new WebSocketClientOptions().setIdleTimeout(1));
     server
       .webSocketHandler(ws -> {})
       .listen().onComplete(onSuccess(v1 -> {
-      client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/")
+      client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/")
         .onComplete(onSuccess(ws -> {
           ws.closeHandler(v2 -> testComplete());
         }));

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -5451,7 +5451,7 @@ public class Http1xTest extends HttpTest {
         assertWaitUntil(() -> ref.get() != null);
       }
     }
-    Future<Void> shutdown = client.close(10, TimeUnit.SECONDS);
+    Future<Void> shutdown = client.shutdown(10, TimeUnit.SECONDS);
     ref.get().response().end("hello");
     awaitFuture(shutdown);
     await();

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -152,12 +152,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(options, options.setVerifyHost(false));
     assertFalse(options.isVerifyHost());
 
-    assertEquals(5, options.getMaxPoolSize());
     rand = TestUtils.randomPositiveInt();
-    assertEquals(options, options.setMaxPoolSize(rand));
-    assertEquals(rand, options.getMaxPoolSize());
-    assertIllegalArgumentException(() -> options.setMaxPoolSize(0));
-    assertIllegalArgumentException(() -> options.setMaxPoolSize(-1));
 
     assertTrue(options.isKeepAlive());
     assertEquals(options, options.setKeepAlive(false));
@@ -173,13 +168,6 @@ public class Http1xTest extends HttpTest {
     assertEquals(rand, options.getPipeliningLimit());
     assertIllegalArgumentException(() -> options.setPipeliningLimit(0));
     assertIllegalArgumentException(() -> options.setPipeliningLimit(-1));
-
-    assertEquals(HttpClientOptions.DEFAULT_HTTP2_MAX_POOL_SIZE, options.getHttp2MaxPoolSize());
-    rand = TestUtils.randomPositiveInt();
-    assertEquals(options, options.setHttp2MaxPoolSize(rand));
-    assertEquals(rand, options.getHttp2MaxPoolSize());
-    assertIllegalArgumentException(() -> options.setHttp2MaxPoolSize(0));
-    assertIllegalArgumentException(() -> options.setHttp2MaxPoolSize(-1));
 
     assertEquals(HttpClientOptions.DEFAULT_HTTP2_MULTIPLEXING_LIMIT, options.getHttp2MultiplexingLimit());
     rand = TestUtils.randomPositiveInt();
@@ -229,10 +217,6 @@ public class Http1xTest extends HttpTest {
     assertEquals(HttpClientOptions.DEFAULT_MAX_HEADER_SIZE, options.getMaxHeaderSize());
     assertEquals(options, options.setMaxHeaderSize(100));
     assertEquals(100, options.getMaxHeaderSize());
-
-    assertEquals(HttpClientOptions.DEFAULT_MAX_WAIT_QUEUE_SIZE, options.getMaxWaitQueueSize());
-    assertEquals(options, options.setMaxWaitQueueSize(100));
-    assertEquals(100, options.getMaxWaitQueueSize());
 
     Http2Settings initialSettings = randomHttp2Settings();
     assertEquals(new Http2Settings(), options.getInitialSettings());
@@ -481,11 +465,9 @@ public class Http1xTest extends HttpTest {
     options.addCrlPath(crlPath);
     options.addCrlValue(crlValue);
     options.setVerifyHost(verifyHost);
-    options.setMaxPoolSize(maxPoolSize);
     options.setKeepAlive(keepAlive);
     options.setPipelining(pipelining);
     options.setPipeliningLimit(pipeliningLimit);
-    options.setHttp2MaxPoolSize(http2MaxPoolSize);
     options.setHttp2MultiplexingLimit(http2MultiplexingLimit);
     options.setHttp2ConnectionWindowSize(http2ConnectionWindowSize);
     options.setTryUseCompression(tryUseCompression);
@@ -493,7 +475,6 @@ public class Http1xTest extends HttpTest {
     options.setMaxChunkSize(maxChunkSize);
     options.setMaxInitialLineLength(maxInitialLineLength);
     options.setMaxHeaderSize(maxHeaderSize);
-    options.setMaxWaitQueueSize(maxWaitQueueSize);
     options.setInitialSettings(initialSettings);
     options.setUseAlpn(useAlpn);
     options.setSslEngineOptions(sslEngine);
@@ -534,11 +515,9 @@ public class Http1xTest extends HttpTest {
   public void testDefaultClientOptionsJson() {
     HttpClientOptions def = new HttpClientOptions();
     HttpClientOptions json = new HttpClientOptions(new JsonObject());
-    assertEquals(def.getMaxPoolSize(), json.getMaxPoolSize());
     assertEquals(def.isKeepAlive(), json.isKeepAlive());
     assertEquals(def.isPipelining(), json.isPipelining());
     assertEquals(def.getPipeliningLimit(), json.getPipeliningLimit());
-    assertEquals(def.getHttp2MaxPoolSize(), json.getHttp2MaxPoolSize());
     assertEquals(def.getHttp2MultiplexingLimit(), json.getHttp2MultiplexingLimit());
     assertEquals(def.getHttp2ConnectionWindowSize(), json.getHttp2ConnectionWindowSize());
     assertEquals(def.isVerifyHost(), json.isVerifyHost());
@@ -552,7 +531,6 @@ public class Http1xTest extends HttpTest {
     assertEquals(def.getSoLinger(), json.getSoLinger());
     assertEquals(def.isSsl(), json.isSsl());
     assertEquals(def.getProtocolVersion(), json.getProtocolVersion());
-    assertEquals(def.getMaxWaitQueueSize(), json.getMaxWaitQueueSize());
     assertEquals(def.getMaxChunkSize(), json.getMaxChunkSize());
     assertEquals(def.getMaxInitialLineLength(), json.getMaxInitialLineLength());
     assertEquals(def.getMaxHeaderSize(), json.getMaxHeaderSize());
@@ -688,11 +666,9 @@ public class Http1xTest extends HttpTest {
     assertEquals(1, options.getCrlPaths().size());
     assertEquals(crlPath, options.getCrlPaths().get(0));
     assertEquals(verifyHost, options.isVerifyHost());
-    assertEquals(maxPoolSize, options.getMaxPoolSize());
     assertEquals(keepAlive, options.isKeepAlive());
     assertEquals(pipelining, options.isPipelining());
     assertEquals(pipeliningLimit, options.getPipeliningLimit());
-    assertEquals(http2MaxPoolSize, options.getHttp2MaxPoolSize());
     assertEquals(http2MultiplexingLimit, options.getHttp2MultiplexingLimit());
     assertEquals(http2ConnectionWindowSize, options.getHttp2ConnectionWindowSize());
     assertEquals(tryUseCompression, options.isTryUseCompression());
@@ -700,7 +676,6 @@ public class Http1xTest extends HttpTest {
     assertEquals(maxChunkSize, options.getMaxChunkSize());
     assertEquals(maxInitialLineLength, options.getMaxInitialLineLength());
     assertEquals(maxHeaderSize, options.getMaxHeaderSize());
-    assertEquals(maxWaitQueueSize, options.getMaxWaitQueueSize());
     assertEquals(initialSettings, options.getInitialSettings());
     assertEquals(useAlpn, options.isUseAlpn());
     switch (sslEngine) {
@@ -1041,7 +1016,7 @@ public class Http1xTest extends HttpTest {
     awaitLatch(firstCloseLatch);
 
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(false).setMaxPoolSize(1));
+    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(false), new PoolOptions().setHttp1MaxSize(1));
     AtomicInteger requestCount = new AtomicInteger(0);
     // We need a net server because we need to intercept the socket connection, not just full http requests
     NetServer server = vertx.createNetServer();
@@ -1103,7 +1078,7 @@ public class Http1xTest extends HttpTest {
   @Test
   public void testPipeliningOrder() throws Exception {
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(true).setPipelining(true).setMaxPoolSize(1));
+    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(true).setPipelining(true), new PoolOptions().setHttp1MaxSize(1));
     int requests = 100;
 
     AtomicInteger reqCount = new AtomicInteger(0);
@@ -1159,8 +1134,7 @@ public class Http1xTest extends HttpTest {
     client = vertx.createHttpClient(new HttpClientOptions().
         setKeepAlive(true).
         setPipelining(true).
-        setPipeliningLimit(limit).
-        setMaxPoolSize(1));
+        setPipeliningLimit(limit), new PoolOptions().setHttp1MaxSize(1));
     AtomicInteger count = new AtomicInteger();
     String data = "GET /somepath HTTP/1.1\r\n" +
         "host: localhost:8080\r\n" +
@@ -1216,7 +1190,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(n).setPipelining(true));
+    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true), new PoolOptions().setHttp1MaxSize(n));
     AtomicBoolean completed = new AtomicBoolean();
     client.connectionHandler(conn -> {
       conn.closeHandler(v -> {
@@ -1237,7 +1211,7 @@ public class Http1xTest extends HttpTest {
   public void testPipeliningFailure() throws Exception {
     int n = 5;
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(true).setPipelining(true).setPipeliningLimit(n).setMaxPoolSize(1));
+    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(true).setPipelining(true).setPipeliningLimit(n), new PoolOptions().setHttp1MaxSize(1));
     AtomicBoolean first = new AtomicBoolean(true);
     CompletableFuture<Void> latch = new CompletableFuture<>();
     server.requestHandler(req -> {
@@ -1360,7 +1334,7 @@ public class Http1xTest extends HttpTest {
   public void testPipeliningPauseRequest() throws Exception {
     int n = 10;
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(true).setPipelining(true).setMaxPoolSize(1));
+    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(true).setPipelining(true), new PoolOptions().setHttp1MaxSize(1));
     server.requestHandler(req -> {
       AtomicBoolean paused = new AtomicBoolean();
       paused.set(true);
@@ -1508,7 +1482,7 @@ public class Http1xTest extends HttpTest {
     awaitLatch(firstCloseLatch);
 
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(keepAlive).setPipelining(false).setMaxPoolSize(poolSize));
+    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(keepAlive).setPipelining(false), new PoolOptions().setHttp1MaxSize(poolSize));
     int requests = 100;
 
     // Start the servers
@@ -1582,8 +1556,7 @@ public class Http1xTest extends HttpTest {
     client.close();
     client = vertx.createHttpClient(createBaseClientOptions()
       .setKeepAlive(keepAlive)
-      .setPipelining(pipelining)
-      .setMaxPoolSize(maxPoolSize)
+      .setPipelining(pipelining), new PoolOptions().setHttp1MaxSize(maxPoolSize)
     );
 
     server.requestHandler(req -> {
@@ -1629,10 +1602,7 @@ public class Http1xTest extends HttpTest {
   public void testMaxWaitQueueSizeIsRespected() throws Exception {
     client.close();
 
-    client = vertx.createHttpClient(createBaseClientOptions()
-      .setPipelining(false)
-      .setMaxWaitQueueSize(0)
-      .setMaxPoolSize(1));
+    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(false), new PoolOptions().setHttp1MaxSize(1).setMaxWaitQueueSize(0));
 
     waitFor(2);
 
@@ -1721,7 +1691,7 @@ public class Http1xTest extends HttpTest {
   public void testSharedServersRoundRobin() throws Exception {
     client.close();
     server.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1).setKeepAlive(false));
+    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(false), new PoolOptions().setHttp1MaxSize(1));
     int numServers = VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE / 2- 1;
     int numRequests = numServers * 100;
 
@@ -1987,7 +1957,7 @@ public class Http1xTest extends HttpTest {
     });
     server.listen(testAddress).onComplete(onSuccess(v1 -> {
       client.close();
-      client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(true).setMaxPoolSize(1));
+      client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
       for (int i = 0;i < 3;i++) {
         client.request(requestOptions).compose(req -> req
             .send()
@@ -2020,7 +1990,7 @@ public class Http1xTest extends HttpTest {
     });
 
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(false).setMaxPoolSize(1));
+    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(false), new PoolOptions().setHttp1MaxSize(1));
 
     startServer(testAddress);
 
@@ -2178,7 +2148,7 @@ public class Http1xTest extends HttpTest {
     Context clientCtx = vertx.getOrCreateContext();
     clientCtx.runOnContext(v -> {
       client.close();
-      client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(numReqs));
+      client = vertx.createHttpClient(createBaseClientOptions(), new PoolOptions().setHttp1MaxSize(numReqs));
     });
     waitUntil(() -> client != null);
     // There should be a context per request
@@ -2387,7 +2357,7 @@ public class Http1xTest extends HttpTest {
     startServer(testAddress);
     waitFor(2);
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(true).setMaxPoolSize(1));
+    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     client.request(requestOptions)
       .compose(HttpClientRequest::send)
       .onComplete(onSuccess(resp -> {
@@ -2414,7 +2384,7 @@ public class Http1xTest extends HttpTest {
     startServer(testAddress);
     waitFor(2);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(true).setMaxPoolSize(1));
+    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     for (int i = 0;i < 2;i++) {
       client.request(new RequestOptions(requestOptions).setMethod(PUT))
         .compose(req -> req
@@ -2764,7 +2734,7 @@ public class Http1xTest extends HttpTest {
 
       // We force two pipelined requests to check that the second request does not get stuck after the first failing
       client.close();
-      client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(true).setPipelining(true).setMaxPoolSize(1));
+      client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(true).setPipelining(true), new PoolOptions().setHttp1MaxSize(1));
 
       for (int i = 0;i < 2;i++) {
         AtomicBoolean failed = new AtomicBoolean();
@@ -2876,12 +2846,11 @@ public class Http1xTest extends HttpTest {
     int poolSize = 5;
 
     HttpClientOptions clientOptions = new HttpClientOptions()
-        .setMaxPoolSize(poolSize)
         .setDefaultHost("localhost")
         .setKeepAlive(true)
         .setPipelining(false);
     client.close();
-    client = vertx.createHttpClient(clientOptions);
+    client = vertx.createHttpClient(clientOptions, new PoolOptions().setHttp1MaxSize(1));
 
     int requests = poolSize * 2 + 1;
     AtomicInteger count = new AtomicInteger(requests);
@@ -2909,7 +2878,7 @@ public class Http1xTest extends HttpTest {
   @Test
   public void testDoNotReuseConnectionWhenResponseEndsBeforeRequest() throws Exception {
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(1).setPipelining(true).setKeepAlive(true));
+    client = vertx.createHttpClient(new HttpClientOptions().setPipelining(true).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     AtomicBoolean req1Ended = new AtomicBoolean();
     server.requestHandler(req -> {
       switch (req.path()) {
@@ -2961,7 +2930,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1).setPipelining(true).setKeepAlive(true));
+    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     AtomicInteger connCount = new AtomicInteger();
     client.connectionHandler(conn -> connCount.incrementAndGet());
     CountDownLatch respLatch = new CountDownLatch(2);
@@ -3018,7 +2987,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1));
+    client = vertx.createHttpClient(createBaseClientOptions(), new PoolOptions().setHttp1MaxSize(1));
     client.request(requestOptions)
       .compose(HttpClientRequest::send)
       .onComplete(resp1 -> {
@@ -3149,7 +3118,7 @@ public class Http1xTest extends HttpTest {
       // There might be a race between the request write and the request reset
       // so we do it on the context thread to avoid it
       vertx.runOnContext(v -> {
-        client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1).setKeepAlive(keepAlive).setPipelining(pipelined));
+        client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(keepAlive).setPipelining(pipelined), new PoolOptions().setHttp1MaxSize(1));
         client.request(new RequestOptions(requestOptions).setMethod(PUT))
           .onComplete(onSuccess(req -> {
             req.response().onComplete(onFailure(err -> {
@@ -3202,7 +3171,7 @@ public class Http1xTest extends HttpTest {
       }));
       awaitLatch(listenLatch);
       client.close();
-      client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(1).setPipelining(false).setKeepAlive(true));
+      client = vertx.createHttpClient(new HttpClientOptions().setPipelining(false).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
       AtomicInteger status = new AtomicInteger();
       client.connectionHandler(conn -> {
         conn.closeHandler(v -> {
@@ -3267,7 +3236,7 @@ public class Http1xTest extends HttpTest {
       }));
       awaitLatch(listenLatch);
       client.close();
-      client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1).setPipelining(true).setKeepAlive(true));
+      client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
       client.connectionHandler(conn -> {
         conn.closeHandler(v -> {
           complete();
@@ -3354,7 +3323,7 @@ public class Http1xTest extends HttpTest {
       }));
       awaitLatch(listenLatch);
       client.close();
-      client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(1).setPipelining(pipelined).setKeepAlive(true));
+      client = vertx.createHttpClient(new HttpClientOptions().setPipelining(pipelined).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
       client
         .request(requestOptions)
         .onComplete(onSuccess(req1 -> {
@@ -3461,7 +3430,7 @@ public class Http1xTest extends HttpTest {
       }));
       awaitLatch(listenLatch);
       client.close();
-      client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1).setPipelining(pipelined).setKeepAlive(true));
+      client = vertx.createHttpClient(createBaseClientOptions().setPipelining(pipelined).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
       if (pipelined) {
         client.request(new RequestOptions(requestOptions).setURI("/somepath"))
           .onComplete(onSuccess(req1 -> {
@@ -3580,7 +3549,7 @@ public class Http1xTest extends HttpTest {
       }));
       awaitLatch(listenLatch);
       client.close();
-      client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1).setPipelining(pipelined).setKeepAlive(true));
+      client = vertx.createHttpClient(createBaseClientOptions().setPipelining(pipelined).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
       client.request(new RequestOptions(requestOptions).setURI("/1"))
         .onComplete(onSuccess(req1 -> {
           requestReceived.thenAccept(v -> {
@@ -3843,7 +3812,7 @@ public class Http1xTest extends HttpTest {
       @Override
       public void start() throws Exception {
         client.close();
-        client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(n));
+        client = vertx.createHttpClient(new PoolOptions().setHttp1MaxSize(1));
         for (int i = 0;i < n;i++) {
           AtomicBoolean responseReceived = new AtomicBoolean();
           client.request(requestOptions).onComplete(onSuccess(req -> {
@@ -3869,9 +3838,8 @@ public class Http1xTest extends HttpTest {
   public void testPerHostPooling() throws Exception {
     client.close();
     client = vertx.createHttpClient(new HttpClientOptions()
-      .setMaxPoolSize(1)
       .setKeepAlive(true)
-      .setPipelining(false));
+      .setPipelining(false), new PoolOptions().setHttp1MaxSize(1));
     testPerXXXPooling((i) -> client.request(new RequestOptions()
       .setPort(DEFAULT_HTTP_PORT)
       .setHost("host" + i)
@@ -3883,9 +3851,8 @@ public class Http1xTest extends HttpTest {
   public void testPerPeerPooling() throws Exception {
     client.close();
     client = vertx.createHttpClient(new HttpClientOptions()
-        .setMaxPoolSize(1)
         .setKeepAlive(true)
-        .setPipelining(false));
+        .setPipelining(false), new PoolOptions().setHttp1MaxSize(1));
     testPerXXXPooling((i) -> client.request(new RequestOptions()
       .setServer(SocketAddress.inetSocketAddress(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST))
       .setPort(8080)
@@ -3897,12 +3864,11 @@ public class Http1xTest extends HttpTest {
   public void testPerPeerPoolingWithProxy() throws Exception {
     client.close();
     client = vertx.createHttpClient(new HttpClientOptions()
-        .setMaxPoolSize(1)
         .setKeepAlive(true)
         .setPipelining(false).setProxyOptions(new ProxyOptions()
             .setType(ProxyType.HTTP)
             .setHost(DEFAULT_HTTP_HOST)
-            .setPort(DEFAULT_HTTP_PORT)));
+            .setPort(DEFAULT_HTTP_PORT)), new PoolOptions().setHttp1MaxSize(1));
     testPerXXXPooling((i) -> client.request(new RequestOptions()
       .setPort(80)
       .setHost("host" + i)
@@ -4159,7 +4125,7 @@ public class Http1xTest extends HttpTest {
         req.response().putHeader("keep-alive", "timeout=3").end();
       }
     });
-    testKeepAliveTimeout(new HttpClientOptions().setMaxPoolSize(1).setKeepAliveTimeout(30), 1);
+    testKeepAliveTimeout(new HttpClientOptions().setKeepAliveTimeout(30), new PoolOptions().setHttp1MaxSize(1), 1);
   }
 
   @Test
@@ -4172,7 +4138,7 @@ public class Http1xTest extends HttpTest {
       }
       resp.end();
     });
-    testKeepAliveTimeout(new HttpClientOptions().setMaxPoolSize(1).setKeepAliveTimeout(30), 2);
+    testKeepAliveTimeout(new HttpClientOptions().setKeepAliveTimeout(30), new PoolOptions().setHttp1MaxSize(1), 2);
   }
 
   @Test
@@ -4189,7 +4155,7 @@ public class Http1xTest extends HttpTest {
       resp.putHeader("keep-alive", "timeout=" + timeout);
       resp.end();
     });
-    testKeepAliveTimeout(new HttpClientOptions().setMaxPoolSize(1).setKeepAliveTimeout(30), 2);
+    testKeepAliveTimeout(new HttpClientOptions().setKeepAliveTimeout(30), new PoolOptions().setHttp1MaxSize(1), 2);
   }
 
   @Test
@@ -4214,7 +4180,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1));
+    client = vertx.createHttpClient(createBaseClientOptions(), new PoolOptions().setHttp1MaxSize(1));
     for (int i = 0; i < numRequests; i++) {
       client.request(new RequestOptions(requestOptions).setMethod(PUT)).onComplete(onSuccess(req -> {
         req.send(Buffer.buffer("small")).onComplete(resp -> {
@@ -4250,7 +4216,7 @@ public class Http1xTest extends HttpTest {
     server.requestHandler(req -> req.response().end("ok"));
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1).setKeepAlive(true));
+    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     client.request(requestOptions).onComplete(onSuccess(req -> {
       req.send().onComplete(onSuccess(resp1 -> {
         h.handle(resp1);
@@ -4284,7 +4250,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(2));
+    client = vertx.createHttpClient(createBaseClientOptions(), new PoolOptions().setHttp1MaxSize(2));
     // Make two concurrent requests and finish one first
     List<HttpConnection> connections = Collections.synchronizedList(new ArrayList<>());
     CountDownLatch latch = new CountDownLatch(2);
@@ -4454,7 +4420,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setMaxPoolSize(1).setKeepAlive(true));
+    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     vertx.runOnContext(v -> {
       // Run on context so requests are enqueued with a predictable ordering
       for (int i = 0;i < numReq;i++) {
@@ -4489,7 +4455,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setMaxPoolSize(1).setKeepAlive(true));
+    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     vertx.runOnContext(v -> {
       // Run on context so requests are enqueued with a predictable ordering
       for (int i = 0;i < numReq;i++) {
@@ -4536,7 +4502,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setPipelining(true).setMaxPoolSize(1).setKeepAlive(true));
+    client = vertx.createHttpClient(new HttpClientOptions().setPipelining(true).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     CountDownLatch latch1 = new CountDownLatch(1);
     client.request(new RequestOptions(requestOptions).setMethod(PUT)).onComplete(onSuccess(req -> {
       req.end(TestUtils.randomAlphaString(1024)).onComplete( onSuccess(v -> {
@@ -4572,7 +4538,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setMaxPoolSize(1).setKeepAlive(true));
+    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     client.request(new RequestOptions(requestOptions).setMethod(HttpMethod.POST)).onComplete(onSuccess(req -> {
       req.end(Buffer.buffer(TestUtils.randomAlphaString(1024)));
     }));
@@ -4601,7 +4567,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setMaxPoolSize(1).setKeepAlive(true));
+    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     client.request(new RequestOptions(requestOptions).setMethod(PUT)).onComplete(onSuccess(req -> {
       req.end(Buffer.buffer(TestUtils.randomAlphaString(1024)));
     }));
@@ -4621,7 +4587,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setMaxPoolSize(1).setKeepAlive(true));
+    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     client.request(requestOptions)
       .onComplete(onSuccess(req -> {
         req.response().onComplete(onSuccess(resp -> complete()));
@@ -4645,7 +4611,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(1).setKeepAlive(true));
+    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     client.request(requestOptions).onComplete(onSuccess(req1 -> {
       req1.send().onComplete(onSuccess(resp1 -> {
         // Response is paused but request is put back in the pool since the HTTP response fully arrived
@@ -4675,7 +4641,7 @@ public class Http1xTest extends HttpTest {
     server.requestHandler(req -> req.response().end("ok"));
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(true).setMaxPoolSize(1));
+    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(true), new PoolOptions().setHttp1MaxSize(1));
     client.request(requestOptions).onComplete(onSuccess(req1 -> {
       req1.send().onComplete(onSuccess(resp1 -> {
         resp1.pause();
@@ -5078,7 +5044,7 @@ public class Http1xTest extends HttpTest {
       });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true).setMaxPoolSize(1));
+    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true), new PoolOptions().setHttp1MaxSize(1));
     for (int i = 0;i < n;i++) {
       client.request(requestOptions)
         .compose(req -> req.send().compose(HttpClientResponse::body))
@@ -5168,7 +5134,7 @@ public class Http1xTest extends HttpTest {
     startServer(testAddress);
     AtomicInteger responses = new AtomicInteger();
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1).setPipelining(true));
+    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true), new PoolOptions().setHttp1MaxSize(1));
     vertx.runOnContext(v1 -> {
       client.connectionHandler(conn -> {
         conn.closeHandler(v2 -> {
@@ -5235,7 +5201,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1).setPipelining(true));
+    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true), new PoolOptions().setHttp1MaxSize(1));
     client.connectionHandler(conn -> {
       clientConnectionRef.set(conn);
       long now = System.currentTimeMillis();
@@ -5266,7 +5232,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1).setPipelining(true));
+    client = vertx.createHttpClient(createBaseClientOptions().setPipelining(true), new PoolOptions().setHttp1MaxSize(1));
     client.connectionHandler(clientConnectionRef::set);
     client.request(requestOptions).onComplete(onSuccess(req -> {
       req.send().onComplete(onFailure(err -> complete()));
@@ -5398,9 +5364,9 @@ public class Http1xTest extends HttpTest {
     });
     startServer();
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions()
-      .setMaxPoolSize(maxPoolSize)
-      .setPoolEventLoopSize(size));
+    client = vertx.createHttpClient(new PoolOptions()
+      .setHttp1MaxSize(maxPoolSize)
+      .setEventLoopSize(size));
     List<EventLoop> eventLoops = Collections.synchronizedList(new ArrayList<>());
     client.connectionHandler(conn -> eventLoops.add(((ContextInternal)Vertx.currentContext()).nettyEventLoop()));
     List<Future<Buffer>> futures = new ArrayList<>();
@@ -5434,7 +5400,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1));
+    client = vertx.createHttpClient(createBaseClientOptions(), new PoolOptions().setHttp1MaxSize(1));
     for (int i = 0;i < num;i++) {
       int val = i;
       client
@@ -5466,7 +5432,7 @@ public class Http1xTest extends HttpTest {
     });
     startServer(testAddress);
     client.close();
-    client = vertx.createHttpClient(createBaseClientOptions().setMaxPoolSize(1));
+    client = vertx.createHttpClient(createBaseClientOptions(), new PoolOptions().setHttp1MaxSize(1));
     for (int i = 0;i < num;i++) {
       int val = i;
       client.request(requestOptions)

--- a/src/test/java/io/vertx/core/http/Http2ClientTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientTest.java
@@ -1710,7 +1710,7 @@ public class Http2ClientTest extends Http2TestBase {
       });
       startServer(testAddress);
       client.close();
-      client = vertx.createHttpClient(clientOptions.setUseAlpn(false).setSsl(false).setMaxPoolSize(1));
+      client = vertx.createHttpClient(clientOptions.setUseAlpn(false).setSsl(false), new PoolOptions().setHttp1MaxSize(1));
       waitFor(5);
       for (int i = 0;i < 5;i++) {
         client.request(requestOptions).onComplete(onSuccess(req -> {
@@ -1946,8 +1946,7 @@ public class Http2ClientTest extends Http2TestBase {
     startServer();
     client.close();
     client = vertx.createHttpClient(new HttpClientOptions(clientOptions).
-        setHttp2MaxPoolSize(poolSize).
-        setHttp2MultiplexingLimit(maxConcurrency));
+        setHttp2MultiplexingLimit(maxConcurrency), new PoolOptions().setHttp2MaxSize(poolSize));
     AtomicInteger respCount = new AtomicInteger();
     Set<HttpConnection> clientConnections = Collections.synchronizedSet(new HashSet<>());
     client.connectionHandler(clientConnections::add);

--- a/src/test/java/io/vertx/core/http/Http2TLSTest.java
+++ b/src/test/java/io/vertx/core/http/Http2TLSTest.java
@@ -25,7 +25,7 @@ public class Http2TLSTest extends HttpTLSTest {
   }
 
   @Override
-  HttpClient createHttpClient(HttpClientOptions options) {
+  HttpClientPool createHttpClient(HttpClientOptions options) {
     return vertx.createHttpClient(options.setUseAlpn(true));
   }
 

--- a/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
+++ b/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
@@ -63,10 +63,10 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
   }
 
   private Function<Vertx, HttpServer> serverFactory;
-  private Function<Vertx, HttpClient> clientFactory;
+  private Function<Vertx, HttpClientPool> clientFactory;
 
   public HttpBandwidthLimitingTest(double protoVersion, Function<Vertx, HttpServer> serverFactory,
-                                   Function<Vertx, HttpClient> clientFactory) {
+                                   Function<Vertx, HttpClientPool> clientFactory) {
     this.serverFactory = serverFactory;
     this.clientFactory = clientFactory;
   }

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -1308,7 +1308,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   abstract HttpServer createHttpServer(HttpServerOptions options);
 
-  abstract HttpClient createHttpClient(HttpClientOptions options);
+  abstract HttpClientPool createHttpClient(HttpClientOptions options);
 
   protected TLSTest testTLS(Cert<?> clientCert, Trust<?> clientTrust,
                           Cert<?> serverCert, Trust<?> serverTrust) throws Exception {

--- a/src/test/java/io/vertx/core/http/HttpTestBase.java
+++ b/src/test/java/io/vertx/core/http/HttpTestBase.java
@@ -39,7 +39,7 @@ public class HttpTestBase extends VertxTestBase {
   public static final String DEFAULT_TEST_URI = "some-uri";
 
   protected HttpServer server;
-  protected HttpClient client;
+  protected HttpClientPool client;
   protected TestProxyBase proxy;
   protected SocketAddress testAddress;
   protected RequestOptions requestOptions;

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -89,7 +89,7 @@ public class WebSocketTest extends VertxTestBase {
   private static final String TEST_REASON = "I'm moving away!";
   private static final short TEST_STATUS_CODE = (short)1001;
 
-  private HttpClient client;
+  private WebSocketClient client;
   private HttpServer server;
   private NetServer netServer;
 
@@ -255,7 +255,7 @@ public class WebSocketTest extends VertxTestBase {
   // Server specifies cert that the client trusts (not trust all)
   public void testTLSClientTrustServerCertWithSNI() throws Exception {
     testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_JKS, Trust.NONE, false, false, false, false, true, true, true, true, new String[0],
-      (client) -> client.webSocket(4043, "host2.com", "/"));
+      (client) -> client.connect(4043, "host2.com", "/"));
   }
 
   @Test
@@ -372,28 +372,28 @@ public class WebSocketTest extends VertxTestBase {
   // Client trusts all server certs
   public void testClearClientRequestOptionsSetSSL() throws Exception {
     WebSocketConnectOptions options = new WebSocketConnectOptions().setHost(HttpTestBase.DEFAULT_HTTP_HOST).setURI("/").setPort(4043).setSsl(true);
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE, false, false, true, false, true, false, true, false, new String[0], (client) -> client.webSocket(options));
+    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE, false, false, true, false, true, false, true, false, new String[0], (client) -> client.connect(options));
   }
 
   @Test
   // Client trusts all server certs
   public void testSSLClientRequestOptionsSetSSL() throws Exception {
     WebSocketConnectOptions options = new WebSocketConnectOptions().setHost(HttpTestBase.DEFAULT_HTTP_HOST).setURI("/").setPort(4043).setSsl(true);
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE, false, false, true, false, true, true, true, false, new String[0], (client) -> client.webSocket(options));
+    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE, false, false, true, false, true, true, true, false, new String[0], (client) -> client.connect(options));
   }
 
   @Test
   // Client trusts all server certs
   public void testClearClientRequestOptionsSetClear() throws Exception {
     WebSocketConnectOptions options = new WebSocketConnectOptions().setHost(HttpTestBase.DEFAULT_HTTP_HOST).setURI("/").setPort(4043).setSsl(false);
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE, false, false, true, false, true, false, false, false, new String[0], (client) -> client.webSocket(options));
+    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE, false, false, true, false, true, false, false, false, new String[0], (client) -> client.connect(options));
   }
 
   @Test
   // Client trusts all server certs
   public void testSSLClientRequestOptionsSetClear() throws Exception {
     WebSocketConnectOptions options = new WebSocketConnectOptions().setHost(HttpTestBase.DEFAULT_HTTP_HOST).setURI("/").setPort(4043).setSsl(false);
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE, false, false, true, false, true, true, false, false, new String[0], (client) -> client.webSocket(options));
+    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE, false, false, true, false, true, true, false, false, new String[0], (client) -> client.connect(options));
   }
 
   private void testTLS(Cert<?> clientCert, Trust<?> clientTrust,
@@ -404,7 +404,7 @@ public class WebSocketTest extends VertxTestBase {
     testTLS(clientCert, clientTrust,
         serverCert, serverTrust,
         requireClientAuth, serverUsesCrl, clientTrustAll, clientUsesCrl, shouldPass, true, true, false,
-        enabledCipherSuites, (client) -> client.webSocket(4043, HttpTestBase.DEFAULT_HTTP_HOST, "/"));
+        enabledCipherSuites, (client) -> client.connect(4043, HttpTestBase.DEFAULT_HTTP_HOST, "/"));
   }
 
   private void testTLS(Cert<?> clientCert, Trust<?> clientTrust,
@@ -415,8 +415,8 @@ public class WebSocketTest extends VertxTestBase {
                        boolean serverSsl,
                        boolean sni,
                        String[] enabledCipherSuites,
-                       Function<HttpClient, Future<WebSocket>> wsProvider) throws Exception {
-    HttpClientOptions options = new HttpClientOptions();
+                       Function<WebSocketClient, Future<WebSocket>> wsProvider) throws Exception {
+    WebSocketClientOptions options = new WebSocketClientOptions();
     options.setSsl(clientSsl);
     options.setTrustAll(clientTrustAll);
     if (clientUsesCrl) {
@@ -427,7 +427,7 @@ public class WebSocketTest extends VertxTestBase {
     for (String suite: enabledCipherSuites) {
       options.addEnabledCipherSuite(suite);
     }
-    client = vertx.createHttpClient(options);
+    client = vertx.createWebSocketClient(options);
     HttpServerOptions serverOptions = new HttpServerOptions();
     serverOptions.setSsl(serverSsl);
     serverOptions.setSni(sni);
@@ -499,9 +499,9 @@ public class WebSocketTest extends VertxTestBase {
       }));
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
         ws.handler(buff -> {
           assertEquals(message, buff.toString("UTF-8"));
           testComplete();
@@ -537,10 +537,10 @@ public class WebSocketTest extends VertxTestBase {
     }
 
     // Create a bunch of connections
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     CountDownLatch latchClient = new CountDownLatch(numConnections);
     for (int i = 0; i < numConnections; i++) {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
         ws.closeHandler(v -> latchClient.countDown());
         ws.close();
       }));
@@ -652,8 +652,8 @@ public class WebSocketTest extends VertxTestBase {
       .setURI(path + "?" + query)
       .setVersion(version);
 
-    client = vertx.createHttpClient();
-    client.webSocket(options).onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(options).onComplete(onSuccess(ws -> {
       final Buffer received = Buffer.buffer();
       ws.handler(data -> {
         received.appendBuffer(data);
@@ -729,12 +729,12 @@ public class WebSocketTest extends VertxTestBase {
       .setURI(path + "?" + query)
       .setVersion(version);
 
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
 
     int bsize = 100;
     int msgs = 10;
 
-    Future<WebSocket> webSocketFuture = client.webSocket(options);
+    Future<WebSocket> webSocketFuture = client.connect(options);
     webSocketFuture.onComplete(onSuccess(ws -> {
       final List<Buffer> sent = new ArrayList<>();
       final List<Buffer> received = new ArrayList<>();
@@ -844,8 +844,8 @@ public class WebSocketTest extends VertxTestBase {
 
     awaitFuture(server.listen());
 
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
         ws.frameHandler(frame -> {
           if (frame.isClose()) {
             complete();
@@ -894,9 +894,9 @@ public class WebSocketTest extends VertxTestBase {
       .setHost(DEFAULT_HTTP_HOST)
       .setURI(path)
       .setVersion(version);
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(options).onComplete(onSuccess(ws -> {
+      client.connect(options).onComplete(onSuccess(ws -> {
         AtomicBoolean receivedFirstFrame = new AtomicBoolean();
         ws.frameHandler(received -> {
           Buffer receivedBuffer = Buffer.buffer(received.textData());
@@ -930,9 +930,9 @@ public class WebSocketTest extends VertxTestBase {
       .setHost(DEFAULT_HTTP_HOST)
       .setURI(path)
       .setVersion(version);
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(options).onComplete(onSuccess(ws -> {
+      client.connect(options).onComplete(onSuccess(ws -> {
         Buffer received = Buffer.buffer();
         ws.handler(data -> {
           received.appendBuffer(data);
@@ -963,11 +963,11 @@ public class WebSocketTest extends VertxTestBase {
         });
 
     awaitFuture(server.listen());
-    HttpClientOptions options = new HttpClientOptions();
-    options.setTryUsePerFrameWebSocketCompression(true);
-    client = vertx.createHttpClient(options);
+    WebSocketClientOptions options = new WebSocketClientOptions();
+    options.setTryUsePerFrameCompression(true);
+    client = vertx.createWebSocketClient(options);
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
         final Buffer received = Buffer.buffer();
         ws.handler(data -> {
           received.appendBuffer(data);
@@ -997,11 +997,11 @@ public class WebSocketTest extends VertxTestBase {
     });
 
     awaitFuture(server.listen());
-    HttpClientOptions options = new HttpClientOptions();
-    options.setTryUsePerMessageWebSocketCompression(true);
-    client = vertx.createHttpClient(options);
+    WebSocketClientOptions options = new WebSocketClientOptions();
+    options.setTryUsePerMessageCompression(true);
+    client = vertx.createWebSocketClient(options);
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
         final Buffer received = Buffer.buffer();
         ws.handler(data -> {
           received.appendBuffer(data);
@@ -1020,7 +1020,7 @@ public class WebSocketTest extends VertxTestBase {
   // Test if WebSocket compression is enabled by checking that the switch protocols response header contains the requested compression
   public void testWSPermessageDeflateCompressionEnabled() throws InterruptedException {
     waitFor(2);
-    client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(1));
+    HttpClient client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(1));
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).webSocketHandler(ws -> {
       assertEquals("upgrade", ws.headers().get("Connection"));
       assertEquals("permessage-deflate", ws.headers().get("sec-websocket-extensions"));
@@ -1063,10 +1063,9 @@ public class WebSocketTest extends VertxTestBase {
     });
 
     awaitFuture(server.listen());
-    HttpClientOptions options = new HttpClientOptions();
-    client = vertx.createHttpClient(options);
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
         final Buffer received = Buffer.buffer();
         ws.handler(data -> {
           received.appendBuffer(data);
@@ -1100,9 +1099,9 @@ public class WebSocketTest extends VertxTestBase {
       .setURI(path)
       .setVersion(version)
       .setSubProtocols(clientSubProtocols);
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(options).onComplete(onSuccess(ws -> {
+      client.connect(options).onComplete(onSuccess(ws -> {
         assertEquals("commonproto", ws.subProtocol());
         final Buffer received = Buffer.buffer();
         ws.handler(data -> {
@@ -1130,15 +1129,15 @@ public class WebSocketTest extends VertxTestBase {
       .setVersion(version)
       .addSubProtocol(subProtocol);
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
-    client.webSocket(options).onComplete(onFailure(err -> {
+    client = vertx.createWebSocketClient();
+    client.connect(options).onComplete(onFailure(err -> {
       // Should fail
       testComplete();
     }));
     await();
   }
 
-  Consumer<Handler<AsyncResult<HttpClientResponse>>> INVALID_MISSING_CONNECTION_HEADER = handler -> {
+  BiConsumer<HttpClient, Handler<AsyncResult<HttpClientResponse>>> INVALID_MISSING_CONNECTION_HEADER = (client, handler) -> {
     client.request(new RequestOptions()
       .setPort(DEFAULT_HTTP_PORT)
       .setHost(DEFAULT_HTTPS_HOST)
@@ -1162,7 +1161,7 @@ public class WebSocketTest extends VertxTestBase {
     await();
   }
 
-  Consumer<Handler<AsyncResult<HttpClientResponse>>> INVALID_HTTP_METHOD = handler -> {
+  BiConsumer<HttpClient, Handler<AsyncResult<HttpClientResponse>>> INVALID_HTTP_METHOD = (client, handler) -> {
 
     client.request(new RequestOptions()
       .setMethod(HttpMethod.HEAD)
@@ -1187,7 +1186,7 @@ public class WebSocketTest extends VertxTestBase {
     await();
   }
 
-  Consumer<Handler<AsyncResult<HttpClientResponse>>> INVALID_URI = handler -> {
+  BiConsumer<HttpClient, Handler<AsyncResult<HttpClientResponse>>> INVALID_URI = (client, handler) -> {
     client.request(new RequestOptions()
       .setPort(DEFAULT_HTTP_PORT)
       .setHost(DEFAULT_HTTPS_HOST)
@@ -1211,7 +1210,7 @@ public class WebSocketTest extends VertxTestBase {
     await();
   }
 
-  Consumer<Handler<AsyncResult<HttpClientResponse>>> INVALID_WEBSOCKET_VERSION = handler -> {
+  BiConsumer<HttpClient, Handler<AsyncResult<HttpClientResponse>>> INVALID_WEBSOCKET_VERSION = (client, handler) -> {
 
     client.request(new RequestOptions()
       .setPort(DEFAULT_HTTP_PORT)
@@ -1237,7 +1236,7 @@ public class WebSocketTest extends VertxTestBase {
     await();
   }
 
-  Consumer<Handler<AsyncResult<HttpClientResponse>>> HANDSHAKE_EXCEPTION = handler -> {
+  BiConsumer<HttpClient, Handler<AsyncResult<HttpClientResponse>>> HANDSHAKE_EXCEPTION = (client, handler) -> {
     client.request(new RequestOptions()
       .setPort(DEFAULT_HTTP_PORT)
       .setHost(DEFAULT_HTTPS_HOST)
@@ -1264,11 +1263,11 @@ public class WebSocketTest extends VertxTestBase {
   }
 
   // Check client response with the ws handler
-  private void testInvalidHandshake(Consumer<Handler<AsyncResult<HttpClientResponse>>> requestProvider,
+  private void testInvalidHandshake(BiConsumer<HttpClient, Handler<AsyncResult<HttpClientResponse>>> requestProvider,
                                     boolean expectEvent,
                                     boolean upgradeRequest,
                                     int expectedStatus) {
-    client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(1));
+    HttpClient client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(1));
     if (upgradeRequest) {
       server = vertx.createHttpServer()
         .webSocketHandler(ws -> {
@@ -1294,7 +1293,7 @@ public class WebSocketTest extends VertxTestBase {
       });
     }
     server.listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST).onComplete(onSuccess(s -> {
-      requestProvider.accept(onSuccess(resp -> {
+      requestProvider.accept(client, onSuccess(resp -> {
         assertEquals(expectedStatus, resp.statusCode());
         resp.endHandler(v1 -> {
           // Make another request to check the connection remains usable
@@ -1331,8 +1330,8 @@ public class WebSocketTest extends VertxTestBase {
         .setHost(DEFAULT_HTTP_HOST)
         .setURI(path)
         .setVersion(version);
-      client = vertx.createHttpClient();
-      client.webSocket(options).onComplete(onFailure(t -> {
+      client = vertx.createWebSocketClient();
+      client.connect(options).onComplete(onFailure(t -> {
         assertTrue(t instanceof UpgradeRejectedException);
         UpgradeRejectedException rejection = (UpgradeRejectedException) t;
         assertEquals(expectedRejectionStatus, rejection.getStatus());
@@ -1368,8 +1367,8 @@ public class WebSocketTest extends VertxTestBase {
       });
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/some/path").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/some/path").onComplete(onSuccess(ws -> {
       assertTrue(resolved.get());
       testComplete();
     }));
@@ -1386,9 +1385,9 @@ public class WebSocketTest extends VertxTestBase {
 //      assertEquals(101, (int)result.result());
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v1 -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/some/path").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/some/path").onComplete(onSuccess(ws -> {
         ws.closeHandler(v2 -> {
           testComplete();
         });
@@ -1399,25 +1398,25 @@ public class WebSocketTest extends VertxTestBase {
 
   @Test
   public void testServerClose() throws InterruptedException {
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     testClose(false, true, true);
   }
 
   @Test
   public void testClientClose() throws InterruptedException {
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     testClose(true, false, true);
   }
 
   @Test
   public void testClientAndServerClose() throws InterruptedException {
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     testClose(true, false, true);
   }
 
   @Test
   public void testConnectionClose() throws InterruptedException {
-    client = vertx.createHttpClient(new HttpClientOptions().setIdleTimeout(1));
+    client = vertx.createWebSocketClient(new WebSocketClientOptions().setIdleTimeout(1));
     testClose(false, false, false);
   }
 
@@ -1458,7 +1457,7 @@ public class WebSocketTest extends VertxTestBase {
     });
     awaitFuture(server.listen());
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/some/path").onComplete(
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/some/path").onComplete(
         onSuccess(ws -> {
           test.accept(ws);
           if (closeClient) {
@@ -1475,8 +1474,8 @@ public class WebSocketTest extends VertxTestBase {
       req.connection().close();
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/some/path").onComplete(onFailure(err -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/some/path").onComplete(onFailure(err -> {
       testComplete();
     }));
     await();
@@ -1487,7 +1486,7 @@ public class WebSocketTest extends VertxTestBase {
     String path = "/some/path";
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).webSocketHandler(ws -> fail());
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    HttpClient client = vertx.createHttpClient();
     client.request(new RequestOptions()
       .setHost(DEFAULT_HTTP_HOST)
       .setPort(DEFAULT_HTTP_PORT)
@@ -1548,7 +1547,7 @@ public class WebSocketTest extends VertxTestBase {
   }
 
   private void testWriteMessage(int size, WebsocketVersion version) throws InterruptedException {
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     waitFor(2);
     String path = "/some/path";
     byte[] expected = TestUtils.randomByteArray(size);
@@ -1567,7 +1566,7 @@ public class WebSocketTest extends VertxTestBase {
       .setURI(path)
       .setVersion(version);
     vertx.runOnContext(v1 -> {
-      client.webSocket(options).onComplete(onSuccess(ws -> {
+      client.connect(options).onComplete(onSuccess(ws -> {
         Buffer actual = Buffer.buffer();
         ws.handler(actual::appendBuffer);
         ws.closeHandler(v2 -> {
@@ -1629,7 +1628,7 @@ public class WebSocketTest extends VertxTestBase {
 
   @Test
   public void testTooLargeMessage() throws InterruptedException {
-    String messageToSend = randomAlphaString(HttpClientOptions.DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE + 1);
+    String messageToSend = randomAlphaString(WebSocketClientOptions.DEFAULT_MAX_MESSAGE_SIZE + 1);
     SocketMessages socketMessages = testWriteTextMessages(Collections.singletonList(messageToSend), WebsocketVersion.V13);
     List<String> receivedMessages = socketMessages.getReceivedMessages();
     List<String> expectedMessages = Collections.emptyList();
@@ -1642,9 +1641,9 @@ public class WebSocketTest extends VertxTestBase {
 
   @Test
   public void testContinueAfterTooLargeMessage() throws InterruptedException {
-    int shortMessageLength = HttpClientOptions.DEFAULT_MAX_WEBSOCKET_FRAME_SIZE;
+    int shortMessageLength = WebSocketClientOptions.DEFAULT_MAX_FRAME_SIZE;
     String shortFirstMessage = randomAlphaString(shortMessageLength);
-    String tooLongMiddleMessage = randomAlphaString(HttpClientOptions.DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE * 2);
+    String tooLongMiddleMessage = randomAlphaString(WebSocketClientOptions.DEFAULT_MAX_MESSAGE_SIZE * 2);
     String shortLastMessage = randomAlphaString(shortMessageLength);
     List<String> messagesToSend = Arrays.asList(shortFirstMessage, tooLongMiddleMessage, shortLastMessage);
 
@@ -1679,9 +1678,9 @@ public class WebSocketTest extends VertxTestBase {
       .setHost(DEFAULT_HTTP_HOST)
       .setURI(path)
       .setVersion(version);
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v1 -> {
-      client.webSocket(options).onComplete(onSuccess(ws -> {
+      client.connect(options).onComplete(onSuccess(ws -> {
         ws.textMessageHandler(receivedMessages::add);
         ws.exceptionHandler(receivedExceptions::add);
         ws.closeHandler(v2 -> testComplete());
@@ -1720,13 +1719,13 @@ public class WebSocketTest extends VertxTestBase {
       .toCompletableFuture()
       .get(20, TimeUnit.SECONDS);
     try {
-      client = vertx.createHttpClient(new HttpClientOptions().setConnectTimeout(1000));
+      client = vertx.createWebSocketClient(new WebSocketClientOptions().setConnectTimeout(1000));
       WebSocketConnectOptions options = new WebSocketConnectOptions()
         .setPort(1234)
         .setHost(DEFAULT_HTTP_HOST)
         .setURI("/")
         .setTimeout(1000);
-      client.webSocket(options).onComplete(onFailure(err -> {
+      client.connect(options).onComplete(onFailure(err -> {
         assertEquals(WebSocketHandshakeException.class, err.getClass());
         testComplete();
       }));
@@ -1736,9 +1735,9 @@ public class WebSocketTest extends VertxTestBase {
     }
   }
 
-  private void connectUntilWebSocketReject(HttpClient client, int count, Handler<AsyncResult<Void>> doneHandler) {
+  private void connectUntilWebSocketReject(WebSocketClient client, int count, Handler<AsyncResult<Void>> doneHandler) {
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/some/path").onComplete(ar -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/some/path").onComplete(ar -> {
         if (ar.succeeded()) {
           if (count < 100) {
             connectUntilWebSocketReject(client, count + 1, doneHandler);
@@ -1782,9 +1781,9 @@ public class WebSocketTest extends VertxTestBase {
     String path = "/some/path";
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).webSocketHandler(WebSocketBase::close);
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
         ws.endHandler(v2 -> {
           try {
             ws.endHandler(null);
@@ -1806,9 +1805,9 @@ public class WebSocketTest extends VertxTestBase {
     String path = "/some/path";
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).webSocketHandler(WebSocketBase::close);
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
         ws.endHandler(v2 -> {
           ws.write(Buffer.buffer("test")).onComplete(onFailure(err -> {
             testComplete();
@@ -1826,8 +1825,8 @@ public class WebSocketTest extends VertxTestBase {
     });
     AtomicReference<WebSocket> webSocketRef = new AtomicReference<>();
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/some/path").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/some/path").onComplete(onSuccess(ws -> {
       MultiMap entries = ws.headers();
       assertNotNull(entries);
       assertFalse(entries.isEmpty());
@@ -1889,9 +1888,9 @@ public class WebSocketTest extends VertxTestBase {
       }
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v1 -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
         Buffer buff = Buffer.buffer();
         ws.handler(buff::appendBuffer);
         ws.endHandler(v2 -> {
@@ -1914,7 +1913,7 @@ public class WebSocketTest extends VertxTestBase {
       }));
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    HttpClient client = vertx.createHttpClient();
     handshake(client, req -> {
       req.putHeader(HttpHeaders.CONTENT_LENGTH, "100");
       req.sendHead().onComplete(onSuccess(v -> {
@@ -1927,7 +1926,7 @@ public class WebSocketTest extends VertxTestBase {
   @Test
   public void testUnmaskedFrameRequest(){
 
-    client = vertx.createHttpClient(new HttpClientOptions().setSendUnmaskedFrames(true));
+    client = vertx.createWebSocketClient(new WebSocketClientOptions().setSendUnmaskedFrames(true));
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT).setAcceptUnmaskedFrames(true));
     server.requestHandler(req -> {
       req.response().setChunked(true).write("connect");
@@ -1943,7 +1942,7 @@ public class WebSocketTest extends VertxTestBase {
 
     });
     server.listen().onComplete(onSuccess(server -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
         ws.writeFinalTextFrame("first unmasked frame");
       }));
     }));
@@ -1953,7 +1952,7 @@ public class WebSocketTest extends VertxTestBase {
   @Test
   public void testInvalidUnmaskedFrameRequest() throws InterruptedException {
 
-    client = vertx.createHttpClient(new HttpClientOptions().setSendUnmaskedFrames(true));
+    client = vertx.createWebSocketClient(new WebSocketClientOptions().setSendUnmaskedFrames(true));
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT).setAcceptUnmaskedFrames(false));
     server.requestHandler(req -> {
       req.response().setChunked(true).write("connect");
@@ -1972,7 +1971,7 @@ public class WebSocketTest extends VertxTestBase {
     });
 
     awaitFuture(server.listen());
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
       ws.writeFinalTextFrame("first unmasked frame");
     }));
 
@@ -1990,7 +1989,7 @@ public class WebSocketTest extends VertxTestBase {
       request.response().end();
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    HttpClient client = vertx.createHttpClient();
     client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/")
       .compose(HttpClientRequest::send)
       .onComplete(onSuccess(resp -> {
@@ -2103,8 +2102,8 @@ public class WebSocketTest extends VertxTestBase {
     });
     server.listen().onComplete(onSuccess(s -> {
       context.runOnContext(v -> {
-        client = vertx.createHttpClient();
-        client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+        client = vertx.createWebSocketClient();
+        client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
           ws.handler(buf -> {
             assertEquals("hello", buf.toString());
             testComplete();
@@ -2124,9 +2123,9 @@ public class WebSocketTest extends VertxTestBase {
       ws.write(Buffer.buffer("hello"));
     });
     server.listen().onComplete(onSuccess(s -> {
-      client = vertx.createHttpClient();
+      client = vertx.createWebSocketClient();
       workers.get(0).runOnContext(v -> {
-        client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+        client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
           ws.handler(buf -> {
             assertEquals("hello", buf.toString());
             testComplete();
@@ -2164,8 +2163,8 @@ public class WebSocketTest extends VertxTestBase {
       vertx.deployVerticle(() -> new AbstractVerticle() {
         @Override
         public void start() {
-          client = vertx.createHttpClient();
-          Future<WebSocket> fut = client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/");
+          client = vertx.createWebSocketClient();
+          Future<WebSocket> fut = client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/");
           fut.onComplete(onSuccess(ws -> {
             assertTrue(Context.isOnWorkerThread());
             ws.write(Buffer.buffer("ping"));
@@ -2187,8 +2186,8 @@ public class WebSocketTest extends VertxTestBase {
   @Test
   public void httpClientWebSocketConnectionFailureHandlerShouldBeCalled() throws Exception {
     int port = 7867;
-    HttpClient client = vertx.createHttpClient();
-    client.webSocket(port, "localhost", "").onComplete(onFailure(err -> {
+    client = vertx.createWebSocketClient();
+    client.connect(port, "localhost", "").onComplete(onFailure(err -> {
       testComplete();
     }));
     await();
@@ -2196,7 +2195,8 @@ public class WebSocketTest extends VertxTestBase {
 
   @Test
   public void testClientWebSocketWithHttp2Client() throws Exception {
-    client = vertx.createHttpClient(new HttpClientOptions().setHttp2ClearTextUpgrade(false).setProtocolVersion(HttpVersion.HTTP_2));
+    client = vertx.createWebSocketClient();
+    HttpClient client = vertx.createHttpClient(new HttpClientOptions().setHttp2ClearTextUpgrade(false).setProtocolVersion(HttpVersion.HTTP_2));
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT));
     server.requestHandler(req -> {
       req.response().setChunked(true).write("connect");
@@ -2208,7 +2208,7 @@ public class WebSocketTest extends VertxTestBase {
     client.request(new RequestOptions().setPort(DEFAULT_HTTP_PORT).setHost(DEFAULT_HTTP_HOST))
       .onComplete(onSuccess(req -> {
         req.send().onComplete(onSuccess(resp -> {
-          client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+          this.client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
             ws.handler(buff -> {
               assertEquals("ok", buff.toString());
               testComplete();
@@ -2276,9 +2276,8 @@ public class WebSocketTest extends VertxTestBase {
       NetServer server = ar.result();
       int port = server.actualPort();
 
-      HttpClientOptions opts = new HttpClientOptions().setKeepAlive(keepAliveInOptions);
-      client = vertx.createHttpClient(opts);
-      client.webSocket(port, "localhost", "/").onComplete(ar2 -> {
+      client = vertx.createWebSocketClient();
+      client.connect(port, "localhost", "/").onComplete(ar2 -> {
         if (ar2.succeeded()) {
           addResult(new AssertionError("WebSocket unexpectedly connected"));
           ar2.result().close();
@@ -2310,15 +2309,15 @@ public class WebSocketTest extends VertxTestBase {
     HttpServerOptions serverOptions = new HttpServerOptions().setPort(DEFAULT_HTTPS_PORT)
       .setSsl(true)
       .setKeyCertOptions(Cert.SERVER_JKS.get());
-    HttpClientOptions clientOptions = new HttpClientOptions()
+    WebSocketClientOptions clientOptions = new WebSocketClientOptions()
       .setTrustAll(true)
       .setVerifyHost(false);
-    client = vertx.createHttpClient(clientOptions);
+    client = vertx.createWebSocketClient(clientOptions);
     server = vertx.createHttpServer(serverOptions).webSocketHandler(WebSocketBase::close);
     awaitFuture(server.listen());
     WebSocketConnectOptions options = new WebSocketConnectOptions().setPort(DEFAULT_HTTPS_PORT).setSsl(true);
     vertx.runOnContext(v1 -> {
-      client.webSocket(options).onComplete(onSuccess(ws -> {
+      client.connect(options).onComplete(onSuccess(ws -> {
         ws.closeHandler(v2 -> {
           testComplete();
         });
@@ -2338,9 +2337,9 @@ public class WebSocketTest extends VertxTestBase {
       ws.writePing(Buffer.buffer("ping"));
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
         ws.handler(buff -> {
           fail("Should not receive a buffer");
         });
@@ -2363,9 +2362,9 @@ public class WebSocketTest extends VertxTestBase {
       ws.writePing(Buffer.buffer("ping"));
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
         ws.pause();
         ws.handler(buff -> {
           fail("Should not receive a buffer");
@@ -2414,9 +2413,9 @@ public class WebSocketTest extends VertxTestBase {
       }));
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
         ws.closeHandler(v2 -> {
           testComplete();
         });
@@ -2437,8 +2436,8 @@ public class WebSocketTest extends VertxTestBase {
       vertx.setTimer(2000, id -> testComplete());
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {}));
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {}));
     await();
   }
 
@@ -2450,8 +2449,8 @@ public class WebSocketTest extends VertxTestBase {
     server = vertx.createHttpServer(new HttpServerOptions().setIdleTimeout(1).setPort(DEFAULT_HTTP_PORT).setHost(HttpTestBase.DEFAULT_HTTP_HOST).setMaxWebSocketFrameSize(maxFrameSize));
     server.webSocketHandler(ws -> { });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
       ws.pongHandler(buffer -> fail());
       ws.writeFrame(WebSocketFrame.pingFrame(Buffer.buffer(pingBody)));
       vertx.setTimer(2000, id -> testComplete());
@@ -2469,9 +2468,9 @@ public class WebSocketTest extends VertxTestBase {
       ws.writeFrame(WebSocketFrame.pongFrame(Buffer.buffer(pingBody)));
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
         ws.pongHandler(buff -> fail());
         vertx.setTimer(2000, id -> testComplete());
       }));
@@ -2490,8 +2489,8 @@ public class WebSocketTest extends VertxTestBase {
       vertx.setTimer(2000, id -> testComplete());
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
       ws.writeFrame(WebSocketFrame.pongFrame(Buffer.buffer(pingBody)));
     }));
     await();
@@ -2516,8 +2515,8 @@ public class WebSocketTest extends VertxTestBase {
       });
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
       try {
         ws.writeFrame(new WebSocketFrameImpl(WebSocketFrameType.PONG, ((BufferInternal)ping1.copy()).getByteBuf(), false));
         ws.writeFrame(new WebSocketFrameImpl(WebSocketFrameType.PONG, ((BufferInternal)ping2.copy()).getByteBuf(), true));
@@ -2545,9 +2544,9 @@ public class WebSocketTest extends VertxTestBase {
       }
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
         List<Buffer> pongs = new ArrayList<>();
         ws.pongHandler(pong -> {
           pongs.add(pong);
@@ -2573,9 +2572,9 @@ public class WebSocketTest extends VertxTestBase {
 
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
         List<Buffer> pongs = new ArrayList<>();
         ws.pongHandler(pong -> {
           pongs.add(pong);
@@ -2607,9 +2606,9 @@ public class WebSocketTest extends VertxTestBase {
 
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
         List<Buffer> pongs = new ArrayList<>();
         ws.pongHandler(pong -> {
           pongs.add(pong);
@@ -2635,8 +2634,8 @@ public class WebSocketTest extends VertxTestBase {
     server.webSocketHandler(ws -> {
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
       ws.pongHandler( pong -> {
         assertEquals("ping", pong.toString());
         testComplete();
@@ -2651,10 +2650,10 @@ public class WebSocketTest extends VertxTestBase {
     HttpServerOptions serverOptions = new HttpServerOptions().setPort(DEFAULT_HTTPS_PORT)
       .setSsl(true)
       .setKeyCertOptions(Cert.SERVER_JKS.get());
-    HttpClientOptions clientOptions = new HttpClientOptions()
+    WebSocketClientOptions clientOptions = new WebSocketClientOptions()
       .setTrustAll(true)
       .setVerifyHost(false);
-    client = vertx.createHttpClient(clientOptions);
+    client = vertx.createWebSocketClient(clientOptions);
     server = vertx.createHttpServer(serverOptions).requestHandler(request -> {
       if ("/test".equals(request.path())) {
         request
@@ -2665,8 +2664,8 @@ public class WebSocketTest extends VertxTestBase {
       }
     });
     awaitFuture(server.listen());
-    String url = "wss://" + clientOptions.getDefaultHost() + ":" + DEFAULT_HTTPS_PORT + "/test";
-    client.webSocketAbs(url, null, null, null).onComplete(onSuccess(ws -> {
+    String url = "wss://" + "localhost" + ":" + DEFAULT_HTTPS_PORT + "/test";
+    client.connect(new WebSocketConnectOptions().setAbsoluteURI(url)).onComplete(onSuccess(ws -> {
       ws.closeHandler(v -> {
         testComplete();
       });
@@ -2687,7 +2686,7 @@ public class WebSocketTest extends VertxTestBase {
   }
 
   private void testCloseStatusCodeFromServer(Consumer<ServerWebSocket> closeOp) throws InterruptedException {
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT))
       .webSocketHandler(socket -> {
         socket.closeHandler(a -> {
@@ -2697,7 +2696,7 @@ public class WebSocketTest extends VertxTestBase {
       });
     awaitFuture(server.listen());
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
         ws.frameHandler(frame -> {
           assertEquals(1000, ((BufferInternal)frame.binaryData()).getByteBuf().getShort(0));
           assertEquals(1000, frame.closeStatusCode());
@@ -2716,7 +2715,7 @@ public class WebSocketTest extends VertxTestBase {
   @Test
   public void testCloseStatusCodeFromClient() throws InterruptedException {
     CountDownLatch latch = new CountDownLatch(2);
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT))
       .webSocketHandler(socket -> {
         socket.closeHandler(a -> {
@@ -2730,14 +2729,14 @@ public class WebSocketTest extends VertxTestBase {
         });
       });
     awaitFuture(server.listen());
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(WebSocketBase::close));
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(WebSocketBase::close));
     awaitLatch(latch);
   }
 
   @Test
   public void testCloseFrame() throws InterruptedException {
     waitFor(3);
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT))
       .webSocketHandler(socket -> {
         socket.closeHandler(a -> {
@@ -2757,7 +2756,7 @@ public class WebSocketTest extends VertxTestBase {
         });
       });
     awaitFuture(server.listen());
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
       ws.writeTextMessage("Hello");
       ws.close(TEST_STATUS_CODE, TEST_REASON);
     }));
@@ -2777,7 +2776,7 @@ public class WebSocketTest extends VertxTestBase {
   }
 
   private void testCloseCustomPayloadFromServer(Consumer<ServerWebSocket> closeOp) throws InterruptedException {
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT))
       .webSocketHandler(socket -> {
         socket.closeHandler(a -> {
@@ -2789,7 +2788,7 @@ public class WebSocketTest extends VertxTestBase {
       });
     awaitFuture(server.listen());
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
         ws.frameHandler(frame -> {
           assertEquals(TEST_REASON, ((BufferInternal)frame.binaryData()).getByteBuf().readerIndex(2).toString(StandardCharsets.UTF_8));
           assertEquals(TEST_STATUS_CODE, ((BufferInternal)frame.binaryData()).getByteBuf().getShort(0));
@@ -2815,7 +2814,7 @@ public class WebSocketTest extends VertxTestBase {
   }
 
   private void testCloseCustomPayloadFromClient(Consumer<WebSocket> closeOp) throws InterruptedException {
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT))
       .webSocketHandler(socket -> {
         socket.closeHandler(a -> {
@@ -2830,7 +2829,7 @@ public class WebSocketTest extends VertxTestBase {
         });
       });
     awaitFuture(server.listen());
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(closeOp));
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(closeOp));
     await();
   }
 
@@ -2846,7 +2845,7 @@ public class WebSocketTest extends VertxTestBase {
       });
     });
     server.listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST).onComplete(onSuccess(v1 -> {
-      client = vertx.createHttpClient();
+      HttpClient client = vertx.createHttpClient();
       handshake(client, req -> {
         req.send().onComplete(onSuccess(resp -> {
           assertEquals(101, resp.statusCode());
@@ -2914,9 +2913,8 @@ public class WebSocketTest extends VertxTestBase {
       }));
     });
     server.listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST).onComplete(onSuccess(v1 -> {
-      HttpClientOptions options = new HttpClientOptions();
-      client = vertx.createHttpClient(options);
-      client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/chat").onComplete(onSuccess(ws -> {
+      client = vertx.createWebSocketClient();
+      client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/chat").onComplete(onSuccess(ws -> {
         ws.closeHandler(v -> {
           complete();
         });
@@ -2957,8 +2955,8 @@ public class WebSocketTest extends VertxTestBase {
       }));
     });
     server.listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST).onComplete(onSuccess(v1 -> {
-      client = vertx.createHttpClient(new HttpClientOptions().setWebSocketClosingTimeout(timeout));
-      client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/chat").onComplete(onSuccess(ws -> {
+      client = vertx.createWebSocketClient(new WebSocketClientOptions().setClosingTimeout(timeout));
+      client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/chat").onComplete(onSuccess(ws -> {
         ws.endHandler(v -> {
           complete();
         });
@@ -3005,7 +3003,7 @@ public class WebSocketTest extends VertxTestBase {
         ws.close();
       });
     awaitFuture(server.listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST));
-    client = vertx.createHttpClient();
+    HttpClient client = vertx.createHttpClient();
     handshake(client, req -> {
       req.send().onComplete(onSuccess(resp -> {
         assertEquals(101, resp.statusCode());
@@ -3023,7 +3021,7 @@ public class WebSocketTest extends VertxTestBase {
 
   @Test
   public void testCloseServer() throws InterruptedException {
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT))
       .webSocketHandler(socket -> {
         socket.textMessageHandler(msg -> {
@@ -3031,7 +3029,7 @@ public class WebSocketTest extends VertxTestBase {
         });
       });
     awaitFuture(server.listen());
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
       ws.writeTextMessage("ping");
       AtomicBoolean closeFrameReceived = new AtomicBoolean();
       ws.frameHandler(frame -> {
@@ -3049,7 +3047,7 @@ public class WebSocketTest extends VertxTestBase {
 
   @Test
   public void testCloseClient() throws InterruptedException {
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT))
       .webSocketHandler(ws -> {
         AtomicBoolean closeFrameReceived = new AtomicBoolean();
@@ -3064,7 +3062,7 @@ public class WebSocketTest extends VertxTestBase {
         });
       });
     awaitFuture(server.listen());
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
       client.close();
     }));
     await();
@@ -3086,9 +3084,9 @@ public class WebSocketTest extends VertxTestBase {
       .setHost(DEFAULT_HTTP_HOST)
       .setURI("/some/path")
       .setVersion(WebsocketVersion.V13);
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v1 -> {
-      client.webSocket(options).onComplete(onSuccess(ws -> {
+      client.connect(options).onComplete(onSuccess(ws -> {
         AtomicReference<Throwable> failure = new AtomicReference<>();
         ws.closeHandler(v2 -> {
           assertNotNull(failure.get());
@@ -3111,7 +3109,7 @@ public class WebSocketTest extends VertxTestBase {
       ws.exceptionHandler(failure::set);
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    HttpClient client = vertx.createHttpClient();
     handshake(client, req -> {
       req.connect().onComplete(onSuccess(resp -> {
         assertEquals(101, resp.statusCode());
@@ -3140,9 +3138,9 @@ public class WebSocketTest extends VertxTestBase {
       });
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
+      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
         vertx.setTimer(1000, id -> {
           ws.close();
         });
@@ -3159,8 +3157,8 @@ public class WebSocketTest extends VertxTestBase {
       });
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
       CheckingSender sender = new CheckingSender(vertx.getOrCreateContext(), ws);
       sender.send();
       ws.closeHandler(v -> {
@@ -3205,8 +3203,8 @@ public class WebSocketTest extends VertxTestBase {
     // Create a new client that will use the same event-loop than the server
     // so the ws.writeQueueFull() will return true since the client won't be able to read the socket
     // when the server is busy writing the WebSocket
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
       CheckingSender sender = new CheckingSender(vertx.getOrCreateContext(), ws);
       ws.closeHandler(v -> sender.close());
       sender.send();
@@ -3221,7 +3219,7 @@ public class WebSocketTest extends VertxTestBase {
       .webSocketHandler(ws -> fail())
       .listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST).onComplete(onSuccess(v -> latch.countDown()));
     awaitLatch(latch);
-    client = vertx.createHttpClient();
+    HttpClient client = vertx.createHttpClient();
     client.request(new RequestOptions()
       .setHost(DEFAULT_HTTP_HOST)
       .setPort(DEFAULT_HTTP_PORT)).onComplete(onSuccess(req -> {
@@ -3253,8 +3251,8 @@ public class WebSocketTest extends VertxTestBase {
         });
       });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
       ws.close();
     }));
     await();
@@ -3285,8 +3283,8 @@ public class WebSocketTest extends VertxTestBase {
         });
       });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
       ws.write(expected);
       ws.close();
     }));
@@ -3321,11 +3319,11 @@ public class WebSocketTest extends VertxTestBase {
       server.listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST).onComplete(onSuccess(s -> latch.countDown()));
     });
     awaitLatch(latch);
-    client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(num));
+    client = vertx.createWebSocketClient();
     for (int i = 0;i < num;i++) {
       Context clientCtx = vertx.getOrCreateContext();
       clientCtx.runOnContext(v -> {
-        client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
+        client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
           assertEquals(clientCtx, Vertx.currentContext());
           ws.write(Buffer.buffer("data"));
           ws.pongHandler(pong -> {
@@ -3363,8 +3361,8 @@ public class WebSocketTest extends VertxTestBase {
         });
       });
     awaitFuture(server.listen(DEFAULT_HTTP_PORT));
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
       ws.pause();
       resume.future().onComplete(onSuccess(v2 -> {
         ws.resume();
@@ -3384,8 +3382,8 @@ public class WebSocketTest extends VertxTestBase {
         }));
       });
     awaitFuture(server.listen(DEFAULT_HTTP_PORT));
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
       while (!ws.writeQueueFull()) {
         ws.writeFrame(WebSocketFrame.textFrame(randomAlphaString(512), true));
       }
@@ -3407,8 +3405,8 @@ public class WebSocketTest extends VertxTestBase {
         });
       });
     awaitFuture(server.listen(DEFAULT_HTTP_PORT));
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
       ws.write(Buffer.buffer("foo")).onComplete(onSuccess(v -> {
         complete();
       }));
@@ -3422,8 +3420,8 @@ public class WebSocketTest extends VertxTestBase {
       .webSocketHandler(ServerWebSocket::pause);
     awaitFuture(server.listen(DEFAULT_HTTP_PORT));
     Buffer buffer = TestUtils.randomBuffer(1024);
-    client = vertx.createHttpClient();
-    client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(onSuccess(ws -> {
       while (!ws.writeQueueFull()) {
         ws.write(buffer);
       }
@@ -3437,13 +3435,13 @@ public class WebSocketTest extends VertxTestBase {
 
   @Test
   public void testCloseClientImmediately() throws InterruptedException {
-    HttpClient client = vertx.createHttpClient();
+    WebSocketClient client = vertx.createWebSocketClient();
     server = vertx.createHttpServer()
       .webSocketHandler(ws -> {
       });
     awaitFuture(server.listen(DEFAULT_HTTP_PORT));
     AtomicBoolean resolved = new AtomicBoolean();
-    client.webSocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(ar -> {
+    client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/someuri").onComplete(ar -> {
       if (resolved.compareAndSet(false, true)) {
         if (ar.succeeded()) {
           fail();
@@ -3477,8 +3475,8 @@ public class WebSocketTest extends VertxTestBase {
         });
       });
     awaitFuture(server.listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST));
-    client = vertx.createHttpClient();
-    client.webSocket(proxy.getPort(), proxy.getHost(), "/someuri").onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(proxy.getPort(), proxy.getHost(), "/someuri").onComplete(onSuccess(ws -> {
       ws.write(Buffer.buffer("foo")).onComplete(onSuccess(v -> {
         complete();
       }));
@@ -3492,6 +3490,7 @@ public class WebSocketTest extends VertxTestBase {
 
   @Test
   public void testWebSocketDisablesALPN() throws InterruptedException {
+/*
     client = vertx.createHttpClient(new HttpClientOptions()
       .setProtocolVersion(HttpVersion.HTTP_2)
       .setUseAlpn(true)
@@ -3524,6 +3523,7 @@ public class WebSocketTest extends VertxTestBase {
       }));
     }));
     await();
+*/
   }
 
   @Test
@@ -3581,7 +3581,7 @@ public class WebSocketTest extends VertxTestBase {
       }
     });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     WebSocketConnectOptions options = new WebSocketConnectOptions()
       .setVersion(version)
       .setAllowOriginHeader(allow)
@@ -3591,7 +3591,7 @@ public class WebSocketTest extends VertxTestBase {
     if (origin != null) {
       options.addHeader(header, origin);
     }
-    client.webSocket(options).onComplete(onSuccess(ws -> {
+    client.connect(options).onComplete(onSuccess(ws -> {
       testComplete();
     }));
     await();
@@ -3620,8 +3620,8 @@ public class WebSocketTest extends VertxTestBase {
       .setPort(DEFAULT_HTTP_PORT)
       .setHost(DEFAULT_HTTP_HOST)
       .setURI(path);
-    client = vertx.createHttpClient();
-    client.webSocket(options).onComplete(onSuccess(ws -> {
+    client = vertx.createWebSocketClient();
+    client.connect(options).onComplete(onSuccess(ws -> {
       assertNull(ws.textHandlerID());
       assertNull(ws.binaryHandlerID());
       ws
@@ -3672,13 +3672,13 @@ public class WebSocketTest extends VertxTestBase {
 
     awaitFuture(server.listen());
 
-    client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(numConnections));
+    client = vertx.createWebSocketClient();
     for (int i = 0; i < numConnections; i++) {
       WebSocketConnectOptions options = new WebSocketConnectOptions()
         .setPort(DEFAULT_HTTP_PORT)
         .setHost(DEFAULT_HTTP_HOST)
         .setURI(path);
-      client.webSocket(options).onComplete(onSuccess(ws -> {
+      client.connect(options).onComplete(onSuccess(ws -> {
         messageHandlerSetter.accept(ws, data -> {
           assertEquals(bye, data);
           complete();
@@ -3703,7 +3703,7 @@ public class WebSocketTest extends VertxTestBase {
         });
       });
     awaitFuture(server.listen());
-    client = vertx.createHttpClient();
+    client = vertx.createWebSocketClient();
     ClientWebSocket ws = client.webSocket();
     WebSocketConnectOptions options = new WebSocketConnectOptions()
       .setPort(DEFAULT_HTTP_PORT)

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -3689,4 +3689,36 @@ public class WebSocketTest extends VertxTestBase {
 
     await();
   }
+
+  @Test
+  public void testConnect() throws Exception {
+    waitFor(2);
+    server = vertx.createHttpServer(new HttpServerOptions()
+      .setPort(DEFAULT_HTTP_PORT)
+      .setHost(HttpTestBase.DEFAULT_HTTP_HOST))
+      .webSocketHandler(ws -> {
+        ws.write(Buffer.buffer("Ping"));
+        ws.handler(buff -> {
+          ws.close();
+        });
+      });
+    awaitFuture(server.listen());
+    client = vertx.createHttpClient();
+    ClientWebSocket ws = client.webSocket();
+    WebSocketConnectOptions options = new WebSocketConnectOptions()
+      .setPort(DEFAULT_HTTP_PORT)
+      .setHost(DEFAULT_HTTP_HOST);
+    ws.handler(buff -> {
+        ws.write(buff);
+        ws.connect(options)
+          .onComplete(onFailure(err -> {
+          complete();
+        }));
+      })
+      .closeHandler(v -> complete()).connect(options
+      ).onComplete(onSuccess(v -> {
+
+      }));
+    await();
+  }
 }

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -1020,7 +1020,7 @@ public class WebSocketTest extends VertxTestBase {
   // Test if WebSocket compression is enabled by checking that the switch protocols response header contains the requested compression
   public void testWSPermessageDeflateCompressionEnabled() throws InterruptedException {
     waitFor(2);
-    HttpClient client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(1));
+    HttpClient client = vertx.createHttpClient(new PoolOptions().setHttp1MaxSize(1));
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).webSocketHandler(ws -> {
       assertEquals("upgrade", ws.headers().get("Connection"));
       assertEquals("permessage-deflate", ws.headers().get("sec-websocket-extensions"));
@@ -1267,7 +1267,7 @@ public class WebSocketTest extends VertxTestBase {
                                     boolean expectEvent,
                                     boolean upgradeRequest,
                                     int expectedStatus) {
-    HttpClient client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(1));
+    HttpClient client = vertx.createHttpClient(new PoolOptions().setHttp1MaxSize(1));
     if (upgradeRequest) {
       server = vertx.createHttpServer()
         .webSocketHandler(ws -> {

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
@@ -149,7 +149,7 @@ public class MetricsContextTest extends VertxTestBase {
       }));
     });
     awaitLatch(latch);
-    HttpClient client = vertx.createHttpClient();
+    HttpClientPool client = vertx.createHttpClient();
     client.connectionHandler(conn -> {
       conn.closeHandler(v -> {
         vertx.close().onComplete(v4 -> {

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
@@ -238,7 +238,7 @@ public class MetricsContextTest extends VertxTestBase {
       latch.countDown();
     }));
     awaitLatch(latch);
-    HttpClient client = vertx.createHttpClient(new HttpClientOptions().setPipelining(true).setMaxPoolSize(1));
+    HttpClient client = vertx.createHttpClient(new HttpClientOptions().setPipelining(true), new PoolOptions().setHttp1MaxSize(1));
     vertx.runOnContext(v -> {
       for (int i = 0;i < 2;i++) {
         client.request(HttpMethod.GET, 8080, "localhost", "/" + (i + 1)).onComplete(onSuccess(req -> {

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
@@ -344,8 +344,8 @@ public class MetricsContextTest extends VertxTestBase {
       }));
     });
     awaitLatch(latch);
-    HttpClient client = vertx.createHttpClient();
-    client.webSocket(8080, "localhost", "/").onComplete(onSuccess(ws -> {
+    WebSocketClient client = vertx.createWebSocketClient();
+    client.connect(8080, "localhost", "/").onComplete(onSuccess(ws -> {
       ws.handler(buf -> {
         ws.closeHandler(v -> {
           vertx.close().onComplete(v4 -> {
@@ -535,8 +535,8 @@ public class MetricsContextTest extends VertxTestBase {
     awaitFuture(server.listen(8080, "localhost"));
     Context ctx = contextFactory.apply(vertx);
     ctx.runOnContext(v1 -> {
-      HttpClient client = vertx.createHttpClient();
-      client.webSocket(8080, "localhost", "/").onComplete(onSuccess(ws -> {
+      WebSocketClient client = vertx.createWebSocketClient();
+      client.connect(8080, "localhost", "/").onComplete(onSuccess(ws -> {
         ws.handler(buf -> {
           ws.closeHandler(v2 -> {
             TestUtils.executeInVanillaVertxThread(() -> {

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -57,11 +57,19 @@ public class MetricsTest extends VertxTestBase {
 
   private HttpServer server;
   private HttpClient client;
+  private WebSocketClient wsClient;
 
   protected void tearDown() throws Exception {
     if (client != null) {
       try {
         client.close();
+      } catch (IllegalStateException ignore) {
+        // Client was already closed by the test
+      }
+    }
+    if (wsClient != null) {
+      try {
+        wsClient.close();
       } catch (IllegalStateException ignore) {
         // Client was already closed by the test
       }
@@ -563,8 +571,8 @@ public class MetricsTest extends VertxTestBase {
       });
     });
     awaitFuture(server.listen(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST));
-    client = vertx.createHttpClient();
-    client.webSocket(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+    wsClient = vertx.createWebSocketClient();
+    wsClient.connect(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
       ws.write(Buffer.buffer("wibble"));
       ws.handler(buff -> ws.close());
     }));
@@ -590,8 +598,8 @@ public class MetricsTest extends VertxTestBase {
       }));
     });
     awaitFuture(server.listen(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST));
-    client = vertx.createHttpClient();
-    client.webSocket(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/" + TestUtils.randomAlphaString(16))
+    wsClient = vertx.createWebSocketClient();
+    wsClient.connect(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/" + TestUtils.randomAlphaString(16))
       .onComplete(onSuccess(ws -> {
         ws.write(Buffer.buffer("wibble"));
         ws.handler(buff -> {
@@ -609,10 +617,10 @@ public class MetricsTest extends VertxTestBase {
       ws.handler(buff -> ws.close());
     });
     awaitFuture(server.listen(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST));
-    client = vertx.createHttpClient();
+    wsClient = vertx.createWebSocketClient();
     vertx.runOnContext(v -> {
-      client.webSocket(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
-        FakeHttpClientMetrics metrics = FakeMetricsBase.getMetrics(client);
+      wsClient.connect(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, "/").onComplete(onSuccess(ws -> {
+        FakeHttpClientMetrics metrics = FakeMetricsBase.getMetrics(wsClient);
         WebSocketMetric metric = metrics.getMetric(ws);
         assertNotNull(metric);
         ws.closeHandler(closed -> {

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -56,7 +56,7 @@ public class MetricsTest extends VertxTestBase {
   private static final String ADDRESS1 = "some-address1";
 
   private HttpServer server;
-  private HttpClient client;
+  private HttpClientPool client;
   private WebSocketClient wsClient;
 
   protected void tearDown() throws Exception {
@@ -635,12 +635,12 @@ public class MetricsTest extends VertxTestBase {
 
   @Test
   public void testHttpClientName() throws Exception {
-    HttpClient client1 = vertx.createHttpClient();
+    HttpClientPool client1 = vertx.createHttpClient();
     try {
       FakeHttpClientMetrics metrics1 = FakeMetricsBase.getMetrics(client1);
       assertEquals("", metrics1.getName());
       String name = TestUtils.randomAlphaString(10);
-      HttpClient client2 = vertx.createHttpClient(new HttpClientOptions().setMetricsName(name));
+      HttpClientPool client2 = vertx.createHttpClient(new HttpClientOptions().setMetricsName(name));
       try {
         FakeHttpClientMetrics metrics2 = FakeMetricsBase.getMetrics(client2);
         assertEquals(name, metrics2.getName());

--- a/src/test/java/io/vertx/test/proxy/HttpProxy.java
+++ b/src/test/java/io/vertx/test/proxy/HttpProxy.java
@@ -53,7 +53,7 @@ public class HttpProxy extends TestProxyBase<HttpProxy> {
   private static final Logger log = LoggerFactory.getLogger(HttpProxy.class);
 
   private HttpServer server;
-  private Map<HttpConnection, HttpClient> clientMap = new ConcurrentHashMap<>();
+  private Map<HttpConnection, HttpClientPool> clientMap = new ConcurrentHashMap<>();
 
   private int error = 0;
 
@@ -145,7 +145,7 @@ public class HttpProxy extends TestProxyBase<HttpProxy> {
         RequestOptions opts = new RequestOptions();
         opts.setAbsoluteURI(uri);
         HttpConnection serverConn = request.connection();
-        HttpClient client = clientMap.get(serverConn);
+        HttpClientPool client = clientMap.get(serverConn);
         if (client == null) {
           client = vertx.createHttpClient(new PoolOptions().setHttp1MaxSize(1));
           client.connectionHandler(conn -> localAddresses.add(conn.localAddress().toString()));

--- a/src/test/java/io/vertx/test/proxy/HttpProxy.java
+++ b/src/test/java/io/vertx/test/proxy/HttpProxy.java
@@ -147,7 +147,7 @@ public class HttpProxy extends TestProxyBase<HttpProxy> {
         HttpConnection serverConn = request.connection();
         HttpClient client = clientMap.get(serverConn);
         if (client == null) {
-          client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(1));
+          client = vertx.createHttpClient(new PoolOptions().setHttp1MaxSize(1));
           client.connectionHandler(conn -> localAddresses.add(conn.localAddress().toString()));
           clientMap.put(serverConn, client);
           serverConn.closeHandler(v -> clientMap.remove(serverConn));


### PR DESCRIPTION
A set of improvements and removal for HTTP client

## Goals

### Goal 1

The `HttpClient` interface aims in Vert.x 5 to contains only HTTP interactions related methods, unfortunately this interface contains other methods which need to be deprecated and exposed in a more suitable API

- pool related methods such as `redirectHandler`, `updateSSLOptions` and `connectionHandler`, these methods actually act on the pool of the `HttpClient` : it has been chosen to deprecate these methods and expose them in a new `HttpClientPool` interface (which extends `HttpClient`).
- WebSocket methods are moved to a new `WebSocketClient`, actually the `HttpClient` has currently two connection manager: HTTP connection manager and WebSocket connection manager. `WebSocketClient` only holds the WebSocket connection manager without the extra burden of the HTTP connection manager.

In Vert.x 5 we want to have the opportunity to map an existing connection to an `HttpClient` interface:

```java
// Speculative API
pool.getConnection(conn -> {
  // An HTTP client connection could be an HttpClient API
  HttpClient client = conn;

  // Schedule a request on this particular connection
  // which might be HTTP/1 (queued) or HTTP/2 (multiplexed)
  Future<Buffer> fut = client.request(HttpMethod.GET, "/requestUri", request -> request.send().compose(resp -> resp.body));
});

```

### Goal 2

Prepare for address resolver (Vert.x 5 feature), the resolver only makes sense for HTTP services and not WebSocket. The split between HTTP and WebSocket makes the API more consistent with this respect and does prevent the expectation that the resolver will act on WebSocket.

```java
// Instead of using a SocketAddress we use instead another kind of Address
// Address has been introduced in Vert.x 5 to extends address resolution beyond DNS hostname resolution
Address address = ServiceAddress.create("quote-of-the-day-service");

// Use an HTTP client capable of resolving address to the actual endpoint
Future<HttpClientRequest> request = client.request(address, HttpMethod.GET, "/quote");
```

### Goal 3

Provide a non racy API for connecting WebSocket from a non vertx thread.

## Changes

### WebSocketClient

A new `WebSocketClient` replaces the `HttpClient#webSocket` methods

```java
// Before
HttpClient httpClient = vertx.createHttpClient();
Future<WebSocket> fut2 = httpClient.webSocket(connectOptions);

// After
WebSocketClient wsClient = vertx.createWebSocketClient();
Future<WebSocket> fut2 = wsClient.connect(connectOptions);
```

### HttpClientPool

A new `HttpClientPool` extends `HttpClient` and exposes connection related methods

- `redirectHandler`
- `connectionHandler`
- `updateSSLOptions`

Corresponding methods in `HttpClientOptions` are deprecated in Vert.x 4 and removed in Vert.x 5

```java
// Existing code in Vert.x 4, nothing wrong here
HttpClient client = vertx.createHttpClient();

// However this should not be done anymore because this assumes we are dealing with a pool
// it would not make sense with an existing connection
// this should be avoided in Vert.x 4 and certainly breaks with Vert.x 5 that removed these methods
client.connectionHandler(conn -> ...); 
client.updateSSLOptions(newSSLOptions);

// Actually now createHttpClient() returns an HttpClientPool
// HttpClientPool extends HttpClient 
// In Vert.x 4 this interface overrides the deprecated methods and remove the deprecation
// In Vert.x 5 this interface defines these methods since they are removed from HttpClient

// So the bottom line is to change your code to use HttpClientPool if you need to use such interfaces
// otherwise you can continue using HttpClient instead
HttpClientPool client = vertx.createHttpClient();

// And it makes sense to have the opportunity to handle connection when using a pool
client.connectionHandler(conn -> ...);

// Same for updating SSL options
client.updateSSLOptions(newSSLOptions);
```

### ClientWebSocket

A new `ClientWebSocket` allows to create a WebSocket in a un-connected state with explicit `connect` methods.

This allows to set handlers before connecting which is useful when connecting WebSocket from a non Vert.x thread.

```java
client
  .webSocket()
  .textMessageHandler(msg -> ...)
  .connect(connectOptions);
```

