### PR TITLE
Address resolver initialisation

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpClientBuilder.java
+++ b/src/main/java/io/vertx/core/http/HttpClientBuilder.java
@@ -15,7 +15,7 @@ import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.net.AddressResolver;
+import io.vertx.core.net.AddressLookup;
 
 import java.util.function.Function;
 
@@ -74,12 +74,12 @@ public interface HttpClientBuilder {
   HttpClientBuilder withRedirectHandler(Function<HttpClientResponse, Future<RequestOptions>> handler);
 
   /**
-   * Configure the client to use an address resolver.
+   * Configure the client to use a specific address lookup.
    *
-   * @param addressResolver the address resolver
+   * @param lookup the address lookup
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  HttpClientBuilder withAddressResolver(AddressResolver addressResolver);
+  HttpClientBuilder withLookup(AddressLookup lookup);
 
   /**
    * Build and return the client.

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -21,7 +21,7 @@ import io.vertx.core.net.*;
 import io.vertx.core.net.impl.pool.*;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
-import io.vertx.core.spi.resolver.AddressResolver;
+import io.vertx.core.spi.lookup.AddressResolver;
 
 import java.lang.ref.WeakReference;
 import java.net.URI;

--- a/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
@@ -22,7 +22,7 @@ import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.StreamPriority;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.spi.resolver.AddressResolver;
+import io.vertx.core.spi.lookup.AddressResolver;
 import io.vertx.core.streams.WriteStream;
 
 /**

--- a/src/main/java/io/vertx/core/net/AddressLookup.java
+++ b/src/main/java/io/vertx/core/net/AddressLookup.java
@@ -10,9 +10,21 @@
  */
 package io.vertx.core.net;
 
+import io.vertx.core.Vertx;
+import io.vertx.core.spi.lookup.AddressResolver;
+
 /**
- * A generic address resolver market interface. Implementation must also implement the SPI interface {@link io.vertx.core.spi.resolver.AddressResolver}
+ * A generic address resolver market interface. Implementation must also implement the SPI interface {@link io.vertx.core.spi.lookup.AddressResolver}
  * and can be cast to this type.
  */
-public interface AddressResolver {
+public interface AddressLookup {
+
+  /**
+   * Return a resolver capable of resolving addresses for a client.
+   *
+   * @param vertx the vertx instance
+   * @return the resolver
+   */
+  AddressResolver<?, ?, ?> resolver(Vertx vertx);
+
 }

--- a/src/main/java/io/vertx/core/net/impl/pool/EndpointResolver.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/EndpointResolver.java
@@ -15,7 +15,7 @@ import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.net.Address;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.spi.resolver.AddressResolver;
+import io.vertx.core.spi.lookup.AddressResolver;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;

--- a/src/main/java/io/vertx/core/spi/lookup/AddressResolver.java
+++ b/src/main/java/io/vertx/core/spi/lookup/AddressResolver.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.core.spi.resolver;
+package io.vertx.core.spi.lookup;
 
 import io.vertx.core.Future;
 import io.vertx.core.net.Address;
@@ -26,7 +26,7 @@ import io.vertx.core.net.SocketAddress;
  * @param <A> the type of {@link Address} resolved
  * @param <M> the type of metrics, implementations can use {@code Void} when metrics are not managed
  */
-public interface AddressResolver<S, A extends Address, M> extends io.vertx.core.net.AddressResolver {
+public interface AddressResolver<S, A extends Address, M> {
 
   /**
    * Try to cast the {@code address} to an address instance that can be resolved by this resolver instance.


### PR DESCRIPTION
The new address resolver implementations must be passed a Vert.x instance, given that most of the time such resolver is used within a client that already references a vertx instance, we can lazy init the resolver and pass it the vertx instance of the client which removes a step in the client configuration and make sure that the vertx instance used by the client and the resolver are the same.
