### PR TITLE
Save creating (and validating) a peer INET address if not required

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -363,7 +363,8 @@ class NetClientImpl implements NetClientInternal {
     String peerHost = connectOptions.getHost();
     Integer peerPort = connectOptions.getPort();
     if (remoteAddress.isInetSocket()) {
-      if (peerHost == null && peerPort == null) {
+      if ((peerHost == null || peerHost.equals(remoteAddress.host()))
+        && (peerPort == null || peerPort.intValue() == remoteAddress.port())) {
         return remoteAddress;
       }
       if (peerHost == null) {


### PR DESCRIPTION
In the hot path while sending requests (spotted in some grpc client's tests) we keep on creating "peer" addresses, even if not required ie when no SSL is used or we already copy the fields of the existing INET remote socket address.
This change aim to reduce both the allocation pressure (which is fairly low, it's just a single socket addr instance), but saving a useless validation too, saving CPU resources too.