### PR TITLE
Add serialVersionUID to serializable class

### DIFF
--- a/src/main/java/io/vertx/core/impl/future/FutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureImpl.java
@@ -256,6 +256,8 @@ class FutureImpl<T> extends FutureBase<T> {
   }
 
   private static class ListenerArray<T> extends ArrayList<Listener<T>> implements Listener<T> {
+    private static final long serialVersionUID = -5473212942546597080L;
+    
     @Override
     public void onSuccess(T value) {
       for (Listener<T> handler : this) {


### PR DESCRIPTION
##### Motivation:

In file: FutureImpl.java, the class ListenerArray is serializable but it does not contain any serialVersionUID field. The compiler generates one by default in such scenarios, but the generated id is dependent on compiler implementation and may cause unwanted problems during deserialization.

##### The Role of serialVersionUID:

The primary role of serialVersionUID is to provide version control during deserialization. When we deserialize an object, the JVM checks whether the serialVersionUID of the serialized data matches the serialVersionUID of the class in the current classpath. If they match, the deserialization proceeds without issues. However, if they do not match, programmers encounter InvalidClassException.

As, serialVersionUID servers the purpose of version control of class during serialization-deserialization, without a serialVersionUID, we risk breaking backward compatibility when we make changes to our classes, which can lead to unexpected issues and errors during deserialization.

##### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
