### PR TITLE
Expose HTTP client control over creation of un-pooled HTTP connections

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -21,6 +21,8 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 
+import java.util.function.Function;
+
 /**
  * Represents a client-side HTTP request.
  * <p>
@@ -85,6 +87,11 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   HttpClientRequest setFollowRedirects(boolean followRedirects);
 
   /**
+   * @return whether HTTP redirections should be followed
+   */
+  boolean isFollowRedirects();
+
+  /**
    * Set the max number of HTTP redirects this request will follow. The default is {@code 0} which means
    * no redirects.
    *
@@ -93,6 +100,16 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    */
   @Fluent
   HttpClientRequest setMaxRedirects(int maxRedirects);
+
+  /**
+   * @return the maximum number of HTTP redirections to follow
+   */
+  int getMaxRedirects();
+
+  /**
+   * @return the number of followed redirections for the current HTTP request
+   */
+  int numberOfRedirections();
 
   /**
    * If chunked is true then the request will be set into HTTP chunked mode
@@ -193,6 +210,19 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   HttpClientRequest putHeader(CharSequence name, Iterable<CharSequence> values);
 
   /**
+   * Set the trace operation of this request.
+   *
+   * @param op the operation
+   * @return @return a reference to this, so the API can be used fluently
+   */
+  HttpClientRequest traceOperation(String op);
+
+  /**
+   * @return the trace operation of this request
+   */
+  String traceOperation();
+
+  /**
    * @return the HTTP version for this request
    */
   HttpVersion version();
@@ -237,6 +267,9 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    */
   @Fluent
   HttpClientRequest earlyHintsHandler(@Nullable Handler<MultiMap> handler);
+
+  @Fluent
+  HttpClientRequest redirectHandler(@Nullable Function<HttpClientResponse, Future<HttpClientRequest>>  handler);
 
   /**
    * Forces the head of the request to be written before {@link #end()} is called on the request or any data is

--- a/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -15,6 +15,8 @@ import io.vertx.core.Promise;
 import io.vertx.core.http.*;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.ClientSSLOptions;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.NetClientInternal;
 import io.vertx.core.spi.metrics.Metrics;
 
@@ -113,4 +115,8 @@ public class CleanableHttpClient implements HttpClientInternal {
     delegate.close(completion);
   }
 
+  @Override
+  public Future<HttpClientConnection> connect(SocketAddress server, HostAndPort peer) {
+    return delegate.connect(server, peer);
+  }
 }

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -1248,6 +1248,11 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   }
 
   @Override
+  public Future<HttpClientRequest> createRequest(ContextInternal context) {
+    return ((HttpClientImpl)client).createRequest(this, context);
+  }
+
+  @Override
   public Future<HttpClientStream> createStream(ContextInternal context) {
     PromiseInternal<HttpClientStream> promise = context.promise();
     createStream(context, promise);

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -192,6 +192,11 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     return options.isPipelining() ? options.getPipeliningLimit() : 1;
   }
 
+  @Override
+  public synchronized long activeStreams() {
+    return requests.isEmpty() && responses.isEmpty() ? 0 : 1;
+  }
+
   /**
    * @return a raw {@code NetSocket} - for internal use - must be called from event-loop
    */

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -89,6 +89,11 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
   }
 
   @Override
+  public long activeStreams() {
+    return handler.connection().numActiveStreams();
+  }
+
+  @Override
   boolean onGoAwaySent(GoAway goAway) {
     boolean goneAway = super.onGoAwaySent(goAway);
     if (goneAway) {

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -155,6 +155,11 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
     }
   }
 
+  @Override
+  public Future<HttpClientRequest> createRequest(ContextInternal context) {
+    return ((HttpClientImpl)client).createRequest(this, context);
+  }
+
   private StreamImpl createStream2(ContextInternal context) {
     return new StreamImpl(this, context, false);
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -84,6 +84,11 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
   }
 
   @Override
+  public long activeStreams() {
+    return current.concurrency();
+  }
+
+  @Override
   public ChannelHandlerContext channelHandlerContext() {
     return current.channelHandlerContext();
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -790,6 +790,11 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
   }
 
   @Override
