### PR TITLE
HTTP server should not close a WebSocket when the connection is not persistent

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -142,7 +142,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
 
   public void handleMessage(Object msg) {
     assert msg != null;
-    if (requestInProgress == null && !keepAlive) {
+    if (requestInProgress == null && !keepAlive && webSocket == null) {
       // Discard message
       return;
     }
@@ -255,7 +255,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
             handleNext(next);
           }
         } else {
-          if (requestInProgress == request) {
+          if (requestInProgress == request || webSocket != null) {
             // Deferred
           } else {
             flushAndClose();


### PR DESCRIPTION
The Vert.x HTTP server does not handle anymore WebSocket upgrades when the client presents a request with a connection header containing a close header (like nginx can send) and instead close the connection.

The server now will not close the connection when it is not persistent in case of a WebSocket upgrade.