### PR TITLE
Fix IllegalStateException in DnsClient when DNS server responds with DNAME record

### DIFF
--- a/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
+++ b/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
@@ -14,6 +14,7 @@ package io.vertx.core.dns.impl;
 import io.netty.channel.*;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.InternetProtocolFamily;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.dns.*;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.util.collection.LongObjectHashMap;
@@ -333,7 +334,14 @@ public final class DnsClientImpl implements DnsClient {
         List<T> records = new ArrayList<>(count);
         for (int idx = 0;idx < count;idx++) {
           DnsRecord a = msg.recordAt(DnsSection.ANSWER, idx);
-          T record = RecordDecoder.decode(a);
+          T record;
+          try {
+            record = RecordDecoder.decode(a);
+          } catch (DecoderException e) {
+            fail(e);
+            return;
+          }
+
           if (isRequestedType(a.type(), types)) {
             records.add(record);
           }

--- a/src/main/java/io/vertx/core/dns/impl/decoder/RecordDecoder.java
+++ b/src/main/java/io/vertx/core/dns/impl/decoder/RecordDecoder.java
@@ -220,7 +220,7 @@ public class RecordDecoder {
         DnsRecordType type = record.type();
         Function<DnsRecord, ?> decoder = decoders.get(type);
         if (decoder == null) {
-            throw new IllegalStateException("Unsupported resource record type [id: " + type + "].");
+            throw new DecoderException("DNS record decoding error occurred: Unsupported resource record type [id: " + type + "].");
         }
         T result = null;
         try {

--- a/src/test/java/io/vertx/core/dns/DNSTest.java
+++ b/src/test/java/io/vertx/core/dns/DNSTest.java
@@ -372,6 +372,19 @@ public class DNSTest extends VertxTestBase {
     await();
   }
 
+  @Test
+  public void testResolveMXWhenDNSRepliesWithDNAMERecord() throws Exception {
+    final DnsClient dns = prepareDns();
+    dnsServer.testResolveDNAME("mail.vertx.io");
+
+    dns.resolveMX("vertx.io")
+      .onComplete(ar -> {
+        assertTrue(ar.failed());
+        testComplete();
+      });
+    await();
+  }
+
   private TestLoggerFactory testLogging(DnsClientOptions options) {
     final String ip = "10.0.0.1";
     dnsServer.testResolveA(ip);

--- a/src/test/java/io/vertx/test/fakedns/DnameRecordEncoder.java
+++ b/src/test/java/io/vertx/test/fakedns/DnameRecordEncoder.java
@@ -1,0 +1,15 @@
+package io.vertx.test.fakedns;
+
+import org.apache.directory.server.dns.io.encoder.ResourceRecordEncoder;
+import org.apache.directory.server.dns.messages.ResourceRecord;
+import org.apache.directory.server.dns.store.DnsAttribute;
+import org.apache.mina.core.buffer.IoBuffer;
+
+public class DnameRecordEncoder extends ResourceRecordEncoder  {
+
+  protected void putResourceRecordData(IoBuffer byteBuffer, ResourceRecord record )
+  {
+    String domainName = record.get( DnsAttribute.DOMAIN_NAME );
+    putDomainName( byteBuffer, domainName );
+  }
+}

--- a/src/test/java/io/vertx/test/fakedns/DnsMessageEncoder.java
+++ b/src/test/java/io/vertx/test/fakedns/DnsMessageEncoder.java
@@ -1,0 +1,233 @@
+package io.vertx.test.fakedns;
+
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+
+  import java.io.IOException;
+  import java.util.*;
+
+  import org.apache.directory.server.dns.io.encoder.*;
+  import org.apache.directory.server.dns.messages.DnsMessage;
+  import org.apache.directory.server.dns.messages.MessageType;
+  import org.apache.directory.server.dns.messages.OpCode;
+  import org.apache.directory.server.dns.messages.QuestionRecord;
+  import org.apache.directory.server.dns.messages.RecordType;
+  import org.apache.directory.server.dns.messages.ResourceRecord;
+  import org.apache.directory.server.dns.messages.ResponseCode;
+  import org.apache.directory.server.i18n.I18n;
+  import org.apache.mina.core.buffer.IoBuffer;
+  import org.slf4j.Logger;
+  import org.slf4j.LoggerFactory;
+
+
+/**
+ * An encoder for DNS messages.  The primary usage of the DnsMessageEncoder is
+ * to call the <code>encode(ByteBuffer, DnsMessage)</code> method which will
+ * write the message to the outgoing ByteBuffer according to the DnsMessage
+ * encoding in RFC-1035.
+ *
+ * @author <a href="mailto:dev@directory.apache.org">Apache Directory Project</a>
+ * @version $Rev$, $Date$
+ */
+public class DnsMessageEncoder
+{
+  /** the log for this class */
+  private static final Logger log = LoggerFactory.getLogger( DnsMessageEncoder.class );
+
+  /**
+   * A Hashed Adapter mapping record types to their encoders.
+   */
+  private static final Map<RecordType, RecordEncoder> DEFAULT_ENCODERS;
+
+  static
+  {
+    Map<RecordType, RecordEncoder> map = new HashMap<RecordType, RecordEncoder>();
+
+    map.put( RecordType.SOA, new StartOfAuthorityRecordEncoder() );
+    map.put( RecordType.A, new AddressRecordEncoder() );
+    map.put( RecordType.NS, new NameServerRecordEncoder() );
+    map.put( RecordType.CNAME, new CanonicalNameRecordEncoder() );
+    map.put( RecordType.PTR, new PointerRecordEncoder() );
+    map.put( RecordType.MX, new MailExchangeRecordEncoder() );
+    map.put( RecordType.SRV, new ServerSelectionRecordEncoder() );
+    map.put( RecordType.TXT, new TextRecordEncoder() );
+    map.put( RecordType.DNAME,  new DnameRecordEncoder());
+
+    DEFAULT_ENCODERS = Collections.unmodifiableMap( map );
+  }
+
+
+  /**
+   * Encodes the {@link DnsMessage} into the {@link ByteBuffer}.
+   *
+   * @param byteBuffer
+   * @param message
+   */
+  public void encode( IoBuffer byteBuffer, DnsMessage message )
+  {
+    byteBuffer.putShort( ( short ) message.getTransactionId() );
+
+    byte header = ( byte ) 0x00;
+    header |= encodeMessageType( message.getMessageType() );
+    header |= encodeOpCode( message.getOpCode() );
+    header |= encodeAuthoritativeAnswer( message.isAuthoritativeAnswer() );
+    header |= encodeTruncated( message.isTruncated() );
+    header |= encodeRecursionDesired( message.isRecursionDesired() );
+    byteBuffer.put( header );
+
+    header = ( byte ) 0x00;
+    header |= encodeRecursionAvailable( message.isRecursionAvailable() );
+    header |= encodeResponseCode( message.getResponseCode() );
+    byteBuffer.put( header );
+
+    byteBuffer
+      .putShort( ( short ) ( message.getQuestionRecords() != null ? message.getQuestionRecords().size() : 0 ) );
+    byteBuffer.putShort( ( short ) ( message.getAnswerRecords() != null ? message.getAnswerRecords().size() : 0 ) );
+    byteBuffer.putShort( ( short ) ( message.getAuthorityRecords() != null ? message.getAuthorityRecords().size()
+      : 0 ) );
+    byteBuffer.putShort( ( short ) ( message.getAdditionalRecords() != null ? message.getAdditionalRecords().size()
+      : 0 ) );
+
+    putQuestionRecords( byteBuffer, message.getQuestionRecords() );
+    putResourceRecords( byteBuffer, message.getAnswerRecords() );
+    putResourceRecords( byteBuffer, message.getAuthorityRecords() );
+    putResourceRecords( byteBuffer, message.getAdditionalRecords() );
+  }
+
+
+  private void putQuestionRecords( IoBuffer byteBuffer, List<QuestionRecord> questions )
+  {
+    if ( questions == null )
+    {
+      return;
+    }
+
+    QuestionRecordEncoder encoder = new QuestionRecordEncoder();
+
+    Iterator<QuestionRecord> it = questions.iterator();
+
+    while ( it.hasNext() )
+    {
+      QuestionRecord question = it.next();
+      encoder.put( byteBuffer, question );
+    }
+  }
+
+
+  private void putResourceRecords( IoBuffer byteBuffer, List<ResourceRecord> records )
+  {
+    if ( records == null )
+    {
+      return;
+    }
+
+    Iterator<ResourceRecord> it = records.iterator();
+
+    while ( it.hasNext() )
+    {
+      ResourceRecord record = it.next();
+
+      try
+      {
+        put( byteBuffer, record );
+      }
+      catch ( IOException ioe )
+      {
+        log.error( ioe.getLocalizedMessage(), ioe );
+      }
+    }
+  }
+
+
+  private void put( IoBuffer byteBuffer, ResourceRecord record ) throws IOException
+  {
+    RecordType type = record.getRecordType();
+
+    RecordEncoder encoder = DEFAULT_ENCODERS.get( type );
+
+    if ( encoder == null )
+    {
+      throw new IOException( I18n.err( I18n.ERR_597, type ) );
+    }
+
+    encoder.put( byteBuffer, record );
+  }
+
+
+  private byte encodeMessageType( MessageType messageType )
+  {
+    byte oneBit = ( byte ) ( messageType.convert() & 0x01 );
+    return ( byte ) ( oneBit << 7 );
+  }
+
+
+  private byte encodeOpCode( OpCode opCode )
+  {
+    byte fourBits = ( byte ) ( opCode.convert() & 0x0F );
+    return ( byte ) ( fourBits << 3 );
+  }
+
+
+  private byte encodeAuthoritativeAnswer( boolean authoritative )
+  {
+    if ( authoritative )
+    {
+      return ( byte ) ( ( byte ) 0x01 << 2 );
+    }
+    return ( byte ) 0;
+  }
+
+
+  private byte encodeTruncated( boolean truncated )
+  {
+    if ( truncated )
+    {
+      return ( byte ) ( ( byte ) 0x01 << 1 );
+    }
+    return 0;
+  }
+
+
+  private byte encodeRecursionDesired( boolean recursionDesired )
+  {
+    if ( recursionDesired )
+    {
+      return ( byte ) 0x01;
+    }
+    return 0;
+  }
+
+
+  private byte encodeRecursionAvailable( boolean recursionAvailable )
+  {
+    if ( recursionAvailable )
+    {
+      return ( byte ) ( ( byte ) 0x01 << 7 );
+    }
+    return 0;
+  }
+
+
+  private byte encodeResponseCode( ResponseCode responseCode )
+  {
+    return ( byte ) ( responseCode.convert() & 0x0F );
+  }
+}

--- a/src/test/java/io/vertx/test/fakedns/FakeDNSServer.java
+++ b/src/test/java/io/vertx/test/fakedns/FakeDNSServer.java
@@ -262,6 +262,24 @@ public final class FakeDNSServer extends DnsServer {
     });
   }
 
+  public FakeDNSServer testResolveDNAME(final String dname) {
+    return store(new RecordStore() {
+      @Override
+      public Set<ResourceRecord> getRecords(QuestionRecord questionRecord) throws org.apache.directory.server.dns.DnsException {
+        Set<ResourceRecord> set = new HashSet<>();
+
+        ResourceRecordModifier rm = new ResourceRecordModifier();
+        rm.setDnsClass(RecordClass.IN);
+        rm.setDnsName("dns.vertx.io");
+        rm.setDnsTtl(100);
+        rm.setDnsType(RecordType.DNAME);
+        rm.put(DnsAttribute.DOMAIN_NAME, dname);
+        set.add(rm.getEntry());
+        return set;
+      }
+    });
+  }
+
   public FakeDNSServer testLookup4(final String ip) {
     return store(new RecordStore() {
       @Override

--- a/src/test/java/io/vertx/test/fakedns/FakeDNSServer.java
+++ b/src/test/java/io/vertx/test/fakedns/FakeDNSServer.java
@@ -13,7 +13,6 @@ package io.vertx.test.fakedns;
 
 import org.apache.directory.server.dns.DnsException;
 import org.apache.directory.server.dns.DnsServer;
-import org.apache.directory.server.dns.io.encoder.DnsMessageEncoder;
 import org.apache.directory.server.dns.io.encoder.ResourceRecordEncoder;
 import org.apache.directory.server.dns.messages.DnsMessage;
 import org.apache.directory.server.dns.messages.DnsMessageModifier;


### PR DESCRIPTION
Motivation:

When trying to resolve any record type using `DnsClient`, if the DNS server replies back with a DNAME record, the handler passed to `DnsClient#resolve*()` methods is never called. This is because internally, `DnsClientImpl` uses `RecordDecoder` which currently throws `IllegalStateException` if it encounters a record type it does not know how to decode. `DnsClientImpl` does not catch this exception, causing the query to never be completed.

If you try to do this:

```
dnsClient.resolveMX("some-domain-with-dname-record.com", System::out::println);
```

The handler that would print the result is never called, instead this is logged:

```
WARNING: An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
java.lang.IllegalStateException: Unsupported resource record type [id: DNAME(39)].
    at io.vertx.core.dns.impl.decoder.RecordDecoder.decode(RecordDecoder.java:223)
    at io.vertx.core.dns.impl.DnsClientImpl$Query.handle(DnsClientImpl.java:336)
    at io.vertx.core.dns.impl.DnsClientImpl$1.channelRead0(DnsClientImpl.java:89)
    at io.vertx.core.dns.impl.DnsClientImpl$1.channelRead0(DnsClientImpl.java:83)
    at ...
```

In this PR, this is fixed by making `RecordDecoder` throw `DecoderException` when the DNS server replies back with any record type it doesn't know how to decode. Then, `DnsClientImpl` is made to catch this and fail the query when this exception is encountered during decoding. Another potential fix would be add DNAME record decoder to the list of supported decoders in `RecordDecoder`, but even though it would fix this specific issue, I figured it's better to have the `try..catch` as that would allow handling any other unsupported record types in similar fashion.

Note that DNAME (Delegation Name) records are valid DNS records and are used as a means of redirecting the whole domain (including all of it's subdomains) to another domain. So very similar to CNAME, but with CNAME the alias applies to only single subdomain, whereas with DNAME it applies to the name and all of its subnames. Properly handling these would likely involve following those redirects. This PR does not attempt to do that, it just fixes the issue where the error is not propagated to the caller.

Unfortunately testing this scenario requires extending `DnsMessageEncoder` from apacheds-protocol-dns in a way I'm not happy about, as the encoder map used by the class is final and also unmodifidable. The class does not provide any usable extension points either, so subclasses would need to rewrite significant portions. I briefly checked the option of upgrading to newer 2.X versions, but the issue remains there as well. I'll welcome any suggestions if there is a better way than outright copying the class to vert.x as I've done here.

There are also potential other issues with `DnsClientImpl` that I didn't have time to look at too deeply. For example, if the DNS server returns malformed supported record type that the `RecordDecoder` can't parse, the exception is catched and logged, but `RecordDecoder` will in this case return null. `DnsClientImpl` does not check for null value, so there is potential for it to throw `NullPointerException` in this scenario. This would lead to a similar issue where the handler would never be called. Unfortunately extending `FakeDNSServer` to support returning malformed records (as it uses standards conforming apacheds-protocol-dns underneath) is not trivial, so fixing this would require either taking a leap of faith with no tests, or perhaps rewriting portions of `FakeDNSServer`.
