### PR TITLE
Add a Future#await() instance method

### DIFF
--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -611,26 +611,35 @@ public interface Future<T> extends AsyncResult<T> {
    *
    * This method must be called from a virtual thread.
    *
-   * @param future the future to await
    * @return the result
    * @throws IllegalStateException when called from an event-loop thread or a non Vert.x thread
    */
-  static <T> T await(Future<T> future) {
+  default T await() {
     io.vertx.core.impl.WorkerExecutor executor = io.vertx.core.impl.WorkerExecutor.unwrapWorkerExecutor();
     io.vertx.core.impl.WorkerExecutor.TaskController cont = executor.current();
-    future.onComplete(ar -> cont.resume());
+    onComplete(ar -> cont.resume());
     try {
       cont.suspendAndAwaitResume();
     } catch (InterruptedException e) {
       Utils.throwAsUnchecked(e.getCause());
       return null;
     }
-    if (future.succeeded()) {
-      return future.result();
+    if (succeeded()) {
+      return result();
     } else {
-      Utils.throwAsUnchecked(future.cause());
+      Utils.throwAsUnchecked(cause());
       return null;
     }
   }
 
+  /**
+   * Calls {@link #await()} on {@code future}.
+   *
+   * @param future the future to await
+   * @return the result
+   * @throws IllegalStateException when called from an event-loop thread or a non Vert.x thread
+   */
+  static <T> T await(Future<T> future) {
+    return future.await();
+  }
 }

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -1013,7 +1013,7 @@ public class ContextTest extends VertxTestBase {
         Promise<String> promise = Promise.promise();
         vertx.setTimer(10, id -> promise.complete("foo"));
         try {
-          String res = Future.await(promise.future());
+          String res = promise.future().await();
           assertFalse(fail);
           assertEquals("foo", res);
         } catch (IllegalStateException e) {

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -1733,7 +1733,7 @@ public class FutureTest extends FutureTestBase {
   @Test
   public void testAwaitFromPlainThread() {
     try {
-      Future.await(Promise.promise().future());
+      Promise.promise().future().await();
       fail();
     } catch (IllegalStateException e) {
     }

--- a/src/test/java/io/vertx/core/VirtualThreadContextTest.java
+++ b/src/test/java/io/vertx/core/VirtualThreadContextTest.java
@@ -66,7 +66,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
         }
         promise.complete(result);
       }).start();
-      assertSame(result, Future.await(promise.future()));
+      assertSame(result, promise.future().await());
       testComplete();
     });
     await();
@@ -87,7 +87,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
         promise.fail(failure);
       }).start();
       try {
-        Future.await(promise.future());
+        promise.future().await();
       } catch (Exception e) {
         assertSame(failure, e);
         testComplete();
@@ -112,7 +112,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
         }
         promise.complete(result);
       }).start();
-      assertSame("HELLO", Future.await(promise.future().map(res -> "HELLO")));
+      assertSame("HELLO", promise.future().map(res -> "HELLO").await());
       testComplete();
     });
     await();
@@ -163,7 +163,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
             });
           }
           Future<Void> f = promise.future();
-          Future.await(f);
+          f.await();
           complete();
         });
       }
@@ -180,7 +180,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
       vertx.setTimer(100, id -> {
         promise.complete("foo");
       });
-      String res = Future.await(promise);
+      String res = promise.await();
       assertEquals("foo", res);
       testComplete();
     });

--- a/src/test/java/io/vertx/core/VirtualThreadDeploymentTest.java
+++ b/src/test/java/io/vertx/core/VirtualThreadDeploymentTest.java
@@ -61,7 +61,7 @@ public class VirtualThreadDeploymentTest extends VertxTestBase {
       public void start() {
         assertTrue(isVirtual(Thread.currentThread()));
         Future<Void> fut = Future.future(p -> vertx.setTimer(500, id -> p.complete()));
-        Future.await(fut);
+        fut.await();
         testComplete();
       }
     }, new DeploymentOptions().setThreadingModel(ThreadingModel.VIRTUAL_THREAD));
@@ -78,7 +78,7 @@ public class VirtualThreadDeploymentTest extends VertxTestBase {
           assertTrue(isVirtual(Thread.currentThread()));
           return Thread.currentThread().getName();
         });
-        String res = Future.await(fut);
+        String res = fut.await();
         assertNotSame(Thread.currentThread().getName(), res);
         testComplete();
       }
@@ -102,13 +102,13 @@ public class VirtualThreadDeploymentTest extends VertxTestBase {
             max.set(Math.max(val, max.get()));
             Future<Void> fut = Future.future(p -> vertx.setTimer(50, id -> p.complete()));
             processing.set(false);
-            Future.await(fut);
+            fut.await();
             assertFalse(processing.getAndSet(true));
             req.response().end();
             inflight.decrementAndGet();
             processing.set(false);
           });
-          Future.await(server.listen(8080, "localhost"));
+          server.listen(8080, "localhost").await();
         }
       }, new DeploymentOptions().setThreadingModel(ThreadingModel.VIRTUAL_THREAD))
       .toCompletionStage()

--- a/src/test/java/io/vertx/core/eventbus/VirtualThreadEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/VirtualThreadEventBusTest.java
@@ -35,7 +35,7 @@ public class VirtualThreadEventBusTest extends VertxTestBase {
       msg.reply(msg.body());
     });
     vertx.createVirtualThreadContext().runOnContext(v -> {
-      Message<String> ret = Future.await(eb.request("test-addr", "test"));
+      Message<String> ret = eb.<String>request("test-addr", "test").await();
       assertEquals("test", ret.body());
       testComplete();
     });


### PR DESCRIPTION
Add a Future#await() method that is more convenient than the static Future#await(Future) developed in 4.x

