### PR TITLE
Wrapper classes testing

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -393,7 +393,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
 
   @Override
   public SocketAddress remoteAddress() {
-    return conn.remoteAddress();
+    return super.remoteAddress();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -386,7 +386,7 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
 
   @Override
   public SocketAddress remoteAddress() {
-    return stream.conn.remoteAddress();
+    return super.remoteAddress();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
@@ -92,12 +92,6 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  public boolean isSSL() {
-    return delegate.isSSL();
-  }
-
-  @Override
-  @Nullable
   public String scheme() {
     return delegate.scheme();
   }
@@ -108,19 +102,17 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  @Nullable
   public String path() {
     return delegate.path();
   }
 
   @Override
-  @Nullable
   public String query() {
     return delegate.query();
   }
 
   @Override
-  public @Nullable HostAndPort authority() {
+  public HostAndPort authority() {
     return delegate.authority();
   }
 
@@ -130,31 +122,16 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  @CacheReturn
   public HttpServerResponse response() {
     return delegate.response();
   }
 
   @Override
-  @CacheReturn
   public MultiMap headers() {
     return delegate.headers();
   }
 
   @Override
-  @Nullable
-  public String getHeader(String headerName) {
-    return delegate.getHeader(headerName);
-  }
-
-  @Override
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  public String getHeader(CharSequence headerName) {
-    return delegate.getHeader(headerName);
-  }
-
-  @Override
-  @Fluent
   public HttpServerRequest setParamsCharset(String charset) {
     return delegate.setParamsCharset(charset);
   }
@@ -165,38 +142,8 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  @CacheReturn
   public MultiMap params() {
     return delegate.params();
-  }
-
-  @Override
-  @Nullable
-  public String getParam(String paramName) {
-    return delegate.getParam(paramName);
-  }
-
-  @Override
-  public String getParam(String paramName, String defaultValue) {
-    return delegate.getParam(paramName, defaultValue);
-  }
-
-  @Override
-  @CacheReturn
-  public SocketAddress remoteAddress() {
-    return delegate.remoteAddress();
-  }
-
-  @Override
-  @CacheReturn
-  public SocketAddress localAddress() {
-    return delegate.localAddress();
-  }
-
-  @Override
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  public SSLSession sslSession() {
-    return delegate.sslSession();
   }
 
   @Override
@@ -208,12 +155,6 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   @Override
   public String absoluteURI() {
     return delegate.absoluteURI();
-  }
-
-  @Override
-  @Fluent
-  public HttpServerRequest bodyHandler(@Nullable Handler<Buffer> bodyHandler) {
-    return delegate.bodyHandler(bodyHandler);
   }
 
   @Override
@@ -316,17 +257,6 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  public int cookieCount() {
-    return delegate.cookieCount();
-  }
-
-  @Override
-  @Deprecated
-  public Map<String, Cookie> cookieMap() {
-    return delegate.cookieMap();
-  }
-
-  @Override
   public Set<Cookie> cookies(String name) {
     return delegate.cookies(name);
   }
@@ -350,16 +280,6 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   @Override
   public Object metric() {
     return delegate.metric();
-  }
-
-  @Override
-  public Pipe<Buffer> pipe() {
-    return delegate.pipe();
-  }
-
-  @Override
-  public Future<Void> pipeTo(WriteStream<Buffer> dst) {
-    return delegate.pipeTo(dst);
   }
 
 }

--- a/src/main/java/io/vertx/core/impl/VertxWrapper.java
+++ b/src/main/java/io/vertx/core/impl/VertxWrapper.java
@@ -13,12 +13,7 @@ package io.vertx.core.impl;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.resolver.AddressResolverGroup;
-import io.vertx.core.Closeable;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Verticle;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.dns.DnsClient;
@@ -82,18 +77,8 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public NetServer createNetServer() {
-    return delegate.createNetServer();
-  }
-
-  @Override
   public NetClient createNetClient(NetClientOptions options) {
     return delegate.createNetClient(options);
-  }
-
-  @Override
-  public NetClient createNetClient() {
-    return delegate.createNetClient();
   }
 
   @Override
@@ -102,28 +87,18 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public HttpServer createHttpServer() {
-    return delegate.createHttpServer();
+  public HttpClientBuilder httpClientBuilder() {
+    return delegate.httpClientBuilder();
   }
 
   @Override
-  public HttpClient createHttpClient(HttpClientOptions options) {
-    return delegate.createHttpClient(options);
-  }
-
-  @Override
-  public HttpClient createHttpClient() {
-    return delegate.createHttpClient();
+  public WebSocketClient createWebSocketClient(WebSocketClientOptions options) {
+    return delegate.createWebSocketClient(options);
   }
 
   @Override
   public DatagramSocket createDatagramSocket(DatagramSocketOptions options) {
     return delegate.createDatagramSocket(options);
-  }
-
-  @Override
-  public DatagramSocket createDatagramSocket() {
-    return delegate.createDatagramSocket();
   }
 
   @Override
@@ -162,11 +137,6 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public long setPeriodic(long delay, Handler<Long> handler) {
-    return delegate.setPeriodic(delay, handler);
-  }
-
-  @Override
   public long setPeriodic(long initialDelay, long delay, Handler<Long> handler) {
     return delegate.setPeriodic(initialDelay, delay, handler);
   }
@@ -187,11 +157,6 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public Future<String> deployVerticle(Verticle verticle) {
-    return delegate.deployVerticle(verticle);
-  }
-
-  @Override
   public Future<String> deployVerticle(Verticle verticle, DeploymentOptions options) {
     return delegate.deployVerticle(verticle, options);
   }
@@ -204,11 +169,6 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public Future<String> deployVerticle(Supplier<Verticle> verticleSupplier, DeploymentOptions options) {
     return delegate.deployVerticle(verticleSupplier, options);
-  }
-
-  @Override
-  public Future<String> deployVerticle(String name) {
-    return delegate.deployVerticle(name);
   }
 
   @Override
@@ -247,16 +207,6 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
-    return delegate.executeBlockingInternal(blockingCodeHandler, ordered);
-  }
-
-  @Override
-  public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler) {
-    return delegate.executeBlockingInternal(blockingCodeHandler);
-  }
-
-  @Override
   public EventLoopGroup nettyEventLoopGroup() {
     return delegate.nettyEventLoopGroup();
   }
@@ -284,6 +234,11 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public <T> PromiseInternal<T> promise() {
     return delegate.promise();
+  }
+
+  @Override
+  public <T> PromiseInternal<T> promise(Promise<T> promise) {
+    return delegate.promise(promise);
   }
 
   @Override
@@ -352,11 +307,6 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public <C> C createSharedResource(String resourceKey, String resourceName, CloseFuture closeFuture, Function<CloseFuture, C> supplier) {
-    return delegate.createSharedResource(resourceKey, resourceName, closeFuture, supplier);
-  }
-
-  @Override
   public ContextInternal getContext() {
     return delegate.getContext();
   }
@@ -374,6 +324,21 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public ContextInternal createEventLoopContext() {
     return delegate.createEventLoopContext();
+  }
+
+  @Override
+  public ContextInternal createVirtualThreadContext(Deployment deployment, CloseFuture closeFuture, ClassLoader tccl) {
+    return delegate.createVirtualThreadContext(deployment, closeFuture, tccl);
+  }
+
+  @Override
+  public ContextInternal createVirtualThreadContext(EventLoop eventLoop, ClassLoader tccl) {
+    return delegate.createVirtualThreadContext(eventLoop, tccl);
+  }
+
+  @Override
+  public ContextInternal createVirtualThreadContext() {
+    return delegate.createVirtualThreadContext();
   }
 
   @Override
@@ -449,16 +414,6 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public File resolveFile(String fileName) {
     return delegate.resolveFile(fileName);
-  }
-
-  @Override
-  public <T> Future<T> executeBlockingInternal(Callable<T> blockingCodeHandler) {
-    return delegate.executeBlockingInternal(blockingCodeHandler);
-  }
-
-  @Override
-  public <T> Future<T> executeBlockingInternal(Callable<T> blockingCodeHandler, boolean ordered) {
-    return delegate.executeBlockingInternal(blockingCodeHandler, ordered);
   }
 
   @Override

--- a/src/test/java/io/vertx/core/wrapper/HttpServerRequestWrapperImpl.java
+++ b/src/test/java/io/vertx/core/wrapper/HttpServerRequestWrapperImpl.java
@@ -1,0 +1,16 @@
+package io.vertx.core.wrapper;
+
+import io.vertx.core.http.impl.HttpServerRequestInternal;
+import io.vertx.core.http.impl.HttpServerRequestWrapper;
+
+/**
+ * Just here to make sure that a class extending {@link HttpServerRequestWrapper} does not need to implement any method.
+ *
+ * We need this class to not override/implement method of the {@link HttpServerRequestWrapper} interface and compile.
+ */
+public class HttpServerRequestWrapperImpl extends HttpServerRequestWrapper {
+
+  public HttpServerRequestWrapperImpl(HttpServerRequestInternal delegate) {
+    super(delegate);
+  }
+}

--- a/src/test/java/io/vertx/core/wrapper/VertxWrapperImpl.java
+++ b/src/test/java/io/vertx/core/wrapper/VertxWrapperImpl.java
@@ -1,0 +1,16 @@
+package io.vertx.core.wrapper;
+
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.impl.VertxWrapper;
+
+/**
+ * Just here to make sure that a class extending {@link VertxWrapper} does not need to implement any method.
+ *
+ * We need this class to not override/implement method of the {@link VertxWrapper} interface and compile.
+ */
+public class VertxWrapperImpl extends VertxWrapper {
+
+  protected VertxWrapperImpl(VertxInternal delegate) {
+    super(delegate);
+  }
+}


### PR DESCRIPTION
Add test to ensure that HttpServerRequestWrapper and VertxWrapper can be extended without declaring any method of the wrapper's interfaces.
