### PR TITLE
Fix incorrect handling of empty host portion of the host header

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -136,8 +136,10 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   String query();
 
   /**
-   * @return the request authority. For HTTP2 it returns the {@literal :authority} pseudo header otherwise it returns the {@literal Host} header.
-   *         When the authority string does not carry a port, the {@link HostAndPort#port()} returns {@code -1} to indicate the scheme port is prevalent.
+   * @return the request authority. For HTTP/2 the {@literal :authority} pseudo header is returned, for HTTP/1.x the
+   *         {@literal Host} header is returned or {@code null} when no such header is present. When the authority
+   *         string does not carry a port, the {@link HostAndPort#port()} returns {@code -1} to indicate the
+   *         scheme port is prevalent.
    */
   @Nullable
   HostAndPort authority();

--- a/src/main/java/io/vertx/core/http/impl/EndpointKey.java
+++ b/src/main/java/io/vertx/core/http/impl/EndpointKey.java
@@ -16,7 +16,7 @@ import io.vertx.core.net.SocketAddress;
 
 import java.util.Objects;
 
-class EndpointKey {
+final class EndpointKey {
 
   final boolean ssl;
   final SocketAddress server;
@@ -27,9 +27,6 @@ class EndpointKey {
     if (server == null) {
       throw new NullPointerException("No null server address");
     }
-    if (authority == null) {
-      throw new NullPointerException("No null authority address");
-    }
     this.ssl = ssl;
     this.proxyOptions = proxyOptions;
     this.authority = authority;
@@ -38,17 +35,23 @@ class EndpointKey {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    EndpointKey that = (EndpointKey) o;
-    return ssl == that.ssl && server.equals(that.server) && authority.equals(that.authority) && equals(proxyOptions, that.proxyOptions);
+    if (this == o) {
+      return true;
+    };
+    if (o instanceof EndpointKey) {
+      EndpointKey that = (EndpointKey) o;
+      return ssl == that.ssl && server.equals(that.server) && Objects.equals(authority, that.authority) && equals(proxyOptions, that.proxyOptions);
+    }
+    return false;
   }
 
   @Override
   public int hashCode() {
     int result = ssl ? 1 : 0;
-    result = 31 * result + authority.hashCode();
     result = 31 * result + server.hashCode();
+    if (authority != null) {
+      result = 31 * result + authority.hashCode();
+    }
     if (proxyOptions != null) {
       result = 31 * result + hashCode(proxyOptions);
     }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -66,7 +66,9 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   }
 
   protected String authority() {
-    if ((authority.port() == 80 && !ssl) || (authority.port() == 443 && ssl) || authority.port() < 0) {
+    if (authority == null) {
+      return null;
+    } else if ((authority.port() == 80 && !ssl) || (authority.port() == 443 && ssl) || authority.port() < 0) {
       return authority.host();
     } else {
       return authority.host() + ':' + authority.port();

--- a/src/main/java/io/vertx/core/net/impl/HostAndPortImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/HostAndPortImpl.java
@@ -115,9 +115,6 @@ public class HostAndPortImpl implements HostAndPort {
    */
   public static HostAndPortImpl parseHostAndPort(String s, int schemePort) {
     int pos = parseHost(s, 0, s.length());
-    if (pos < 1) {
-      return null;
-    }
     if (pos == s.length()) {
       return new HostAndPortImpl(s, schemePort);
     }

--- a/src/test/java/io/vertx/core/net/impl/HostAndPortTest.java
+++ b/src/test/java/io/vertx/core/net/impl/HostAndPortTest.java
@@ -57,7 +57,8 @@ public class HostAndPortTest {
     assertHostAndPort("example.com", -1, "example.com");
     assertHostAndPort("0.1.2.3", -1, "0.1.2.3");
     assertHostAndPort("[0::]", -1, "[0::]");
-    assertNull(HostAndPortImpl.parseHostAndPort("", -1));
+    assertHostAndPort("", -1, "");
+    assertHostAndPort("", 8080, ":8080");
     assertNull(HostAndPortImpl.parseHostAndPort("/", -1));
   }
 


### PR DESCRIPTION
Fix a regression with the introduction of HTTP authority handling with HTTP/1.1 in which the server fails when handling an empty host portion of the host header. The authority method can also return null when no host header is present for HTTP/1.x
