### PR TITLE
Add file store name to the FileSystemProps interface

### DIFF
--- a/src/main/java/io/vertx/core/file/FileSystemProps.java
+++ b/src/main/java/io/vertx/core/file/FileSystemProps.java
@@ -23,6 +23,11 @@ import io.vertx.codegen.annotations.VertxGen;
 public interface FileSystemProps {
 
   /**
+   * @return The name of this file store
+   */
+  String name();
+
+  /**
    * @return The total space on the file system, in bytes
    */
   long totalSpace();

--- a/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
@@ -12,10 +12,7 @@
 package io.vertx.core.file.impl;
 
 import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.AsyncFile;
 import io.vertx.core.file.CopyOptions;
@@ -959,7 +956,7 @@ public class FileSystemImpl implements FileSystem {
         try {
           Path target = vertx.resolveFile(path).toPath();
           FileStore fs = Files.getFileStore(target);
-          return new FileSystemPropsImpl(fs.getTotalSpace(), fs.getUnallocatedSpace(), fs.getUsableSpace());
+          return new FileSystemPropsImpl(fs.name(), fs.getTotalSpace(), fs.getUnallocatedSpace(), fs.getUsableSpace());
         } catch (IOException e) {
           throw new FileSystemException(getFileAccessErrorMessage("analyse", path), e);
         }

--- a/src/main/java/io/vertx/core/file/impl/FileSystemPropsImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileSystemPropsImpl.java
@@ -15,14 +15,21 @@ import io.vertx.core.file.FileSystemProps;
 
 public class FileSystemPropsImpl implements FileSystemProps {
 
+  private final String name;
   private final long totalSpace;
   private final long unallocatedSpace;
   private final long usableSpace;
 
-  public FileSystemPropsImpl(long totalSpace, long unallocatedSpace, long usableSpace) {
+  public FileSystemPropsImpl(String name, long totalSpace, long unallocatedSpace, long usableSpace) {
+    this.name = name;
     this.totalSpace = totalSpace;
     this.unallocatedSpace = unallocatedSpace;
     this.usableSpace = usableSpace;
+  }
+
+  @Override
+  public String name() {
+    return name;
   }
 
   @Override

--- a/src/test/java/io/vertx/core/file/FileSystemTest.java
+++ b/src/test/java/io/vertx/core/file/FileSystemTest.java
@@ -1603,6 +1603,7 @@ public class FileSystemTest extends VertxTestBase {
     String fileName = "some-file.txt";
     createFileWithJunk(fileName, 1234);
     testFSProps(fileName, props -> {
+      assertNotNull(props.name());
       assertTrue(props.totalSpace() > 0);
       assertTrue(props.unallocatedSpace() > 0);
       assertTrue(props.usableSpace() > 0);


### PR DESCRIPTION
Motivation:

The file store name is part of the `java.nio.file.FileStore` object which is used to build the `io.vertx.core.file.impl.FileSystemPropsImpl` object. However, the name is not defined as part of the `io.vertx.core.file.FileSystemProps` interface.

This piece of information is important including when logging information about the `io.vertx.core.file.FileSystemProps` concrete object when consuming it through `vertx.fileSystem().fsProps()` calls.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
