### PR TITLE
NetSocket upgrade with options

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
@@ -19,6 +19,7 @@ import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.StreamResetException;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.streams.ReadStream;
@@ -244,12 +245,12 @@ class HttpNetSocket implements NetSocket {
   }
 
   @Override
-  public Future<Void> upgradeToSsl() {
+  public Future<Void> upgradeToSsl(String serverName) {
     return Future.failedFuture("Cannot upgrade stream to SSL");
   }
 
   @Override
-  public Future<Void> upgradeToSsl(String serverName) {
+  public Future<Void> upgradeToSsl(SSLOptions sslOptions, String serverName) {
     return Future.failedFuture("Cannot upgrade stream to SSL");
   }
 

--- a/src/main/java/io/vertx/core/net/ConnectOptions.java
+++ b/src/main/java/io/vertx/core/net/ConnectOptions.java
@@ -27,7 +27,7 @@ public class ConnectOptions {
   public static final boolean DEFAULT_SSL = false;
 
   private String host;
-  private int port;
+  private Integer port;
   private String sniServerName;
   private SocketAddress remoteAddress;
   private ProxyOptions proxyOptions;
@@ -39,7 +39,7 @@ public class ConnectOptions {
     */
   public ConnectOptions() {
     host = null;
-    port = 0;
+    port = null;
     sniServerName = null;
     remoteAddress = null;
     proxyOptions = null;
@@ -202,10 +202,12 @@ public class ConnectOptions {
    * Set the SSL options to use.
    * <p>
    * When none is provided, the {@link NetClientOptions} SSL options will be used instead.
-   * @param sslOptions the SSL optiosn to use
+   * @param sslOptions the SSL options to use
+   * @return a reference to this, so the API can be used fluently
    */
-  public void setSslOptions(ClientSSLOptions sslOptions) {
+  public ConnectOptions setSslOptions(ClientSSLOptions sslOptions) {
     this.sslOptions = sslOptions;
+    return this;
   }
 
    /**

--- a/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/src/main/java/io/vertx/core/net/NetSocket.java
@@ -194,7 +194,9 @@ public interface NetSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
    *
    * @return a future completed when the connection has been upgraded to SSL
    */
-  Future<Void> upgradeToSsl();
+  default Future<Void> upgradeToSsl() {
+    return upgradeToSsl((String) null);
+  }
 
   /**
    * Upgrade channel to use SSL/TLS. Be aware that for this to work SSL must be configured.
@@ -203,6 +205,25 @@ public interface NetSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
    * @return a future completed when the connection has been upgraded to SSL
    */
   Future<Void> upgradeToSsl(String serverName);
+
+  /**
+   * Upgrade channel to use SSL/TLS. Be aware that for this to work SSL must be configured.
+   *
+   * @param sslOptions the SSL options
+   * @param serverName the server name
+   * @return a future completed when the connection has been upgraded to SSL
+   */
+  Future<Void> upgradeToSsl(SSLOptions sslOptions, String serverName);
+
+  /**
+   * Upgrade channel to use SSL/TLS. Be aware that for this to work SSL must be configured.
+   *
+   * @param sslOptions the SSL options
+   * @return a future completed when the connection has been upgraded to SSL
+   */
+  default Future<Void> upgradeToSsl(SSLOptions sslOptions) {
+    return upgradeToSsl(sslOptions, null);
+  }
 
   /**
    * @return true if this {@link io.vertx.core.net.NetSocket} is encrypted via SSL/TLS.

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -265,7 +265,7 @@ class NetClientImpl implements NetClientInternal {
           }
         });
       } else {
-        connectInternal2(connectOptions, null, null, registerWriteHandlers, connectHandler, context, remainingAttempts);
+        connectInternal2(connectOptions, connectOptions.getSslOptions(), null, registerWriteHandlers, connectHandler, context, remainingAttempts);
       }
     }
   }
@@ -324,6 +324,7 @@ class NetClientImpl implements NetClientInternal {
       SocketAddress peerAddress = peerHost != null && peerPort != null ? SocketAddress.inetSocketAddress(peerPort, peerHost) : null;
       channelProvider.handler(ch -> connected(
         context,
+        sslOptions,
         ch,
         connectHandler,
         captured,
@@ -365,6 +366,7 @@ class NetClientImpl implements NetClientInternal {
   }
 
   private void connected(ContextInternal context,
+                         ClientSSLOptions sslOptions,
                          Channel ch,
                          Promise<NetSocket> connectHandler,
                          SocketAddress remoteAddress,


### PR DESCRIPTION
Make sure to use the correct options when upgrading a NetSocket, in addition we can now provide an SSL upgrade with a specified SSLOptions instead of using the client/connect options if desired.
