### PR TITLE
HTTP server should not close a WebSocket when the connection is not persistent

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -183,15 +183,17 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   }
 
   /**
-   * @return a raw {@code NetSocket} - for internal use
+   * @return a raw {@code NetSocket} - for internal use - must be called from event-loop
    */
   public NetSocketInternal toNetSocket() {
-    removeChannelHandlers();
-    NetSocketImpl socket = new NetSocketImpl(context, chctx, null, metrics(), false);
-    socket.metric(metric());
     evictionHandler.handle(null);
-    chctx.pipeline().replace("handler", "handler", VertxHandler.create(ctx -> socket));
-    return socket;
+    chctx.pipeline().replace("handler", "handler", VertxHandler.create(ctx -> {
+      NetSocketImpl socket = new NetSocketImpl(context, ctx, null, metrics(), false);
+      socket.metric(metric());
+      return socket;
+    }));
+    VertxHandler<NetSocketImpl> handler = (VertxHandler<NetSocketImpl>) chctx.pipeline().get(VertxHandler.class);
+    return handler.getConnection();
   }
 
   private HttpRequest createRequest(

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -150,7 +150,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
 
   public void handleMessage(Object msg) {
     assert msg != null;
-    if (requestInProgress == null && !keepAlive) {
+    if (requestInProgress == null && !keepAlive && webSocket == null) {
       // Discard message
       return;
     }
@@ -247,7 +247,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
             handleNext(next);
           }
         } else {
-          if (requestInProgress == request) {
+          if (requestInProgress == request || webSocket != null) {
             // Deferred
           } else {
             flushAndClose();

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -12,11 +12,9 @@
 package io.vertx.core.http;
 
 
+import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
-import io.netty.handler.codec.http.websocketx.WebSocket13FrameDecoder;
-import io.netty.handler.codec.http.websocketx.WebSocket13FrameEncoder;
-import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
+import io.netty.handler.codec.http.websocketx.*;
 import io.netty.util.ReferenceCountUtil;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
@@ -2953,6 +2951,44 @@ public class WebSocketTest extends VertxTestBase {
   }
 
   @Test
+  public void testServerWebSocketHandshakeWithNonPersistentConnection() {
+    server = vertx.createHttpServer();
+    server.webSocketHandler(ws -> {
+      ws.frameHandler(frame -> {
+        ws.close();
+      });
+    });
+    server.listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, onSuccess(v1 -> {
+      handshake(vertx.createHttpClient(), req -> {
+        MultiMap headers = req.headers();
+        headers.add("Connection", "close");
+        req.send(onSuccess(resp -> {
+          assertEquals(101, resp.statusCode());
+          resp.endHandler(v -> {
+            Http1xClientConnection conn = (Http1xClientConnection) req.connection();
+            NetSocketInternal soi = conn.toNetSocket();
+            soi.messageHandler(msg -> {
+              if (msg instanceof CloseWebSocketFrame) {
+                soi.close();
+              }
+            });
+            ChannelPipeline pipeline = soi.channelHandlerContext().pipeline();
+            pipeline.addBefore("handler", "encoder", new WebSocket13FrameEncoder(true));
+            pipeline.addBefore("handler", "decoder", new WebSocket13FrameDecoder(false, false, 1000));
+            pipeline.remove("codec");
+            soi.writeMessage(new PingWebSocketFrame()).onComplete(onSuccess(written -> {
+            }));
+            soi.closeHandler(v2 -> {
+              testComplete();
+            });
+          });
+        }));
+      });
+    }));
+    await();
+  }
+
+  @Test
   public void testServerCloseHandshake() {
     short status = (short)(4000 + TestUtils.randomPositiveInt() % 100);
     waitFor(2);
@@ -2970,8 +3006,10 @@ public class WebSocketTest extends VertxTestBase {
           assertEquals(101, resp.statusCode());
           Http1xClientConnection conn = (Http1xClientConnection) req.connection();
           NetSocketInternal soi = conn.toNetSocket();
-          soi.channelHandlerContext().pipeline().addBefore("handler", "encoder", new WebSocket13FrameEncoder(true));
-          soi.channelHandlerContext().pipeline().addBefore("handler", "decoder", new WebSocket13FrameDecoder(false, false, 1000));
+          ChannelPipeline pipeline = soi.channelHandlerContext().pipeline();
+          pipeline.addBefore("handler", "encoder", new WebSocket13FrameEncoder(true));
+          pipeline.addBefore("handler", "decoder", new WebSocket13FrameDecoder(false, false, 1000));
+          pipeline.remove("codec");
           String reason = randomAlphaString(10);
           soi.writeMessage(new CloseWebSocketFrame(status, reason));
           AtomicBoolean closeFrameReceived = new AtomicBoolean();


### PR DESCRIPTION
The Vert.x HTTP server does not handle anymore WebSocket upgrades when the client presents a request with a connection header containing a close header (like nginx can send) and instead close the connection.

The server now will not close the connection when it is not persistent in case of a WebSocket upgrade.