### PR TITLE
Expose HTTP client control over creation of un-pooled HTTP connections

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -22,6 +22,8 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 
+import java.util.function.Function;
+
 /**
  * Represents a client-side HTTP request.
  * <p>
@@ -125,6 +127,11 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   HttpClientRequest setFollowRedirects(boolean followRedirects);
 
   /**
+   * @return whether HTTP redirections should be followed
+   */
+  boolean isFollowRedirects();
+
+  /**
    * Set the max number of HTTP redirects this request will follow. The default is {@code 0} which means
    * no redirects.
    *
@@ -133,6 +140,16 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    */
   @Fluent
   HttpClientRequest setMaxRedirects(int maxRedirects);
+
+  /**
+   * @return the maximum number of HTTP redirections to follow
+   */
+  int getMaxRedirects();
+
+  /**
+   * @return the number of followed redirections for the current HTTP request
+   */
+  int numberOfRedirections();
 
   /**
    * If chunked is true then the request will be set into HTTP chunked mode
@@ -233,6 +250,19 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   HttpClientRequest putHeader(CharSequence name, Iterable<CharSequence> values);
 
   /**
+   * Set the trace operation of this request.
+   *
+   * @param op the operation
+   * @return @return a reference to this, so the API can be used fluently
+   */
+  HttpClientRequest traceOperation(String op);
+
+  /**
+   * @return the trace operation of this request
+   */
+  String traceOperation();
+
+  /**
    * @return the HTTP version for this request
    */
   HttpVersion version();
@@ -287,6 +317,9 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    */
   @Fluent
   HttpClientRequest earlyHintsHandler(@Nullable Handler<MultiMap> handler);
+
+  @Fluent
+  HttpClientRequest redirectHandler(@Nullable Function<HttpClientResponse, Future<HttpClientRequest>>  handler);
 
   /**
    * Forces the head of the request to be written before {@link #end()} is called on the request or any data is

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -147,6 +147,11 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     return options.isPipelining() ? options.getPipeliningLimit() : 1;
   }
 
+  @Override
+  public synchronized long activeStreams() {
+    return requests.isEmpty() && responses.isEmpty() ? 0 : 1;
+  }
+
   /**
    * @return a raw {@code NetSocket} - for internal use - must be called from event-loop
    */

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -1223,6 +1223,11 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   }
 
   @Override
