### PR TITLE
Wrapper classes testing

### DIFF
--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -359,7 +359,7 @@ public interface Vertx extends Measured {
    */
   @Deprecated
   default TimeoutStream periodicStream(long delay) {
-    return periodicStream(0, delay);
+    return periodicStream(0L, delay);
   }
 
   /**

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -398,7 +398,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
 
   @Override
   public SocketAddress remoteAddress() {
-    return conn.remoteAddress();
+    return super.remoteAddress();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -390,7 +390,7 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
 
   @Override
   public SocketAddress remoteAddress() {
-    return stream.conn.remoteAddress();
+    return super.remoteAddress();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
@@ -94,12 +94,6 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  public boolean isSSL() {
-    return delegate.isSSL();
-  }
-
-  @Override
-  @Nullable
   public String scheme() {
     return delegate.scheme();
   }
@@ -110,19 +104,17 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  @Nullable
   public String path() {
     return delegate.path();
   }
 
   @Override
-  @Nullable
   public String query() {
     return delegate.query();
   }
 
   @Override
-  public @Nullable HostAndPort authority() {
+  public HostAndPort authority() {
     return delegate.authority();
   }
 
@@ -137,31 +129,16 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  @CacheReturn
   public HttpServerResponse response() {
     return delegate.response();
   }
 
   @Override
-  @CacheReturn
   public MultiMap headers() {
     return delegate.headers();
   }
 
   @Override
-  @Nullable
-  public String getHeader(String headerName) {
-    return delegate.getHeader(headerName);
-  }
-
-  @Override
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  public String getHeader(CharSequence headerName) {
-    return delegate.getHeader(headerName);
-  }
-
-  @Override
-  @Fluent
   public HttpServerRequest setParamsCharset(String charset) {
     return delegate.setParamsCharset(charset);
   }
@@ -172,38 +149,8 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  @CacheReturn
   public MultiMap params() {
     return delegate.params();
-  }
-
-  @Override
-  @Nullable
-  public String getParam(String paramName) {
-    return delegate.getParam(paramName);
-  }
-
-  @Override
-  public String getParam(String paramName, String defaultValue) {
-    return delegate.getParam(paramName, defaultValue);
-  }
-
-  @Override
-  @CacheReturn
-  public SocketAddress remoteAddress() {
-    return delegate.remoteAddress();
-  }
-
-  @Override
-  @CacheReturn
-  public SocketAddress localAddress() {
-    return delegate.localAddress();
-  }
-
-  @Override
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  public SSLSession sslSession() {
-    return delegate.sslSession();
   }
 
   @Override
@@ -218,34 +165,13 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  @Fluent
-  public HttpServerRequest bodyHandler(@Nullable Handler<Buffer> bodyHandler) {
-    return delegate.bodyHandler(bodyHandler);
-  }
-
-  @Override
-  public HttpServerRequest body(Handler<AsyncResult<Buffer>> handler) {
-    return delegate.body(handler);
-  }
-
-  @Override
   public Future<Buffer> body() {
     return delegate.body();
   }
 
   @Override
-  public void end(Handler<AsyncResult<Void>> handler) {
-    delegate.end(handler);
-  }
-
-  @Override
   public Future<Void> end() {
     return delegate.end();
-  }
-
-  @Override
-  public void toNetSocket(Handler<AsyncResult<NetSocket>> handler) {
-    delegate.toNetSocket(handler);
   }
 
   @Override
@@ -286,11 +212,6 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   @CacheReturn
   public int streamId() {
     return delegate.streamId();
-  }
-
-  @Override
-  public void toWebSocket(Handler<AsyncResult<ServerWebSocket>> handler) {
-    delegate.toWebSocket(handler);
   }
 
   @Override
@@ -343,17 +264,6 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  public int cookieCount() {
-    return delegate.cookieCount();
-  }
-
-  @Override
-  @Deprecated
-  public Map<String, Cookie> cookieMap() {
-    return delegate.cookieMap();
-  }
-
-  @Override
   public Set<Cookie> cookies(String name) {
     return delegate.cookies(name);
   }
@@ -379,18 +289,4 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
     return delegate.metric();
   }
 
-  @Override
-  public Pipe<Buffer> pipe() {
-    return delegate.pipe();
-  }
-
-  @Override
-  public Future<Void> pipeTo(WriteStream<Buffer> dst) {
-    return delegate.pipeTo(dst);
-  }
-
-  @Override
-  public void pipeTo(WriteStream<Buffer> dst, Handler<AsyncResult<Void>> handler) {
-    delegate.pipeTo(dst, handler);
-  }
 }

--- a/src/main/java/io/vertx/core/impl/VertxWrapper.java
+++ b/src/main/java/io/vertx/core/impl/VertxWrapper.java
@@ -84,18 +84,8 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public NetServer createNetServer() {
-    return delegate.createNetServer();
-  }
-
-  @Override
   public NetClient createNetClient(NetClientOptions options) {
     return delegate.createNetClient(options);
-  }
-
-  @Override
-  public NetClient createNetClient() {
-    return delegate.createNetClient();
   }
 
   @Override
@@ -111,11 +101,6 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public DatagramSocket createDatagramSocket(DatagramSocketOptions options) {
     return delegate.createDatagramSocket(options);
-  }
-
-  @Override
-  public DatagramSocket createDatagramSocket() {
-    return delegate.createDatagramSocket();
   }
 
   @Override
@@ -159,18 +144,8 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public long setPeriodic(long delay, Handler<Long> handler) {
-    return delegate.setPeriodic(delay, handler);
-  }
-
-  @Override
   public long setPeriodic(long initialDelay, long delay, Handler<Long> handler) {
     return delegate.setPeriodic(initialDelay, delay, handler);
-  }
-
-  @Override
-  public TimeoutStream periodicStream(long delay) {
-    return delegate.periodicStream(delay);
   }
 
   @Override
@@ -196,11 +171,6 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public void close(Handler<AsyncResult<Void>> completionHandler) {
     delegate.close(completionHandler);
-  }
-
-  @Override
-  public Future<String> deployVerticle(Verticle verticle) {
-    return delegate.deployVerticle(verticle);
   }
 
   @Override
@@ -236,16 +206,6 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public void deployVerticle(Supplier<Verticle> verticleSupplier, DeploymentOptions options, Handler<AsyncResult<String>> completionHandler) {
     delegate.deployVerticle(verticleSupplier, options, completionHandler);
-  }
-
-  @Override
-  public Future<String> deployVerticle(String name) {
-    return delegate.deployVerticle(name);
-  }
-
-  @Override
-  public void deployVerticle(String name, Handler<AsyncResult<String>> completionHandler) {
-    delegate.deployVerticle(name, completionHandler);
   }
 
   @Override
@@ -291,36 +251,6 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public boolean isClustered() {
     return delegate.isClustered();
-  }
-
-  @Override
-  public <T> void executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> asyncResultHandler) {
-    delegate.executeBlocking(blockingCodeHandler, ordered, asyncResultHandler);
-  }
-
-  @Override
-  public <T> void executeBlocking(Handler<Promise<T>> blockingCodeHandler, Handler<AsyncResult<T>> asyncResultHandler) {
-    delegate.executeBlocking(blockingCodeHandler, asyncResultHandler);
-  }
-
-  @Override
-  public <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, boolean ordered) {
-    return delegate.executeBlocking(blockingCodeHandler, ordered);
-  }
-
-  @Override
-  public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
-    return delegate.executeBlockingInternal(blockingCodeHandler, ordered);
-  }
-
-  @Override
-  public <T> Future<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler) {
-    return delegate.executeBlocking(blockingCodeHandler);
-  }
-
-  @Override
-  public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler) {
-    return delegate.executeBlockingInternal(blockingCodeHandler);
   }
 
   @Override
@@ -429,8 +359,13 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public <C> C createSharedClient(String clientKey, String clientName, CloseFuture closeFuture, Function<CloseFuture, C> supplier) {
-    return delegate.createSharedClient(clientKey, clientName, closeFuture, supplier);
+  public HttpClientBuilder httpClientBuilder() {
+    return delegate.httpClientBuilder();
+  }
+
+  @Override
+  public WebSocketClient createWebSocketClient(WebSocketClientOptions options, CloseFuture closeFuture) {
+    return delegate.createWebSocketClient(options, closeFuture);
   }
 
   @Override
@@ -451,6 +386,21 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public ContextInternal createEventLoopContext() {
     return delegate.createEventLoopContext();
+  }
+
+  @Override
+  public ContextInternal createVirtualThreadContext(Deployment deployment, CloseFuture closeFuture, ClassLoader tccl) {
+    return delegate.createVirtualThreadContext(deployment, closeFuture, tccl);
+  }
+
+  @Override
+  public ContextInternal createVirtualThreadContext(EventLoop eventLoop, ClassLoader tccl) {
+    return delegate.createVirtualThreadContext(eventLoop, tccl);
+  }
+
+  @Override
+  public ContextInternal createVirtualThreadContext() {
+    return delegate.createVirtualThreadContext();
   }
 
   @Override
@@ -526,26 +476,6 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public File resolveFile(String fileName) {
     return delegate.resolveFile(fileName);
-  }
-
-  @Override
-  public <T> void executeBlockingInternal(Handler<Promise<T>> blockingCodeHandler, Handler<AsyncResult<T>> asyncResultHandler) {
-    delegate.executeBlockingInternal(blockingCodeHandler, asyncResultHandler);
-  }
-
-  @Override
-  public <T> Future<T> executeBlockingInternal(Callable<T> blockingCodeHandler) {
-    return delegate.executeBlockingInternal(blockingCodeHandler);
-  }
-
-  @Override
-  public <T> void executeBlockingInternal(Handler<Promise<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> asyncResultHandler) {
-    delegate.executeBlockingInternal(blockingCodeHandler, ordered, asyncResultHandler);
-  }
-
-  @Override
-  public <T> Future<T> executeBlockingInternal(Callable<T> blockingCodeHandler, boolean ordered) {
-    return delegate.executeBlockingInternal(blockingCodeHandler, ordered);
   }
 
   @Override

--- a/src/test/java/io/vertx/core/wrapper/HttpServerRequestWrapperImpl.java
+++ b/src/test/java/io/vertx/core/wrapper/HttpServerRequestWrapperImpl.java
@@ -1,0 +1,16 @@
+package io.vertx.core.wrapper;
+
+import io.vertx.core.http.impl.HttpServerRequestInternal;
+import io.vertx.core.http.impl.HttpServerRequestWrapper;
+
+/**
+ * Just here to make sure that a class extending {@link HttpServerRequestWrapper} does not need to implement any method.
+ *
+ * We need this class to not override/implement method of the {@link HttpServerRequestWrapper} interface and compile.
+ */
+public class HttpServerRequestWrapperImpl extends HttpServerRequestWrapper {
+
+  public HttpServerRequestWrapperImpl(HttpServerRequestInternal delegate) {
+    super(delegate);
+  }
+}

--- a/src/test/java/io/vertx/core/wrapper/VertxWrapperImpl.java
+++ b/src/test/java/io/vertx/core/wrapper/VertxWrapperImpl.java
@@ -1,0 +1,16 @@
+package io.vertx.core.wrapper;
+
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.impl.VertxWrapper;
+
+/**
+ * Just here to make sure that a class extending {@link VertxWrapper} does not need to implement any method.
+ *
+ * We need this class to not override/implement method of the {@link VertxWrapper} interface and compile.
+ */
+public class VertxWrapperImpl extends VertxWrapper {
+
+  protected VertxWrapperImpl(VertxInternal delegate) {
+    super(delegate);
+  }
+}


### PR DESCRIPTION
Add test to ensure that HttpServerRequestWrapper and VertxWrapper can be extended without declaring any method of the wrapper's interfaces.
