### PR TITLE
Fix incorrect handling of empty host portion of the host header

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -137,8 +137,10 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   String query();
 
   /**
-   * @return the request authority. For HTTP2 it returns the {@literal :authority} pseudo header otherwise it returns the {@literal Host} header.
-   *         When the authority string does not carry a port, the {@link HostAndPort#port()} returns {@code -1} to indicate the scheme port is prevalent.
+   * @return the request authority. For HTTP/2 the {@literal :authority} pseudo header is returned, for HTTP/1.x the
+   *         {@literal Host} header is returned or {@code null} when no such header is present. When the authority
+   *         string does not carry a port, the {@link HostAndPort#port()} returns {@code -1} to indicate the
+   *         scheme port is prevalent.
    */
   @Nullable
   HostAndPort authority();

--- a/src/main/java/io/vertx/core/net/impl/HostAndPortImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/HostAndPortImpl.java
@@ -115,9 +115,6 @@ public class HostAndPortImpl implements HostAndPort {
    */
   public static HostAndPortImpl parseHostAndPort(String s, int schemePort) {
     int pos = parseHost(s, 0, s.length());
-    if (pos < 1) {
-      return null;
-    }
     if (pos == s.length()) {
       return new HostAndPortImpl(s, schemePort);
     }

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -15,6 +15,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.TooLongHttpHeaderException;
 import io.vertx.core.*;
 import io.vertx.core.Future;
@@ -5434,5 +5435,46 @@ public class Http1xTest extends HttpTest {
   @Test
   public void testServerResponseChunkedSend() throws Exception {
     testServerResponseSend(true);
+  }
+
+  @Test
+  public void testEmptyHostHeader() throws Exception {
+    testEmptyHostPortionOfHostHeader("", -1);
+  }
+
+  @Test
+  public void testEmptyHostPortionOfHostHeader() throws Exception {
+    testEmptyHostPortionOfHostHeader(":8080", 8080);
+  }
+
+  private void testEmptyHostPortionOfHostHeader(String hostHeader, int expectedPort) throws Exception {
+    server.requestHandler(req -> {
+      assertEquals(hostHeader, req.host());
+      assertEquals("", req.authority().host());
+      assertEquals(expectedPort, req.authority().port());
+      req.response().end();
+    });
+    startServer(testAddress);
+    client.request(new RequestOptions().setServer(testAddress).putHeader(HttpHeaderNames.HOST, hostHeader))
+      .compose(req -> req
+        .send()
+        .compose(HttpClientResponse::body))
+      .onComplete(onSuccess(v -> testComplete()));
+    await();
+  }
+
+  @Test
+  public void testMissingHostHeader() throws Exception {
+    server.requestHandler(req -> {
+      assertEquals(null, req.host());
+      assertEquals(null, req.authority());
+      testComplete();
+    });
+    startServer(testAddress);
+    NetClient nc = vertx.createNetClient();
+    nc.connect(testAddress).onComplete(onSuccess(so -> {
+      so.write("GET / HTTP/1.1\r\n\r\n");
+    }));
+    await();
   }
 }

--- a/src/test/java/io/vertx/core/net/impl/HostAndPortTest.java
+++ b/src/test/java/io/vertx/core/net/impl/HostAndPortTest.java
@@ -57,7 +57,8 @@ public class HostAndPortTest {
     assertHostAndPort("example.com", -1, "example.com");
     assertHostAndPort("0.1.2.3", -1, "0.1.2.3");
     assertHostAndPort("[0::]", -1, "[0::]");
-    assertNull(HostAndPortImpl.parseHostAndPort("", -1));
+    assertHostAndPort("", -1, "");
+    assertHostAndPort("", 8080, ":8080");
     assertNull(HostAndPortImpl.parseHostAndPort("/", -1));
   }
 


### PR DESCRIPTION
Fix a regression with the introduction of HTTP authority handling with HTTP/1.1 in which the server fails when handling an empty host portion of the host header. The authority method can also return null when no host header is present for HTTP/1.x