+  public Future<HttpClientRequest> createRequest(ContextInternal context) {
+    return ((HttpClientImpl)client).createRequest(this, context);
+  }
+
+  @Override
   public void createStream(ContextInternal context, Handler<AsyncResult<HttpClientStream>> handler) {
     EventLoop eventLoop = context.nettyEventLoop();
     if (eventLoop.inEventLoop()) {

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -156,6 +156,10 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
     context.emit(fut, handler);
   }
 
+  public Future<HttpClientRequest> createRequest(ContextInternal context) {
+    return ((HttpClientImpl)client).createRequest(this, context);
+  }
+
   private StreamImpl createStream(ContextInternal context) {
     return new StreamImpl(this, context, false);
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -75,6 +75,11 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
   }
 
   @Override
+  public long activeStreams() {
+    return handler.connection().numActiveStreams();
+  }
+
+  @Override
   boolean onGoAwaySent(GoAway goAway) {
     boolean goneAway = super.onGoAwaySent(goAway);
     if (goneAway) {

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -794,6 +794,11 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
   }
 
   @Override
+  public Future<HttpClientRequest> createRequest(ContextInternal context) {
+    return ((HttpClientImpl)client).createRequest(this, context);
+  }
+
+  @Override
   public ContextInternal getContext() {
     return current.getContext();
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -77,6 +77,11 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
   }
 
   @Override
+  public long activeStreams() {
+    return current.concurrency();
+  }
+
+  @Override
   public ChannelHandlerContext channelHandlerContext() {
     return current.channelHandlerContext();
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -56,6 +56,11 @@ public interface HttpClientConnection extends HttpConnection {
   long concurrency();
 
   /**
+   * @return the number of active streams
+   */
+  long activeStreams();
+
+  /**
    * @return the connection channel
    */
   Channel channel();

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -14,7 +14,9 @@ package io.vertx.core.http.impl;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.logging.Logger;
@@ -69,6 +71,14 @@ public interface HttpClientConnection extends HttpConnection {
    * @return the {@link ChannelHandlerContext} of the handler managing the connection
    */
   ChannelHandlerContext channelHandlerContext();
+
+  /**
+   * Create an HTTP stream.
+   *
+   * @param context the stream context
+   * @return a future notified with the created stream
+   */
+  Future<HttpClientRequest> createRequest(ContextInternal context);
 
   /**
    * Create an HTTP stream.

--- a/src/main/java/io/vertx/core/http/impl/HttpClientInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientInternal.java
@@ -11,9 +11,12 @@
 
 package io.vertx.core.http.impl;
 
+import io.vertx.core.Future;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.SocketAddress;
 
 public interface HttpClientInternal extends HttpClient {
 
@@ -23,4 +26,21 @@ public interface HttpClientInternal extends HttpClient {
   VertxInternal vertx();
 
   HttpClientOptions options();
+
+  /**
+   * Connect to a server.
+   *
+   * @param server the server address
+   */
+  default Future<HttpClientConnection> connect(SocketAddress server) {
+    return connect(server, null);
+  }
+
+  /**
+   * Connect to a server.
+   *
+   * @param server the server address
+   * @param peer the peer
+   */
+  Future<HttpClientConnection> connect(SocketAddress server, SocketAddress peer);
 }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -12,14 +12,12 @@
 package io.vertx.core.http.impl;
 
 import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.net.SocketAddress;
+
+import java.util.function.Function;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -31,14 +29,12 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
 
   public HttpClientRequestPushPromise(
     HttpClientStream stream,
-    HttpClientImpl client,
-    boolean ssl,
     HttpMethod method,
     String uri,
     String host,
     int port,
     MultiMap headers) {
-    super(client, stream, stream.connection().getContext().promise(), ssl, method, SocketAddress.inetSocketAddress(port, host), host, port, uri);
+    super(stream, stream.connection().getContext().promise(), method, SocketAddress.inetSocketAddress(port, host), host, port, uri);
     this.stream = stream;
     this.headers = headers;
   }
@@ -100,7 +96,27 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
+  public boolean isFollowRedirects() {
+    return false;
+  }
+
+  @Override
   public HttpClientRequest setMaxRedirects(int maxRedirects) {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public int getMaxRedirects() {
+    return 0;
+  }
+
+  @Override
+  public int numberOfRedirections() {
+    return 0;
+  }
+
+  @Override
+  public HttpClientRequest redirectHandler(@Nullable Function<HttpClientResponse, Future<HttpClientRequest>> handler) {
     throw new IllegalStateException();
   }
 
@@ -126,6 +142,16 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
 
   @Override
   public HttpClientRequest putHeader(CharSequence name, Iterable<CharSequence> values) {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public HttpClientRequest traceOperation(String op) {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public String traceOperation() {
     throw new IllegalStateException();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/SharedHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/SharedHttpClient.java
@@ -21,6 +21,7 @@ import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.net.SSLOptions;
+import io.vertx.core.net.SocketAddress;
 
 import java.util.List;
 import java.util.function.Function;
@@ -171,5 +172,10 @@ public class SharedHttpClient implements HttpClientInternal {
   @Override
   public HttpClientOptions options() {
     return delegate.options();
+  }
+
+  @Override
+  public Future<HttpClientConnection> connect(SocketAddress server, SocketAddress peer) {
+    return delegate.connect(server, peer);
   }
 }

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -4177,10 +4177,10 @@ public abstract class HttpTest extends HttpTestBase {
   @Test
   public void testFollowRedirectLimit() throws Exception {
     Assume.assumeTrue(testAddress.isInetSocket());
-    AtomicInteger redirects = new AtomicInteger();
+    AtomicInteger numberOfRequests = new AtomicInteger();
     server.requestHandler(req -> {
-      int val = redirects.incrementAndGet();
-      if (val > 16) {
+      int val = numberOfRequests.incrementAndGet();
+      if (val > 17) {
         fail();
       } else {
         String scheme = createBaseServerOptions().isSsl() ? "https" : "http";
@@ -4192,7 +4192,7 @@ public abstract class HttpTest extends HttpTestBase {
       .onComplete(onSuccess(req -> {
         req.setFollowRedirects(true);
         req.send(onSuccess(resp -> {
-          assertEquals(16, redirects.get());
+          assertEquals(17, numberOfRequests.get());
           assertEquals(301, resp.statusCode());
           assertEquals("/otherpath", resp.request().path());
           testComplete();
@@ -4352,11 +4352,16 @@ public abstract class HttpTest extends HttpTestBase {
       public HttpClientRequest putHeader(CharSequence name, Iterable<CharSequence> values) { throw new UnsupportedOperationException(); }
       public Future<Void> write(String chunk) { throw new UnsupportedOperationException(); }
       public Future<Void> write(String chunk, String enc) { throw new UnsupportedOperationException(); }
+      public HttpClientRequest traceOperation(String op) { throw new UnsupportedOperationException(); }
+      public String traceOperation() { throw new UnsupportedOperationException(); }
       public void write(Buffer data, Handler<AsyncResult<Void>> handler) { throw new UnsupportedOperationException(); }
       public void write(String chunk, Handler<AsyncResult<Void>> handler) { throw new UnsupportedOperationException(); }
       public void write(String chunk, String enc, Handler<AsyncResult<Void>> handler) { throw new UnsupportedOperationException(); }
       public HttpClientRequest continueHandler(@Nullable Handler<Void> handler) { throw new UnsupportedOperationException(); }
-
+      public boolean isFollowRedirects() { throw new UnsupportedOperationException(); }
+      public int getMaxRedirects() { throw new UnsupportedOperationException(); }
+      public int numberOfRedirections() { throw new UnsupportedOperationException(); }
+      public HttpClientRequest redirectHandler(@Nullable Function<HttpClientResponse, Future<HttpClientRequest>> handler) { throw new UnsupportedOperationException(); }
       public HttpClientRequest earlyHintsHandler(@Nullable Handler<MultiMap> handler) { throw new UnsupportedOperationException(); }
       public Future<Void> sendHead() { throw new UnsupportedOperationException(); }
       public HttpClientRequest sendHead(Handler<AsyncResult<Void>> completionHandler) { throw new UnsupportedOperationException(); }


### PR DESCRIPTION
In some scenario (e.g. load-testing), it is preferable to use un-pooled HTTP connection.

This expose at the internal API level, the creation of HTTP connection and HTTP requests. This will eventually be exposed in the Vert.x API but the current API is still not mature enough to do that and require more work and might require breaking changes.