### PR TITLE
Fix worker verticle using named worker pool regression

### DIFF
--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -306,9 +306,6 @@ public class DeploymentManager {
         status = ST_UNDEPLOYING;
         return doUndeployChildren(undeployingContext).compose(v -> doUndeploy(undeployingContext));
       } else {
-        if (workerPool != null) {
-          workerPool.close();
-        }
         status = ST_UNDEPLOYED;
         List<Future<?>> undeployFutures = new ArrayList<>();
         if (parent != null) {
@@ -340,6 +337,9 @@ public class DeploymentManager {
         Promise<Void> resolvingPromise = undeployingContext.promise();
         Future.all(undeployFutures).<Void>mapEmpty().onComplete(resolvingPromise);
         Future<Void> fut = resolvingPromise.future();
+        if (workerPool != null) {
+          fut = fut.andThen(ar -> workerPool.close());
+        }
         Handler<Void> handler = undeployHandler;
         if (handler != null) {
           undeployHandler = null;


### PR DESCRIPTION
The recent changes in worker pool affected worker verticles with a regression: the named verticle worker pool is closed before undeploying the verticle which leads to have the worker verticle undeployment fail when the worker pool is used only by this verticle.

Close the worker pool after the verticle has been deployed instead of before.