+  public Future<HttpClientRequest> createRequest(ContextInternal context) {
+    return ((HttpClientImpl)client).createRequest(this, context);
+  }
+
+  @Override
   public ContextInternal getContext() {
     return current.getContext();
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -15,6 +15,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.logging.Logger;
@@ -67,6 +68,14 @@ public interface HttpClientConnection extends HttpConnection {
    * @return the {@link ChannelHandlerContext} of the handler managing the connection
    */
   ChannelHandlerContext channelHandlerContext();
+
+  /**
+   * Create an HTTP stream.
+   *
+   * @param context the stream context
+   * @return a future notified with the created stream
+   */
+  Future<HttpClientRequest> createRequest(ContextInternal context);
 
   /**
    * Create an HTTP stream.

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -60,6 +60,11 @@ public interface HttpClientConnection extends HttpConnection {
   long concurrency();
 
   /**
+   * @return the number of active streams
+   */
+  long activeStreams();
+
+  /**
    * @return the connection channel
    */
   Channel channel();

--- a/src/main/java/io/vertx/core/http/impl/HttpClientInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientInternal.java
@@ -14,7 +14,10 @@ package io.vertx.core.http.impl;
 import io.vertx.core.Closeable;
 import io.vertx.core.Future;
 import io.vertx.core.http.*;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.NetClientInternal;
 import io.vertx.core.spi.metrics.MetricsProvider;
 
@@ -31,4 +34,20 @@ public interface HttpClientInternal extends HttpClient, MetricsProvider, Closeab
 
   Future<Void> closeFuture();
 
+  /**
+   * Connect to a server.
+   *
+   * @param server the server address
+   */
+  default Future<HttpClientConnection> connect(SocketAddress server) {
+    return connect(server, null);
+  }
+
+  /**
+   * Connect to a server.
+   *
+   * @param server the server address
+   * @param peer the peer
+   */
+  Future<HttpClientConnection> connect(SocketAddress server, HostAndPort peer);
 }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -12,15 +12,14 @@
 package io.vertx.core.http.impl;
 
 import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
-import io.vertx.core.net.HostAndPort;
-import io.vertx.core.net.SocketAddress;
+
+import java.util.function.Function;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -32,13 +31,10 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
 
   public HttpClientRequestPushPromise(
     HttpClientStream stream,
-    HttpClientImpl client,
-    boolean ssl,
     HttpMethod method,
     String uri,
-    HostAndPort authority,
     MultiMap headers) {
-    super(client, stream, stream.connection().getContext().promise(), ssl, method, authority, uri);
+    super(stream, stream.connection().getContext().promise(), method, uri);
     this.stream = stream;
     this.headers = headers;
   }
@@ -100,7 +96,27 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
+  public boolean isFollowRedirects() {
+    return false;
+  }
+
+  @Override
   public HttpClientRequest setMaxRedirects(int maxRedirects) {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public int getMaxRedirects() {
+    return 0;
+  }
+
+  @Override
+  public int numberOfRedirections() {
+    return 0;
+  }
+
+  @Override
+  public HttpClientRequest redirectHandler(@Nullable Function<HttpClientResponse, Future<HttpClientRequest>> handler) {
     throw new IllegalStateException();
   }
 
@@ -126,6 +142,16 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
 
   @Override
   public HttpClientRequest putHeader(CharSequence name, Iterable<CharSequence> values) {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public HttpClientRequest traceOperation(String op) {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public String traceOperation() {
     throw new IllegalStateException();
   }
 

--- a/src/test/java/io/vertx/core/http/HttpClientConnectionTest.java
+++ b/src/test/java/io/vertx/core/http/HttpClientConnectionTest.java
@@ -13,7 +13,7 @@ package io.vertx.core.http;
 import io.netty.buffer.Unpooled;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.impl.CleanableHttpClient;
-import io.vertx.core.http.impl.HttpClientImpl;
+import io.vertx.core.http.impl.HttpClientInternal;
 import io.vertx.core.http.impl.HttpRequestHead;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.net.HostAndPort;
@@ -28,7 +28,7 @@ public abstract class HttpClientConnectionTest extends HttpTestBase {
 
   protected HostAndPort peerAddress;
   private File tmp;
-  protected HttpClientImpl client;
+  protected HttpClientInternal client;
 
   @Override
   public void setUp() throws Exception {
@@ -40,34 +40,53 @@ public abstract class HttpClientConnectionTest extends HttpTestBase {
       testAddress = SocketAddress.domainSocketAddress(tmp.getAbsolutePath());
       requestOptions.setServer(testAddress);
     }
-    this.client = (HttpClientImpl) ((CleanableHttpClient) super.client).delegate;
+    this.client = (HttpClientInternal) super.client;
   }
 
   @Test
   public void testGet() throws Exception {
+    server.requestHandler(req -> {
+      req.response().end("Hello World");
+    });
+    startServer(testAddress);
+    client.connect(testAddress, peerAddress)
+      .compose(conn -> conn.createRequest((ContextInternal) vertx.getOrCreateContext()))
+      .compose(request -> request
+        .send()
+        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .compose(HttpClientResponse::body))
+      .onComplete(onSuccess(body -> {
+        assertEquals("Hello World", body.toString());
+        testComplete();
+      }));
+    await();
+  }
+
+  @Test
+  public void testStreamGet() throws Exception {
     waitFor(3);
     server.requestHandler(req -> {
-      req.response().end();
+      req.response().end("Hello World");
     });
     startServer(testAddress);
     client.connect(testAddress, peerAddress).onComplete(onSuccess(conn -> {
       conn
         .createStream((ContextInternal) vertx.getOrCreateContext())
         .onComplete(onSuccess(stream -> {
-        stream.writeHead(new HttpRequestHead(
-          HttpMethod.GET, "/", MultiMap.caseInsensitiveMultiMap(), "localhost:8080", "", null), false, Unpooled.EMPTY_BUFFER, true, new StreamPriority(), false);
-        stream.headHandler(resp -> {
-          assertEquals(200, resp.statusCode);
-          complete();
-        });
-        stream.endHandler(headers -> {
-          assertEquals(0, headers.size());
-          complete();
-        });
-        stream.closeHandler(v -> {
-          complete();
-        });
-      }));
+          stream.writeHead(new HttpRequestHead(
+            HttpMethod.GET, "/", MultiMap.caseInsensitiveMultiMap(), "localhost:8080", "", null), false, Unpooled.EMPTY_BUFFER, true, new StreamPriority(), false);
+          stream.headHandler(resp -> {
+            assertEquals(200, resp.statusCode);
+            complete();
+          });
+          stream.endHandler(headers -> {
+            assertEquals(0, headers.size());
+            complete();
+          });
+          stream.closeHandler(v -> {
+            complete();
+          });
+        }));
     }));
     await();
   }

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -4130,10 +4130,10 @@ public abstract class HttpTest extends HttpTestBase {
   @Test
   public void testFollowRedirectLimit() throws Exception {
     Assume.assumeTrue(testAddress.isInetSocket());
-    AtomicInteger redirects = new AtomicInteger();
+    AtomicInteger numberOfRequests = new AtomicInteger();
     server.requestHandler(req -> {
-      int val = redirects.incrementAndGet();
-      if (val > 16) {
+      int val = numberOfRequests.incrementAndGet();
+      if (val > 17) {
         fail();
       } else {
         String scheme = createBaseServerOptions().isSsl() ? "https" : "http";
@@ -4145,7 +4145,7 @@ public abstract class HttpTest extends HttpTestBase {
       .onComplete(onSuccess(req -> {
         req.setFollowRedirects(true);
         req.send().onComplete(onSuccess(resp -> {
-          assertEquals(16, redirects.get());
+          assertEquals(17, numberOfRequests.get());
           assertEquals(301, resp.statusCode());
           assertEquals("/otherpath", resp.request().path());
           testComplete();
@@ -4312,11 +4312,16 @@ public abstract class HttpTest extends HttpTestBase {
       public HttpClientRequest putHeader(CharSequence name, Iterable<CharSequence> values) { throw new UnsupportedOperationException(); }
       public Future<Void> write(String chunk) { throw new UnsupportedOperationException(); }
       public Future<Void> write(String chunk, String enc) { throw new UnsupportedOperationException(); }
+      public HttpClientRequest traceOperation(String op) { throw new UnsupportedOperationException(); }
+      public String traceOperation() { throw new UnsupportedOperationException(); }
       public void write(Buffer data, Handler<AsyncResult<Void>> handler) { throw new UnsupportedOperationException(); }
       public void write(String chunk, Handler<AsyncResult<Void>> handler) { throw new UnsupportedOperationException(); }
       public void write(String chunk, String enc, Handler<AsyncResult<Void>> handler) { throw new UnsupportedOperationException(); }
       public HttpClientRequest continueHandler(@Nullable Handler<Void> handler) { throw new UnsupportedOperationException(); }
-
+      public boolean isFollowRedirects() { throw new UnsupportedOperationException(); }
+      public int getMaxRedirects() { throw new UnsupportedOperationException(); }
+      public int numberOfRedirections() { throw new UnsupportedOperationException(); }
+      public HttpClientRequest redirectHandler(@Nullable Function<HttpClientResponse, Future<HttpClientRequest>> handler) { throw new UnsupportedOperationException(); }
       public HttpClientRequest earlyHintsHandler(@Nullable Handler<MultiMap> handler) { throw new UnsupportedOperationException(); }
       public Future<Void> sendHead() { throw new UnsupportedOperationException(); }
       public HttpClientRequest sendHead(Handler<AsyncResult<Void>> completionHandler) { throw new UnsupportedOperationException(); }


### PR DESCRIPTION
In some scenario (e.g. load-testing), it is preferable to use un-pooled HTTP connection.

This expose at the internal API level, the creation of HTTP connection and HTTP requests. This will eventually be exposed in the Vert.x API but the current API is still not mature enough to do that and require more work and might require breaking changes.