### PR TITLE
[4.4.x] Ensure that the task is not in the tasks queue when it is rejected from the executor

### DIFF
--- a/src/test/java/io/vertx/core/impl/TaskQueueTest.java
+++ b/src/test/java/io/vertx/core/impl/TaskQueueTest.java
@@ -1,0 +1,34 @@
+package io.vertx.core.impl;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author Alexander Schwartz
+ */
+public class TaskQueueTest {
+
+  Executor executorThatAlwaysThrowsRejectedExceptions = new Executor() {
+    @Override
+    public void execute(Runnable command) {
+      throw new RejectedExecutionException();
+    }
+  };
+
+  TaskQueue taskQueue = new TaskQueue();
+
+  @Test
+  public void shouldNotHaveTaskInQueueWhenTaskHasBeenRejected() {
+    assertThatThrownBy(
+      () -> taskQueue.execute(new Thread(), executorThatAlwaysThrowsRejectedExceptions)
+    ).isInstanceOf(RejectedExecutionException.class);
+
+    Assertions.assertThat(taskQueue.isEmpty()).isTrue();
+  }
+
+}


### PR DESCRIPTION
Closes #4900

This is backport of the PR #4904 as the Keycloak project and Quarkus' LTS 3.2 are still on Vert.x 4.4.x. 

It would be great if this could could eventually make it into a 4.4.x release. Not sure when and if the Quarkus team would upgrade, I will need to check that separately.

@vietj - I'd be happy if you could have a  look as you've reviewed the original PRs. Thanks!