### PR TITLE
HTTP client builder API

### DIFF
--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -805,7 +805,7 @@ You can configure compressors according to your needs
 
 === Creating an HTTP client
 
-You create an {@link io.vertx.core.http.HttpClientPool} instance with default options as follows:
+You create an {@link io.vertx.core.http.HttpClient} instance with default options as follows:
 
 [source,$lang]
 ----
@@ -880,6 +880,23 @@ For debugging purposes, network activity can be logged.
 ----
 
 See the chapter on <<logging_network_activity, logging network activity>> for a detailed explanation.
+
+=== Advanced HTTP client creation
+
+You can pass options {@link io.vertx.core.Vertx#createHttpClient} methods to configure the HTTP client.
+
+Alternatively you can build a client with the builder {@link io.vertx.core.http.HttpClientBuilder API} :
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#exampleClientBuilder01}
+----
+
+In addition to {@link io.vertx.core.http.HttpClientOptions} and {@link io.vertx.core.http.PoolOptions}, you
+can set
+
+- a connection event handler notified when the client <<_client_connections,connects>> to a server
+- a redirection handler to implement an alternative HTTP <<_30x_redirection_handling,redirect>> behavior
 
 === Making requests
 
@@ -1527,7 +1544,7 @@ The {@link io.vertx.core.http.HttpClientRequest#connection()} method returns the
 {@link examples.HTTP2Examples#example18}
 ----
 
-A connection handler can be set on the client to be notified when a connection has been established happens:
+A connection handler can be set on a client builder to be notified when a connection has been established happens:
 
 [source,$lang]
 ----

--- a/src/main/java/examples/HTTP2Examples.java
+++ b/src/main/java/examples/HTTP2Examples.java
@@ -209,10 +209,14 @@ public class HTTP2Examples {
     HttpConnection connection = request.connection();
   }
 
-  public void example19(HttpClientPool client) {
-    client.connectionHandler(connection -> {
-      System.out.println("Connected to the server");
-    });
+  public void example19(Vertx vertx, HttpClientOptions options) {
+    vertx
+      .httpClientBuilder()
+      .with(options)
+      .withConnectHandler(connection -> {
+        System.out.println("Connected to the server");
+      })
+      .build();
   }
 
   public void example20(HttpConnection connection) {

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -339,6 +339,14 @@ public class HTTPExamples {
     HttpClient client = vertx.createHttpClient(options);
   }
 
+  public void exampleClientBuilder01(Vertx vertx, HttpClientOptions options) {
+    // Pretty much like vertx.createHttpClient(options)
+    HttpClient build = vertx
+      .httpClientBuilder()
+      .with(options)
+      .build();
+  }
+
   public void example30(HttpClient client) {
     client
       .request(HttpMethod.GET, 8080, "myserver.mycompany.com", "/some-uri")
@@ -804,23 +812,24 @@ public class HTTPExamples {
     throw new UnsupportedOperationException();
   }
 
-  public void exampleFollowRedirect03(HttpClientPool client) {
+  public void exampleFollowRedirect03(Vertx vertx) {
+    HttpClient client = vertx.httpClientBuilder()
+      .withRedirectHandler(response -> {
 
-    client.redirectHandler(response -> {
+        // Only follow 301 code
+        if (response.statusCode() == 301 && response.getHeader("Location") != null) {
 
-      // Only follow 301 code
-      if (response.statusCode() == 301 && response.getHeader("Location") != null) {
+          // Compute the redirect URI
+          String absoluteURI = resolveURI(response.request().absoluteURI(), response.getHeader("Location"));
 
-        // Compute the redirect URI
-        String absoluteURI = resolveURI(response.request().absoluteURI(), response.getHeader("Location"));
+          // Create a new ready to use request that the client will use
+          return Future.succeededFuture(new RequestOptions().setAbsoluteURI(absoluteURI));
+        }
 
-        // Create a new ready to use request that the client will use
-        return Future.succeededFuture(new RequestOptions().setAbsoluteURI(absoluteURI));
-      }
-
-      // We don't redirect
-      return null;
-    });
+        // We don't redirect
+        return null;
+      })
+      .build();
   }
 
   public void example50(HttpClient client) {

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -162,7 +162,6 @@ public interface Vertx extends Measured {
     return createHttpServer(new HttpServerOptions());
   }
 
-
   /**
    * Create a WebSocket client using default options
    *
@@ -181,13 +180,23 @@ public interface Vertx extends Measured {
   WebSocketClient createWebSocketClient(WebSocketClientOptions options);
 
   /**
+   * Provide a builder for {@link HttpClient}, it can be used to configure advanced
+   * HTTP client settings like a redirect handler or a connection handler.
+   * <p>
+   * Example usage: {@code HttpClient client = vertx.httpClientBuilder().with(options).withConnectHandler(conn -> ...).build()}
+   */
+  HttpClientBuilder httpClientBuilder();
+
+  /**
    * Create a HTTP/HTTPS client using the specified client and pool options
    *
    * @param clientOptions  the client options to use
    * @param poolOptions  the pool options to use
    * @return the client
    */
-  HttpClientPool createHttpClient(HttpClientOptions clientOptions, PoolOptions poolOptions);
+  default HttpClient createHttpClient(HttpClientOptions clientOptions, PoolOptions poolOptions) {
+    return httpClientBuilder().with(clientOptions).with(poolOptions).build();
+  }
 
   /**
    * Create a HTTP/HTTPS client using the specified client options
@@ -195,7 +204,7 @@ public interface Vertx extends Measured {
    * @param clientOptions  the options to use
    * @return the client
    */
-  default HttpClientPool createHttpClient(HttpClientOptions clientOptions) {
+  default HttpClient createHttpClient(HttpClientOptions clientOptions) {
     return createHttpClient(clientOptions, new PoolOptions());
   }
 
@@ -205,7 +214,7 @@ public interface Vertx extends Measured {
    * @param poolOptions  the pool options to use
    * @return the client
    */
-  default HttpClientPool createHttpClient(PoolOptions poolOptions) {
+  default HttpClient createHttpClient(PoolOptions poolOptions) {
     return createHttpClient(new HttpClientOptions(), poolOptions);
   }
 
@@ -214,7 +223,7 @@ public interface Vertx extends Measured {
    *
    * @return the client
    */
-  default HttpClientPool createHttpClient() {
+  default HttpClient createHttpClient() {
     return createHttpClient(new HttpClientOptions(), new PoolOptions());
   }
   /**

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -13,6 +13,7 @@ package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
+import io.vertx.core.net.ClientSSLOptions;
 
 import java.util.concurrent.TimeUnit;
 
@@ -45,7 +46,7 @@ import java.util.concurrent.TimeUnit;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
-public interface HttpClient {
+public interface HttpClient extends io.vertx.core.metrics.Measured {
 
   /**
    * Create an HTTP request to send to the server.
@@ -125,4 +126,13 @@ public interface HttpClient {
    */
   Future<Void> shutdown(long timeout, TimeUnit timeUnit);
 
+  /**
+   * Update the client SSL options.
+   *
+   * Update only happens if the SSL options is valid.
+   *
+   * @param options the new SSL options
+   * @return a future signaling the update success
+   */
+  Future<Void> updateSSLOptions(ClientSSLOptions options);
 }

--- a/src/main/java/io/vertx/core/http/HttpClientBuilder.java
+++ b/src/main/java/io/vertx/core/http/HttpClientBuilder.java
@@ -11,27 +11,35 @@
 package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.Fluent;
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.net.ClientSSLOptions;
-import io.vertx.core.net.SSLOptions;
 
 import java.util.function.Function;
 
+/**
+ * A builder for {@link HttpClient}.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
 @VertxGen
-public interface HttpClientPool extends HttpClient, io.vertx.core.metrics.Measured {
+public interface HttpClientBuilder {
 
   /**
-   * Update the client SSL options.
-   *
-   * Update only happens if the SSL options is valid.
-   *
-   * @param options the new SSL options
-   * @return a future signaling the update success
+   * Configure the client options.
+   * @param options the client options
+   * @return a reference to this, so the API can be used fluently
    */
-  Future<Void> updateSSLOptions(ClientSSLOptions options);
+  @Fluent
+  HttpClientBuilder with(HttpClientOptions options);
+
+  /**
+   * Configure the client with the given pool {@code options}.
+   * @param options the pool options
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpClientBuilder with(PoolOptions options);
 
   /**
    * Set a connection handler for the client. This handler is called when a new connection is established.
@@ -39,7 +47,7 @@ public interface HttpClientPool extends HttpClient, io.vertx.core.metrics.Measur
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  HttpClientPool connectionHandler(Handler<HttpConnection> handler);
+  HttpClientBuilder withConnectHandler(Handler<HttpConnection> handler);
 
   /**
    * Set a redirect handler for the http client.
@@ -61,12 +69,12 @@ public interface HttpClientPool extends HttpClient, io.vertx.core.metrics.Measur
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  HttpClientPool redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler);
+  HttpClientBuilder withRedirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler);
 
   /**
-   * @return the current redirect handler.
+   * Build and return the client.
+   * @return the client as configured by this builder
    */
-  @GenIgnore
-  Function<HttpClientResponse, Future<RequestOptions>> redirectHandler();
+  HttpClient build();
 
 }

--- a/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -10,10 +10,7 @@
  */
 package io.vertx.core.http.impl;
 
-import io.vertx.codegen.annotations.Fluent;
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.http.*;
 import io.vertx.core.impl.VertxInternal;
@@ -26,7 +23,6 @@ import io.vertx.core.spi.resolver.AddressResolver;
 import java.lang.ref.Cleaner;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * A lightweight proxy of Vert.x {@link HttpClient} that can be collected by the garbage collector and release
@@ -68,24 +64,6 @@ public class CleanableHttpClient implements HttpClientInternal {
   @Override
   public Future<Void> updateSSLOptions(ClientSSLOptions options) {
     return delegate.updateSSLOptions(options);
-  }
-
-  @Override
-  @Fluent
-  public HttpClientPool connectionHandler(Handler<HttpConnection> handler) {
-    return delegate.connectionHandler(handler);
-  }
-
-  @Override
-  @Fluent
-  public HttpClientPool redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
-    return delegate.redirectHandler(handler);
-  }
-
-  @Override
-  @GenIgnore
-  public Function<HttpClientResponse, Future<RequestOptions>> redirectHandler() {
-    return delegate.redirectHandler();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBuilderImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBuilderImpl.java
@@ -1,0 +1,85 @@
+package io.vertx.core.http.impl;
+
+
+import io.vertx.core.Closeable;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.http.*;
+import io.vertx.core.impl.CloseFuture;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.VertxInternal;
+
+import java.util.function.Function;
+
+public class HttpClientBuilderImpl implements HttpClientBuilder {
+
+  private final VertxInternal vertx;
+  private HttpClientOptions clientOptions;
+  private PoolOptions poolOptions;
+  private Handler<HttpConnection> connectHandler;
+  private Function<HttpClientResponse, Future<RequestOptions>> redirectHandler;
+
+  public HttpClientBuilderImpl(VertxInternal vertx) {
+    this.vertx = vertx;
+  }
+
+  @Override
+  public HttpClientBuilder with(HttpClientOptions options) {
+    this.clientOptions = options;
+    return this;
+  }
+
+  @Override
+  public HttpClientBuilder with(PoolOptions options) {
+    this.poolOptions = options;
+    return this;
+  }
+
+  @Override
+  public HttpClientBuilder withConnectHandler(Handler<HttpConnection> handler) {
+    this.connectHandler = handler;
+    return this;
+  }
+
+  @Override
+  public HttpClientBuilder withRedirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
+    this.redirectHandler = handler;
+    return this;
+  }
+
+  private CloseFuture resolveCloseFuture() {
+    ContextInternal context = vertx.getContext();
+    return context != null ? context.closeFuture() : vertx.closeFuture();
+  }
+
+  @Override
+  public HttpClient build() {
+    HttpClientOptions co = clientOptions != null ? clientOptions : new HttpClientOptions();
+    PoolOptions po = poolOptions != null ? poolOptions : new PoolOptions();
+    CloseFuture cf = resolveCloseFuture();
+    HttpClient client;
+    Closeable closeable;
+    if (co.isShared()) {
+      CloseFuture closeFuture = new CloseFuture();
+      client = vertx.createSharedResource("__vertx.shared.httpClients", co.getName(), closeFuture, cf_ -> {
+        HttpClientImpl impl = new HttpClientImpl(vertx, co, po);
+        cf_.add(completion -> impl.close().onComplete(completion));
+        return impl;
+      });
+      client = new CleanableHttpClient((HttpClientInternal) client, vertx.cleaner(), (timeout, timeunit) -> closeFuture.close());
+      closeable = closeFuture;
+    } else {
+      HttpClientImpl impl = new HttpClientImpl(vertx, co, po);
+      closeable = impl;
+      client = new CleanableHttpClient(impl, vertx.cleaner(), impl::shutdown);
+    }
+    cf.add(closeable);
+    if (redirectHandler != null) {
+      ((HttpClientImpl)((CleanableHttpClient)client).delegate).redirectHandler(redirectHandler);
+    }
+    if (connectHandler != null) {
+      ((HttpClientImpl)((CleanableHttpClient)client).delegate).connectionHandler(connectHandler);
+    }
+    return client;
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -216,24 +216,19 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     }
   }
 
-  @Override
-  public HttpClientPool redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
+  public void redirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler) {
     if (handler == null) {
       handler = DEFAULT_HANDLER;
     }
     redirectHandler = handler;
-    return this;
   }
 
-  @Override
   public Function<HttpClientResponse, Future<RequestOptions>> redirectHandler() {
     return redirectHandler;
   }
 
-  @Override
-  public HttpClientPool connectionHandler(Handler<HttpConnection> handler) {
+  public void connectionHandler(Handler<HttpConnection> handler) {
     connectionHandler = handler;
-    return this;
   }
 
   Handler<HttpConnection> connectionHandler() {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientInternal.java
@@ -20,7 +20,7 @@ import io.vertx.core.net.impl.NetClientInternal;
 import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.resolver.AddressResolver;
 
-public interface HttpClientInternal extends HttpClientPool, MetricsProvider, Closeable {
+public interface HttpClientInternal extends HttpClient, MetricsProvider, Closeable {
 
   /**
    * @return the vertx, for use in package related classes only.

--- a/src/main/java/io/vertx/core/impl/VertxInternal.java
+++ b/src/main/java/io/vertx/core/impl/VertxInternal.java
@@ -29,6 +29,7 @@ import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
 
 import java.io.File;
+import java.lang.ref.Cleaner;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Map;
@@ -89,6 +90,8 @@ public interface VertxInternal extends Vertx {
   VertxMetrics metricsSPI();
 
   Transport transport();
+
+  Cleaner cleaner();
 
   default <C> C createSharedResource(String resourceKey, String resourceName, CloseFuture closeFuture, Function<CloseFuture, C> supplier) {
     return SharedResourceHolder.createSharedResource(this, resourceKey, resourceName, closeFuture, supplier);

--- a/src/main/java/io/vertx/core/impl/VertxWrapper.java
+++ b/src/main/java/io/vertx/core/impl/VertxWrapper.java
@@ -17,7 +17,6 @@ import io.vertx.core.Closeable;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
 import io.vertx.core.datagram.DatagramSocket;
@@ -46,6 +45,7 @@ import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
 
 import java.io.File;
+import java.lang.ref.Cleaner;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Map;
@@ -107,12 +107,12 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public HttpClientPool createHttpClient(HttpClientOptions options) {
+  public HttpClient createHttpClient(HttpClientOptions options) {
     return delegate.createHttpClient(options);
   }
 
   @Override
-  public HttpClientPool createHttpClient() {
+  public HttpClient createHttpClient() {
     return delegate.createHttpClient();
   }
 
@@ -344,6 +344,11 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public Transport transport() {
     return delegate.transport();
+  }
+
+  @Override
+  public Cleaner cleaner() {
+    return delegate.cleaner();
   }
 
   @Override

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -2650,7 +2650,11 @@ public class Http2ServerTest extends Http2TestBase {
 
   private void doRequest(HttpMethod method, Buffer expected, Handler<HttpConnection> connHandler, Promise<HttpClientResponse> fut) {
     if (connHandler != null) {
-      client.connectionHandler(connHandler);
+      client.close();
+      client = vertx.httpClientBuilder()
+        .with(createBaseClientOptions())
+        .withConnectHandler(connHandler)
+        .build();
     }
     client.request(new RequestOptions(requestOptions).setMethod(method)).onComplete(onSuccess(req -> {
       req

--- a/src/test/java/io/vertx/core/http/Http2TLSTest.java
+++ b/src/test/java/io/vertx/core/http/Http2TLSTest.java
@@ -25,7 +25,7 @@ public class Http2TLSTest extends HttpTLSTest {
   }
 
   @Override
-  HttpClientPool createHttpClient(HttpClientOptions options) {
+  HttpClient createHttpClient(HttpClientOptions options) {
     return vertx.createHttpClient(options.setUseAlpn(true));
   }
 

--- a/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
+++ b/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
@@ -63,10 +63,10 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
   }
 
   private Function<Vertx, HttpServer> serverFactory;
-  private Function<Vertx, HttpClientPool> clientFactory;
+  private Function<Vertx, HttpClient> clientFactory;
 
   public HttpBandwidthLimitingTest(double protoVersion, Function<Vertx, HttpServer> serverFactory,
-                                   Function<Vertx, HttpClientPool> clientFactory) {
+                                   Function<Vertx, HttpClient> clientFactory) {
     this.serverFactory = serverFactory;
     this.clientFactory = clientFactory;
   }

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -1308,7 +1308,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   abstract HttpServer createHttpServer(HttpServerOptions options);
 
-  abstract HttpClientPool createHttpClient(HttpClientOptions options);
+  abstract HttpClient createHttpClient(HttpClientOptions options);
 
   protected TLSTest testTLS(Cert<?> clientCert, Trust<?> clientTrust,
                           Cert<?> serverCert, Trust<?> serverTrust) throws Exception {

--- a/src/test/java/io/vertx/core/http/HttpTestBase.java
+++ b/src/test/java/io/vertx/core/http/HttpTestBase.java
@@ -39,7 +39,7 @@ public class HttpTestBase extends VertxTestBase {
   public static final String DEFAULT_TEST_URI = "some-uri";
 
   protected HttpServer server;
-  protected HttpClientPool client;
+  protected HttpClient client;
   protected TestProxyBase proxy;
   protected SocketAddress testAddress;
   protected RequestOptions requestOptions;

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
@@ -149,21 +149,22 @@ public class MetricsContextTest extends VertxTestBase {
       }));
     });
     awaitLatch(latch);
-    HttpClientPool client = vertx.createHttpClient();
-    client.connectionHandler(conn -> {
-      conn.closeHandler(v -> {
-        vertx.close().onComplete(v4 -> {
-          assertTrue(requestBeginCalled.get());
-          assertTrue(responseEndCalled.get());
-          assertTrue(bytesReadCalled.get());
-          assertTrue(bytesWrittenCalled.get());
-          assertTrue(socketConnectedCalled.get());
-          assertTrue(socketDisconnectedCalled.get());
-          assertTrue(closeCalled.get());
-          complete();
+    HttpClient client = vertx.httpClientBuilder()
+      .withConnectHandler(conn -> {
+        conn.closeHandler(v -> {
+          vertx.close().onComplete(v4 -> {
+            assertTrue(requestBeginCalled.get());
+            assertTrue(responseEndCalled.get());
+            assertTrue(bytesReadCalled.get());
+            assertTrue(bytesWrittenCalled.get());
+            assertTrue(socketConnectedCalled.get());
+            assertTrue(socketDisconnectedCalled.get());
+            assertTrue(closeCalled.get());
+            complete();
+          });
         });
-      });
-    });
+      })
+      .build();
     client.request(HttpMethod.PUT, 8080, "localhost", "/")
       .compose(req -> req.send(Buffer.buffer("hello"))
         .onComplete(onSuccess(resp -> {

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -56,7 +56,7 @@ public class MetricsTest extends VertxTestBase {
   private static final String ADDRESS1 = "some-address1";
 
   private HttpServer server;
-  private HttpClientPool client;
+  private HttpClient client;
   private WebSocketClient wsClient;
 
   protected void tearDown() throws Exception {
@@ -635,12 +635,12 @@ public class MetricsTest extends VertxTestBase {
 
   @Test
   public void testHttpClientName() throws Exception {
-    HttpClientPool client1 = vertx.createHttpClient();
+    HttpClient client1 = vertx.createHttpClient();
     try {
       FakeHttpClientMetrics metrics1 = FakeMetricsBase.getMetrics(client1);
       assertEquals("", metrics1.getName());
       String name = TestUtils.randomAlphaString(10);
-      HttpClientPool client2 = vertx.createHttpClient(new HttpClientOptions().setMetricsName(name));
+      HttpClient client2 = vertx.createHttpClient(new HttpClientOptions().setMetricsName(name));
       try {
         FakeHttpClientMetrics metrics2 = FakeMetricsBase.getMetrics(client2);
         assertEquals(name, metrics2.getName());


### PR DESCRIPTION
Implement a builder for HttpClient, this will be useful for configuring the address resolver for service discovery.

The builder allows to retrofit the client redirect/connect handlers like done in SQL client.

