### PR TITLE
Add missing first class endpoint in address resolver

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientBuilderImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBuilderImpl.java
@@ -70,7 +70,7 @@ public class HttpClientBuilderImpl implements HttpClientBuilder {
     if (co.isShared()) {
       CloseFuture closeFuture = new CloseFuture();
       client = vertx.createSharedResource("__vertx.shared.httpClients", co.getName(), closeFuture, cf_ -> {
-        io.vertx.core.spi.net.AddressResolver<?, ?, ?> resolver = addressResolver != null ? addressResolver.resolver(vertx) : null;
+        io.vertx.core.spi.net.AddressResolver<?, ?, ?, ?> resolver = addressResolver != null ? addressResolver.resolver(vertx) : null;
         HttpClientImpl impl = new HttpClientImpl(vertx, resolver, co, po);
         cf_.add(completion -> impl.close().onComplete(completion));
         return impl;
@@ -78,7 +78,7 @@ public class HttpClientBuilderImpl implements HttpClientBuilder {
       client = new CleanableHttpClient((HttpClientInternal) client, vertx.cleaner(), (timeout, timeunit) -> closeFuture.close());
       closeable = closeFuture;
     } else {
-      io.vertx.core.spi.net.AddressResolver<?, ?, ?> resolver = addressResolver != null ? addressResolver.resolver(vertx) : null;
+      io.vertx.core.spi.net.AddressResolver<?, ?, ?, ?> resolver = addressResolver != null ? addressResolver.resolver(vertx) : null;
       HttpClientImpl impl = new HttpClientImpl(vertx, resolver, co, po);
       closeable = impl;
       client = new CleanableHttpClient(impl, vertx.cleaner(), impl::shutdown);

--- a/src/main/java/io/vertx/core/net/AddressResolver.java
+++ b/src/main/java/io/vertx/core/net/AddressResolver.java
@@ -24,6 +24,6 @@ public interface AddressResolver {
    * @param vertx the vertx instance
    * @return the resolver
    */
-  io.vertx.core.spi.net.AddressResolver<?, ?, ?> resolver(Vertx vertx);
+  io.vertx.core.spi.net.AddressResolver<?, ?, ?, ?> resolver(Vertx vertx);
 
 }

--- a/src/main/java/io/vertx/core/net/impl/pool/ConnectionLookup.java
+++ b/src/main/java/io/vertx/core/net/impl/pool/ConnectionLookup.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net.impl.pool;
+
+import io.vertx.core.spi.net.AddressResolver;
+
+/**
+ * A connection lookup to the endpoint resolver, provides additional information.
+ */
+public class ConnectionLookup<C, E, M> {
+
+  private final AddressResolver<?, ?, M, E> resolver;
+  private final C connection;
+  private final E endpoint;
+  private M metric;
+
+  public ConnectionLookup(C connection, AddressResolver<?, ?, M, E> resolver, E endpoint) {
+    this.connection = connection;
+    this.endpoint = endpoint;
+    this.resolver = resolver;
+  }
+
+  public C connection() {
+    return connection;
+  }
+
+  public void beginRequest() {
+    metric = resolver.requestBegin(endpoint);
+  }
+
+  public void endRequest() {
+    resolver.requestEnd(metric);
+  }
+
+  public void beginResponse() {
+    resolver.responseBegin(metric);
+  }
+
+  public void endResponse() {
+    resolver.responseEnd(metric);
+  }
+}


### PR DESCRIPTION
The address resolver is missing the notion of endpoint which is an intermediary between the resolved address and the socket address the client eventually uses. This forces address resolver implementation to determine which internal endpoint was selected based on the socket address the resolver choose, specially when the client report usage statistics to the resolver.

Introduce endpoint in the address resolver, the resolver now does select an endpoint for which a socket address can be determined, metrics can now use the endpoint type to properly report usage statistics.
