### PR TITLE
HTTP client timeout improvements

### DIFF
--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -1083,11 +1083,22 @@ no need to set the `Content-Length` of the request up-front.
 
 ==== Request timeouts
 
-You can set a timeout for a specific http request using {@link io.vertx.core.http.RequestOptions#setTimeout(long)} or
-{@link io.vertx.core.http.HttpClientRequest#setTimeout(long)}.
+You can set an idle timeout to prevent your application from unresponsive servers using {@link io.vertx.core.http.RequestOptions#setIdleTimeout(long)} or {@link io.vertx.core.http.HttpClientRequest#setIdleTimeout(long)}. When the request does not return any data within the timeout period an exception will fail the result and the request will be reset.
 
-If the request does not return any data within the timeout period an exception will be passed to the exception handler
-(if provided) and the request will be closed.
+[source,$lang]
+----
+{@link examples.HTTPExamples#clientIdleTimeout}
+----
+
+NOTE: the timeout starts when the {@link io.vertx.core.http.HttpClientRequest} is available, implying a connection was
+obtained from the pool.
+
+You can set a connect timeout to prevent your application from unresponsive busy client connection pool. The
+`Future<HttpClientRequest>` is failed when a connection is not obtained before the timeout delay.
+
+The connect timeout option is not related to the TCP {@link io.vertx.core.http.HttpClientOptions#setConnectTimeout(int)} option, when a request is made against a pooled HTTP client, the timeout applies to the duration to obtain a connection from the pool to serve the request,
+the timeout might fire because the server does not respond in time or the pool is too busy to serve a request.
+
 
 ==== Writing HTTP/2 frames
 

--- a/src/main/generated/io/vertx/core/http/RequestOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/RequestOptionsConverter.java
@@ -25,6 +25,11 @@ public class RequestOptionsConverter {
             obj.setAbsoluteURI((String)member.getValue());
           }
           break;
+        case "connectTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setConnectTimeout(((Number)member.getValue()).longValue());
+          }
+          break;
         case "followRedirects":
           if (member.getValue() instanceof Boolean) {
             obj.setFollowRedirects((Boolean)member.getValue());
@@ -33,6 +38,11 @@ public class RequestOptionsConverter {
         case "host":
           if (member.getValue() instanceof String) {
             obj.setHost((String)member.getValue());
+          }
+          break;
+        case "idleTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setIdleTimeout(((Number)member.getValue()).longValue());
           }
           break;
         case "port":
@@ -74,12 +84,14 @@ public class RequestOptionsConverter {
   }
 
   public static void toJson(RequestOptions obj, java.util.Map<String, Object> json) {
+    json.put("connectTimeout", obj.getConnectTimeout());
     if (obj.getFollowRedirects() != null) {
       json.put("followRedirects", obj.getFollowRedirects());
     }
     if (obj.getHost() != null) {
       json.put("host", obj.getHost());
     }
+    json.put("idleTimeout", obj.getIdleTimeout());
     if (obj.getPort() != null) {
       json.put("port", obj.getPort());
     }

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -558,6 +558,26 @@ public class HTTPExamples {
     request.end();
   }
 
+  public void clientIdleTimeout(HttpClient client, int port, String host, String uri, int timeoutMS) {
+    Future<Buffer> fut = client
+      .request(new RequestOptions()
+        .setHost(host)
+        .setPort(port)
+        .setURI(uri)
+        .setIdleTimeout(timeoutMS))
+      .compose(request -> request.send().compose(HttpClientResponse::body));
+  }
+
+  public void clientConnectTimeout(HttpClient client, int port, String host, String uri, int timeoutMS) {
+    Future<Buffer> fut = client
+      .request(new RequestOptions()
+        .setHost(host)
+        .setPort(port)
+        .setURI(uri)
+        .setConnectTimeout(timeoutMS))
+      .compose(request -> request.send().compose(HttpClientResponse::body));
+  }
+
   public void useRequestAsStream(HttpClientRequest request) {
 
     request.setChunked(true);

--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -22,6 +22,7 @@ import io.vertx.core.impl.future.SucceededFuture;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -553,6 +554,17 @@ public interface Future<T> extends AsyncResult<T> {
       return (Future<T>) ar;
     });
   }
+
+  /**
+   * Returns a future succeeded or failed with the outcome of this future when it happens before the timeout fires. When
+   * the timeout fires before, the future is failed with a {@link java.util.concurrent.TimeoutException}, guaranteeing
+   * the returned future to complete within the specified {@code delay}.
+   *
+   * @param delay the delay
+   * @param unit the unit of the delay
+   * @return the timeout future
+   */
+  Future<T> timeout(long delay, TimeUnit unit);
 
   /**
    * Bridges this Vert.x future to a {@link CompletionStage} instance.

--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -530,18 +530,26 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   void end(Handler<AsyncResult<Void>> handler);
 
   /**
-   * Set's the amount of time after which if the request does not return any data within the timeout period an
-   * {@link java.util.concurrent.TimeoutException} will be passed to the exception handler (if provided) and
-   * the request will be closed.
-   * <p>
-   * Calling this method more than once has the effect of canceling any existing timeout and starting
-   * the timeout from scratch.
+   * Like {@link #setIdleTimeout(long)} but with a confusing name (hence the deprecation).
    *
-   * @param timeoutMs The quantity of time in milliseconds.
+   * @deprecated instead use {@link #setIdleTimeout(long)}
+   */
+  @Deprecated
+  @Fluent
+  HttpClientRequest setTimeout(long timeout);
+
+  /**
+   * Sets the amount of time after which, if the request does not return any data within the timeout period,
+   * the request/response is closed and the related futures are failed with a {@link java.util.concurrent.TimeoutException},
+   * e.g. {@code Future<HttpClientResponse>} or {@code Future<Buffer>} response body.
+   *
+   * @param timeout the amount of time in milliseconds.
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  HttpClientRequest setTimeout(long timeoutMs);
+  default HttpClientRequest setIdleTimeout(long timeout) {
+    return setTimeout(timeout);
+  }
 
   /**
    * Set a push handler for this request.<p/>

--- a/src/main/java/io/vertx/core/http/RequestOptions.java
+++ b/src/main/java/io/vertx/core/http/RequestOptions.java
@@ -80,6 +80,16 @@ public class RequestOptions {
    */
   public static final long DEFAULT_TIMEOUT = 0;
 
+  /**
+   * The default connect timeout = {@code 0} (disabled)
+   */
+  public static final long DEFAULT_CONNECT_TIMEOUT = 0;
+
+  /**
+   * The default idle timeout = {@code 0} (disabled)
+   */
+  public static final long DEFAULT_IDLE_TIMEOUT = 0;
+
   private ProxyOptions proxyOptions;
   private SocketAddress server;
   private HttpMethod method;
@@ -90,6 +100,8 @@ public class RequestOptions {
   private MultiMap headers;
   private boolean followRedirects;
   private long timeout;
+  private long connectTimeout;
+  private long idleTimeout;
   private String traceOperation;
 
   /**
@@ -105,6 +117,8 @@ public class RequestOptions {
     uri = DEFAULT_URI;
     followRedirects = DEFAULT_FOLLOW_REDIRECTS;
     timeout = DEFAULT_TIMEOUT;
+    connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+    idleTimeout = DEFAULT_IDLE_TIMEOUT;
     traceOperation = null;
   }
 
@@ -123,6 +137,8 @@ public class RequestOptions {
     setURI(other.uri);
     setFollowRedirects(other.followRedirects);
     setTimeout(other.timeout);
+    setIdleTimeout(other.idleTimeout);
+    setConnectTimeout(other.connectTimeout);
     if (other.headers != null) {
       setHeaders(MultiMap.caseInsensitiveMultiMap().setAll(other.headers));
     }
@@ -328,24 +344,69 @@ public class RequestOptions {
   }
 
   /**
-   * @return the amount of time after which if the request does not return any data within the timeout period an
-   *         {@link java.util.concurrent.TimeoutException} will be passed to the exception handler and
-   *         the request will be closed.
+   * @see #setTimeout(long)
    */
+  @Deprecated
   public long getTimeout() {
     return timeout;
   }
 
   /**
-   * Sets the amount of time after which if the request does not return any data within the timeout period an
-   * {@link java.util.concurrent.TimeoutException} will be passed to the exception handler and
-   * the request will be closed.
+   * Equivalent to setting the same timeout value with {@link #setConnectTimeout(long)} and {@link #setIdleTimeout(long)}.
+   *
+   * @deprecated instead use {@link #setConnectTimeout(long)} or/and {@link #setIdleTimeout(long)}
+   */
+  @Deprecated
+  public RequestOptions setTimeout(long timeout) {
+    this.timeout = timeout;
+    return this;
+  }
+
+  /**
+   * @return the amount of time after which, if the request is not obtained from the client within the timeout period,
+   *         the {@code Future<HttpClientRequest>} obtained from the client is failed with a {@link java.util.concurrent.TimeoutException}
+   */
+  public long getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  /**
+   * Sets the amount of time after which, if the request is not obtained from the client within the timeout period,
+   * the {@code Future<HttpClientRequest>} obtained from the client is failed with a {@link java.util.concurrent.TimeoutException}.
+   *
+   * Note this is not related to the TCP {@link HttpClientOptions#setConnectTimeout(int)} option, when a request is made against
+   * a pooled HTTP client, the timeout applies to the duration to obtain a connection from the pool to serve the request, the timeout
+   * might fire because the server does not respond in time or the pool is too busy to serve a request.
    *
    * @param timeout the amount of time in milliseconds.
    * @return a reference to this, so the API can be used fluently
    */
-  public RequestOptions setTimeout(long timeout) {
-    this.timeout = timeout;
+  public RequestOptions setConnectTimeout(long timeout) {
+    this.connectTimeout = timeout;
+    return this;
+  }
+
+  /**
+   * @return the amount of time after which, if the request does not return any data within the timeout period,
+   *         the request/response is closed and the related futures are failed with a {@link java.util.concurrent.TimeoutException}
+   */
+  public long getIdleTimeout() {
+    return idleTimeout;
+  }
+
+  /**
+   * Sets the amount of time after which, if the request does not return any data within the timeout period,
+   * the request/response is closed and the related futures are failed with a {@link java.util.concurrent.TimeoutException},
+   * e.g. {@code Future<HttpClientResponse>} or {@code Future<Buffer>} response body.
+   *
+   * <p/>The timeout starts after a connection is obtained from the client, similar to calling
+   * {@link HttpClientRequest#setIdleTimeout(long)}.
+   *
+   * @param timeout the amount of time in milliseconds.
+   * @return a reference to this, so the API can be used fluently
+   */
+  public RequestOptions setIdleTimeout(long timeout) {
+    this.idleTimeout = timeout;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/WebSocketConnectOptions.java
+++ b/src/main/java/io/vertx/core/http/WebSocketConnectOptions.java
@@ -206,6 +206,23 @@ public class WebSocketConnectOptions extends RequestOptions {
   }
 
   @Override
+  public WebSocketConnectOptions setConnectTimeout(long timeout) {
+    return (WebSocketConnectOptions) super.setConnectTimeout(timeout);
+  }
+
+  /**
+   * Sets the amount of time after which if the WebSocket handshake does not happen within the timeout period an
+   * {@link WebSocketHandshakeException} will be passed to the exception handler and the connection will be closed.
+   *
+   * @param timeout the amount of time in milliseconds.
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Override
+  public WebSocketConnectOptions setIdleTimeout(long timeout) {
+    return (WebSocketConnectOptions) super.setIdleTimeout(timeout);
+  }
+
+  @Override
   public WebSocketConnectOptions addHeader(String key, String value) {
     return (WebSocketConnectOptions) super.addHeader(key, value);
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -209,13 +209,17 @@ public class HttpClientBase implements MetricsProvider, Closeable {
       ar -> {
         if (ar.succeeded()) {
           Http1xClientConnection conn = (Http1xClientConnection) ar.result();
+          long timeout = connectOptions.getTimeout();
+          if (timeout == 0L) {
+            timeout = connectOptions.getIdleTimeout();
+          }
           conn.toWebSocket(ctx,
             connectOptions.getURI(),
             connectOptions.getHeaders(),
             connectOptions.getAllowOriginHeader(),
             connectOptions.getVersion(),
             connectOptions.getSubProtocols(),
-            connectOptions.getTimeout(),
+            timeout,
             connectOptions.isRegisterWriteHandlers(),
             HttpClientBase.this.options.getMaxWebSocketFrameSize(),
             promise);

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -158,10 +158,10 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   }
 
   @Override
-  public synchronized HttpClientRequest setTimeout(long timeoutMs) {
+  public synchronized HttpClientRequest setTimeout(long timeout) {
     cancelTimeout();
-    currentTimeoutMs = timeoutMs;
-    currentTimeoutTimerId = context.setTimer(timeoutMs, id -> handleTimeout(timeoutMs));
+    currentTimeoutMs = timeout;
+    currentTimeoutTimerId = context.setTimer(timeout, id -> handleTimeout(timeout));
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -18,6 +18,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.http.*;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.NoStackTraceTimeoutException;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;

--- a/src/main/java/io/vertx/core/http/impl/SharedClientHttpStreamEndpoint.java
+++ b/src/main/java/io/vertx/core/http/impl/SharedClientHttpStreamEndpoint.java
@@ -16,6 +16,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.NoStackTraceTimeoutException;
 import io.vertx.core.net.impl.pool.ConnectResult;
 import io.vertx.core.net.impl.pool.ConnectionPool;
 import io.vertx.core.net.impl.pool.PoolConnection;

--- a/src/main/java/io/vertx/core/impl/NoStackTraceTimeoutException.java
+++ b/src/main/java/io/vertx/core/impl/NoStackTraceTimeoutException.java
@@ -8,16 +8,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.core.http.impl;
+package io.vertx.core.impl;
 
 import java.util.concurrent.TimeoutException;
 
-class NoStackTraceTimeoutException extends TimeoutException {
-  NoStackTraceTimeoutException(String message) {
+public class NoStackTraceTimeoutException extends TimeoutException {
+
+  public NoStackTraceTimeoutException(String message) {
     super(message);
   }
+
   @Override
   public synchronized Throwable fillInStackTrace() {
     return this;
   }
+
 }

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -22,10 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -836,6 +833,7 @@ public class FutureTest extends FutureTestBase {
       public <V> Future<V> map(V value) { throw new UnsupportedOperationException(); }
       public Future<T> otherwise(Function<Throwable, T> mapper) { throw new UnsupportedOperationException(); }
       public Future<T> otherwise(T value) { throw new UnsupportedOperationException(); }
+      public Future<T> timeout(long delay, TimeUnit unit) { throw new UnsupportedOperationException(); }
 
       public void handle(AsyncResult<T> asyncResult) {
         if (asyncResult.succeeded()) {
@@ -1744,5 +1742,79 @@ public class FutureTest extends FutureTestBase {
       fail();
     } catch (IllegalStateException e) {
     }
+  }
+
+  @Test
+  public void contextFutureTimeoutFires() {
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    Promise<String> promise = ctx.promise();
+    Future<String> fut = promise.future();
+    futureTimeoutFires(ctx, fut);
+  }
+
+  @Test
+  public void futureTimeoutFires() {
+    disableThreadChecks();
+    Promise<String> promise = Promise.promise();
+    Future<String> fut = promise.future();
+    futureTimeoutFires(null, fut);
+  }
+
+  private void futureTimeoutFires(Context ctx, Future<String> fut) {
+    Future<String> timeout = fut.timeout(100, TimeUnit.MILLISECONDS);
+    timeout.onComplete(onFailure(err -> {
+      assertTrue(err instanceof TimeoutException);
+      assertSame(Vertx.currentContext(), ctx);
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
+  public void contextFutureTimeoutExpires() throws Exception {
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    Promise<String> promise = ctx.promise();
+    futureTimeoutExpires(ctx, promise);
+  }
+
+  @Test
+  public void futureTimeoutExpires() throws Exception {
+    disableThreadChecks();
+    Promise<String> promise = Promise.promise();
+    futureTimeoutExpires(null, promise);
+  }
+
+  private void futureTimeoutExpires(Context ctx, Promise<String> promise) throws Exception {
+    Future<String> timeout = promise.future().timeout(10, TimeUnit.SECONDS);
+    timeout.onComplete(onSuccess(val -> {
+      assertSame(Vertx.currentContext(), ctx);
+      assertEquals("value", val);
+      testComplete();
+    }));
+    Thread.sleep(100);
+    promise.complete("value");
+    await();
+  }
+
+  @Test
+  public void contextCompletedFutureTimeout() throws Exception {
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    completedFutureTimeout(ctx, ctx.succeededFuture("value"));
+  }
+
+  @Test
+  public void completedFutureTimeout() throws Exception {
+    disableThreadChecks();
+    completedFutureTimeout(null, Future.succeededFuture("value"));
+  }
+
+  private void completedFutureTimeout(Context ctx, Future<String> future) throws Exception {
+    Future<String> timeout = future.timeout(10, TimeUnit.SECONDS);
+    timeout.onComplete(onSuccess(val -> {
+      assertSame(Vertx.currentContext(), ctx);
+      assertEquals("value", val);
+      testComplete();
+    }));
+    await();
   }
 }

--- a/src/test/java/io/vertx/core/http/Http1xMetricsTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xMetricsTest.java
@@ -10,7 +10,6 @@
  */
 package io.vertx.core.http;
 
-import io.vertx.test.fakemetrics.FakeHttpClientMetrics;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -26,7 +25,7 @@ public class Http1xMetricsTest extends HttpMetricsTestBase {
     server.requestHandler(req -> {
       fail();
     });
-    startServer();
+    startServer(testAddress);
     CountDownLatch latch = new CountDownLatch(1);
     client = vertx.createHttpClient(createBaseClientOptions().setIdleTimeout(2));
     client.request(requestOptions).onComplete(onSuccess(req -> {

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -1032,71 +1032,6 @@ public class Http1xTest extends HttpTest {
   // Extra tests
 
   @Test
-  public void testTimedOutWaiterDoesNotConnect() throws Exception {
-    Assume.assumeTrue("Domain socket don't pass this test", testAddress.isInetSocket());
-    long responseDelay = 300;
-    int requests = 6;
-    client.close();
-    CountDownLatch firstCloseLatch = new CountDownLatch(1);
-    server.close(onSuccess(v -> firstCloseLatch.countDown()));
-    // Make sure server is closed before continuing
-    awaitLatch(firstCloseLatch);
-
-    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(false).setMaxPoolSize(1));
-    AtomicInteger requestCount = new AtomicInteger(0);
-    // We need a net server because we need to intercept the socket connection, not just full http requests
-    NetServer server = vertx.createNetServer();
-    server.connectHandler(socket -> {
-      Buffer content = Buffer.buffer();
-      AtomicBoolean closed = new AtomicBoolean();
-      socket.closeHandler(v -> closed.set(true));
-      socket.handler(buff -> {
-        content.appendBuffer(buff);
-        if (buff.toString().endsWith("\r\n\r\n")) {
-          // Delay and write a proper http response
-          vertx.setTimer(responseDelay, time -> {
-            if (!closed.get()) {
-              requestCount.incrementAndGet();
-              socket.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK");
-            }
-          });
-        }
-      });
-    });
-
-    CountDownLatch latch = new CountDownLatch(requests);
-
-    server.listen(testAddress, onSuccess(s -> {
-      for(int count = 0; count < requests; count++) {
-
-        if (count % 2 == 0) {
-          client.request(requestOptions)
-            .compose(HttpClientRequest::send)
-            .compose(HttpClientResponse::body)
-            .onComplete(onSuccess(buff -> {
-              assertEquals("OK", buff.toString());
-              latch.countDown();
-            }));
-        } else {
-          // Odd requests get a timeout less than the responseDelay, since we have a pool size of one and a delay all but
-          // the first request should end up in the wait queue, the odd numbered requests should time out so we should get
-          // (requests + 1 / 2) connect attempts
-          client
-            .request(new RequestOptions(requestOptions).setTimeout(responseDelay / 2))
-            .onComplete(onFailure(err -> {
-            latch.countDown();
-          }));
-        }
-      }
-    }));
-
-    awaitLatch(latch);
-
-    assertEquals("Incorrect number of connect attempts.", (requests + 1) / 2, requestCount.get());
-    server.close();
-  }
-
-  @Test
   public void testPipeliningOrder() throws Exception {
     client.close();
     client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(true).setPipelining(true).setMaxPoolSize(1));
@@ -1645,38 +1580,6 @@ public class Http1xTest extends HttpTest {
     await();
   }
 
-  // Note : cannot pass for http/2 because flushing is not the same : investigate
-  @Test
-  public void testRequestTimeoutExtendedWhenResponseChunksReceived() {
-    long timeout = 2000;
-    int numChunks = 100;
-    AtomicInteger count = new AtomicInteger(0);
-    long interval = timeout * 2 / numChunks;
-
-    server.requestHandler(req -> {
-      req.response().setChunked(true);
-      vertx.setPeriodic(interval, timerID -> {
-        req.response().write("foo");
-        if (count.incrementAndGet() == numChunks) {
-          req.response().end();
-          vertx.cancelTimer(timerID);
-        }
-      });
-    });
-
-    server.listen(testAddress, onSuccess(s -> {
-      client.request(new RequestOptions(requestOptions)
-        .setTimeout(timeout)).onComplete(onSuccess(req -> {
-          req.send(onSuccess(resp -> {
-            assertEquals(200, resp.statusCode());
-            resp.endHandler(v -> testComplete());
-          }));
-      }));
-    }));
-
-    await();
-  }
-
   @Test
   public void testServerWebSocketIdleTimeout() {
     server.close();
@@ -2008,40 +1911,6 @@ public class Http1xTest extends HttpTest {
     client.request(new RequestOptions().setAbsoluteURI("http://www.google.com"))
       .compose(HttpClientRequest::send)
       .onComplete(onSuccess(resp -> testComplete()));
-    await();
-  }
-
-  @Test
-  public void testRequestsTimeoutInQueue() {
-
-    server.requestHandler(req -> {
-      vertx.setTimer(1000, id -> {
-        HttpServerResponse resp = req.response();
-        if (!resp.closed()) {
-          resp.end();
-        }
-      });
-    });
-
-    client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(false).setMaxPoolSize(1));
-
-    server.listen(testAddress, onSuccess(s -> {
-      // Add a few requests that should all timeout
-      for (int i = 0; i < 5; i++) {
-        client.request(new RequestOptions(requestOptions).setTimeout(500))
-          .compose(HttpClientRequest::send)
-          .onComplete(onFailure(t -> assertTrue(t instanceof TimeoutException)));
-      }
-      // Now another request that should not timeout
-      client.request(new RequestOptions(requestOptions).setTimeout(3000))
-        .compose(HttpClientRequest::send)
-        .onComplete(onSuccess(resp -> {
-          assertEquals(200, resp.statusCode());
-          testComplete();
-        }));
-    }));
-
     await();
   }
 
@@ -3835,39 +3704,6 @@ public class Http1xTest extends HttpTest {
       .onComplete(onSuccess(req -> {
         promise.complete();
       }));
-    await();
-  }
-
-  @Test
-  public void testRequestTimeoutIsNotDelayedAfterResponseIsReceived() throws Exception {
-    int n = 6;
-    waitFor(n);
-    server.requestHandler(req -> {
-      req.response().end();
-    });
-    startServer(testAddress);
-    vertx.deployVerticle(new AbstractVerticle() {
-      @Override
-      public void start() throws Exception {
-        HttpClient client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(n));
-        for (int i = 0;i < n;i++) {
-          AtomicBoolean responseReceived = new AtomicBoolean();
-          client.request(requestOptions).onComplete(onSuccess(req -> {
-            req.setTimeout(500);
-            req.send(onSuccess(resp -> {
-              try {
-                Thread.sleep(150);
-              } catch (InterruptedException e) {
-                fail(e);
-              }
-              responseReceived.set(true);
-              // Complete later, if some timeout tasks have been queued, this will be executed after
-              vertx.runOnContext(v -> complete());
-            }));
-          }));
-        }
-      }
-    }, new DeploymentOptions().setWorker(true));
     await();
   }
 

--- a/src/test/java/io/vertx/core/http/Http2MetricsTest.java
+++ b/src/test/java/io/vertx/core/http/Http2MetricsTest.java
@@ -80,7 +80,7 @@ public class Http2MetricsTest extends HttpMetricsTestBase {
         });
       });
     });
-    startServer();
+    startServer(testAddress);
     client = vertx.createHttpClient(createBaseClientOptions());
     FakeHttpClientMetrics metrics = FakeMetricsBase.getMetrics(client);
     client.request(requestOptions).onComplete(onSuccess(req -> {

--- a/src/test/java/io/vertx/core/http/Http2TestBase.java
+++ b/src/test/java/io/vertx/core/http/Http2TestBase.java
@@ -58,6 +58,11 @@ public class Http2TestBase extends HttpTestBase {
   }
 
   @Override
+  protected void configureDomainSockets() throws Exception {
+    // Nope
+  }
+
+  @Override
   protected void tearDown() throws Exception {
     super.tearDown();
     for (EventLoopGroup eventLoopGroup : eventLoopGroups) {

--- a/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
+++ b/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
@@ -42,6 +42,7 @@ import io.vertx.test.core.TestUtils;
 
 @RunWith(Parameterized.class)
 public class HttpBandwidthLimitingTest extends Http2TestBase {
+
   private static final int OUTBOUND_LIMIT = 64 * 1024;  // 64KB/s
   private static final int INBOUND_LIMIT = 64 * 1024;   // 64KB/s
   private static final int TEST_CONTENT_SIZE = 64 * 1024 * 4;   // 64 * 4 = 256KB

--- a/src/test/java/io/vertx/core/http/HttpClientConnectionTest.java
+++ b/src/test/java/io/vertx/core/http/HttpClientConnectionTest.java
@@ -24,21 +24,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class HttpClientConnectionTest extends HttpTestBase {
 
-  protected SocketAddress peerAddress;
   private File tmp;
   protected HttpClientInternal client;
+  protected SocketAddress peerAddress;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    peerAddress = testAddress;
-    if (USE_DOMAIN_SOCKETS) {
-      assertTrue("Native transport not enabled", USE_NATIVE_TRANSPORT);
-      tmp = TestUtils.tmpFile(".sock");
-      testAddress = SocketAddress.domainSocketAddress(tmp.getAbsolutePath());
-      requestOptions.setServer(testAddress);
-    }
     this.client = (HttpClientInternal) super.client;
+    this.peerAddress = SocketAddress.inetSocketAddress(requestOptions.getPort(), requestOptions.getHost());
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/HttpClientTimeoutTest.java
+++ b/src/test/java/io/vertx/core/http/HttpClientTimeoutTest.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.Utils;
+import io.vertx.core.net.NetServer;
+import io.vertx.test.core.TestUtils;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class HttpClientTimeoutTest extends HttpTestBase {
+
+  @Test
+  public void testEndToEndRequestTimeout() throws Exception {
+    int timeout = 3000;
+    int ratio = 60;
+    int delay = timeout * ratio / 100;
+    server.requestHandler(req -> {
+      switch (req.uri()) {
+        case "/slow":
+          vertx.setTimer(delay, id -> {
+            req.response().end();
+          });
+          break;
+        default:
+          req.response().end();
+          break;
+      }
+    });
+    startServer(testAddress);
+    List<HttpClientRequest> requests = new ArrayList<>();
+    for (int i = 0;i < 5;i++) {
+      HttpClientRequest request = client.request(new RequestOptions(requestOptions)).toCompletionStage().toCompletableFuture().get();
+      requests.add(request);
+    }
+    vertx.setTimer(delay, id -> {
+      requests.forEach(req -> {
+        req.send().compose(HttpClientResponse::body);
+      });
+    });
+    long now = System.currentTimeMillis();
+    client.request(new RequestOptions(requestOptions).setTimeout(timeout).setURI("/slow"))
+      .onComplete(onSuccess(req -> {
+        req.send().compose(HttpClientResponse::body).onComplete(onSuccess(body -> {
+          long elapsed = System.currentTimeMillis() - now;
+          assertTrue(elapsed >= delay * 2);
+          testComplete();
+        }));
+    }));
+    await();
+  }
+
+  @Test
+  public void testConnectTimeoutDoesFire() throws Exception {
+    int timeout = 3000;
+    server.requestHandler(req -> {
+      req.response().end();
+    });
+    startServer(testAddress);
+    List<HttpClientRequest> requests = new ArrayList<>();
+    for (int i = 0;i < 5;i++) {
+      HttpClientRequest request = client.request(new RequestOptions(requestOptions)).toCompletionStage().toCompletableFuture().get();
+      requests.add(request);
+    }
+    long now = System.currentTimeMillis();
+    client.request(new RequestOptions(requestOptions).setConnectTimeout(timeout).setURI("/slow"))
+      .onComplete(onFailure(err -> {
+        assertTrue(System.currentTimeMillis() - now >= timeout);
+        testComplete();
+      }));
+    await();
+  }
+
+  @Test
+  public void testConnectTimeoutDoesNotFire() throws Exception {
+    int timeout = 3000;
+    int ratio = 80;
+    server.requestHandler(req -> {
+      req.response().end();
+    });
+    startServer(testAddress);
+    List<HttpClientRequest> requests = new ArrayList<>();
+    for (int i = 0;i < 5;i++) {
+      HttpClientRequest request = client.request(new RequestOptions(requestOptions)).toCompletionStage().toCompletableFuture().get();
+      requests.add(request);
+    }
+    vertx.setTimer(timeout * ratio / 100, id -> {
+      requests.forEach(req -> {
+        req.send().compose(HttpClientResponse::body);
+      });
+    });
+    long now = System.currentTimeMillis();
+    client.request(new RequestOptions(requestOptions).setConnectTimeout(timeout).setURI("/slow"))
+      .onComplete(onSuccess(req -> {
+        long elapsed = System.currentTimeMillis() - now;
+        assertTrue(elapsed >= timeout * ratio / 100);
+        assertTrue(elapsed <= timeout);
+        testComplete();
+      }));
+    await();
+  }
+
+  @Test
+  public void testTimedOutWaiterDoesNotConnect() throws Exception {
+    Assume.assumeTrue("Domain socket don't pass this test", testAddress.isInetSocket());
+    long responseDelay = 300;
+    int requests = 6;
+    client.close();
+    CountDownLatch firstCloseLatch = new CountDownLatch(1);
+    server.close(onSuccess(v -> firstCloseLatch.countDown()));
+    // Make sure server is closed before continuing
+    awaitLatch(firstCloseLatch);
+
+    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(false).setMaxPoolSize(1));
+    AtomicInteger requestCount = new AtomicInteger(0);
+    // We need a net server because we need to intercept the socket connection, not just full http requests
+    NetServer server = vertx.createNetServer();
+    server.connectHandler(socket -> {
+      Buffer content = Buffer.buffer();
+      AtomicBoolean closed = new AtomicBoolean();
+      socket.closeHandler(v -> closed.set(true));
+      socket.handler(buff -> {
+        content.appendBuffer(buff);
+        if (buff.toString().endsWith("\r\n\r\n")) {
+          // Delay and write a proper http response
+          vertx.setTimer(responseDelay, time -> {
+            if (!closed.get()) {
+              requestCount.incrementAndGet();
+              socket.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK");
+            }
+          });
+        }
+      });
+    });
+
+    CountDownLatch latch = new CountDownLatch(requests);
+
+    server.listen(testAddress, onSuccess(s -> {
+      for(int count = 0; count < requests; count++) {
+
+        if (count % 2 == 0) {
+          client.request(requestOptions)
+            .compose(HttpClientRequest::send)
+            .compose(HttpClientResponse::body)
+            .onComplete(onSuccess(buff -> {
+              assertEquals("OK", buff.toString());
+              latch.countDown();
+            }));
+        } else {
+          // Odd requests get a timeout less than the responseDelay, since we have a pool size of one and a delay all but
+          // the first request should end up in the wait queue, the odd numbered requests should time out so we should get
+          // (requests + 1 / 2) connect attempts
+          client
+            .request(new RequestOptions(requestOptions).setConnectTimeout(responseDelay / 2))
+            .onComplete(onFailure(err -> {
+              latch.countDown();
+            }));
+        }
+      }
+    }));
+
+    awaitLatch(latch);
+
+    assertEquals("Incorrect number of connect attempts.", (requests + 1) / 2, requestCount.get());
+    server.close();
+  }
+
+  @Test
+  public void testRequestIdleTimeoutIsNotDelayedAfterResponseIsReceived() throws Exception {
+    int n = 6;
+    waitFor(n);
+    server.requestHandler(req -> {
+      req.response().end();
+    });
+    startServer(testAddress);
+    vertx.deployVerticle(new AbstractVerticle() {
+      @Override
+      public void start() throws Exception {
+        HttpClient client = vertx.createHttpClient(new HttpClientOptions().setMaxPoolSize(n));
+        for (int i = 0;i < n;i++) {
+          AtomicBoolean responseReceived = new AtomicBoolean();
+          client.request(requestOptions).onComplete(onSuccess(req -> {
+            req.setIdleTimeout(500);
+            req.send(onSuccess(resp -> {
+              try {
+                Thread.sleep(150);
+              } catch (InterruptedException e) {
+                fail(e);
+              }
+              responseReceived.set(true);
+              // Complete later, if some timeout tasks have been queued, this will be executed after
+              vertx.runOnContext(v -> complete());
+            }));
+          }));
+        }
+      }
+    }, new DeploymentOptions().setWorker(true));
+    await();
+  }
+
+  @Test
+  public void testRequestIdleTimeoutCanceledWhenRequestEndsNormally() {
+    server.requestHandler(req -> req.response().end());
+    server.listen(testAddress, onSuccess(s -> {
+      AtomicReference<Throwable> exception = new AtomicReference<>();
+      client.request(requestOptions).onComplete(onSuccess(req -> {
+        req
+          .exceptionHandler(exception::set)
+          .setIdleTimeout(500)
+          .end();
+        vertx.setTimer(1000, id -> {
+          assertNull("Did not expect any exception", exception.get());
+          testComplete();
+        });
+      }));
+    }));
+    await();
+  }
+
+  @Test
+  public void testRequestIdleTimeoutCanceledWhenRequestHasAnotherError() {
+    Assume.assumeFalse(Utils.isWindows());
+    AtomicReference<Throwable> exception = new AtomicReference<>();
+    // There is no server running, should fail to connect
+    client.request(new RequestOptions().setPort(5000).setIdleTimeout(800))
+      .onComplete(onFailure(exception::set));
+    vertx.setTimer(1500, id -> {
+      assertNotNull("Expected an exception to be set", exception.get());
+      assertFalse("Expected to not end with timeout exception, but did: " + exception.get(), exception.get() instanceof TimeoutException);
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testHttpClientRequestIdleTimeoutResetsTheConnection() throws Exception {
+    waitFor(3);
+    server.requestHandler(req -> {
+      AtomicBoolean errored = new AtomicBoolean();
+      req.exceptionHandler(err -> {
+        if (errored.compareAndSet(false, true)) {
+          complete();
+        }
+      });
+    });
+    startServer(testAddress);
+    client.request(requestOptions).onComplete(onSuccess(req -> {
+      req.response(onFailure(err -> {
+        complete();
+      }));
+      req.setChunked(true).sendHead(onSuccess(version -> req.setIdleTimeout(500)));
+      AtomicBoolean errored = new AtomicBoolean();
+      req.exceptionHandler(err -> {
+        if (errored.compareAndSet(false, true)) {
+          complete();
+        }
+      });
+    }));
+    await();
+  }
+
+  @Test
+  public void testResponseDataIdleTimeout() {
+    waitFor(2);
+    Buffer expected = TestUtils.randomBuffer(1000);
+    server.requestHandler(req -> {
+      req.response().setChunked(true).write(expected);
+    });
+    server.listen(testAddress, onSuccess(s -> {
+      Buffer received = Buffer.buffer();
+      client.request(requestOptions).onComplete(onSuccess(req -> {
+        req.response(onSuccess(resp -> {
+          AtomicInteger count = new AtomicInteger();
+          resp.exceptionHandler(t -> {
+            if (count.getAndIncrement() == 0) {
+              assertTrue(t instanceof TimeoutException);
+              assertEquals(expected, received);
+              complete();
+            }
+          });
+          resp.request().setIdleTimeout(500);
+          resp.handler(buff -> {
+            received.appendBuffer(buff);
+            // Force the internal timer to be rescheduled with the remaining amount of time
+            // e.g around 100 ms
+            try {
+              Thread.sleep(100);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+          });
+        }));
+        AtomicInteger count = new AtomicInteger();
+        req.exceptionHandler(t -> {
+          if (count.getAndIncrement() == 0) {
+            assertTrue(t instanceof TimeoutException);
+            assertEquals(expected, received);
+            complete();
+          }
+        });
+        req.sendHead();
+      }));
+    }));
+    await();
+  }
+
+  @Test
+  public void testRequestTimesOutWhenIndicatedPeriodExpiresWithoutAResponseFromRemoteServer() {
+    server.requestHandler(noOpHandler()); // No response handler so timeout triggers
+    AtomicBoolean failed = new AtomicBoolean();
+    server.listen(testAddress, onSuccess(s -> {
+      client.request(new RequestOptions(requestOptions).setIdleTimeout(1000))
+        .compose(HttpClientRequest::send).onComplete(onFailure(t -> {
+          // Catch the first, the second is going to be a connection closed exception when the
+          // server is shutdown on testComplete
+          if (failed.compareAndSet(false, true)) {
+            testComplete();
+          }
+        }));
+    }));
+    await();
+  }
+
+  // Note : cannot pass for http/2 because flushing is not the same : investigate
+  @Test
+  public void testRequestTimeoutExtendedWhenResponseChunksReceived() {
+    long timeout = 2000;
+    int numChunks = 100;
+    AtomicInteger count = new AtomicInteger(0);
+    long interval = timeout * 2 / numChunks;
+
+    server.requestHandler(req -> {
+      req.response().setChunked(true);
+      vertx.setPeriodic(interval, timerID -> {
+        req.response().write("foo");
+        if (count.incrementAndGet() == numChunks) {
+          req.response().end();
+          vertx.cancelTimer(timerID);
+        }
+      });
+    });
+
+    server.listen(testAddress, onSuccess(s -> {
+      client.request(new RequestOptions(requestOptions)
+        .setIdleTimeout(timeout)).onComplete(onSuccess(req -> {
+        req.send(onSuccess(resp -> {
+          assertEquals(200, resp.statusCode());
+          resp.endHandler(v -> testComplete());
+        }));
+      }));
+    }));
+
+    await();
+  }
+
+  @Test
+  public void testRequestsTimeoutInQueue() {
+
+    server.requestHandler(req -> {
+      vertx.setTimer(1000, id -> {
+        HttpServerResponse resp = req.response();
+        if (!resp.closed()) {
+          resp.end();
+        }
+      });
+    });
+
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(false).setMaxPoolSize(1));
+
+    server.listen(testAddress, onSuccess(s -> {
+      // Add a few requests that should all timeout
+      for (int i = 0; i < 5; i++) {
+        client.request(new RequestOptions(requestOptions).setIdleTimeout(500))
+          .compose(HttpClientRequest::send)
+          .onComplete(onFailure(t -> assertTrue(t instanceof TimeoutException)));
+      }
+      // Now another request that should not timeout
+      client.request(new RequestOptions(requestOptions).setIdleTimeout(3000))
+        .compose(HttpClientRequest::send)
+        .onComplete(onSuccess(resp -> {
+          assertEquals(200, resp.statusCode());
+          testComplete();
+        }));
+    }));
+
+    await();
+  }
+}

--- a/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
+++ b/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
@@ -105,7 +105,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
         });
       });
     });
-    startServer();
+    startServer(testAddress);
     CountDownLatch latch = new CountDownLatch(1);
     AtomicReference<HttpClientMetric> clientMetric = new AtomicReference<>();
     AtomicReference<SocketMetric> clientSocketMetric = new AtomicReference<>();
@@ -116,23 +116,20 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
     Context ctx = vertx.getOrCreateContext();
     ctx.runOnContext(v -> {
       assertEquals(Collections.emptySet(), metrics.endpoints());
-      client.request(new RequestOptions()
-        .setPort(DEFAULT_HTTP_PORT)
-        .setHost(DEFAULT_HTTP_HOST)
+      client.request(new RequestOptions(requestOptions)
         .setURI(TestUtils.randomAlphaString(16)))
         .onComplete(onSuccess(req -> {
           req
             .response(onSuccess(resp -> {
-              clientSocketMetric.set(metrics.firstMetric(SocketAddress.inetSocketAddress(8080, "localhost")));
+              clientSocketMetric.set(metrics.firstMetric(testAddress));
               assertNotNull(clientSocketMetric.get());
-              assertEquals(Collections.singleton("localhost:8080"), metrics.endpoints());
+              assertEquals(Collections.singleton(testAddress.toString()), metrics.endpoints());
               clientMetric.set(metrics.getMetric(resp.request()));
               assertNotNull(clientMetric.get());
               assertEquals(contentLength, clientMetric.get().bytesWritten.get());
               // assertNotNull(clientMetric.get().socket);
               // assertTrue(clientMetric.get().socket.connected.get());
-              assertEquals((Integer) 1, metrics.connectionCount("localhost:8080"));
-              assertEquals((Integer) 1, metrics.connectionCount(SocketAddress.inetSocketAddress(8080, "localhost")));
+              assertEquals((Integer) 1, metrics.connectionCount(testAddress));
               resp.bodyHandler(buff -> {
                 assertEquals(contentLength, clientMetric.get().bytesRead.get());
                 assertNull(metrics.getMetric(resp.request()));
@@ -257,7 +254,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
     server.requestHandler(req -> {
       req.response().setChunked(true).write(Buffer.buffer("some-data"));
     });
-    startServer();
+    startServer(testAddress);
     client = vertx.createHttpClient(createBaseClientOptions().setIdleTimeout(2));
     FakeHttpClientMetrics metrics = FakeMetricsBase.getMetrics(client);
     client.request(requestOptions).onComplete(onSuccess(req -> {
@@ -292,7 +289,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
         testComplete();
       });
     });
-    startServer();
+    startServer(testAddress);
     client.request(new RequestOptions(requestOptions).setURI(TestUtils.randomAlphaString(16))).onComplete(onSuccess(HttpClientRequest::send));
     await();
   }
@@ -310,7 +307,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
       req.response().end();
       testComplete();
     });
-    startServer();
+    startServer(testAddress);
     client.request(new RequestOptions(requestOptions).setURI(TestUtils.randomAlphaString(16))).onComplete(onSuccess(HttpClientRequest::send));
     await();
   }
@@ -326,7 +323,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
       assertNull(metric.route.get());
       testComplete();
     });
-    startServer();
+    startServer(testAddress);
     client.request(new RequestOptions(requestOptions).setURI(TestUtils.randomAlphaString(16))).onComplete(onSuccess(HttpClientRequest::send));
     await();
   }
@@ -336,7 +333,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
     FakeHttpClientMetrics metrics = FakeMetricsBase.getMetrics(client);
     server.requestHandler(req -> {
     }).listen(testAddress, onSuccess(v -> {
-      client.request(HttpMethod.GET, 8080, "localhost", "/somepath", onSuccess(request -> {
+      client.request(requestOptions, onSuccess(request -> {
         assertNull(metrics.getMetric(request));
         request.reset(0);
         vertx.setTimer(10, id -> {

--- a/src/test/java/io/vertx/core/http/HttpServerFileUploadTest.java
+++ b/src/test/java/io/vertx/core/http/HttpServerFileUploadTest.java
@@ -42,18 +42,11 @@ public abstract class HttpServerFileUploadTest extends HttpTestBase {
   public TemporaryFolder testFolder = new TemporaryFolder();
 
   protected File testDir;
-  private File tmp;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
     testDir = testFolder.newFolder();
-    if (USE_DOMAIN_SOCKETS) {
-      assertTrue("Native transport not enabled", USE_NATIVE_TRANSPORT);
-      tmp = TestUtils.tmpFile(".sock");
-      testAddress = SocketAddress.domainSocketAddress(tmp.getAbsolutePath());
-      requestOptions.setServer(testAddress);
-    }
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -69,18 +69,11 @@ public abstract class HttpTest extends HttpTestBase {
   public TemporaryFolder testFolder = TemporaryFolder.builder().assureDeletion().build();
 
   protected File testDir;
-  private File tmp;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
     testDir = testFolder.newFolder();
-    if (USE_DOMAIN_SOCKETS) {
-      assertTrue("Native transport not enabled", USE_NATIVE_TRANSPORT);
-      tmp = TestUtils.tmpFile(".sock");
-      testAddress = SocketAddress.domainSocketAddress(tmp.getAbsolutePath());
-      requestOptions.setServer(testAddress);
-    }
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/RequestOptionsTest.java
+++ b/src/test/java/io/vertx/core/http/RequestOptionsTest.java
@@ -36,6 +36,8 @@ public class RequestOptionsTest {
     assertEquals(RequestOptions.DEFAULT_URI, options.getURI());
     assertEquals(RequestOptions.DEFAULT_FOLLOW_REDIRECTS, options.getFollowRedirects());
     assertEquals(RequestOptions.DEFAULT_TIMEOUT, options.getTimeout());
+    assertEquals(RequestOptions.DEFAULT_CONNECT_TIMEOUT, options.getConnectTimeout());
+    assertEquals(RequestOptions.DEFAULT_IDLE_TIMEOUT, options.getIdleTimeout());
   }
 
   @Test
@@ -63,6 +65,8 @@ public class RequestOptionsTest {
       .addHeader("foo", Arrays.asList("bar", "baz"));
     JsonObject expected = new JsonObject()
       .put("timeout", RequestOptions.DEFAULT_TIMEOUT)
+      .put("connectTimeout", RequestOptions.DEFAULT_CONNECT_TIMEOUT)
+      .put("idleTimeout", RequestOptions.DEFAULT_IDLE_TIMEOUT)
       .put("uri", RequestOptions.DEFAULT_URI)
       .put("method", "PUT")
       .put("port", 8443)


### PR DESCRIPTION
The way HTTP client timeouts does not meet all the expectations.

The `timeout` present on `RequestOptions` applies for the time to obtain a connection and then configures the idle timeout of the request.

It is preferable to deprecate `RequestOptions#timeout` property an `HttpClientRequest#setTimeout` because its naming is too broad and introduce a connect timeout and an idle timeout.

`RequestOptions` now has a `connectTimeout` applied when a request is obtained from the client pool and an `idleTimeout` applied to the `HttpClientRequest` after it has been obtained from the pool.

`HttpClientRequest` now has a `setIdleTimeout` method which is a bare rename of `setTimeout` and better carries the meaning of the method.

In addition it should be easier to define a global timeout when interacting with an HTTP server that is not captured by connect or idle timeout. The `Future` interface now has a `timeout` method allowing to define a timeout when obtaining a result, e.g. the result of an HTTP client interaction with a server.

