### PR TITLE
Http client timeout improvements

### DIFF
--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -1083,11 +1083,22 @@ no need to set the `Content-Length` of the request up-front.
 
 ==== Request timeouts
 
-You can set a timeout for a specific http request using {@link io.vertx.core.http.RequestOptions#setTimeout(long)} or
-{@link io.vertx.core.http.HttpClientRequest#setTimeout(long)}.
+You can set an idle timeout to prevent your application from unresponsive servers using {@link io.vertx.core.http.RequestOptions#setIdleTimeout(long)} or {@link io.vertx.core.http.HttpClientRequest#setIdleTimeout(long)}. When the request does not return any data within the timeout period an exception will fail the result and the request will be reset.
 
-If the request does not return any data within the timeout period an exception will be passed to the exception handler
-(if provided) and the request will be closed.
+[source,$lang]
+----
+{@link examples.HTTPExamples#clientIdleTimeout}
+----
+
+NOTE: the timeout starts when the {@link io.vertx.core.http.HttpClientRequest} is available, implying a connection was
+obtained from the pool.
+
+You can set a connect timeout to prevent your application from unresponsive busy client connection pool. The
+`Future<HttpClientRequest>` is failed when a connection is not obtained before the timeout delay.
+
+The connect timeout option is not related to the TCP {@link io.vertx.core.http.HttpClientOptions#setConnectTimeout(int)} option, when a request is made against a pooled HTTP client, the timeout applies to the duration to obtain a connection from the pool to serve the request,
+the timeout might fire because the server does not respond in time or the pool is too busy to serve a request.
+
 
 ==== Writing HTTP/2 frames
 

--- a/src/main/generated/io/vertx/core/http/RequestOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/RequestOptionsConverter.java
@@ -55,6 +55,16 @@ public class RequestOptionsConverter {
             obj.setTimeout(((Number)member.getValue()).longValue());
           }
           break;
+        case "connectTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setConnectTimeout(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "idleTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setIdleTimeout(((Number)member.getValue()).longValue());
+          }
+          break;
         case "absoluteURI":
           if (member.getValue() instanceof String) {
             obj.setAbsoluteURI((String)member.getValue());
@@ -93,6 +103,8 @@ public class RequestOptionsConverter {
       json.put("followRedirects", obj.getFollowRedirects());
     }
     json.put("timeout", obj.getTimeout());
+    json.put("connectTimeout", obj.getConnectTimeout());
+    json.put("idleTimeout", obj.getIdleTimeout());
     if (obj.getTraceOperation() != null) {
       json.put("traceOperation", obj.getTraceOperation());
     }

--- a/src/main/generated/io/vertx/core/http/RequestOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/RequestOptionsConverter.java
@@ -50,11 +50,6 @@ public class RequestOptionsConverter {
             obj.setFollowRedirects((Boolean)member.getValue());
           }
           break;
-        case "timeout":
-          if (member.getValue() instanceof Number) {
-            obj.setTimeout(((Number)member.getValue()).longValue());
-          }
-          break;
         case "connectTimeout":
           if (member.getValue() instanceof Number) {
             obj.setConnectTimeout(((Number)member.getValue()).longValue());
@@ -102,7 +97,6 @@ public class RequestOptionsConverter {
     if (obj.getFollowRedirects() != null) {
       json.put("followRedirects", obj.getFollowRedirects());
     }
-    json.put("timeout", obj.getTimeout());
     json.put("connectTimeout", obj.getConnectTimeout());
     json.put("idleTimeout", obj.getIdleTimeout());
     if (obj.getTraceOperation() != null) {

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -559,6 +559,26 @@ public class HTTPExamples {
     request.end();
   }
 
+  public void clientIdleTimeout(HttpClient client, int port, String host, String uri, int timeoutMS) {
+    Future<Buffer> fut = client
+      .request(new RequestOptions()
+        .setHost(host)
+        .setPort(port)
+        .setURI(uri)
+        .setIdleTimeout(timeoutMS))
+      .compose(request -> request.send().compose(HttpClientResponse::body));
+  }
+
+  public void clientConnectTimeout(HttpClient client, int port, String host, String uri, int timeoutMS) {
+    Future<Buffer> fut = client
+      .request(new RequestOptions()
+        .setHost(host)
+        .setPort(port)
+        .setURI(uri)
+        .setConnectTimeout(timeoutMS))
+      .compose(request -> request.send().compose(HttpClientResponse::body));
+  }
+
   public void useRequestAsStream(HttpClientRequest request) {
 
     request.setChunked(true);

--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -22,6 +22,7 @@ import io.vertx.core.impl.future.SucceededFuture;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -534,6 +535,17 @@ public interface Future<T> extends AsyncResult<T> {
       return (Future<T>) ar;
     });
   }
+
+  /**
+   * Returns a future succeeded or failed with the outcome of this future when it happens before the timeout fires. When
+   * the timeout fires before, the future is failed with a {@link java.util.concurrent.TimeoutException}, guaranteeing
+   * the returned future to complete within the specified {@code delay}.
+   *
+   * @param delay the delay
+   * @param unit the unit of the delay
+   * @return the timeout future
+   */
+  Future<T> timeout(long delay, TimeUnit unit);
 
   /**
    * Bridges this Vert.x future to a {@link CompletionStage} instance.

--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -399,18 +399,26 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   Future<Void> end();
 
   /**
-   * Set's the amount of time after which if the request does not return any data within the timeout period an
-   * {@link java.util.concurrent.TimeoutException} will be passed to the exception handler (if provided) and
-   * the request will be closed.
-   * <p>
-   * Calling this method more than once has the effect of canceling any existing timeout and starting
-   * the timeout from scratch.
+   * Like {@link #setIdleTimeout(long)} but with a confusing name (hence the deprecation).
    *
-   * @param timeoutMs The quantity of time in milliseconds.
+   * @deprecated instead use {@link #setIdleTimeout(long)}
+   */
+  @Deprecated
+  @Fluent
+  HttpClientRequest setTimeout(long timeout);
+
+  /**
+   * Sets the amount of time after which, if the request does not return any data within the timeout period,
+   * the request/response is closed and the related futures are failed with a {@link java.util.concurrent.TimeoutException},
+   * e.g. {@code Future<HttpClientResponse>} or {@code Future<Buffer>} response body.
+   *
+   * @param timeout the amount of time in milliseconds.
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  HttpClientRequest setTimeout(long timeoutMs);
+  default HttpClientRequest setIdleTimeout(long timeout) {
+    return setTimeout(timeout);
+  }
 
   /**
    * Set a push handler for this request.<p/>

--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -399,15 +399,6 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   Future<Void> end();
 
   /**
-   * Like {@link #setIdleTimeout(long)} but with a confusing name (hence the deprecation).
-   *
-   * @deprecated instead use {@link #setIdleTimeout(long)}
-   */
-  @Deprecated
-  @Fluent
-  HttpClientRequest setTimeout(long timeout);
-
-  /**
    * Sets the amount of time after which, if the request does not return any data within the timeout period,
    * the request/response is closed and the related futures are failed with a {@link java.util.concurrent.TimeoutException},
    * e.g. {@code Future<HttpClientResponse>} or {@code Future<Buffer>} response body.
@@ -416,9 +407,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  default HttpClientRequest setIdleTimeout(long timeout) {
-    return setTimeout(timeout);
-  }
+  HttpClientRequest setIdleTimeout(long timeout);
 
   /**
    * Set a push handler for this request.<p/>

--- a/src/main/java/io/vertx/core/http/RequestOptions.java
+++ b/src/main/java/io/vertx/core/http/RequestOptions.java
@@ -81,6 +81,16 @@ public class RequestOptions {
    */
   public static final long DEFAULT_TIMEOUT = 0;
 
+  /**
+   * The default connect timeout = {@code 0} (disabled)
+   */
+  public static final long DEFAULT_CONNECT_TIMEOUT = 0;
+
+  /**
+   * The default idle timeout = {@code 0} (disabled)
+   */
+  public static final long DEFAULT_IDLE_TIMEOUT = 0;
+
   private ProxyOptions proxyOptions;
   private Address server;
   private HttpMethod method;
@@ -91,6 +101,8 @@ public class RequestOptions {
   private MultiMap headers;
   private boolean followRedirects;
   private long timeout;
+  private long connectTimeout;
+  private long idleTimeout;
   private String traceOperation;
 
   /**
@@ -106,6 +118,8 @@ public class RequestOptions {
     uri = DEFAULT_URI;
     followRedirects = DEFAULT_FOLLOW_REDIRECTS;
     timeout = DEFAULT_TIMEOUT;
+    connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+    idleTimeout = DEFAULT_IDLE_TIMEOUT;
     traceOperation = null;
   }
 
@@ -123,6 +137,8 @@ public class RequestOptions {
     setSsl(other.ssl);
     setURI(other.uri);
     setFollowRedirects(other.followRedirects);
+    setIdleTimeout(other.idleTimeout);
+    setConnectTimeout(other.connectTimeout);
     setTimeout(other.timeout);
     if (other.headers != null) {
       setHeaders(MultiMap.caseInsensitiveMultiMap().setAll(other.headers));
@@ -329,24 +345,69 @@ public class RequestOptions {
   }
 
   /**
-   * @return the amount of time after which if the request does not return any data within the timeout period an
-   *         {@link java.util.concurrent.TimeoutException} will be passed to the exception handler and
-   *         the request will be closed.
+   * @see #setTimeout(long)
    */
+  @Deprecated
   public long getTimeout() {
     return timeout;
   }
 
   /**
-   * Sets the amount of time after which if the request does not return any data within the timeout period an
-   * {@link java.util.concurrent.TimeoutException} will be passed to the exception handler and
-   * the request will be closed.
+   * Equivalent to setting the same timeout value with {@link #setConnectTimeout(long)} and {@link #setIdleTimeout(long)}.
+   *
+   * @deprecated instead use {@link #setConnectTimeout(long)} or/and {@link #setIdleTimeout(long)}
+   */
+  @Deprecated
+  public RequestOptions setTimeout(long timeout) {
+    this.timeout = timeout;
+    return this;
+  }
+
+  /**
+   * @return the amount of time after which, if the request is not obtained from the client within the timeout period,
+   *         the {@code Future<HttpClientRequest>} obtained from the client is failed with a {@link java.util.concurrent.TimeoutException}
+   */
+  public long getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  /**
+   * Sets the amount of time after which, if the request is not obtained from the client within the timeout period,
+   * the {@code Future<HttpClientRequest>} obtained from the client is failed with a {@link java.util.concurrent.TimeoutException}.
+   *
+   * Note this is not related to the TCP {@link HttpClientOptions#setConnectTimeout(int)} option, when a request is made against
+   * a pooled HTTP client, the timeout applies to the duration to obtain a connection from the pool to serve the request, the timeout
+   * might fire because the server does not respond in time or the pool is too busy to serve a request.
    *
    * @param timeout the amount of time in milliseconds.
    * @return a reference to this, so the API can be used fluently
    */
-  public RequestOptions setTimeout(long timeout) {
-    this.timeout = timeout;
+  public RequestOptions setConnectTimeout(long timeout) {
+    this.connectTimeout = timeout;
+    return this;
+  }
+
+  /**
+   * @return the amount of time after which, if the request does not return any data within the timeout period,
+   *         the request/response is closed and the related futures are failed with a {@link java.util.concurrent.TimeoutException}
+   */
+  public long getIdleTimeout() {
+    return idleTimeout;
+  }
+
+  /**
+   * Sets the amount of time after which, if the request does not return any data within the timeout period,
+   * the request/response is closed and the related futures are failed with a {@link java.util.concurrent.TimeoutException},
+   * e.g. {@code Future<HttpClientResponse>} or {@code Future<Buffer>} response body.
+   *
+   * <p/>The timeout starts after a connection is obtained from the client, similar to calling
+   * {@link HttpClientRequest#setIdleTimeout(long)}.
+   *
+   * @param timeout the amount of time in milliseconds.
+   * @return a reference to this, so the API can be used fluently
+   */
+  public RequestOptions setIdleTimeout(long timeout) {
+    this.idleTimeout = timeout;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/RequestOptions.java
+++ b/src/main/java/io/vertx/core/http/RequestOptions.java
@@ -77,11 +77,6 @@ public class RequestOptions {
   public static final boolean DEFAULT_FOLLOW_REDIRECTS = false;
 
   /**
-   * The default request timeout = {@code 0} (disabled)
-   */
-  public static final long DEFAULT_TIMEOUT = 0;
-
-  /**
    * The default connect timeout = {@code 0} (disabled)
    */
   public static final long DEFAULT_CONNECT_TIMEOUT = 0;
@@ -100,7 +95,6 @@ public class RequestOptions {
   private String uri;
   private MultiMap headers;
   private boolean followRedirects;
-  private long timeout;
   private long connectTimeout;
   private long idleTimeout;
   private String traceOperation;
@@ -117,7 +111,6 @@ public class RequestOptions {
     ssl = DEFAULT_SSL;
     uri = DEFAULT_URI;
     followRedirects = DEFAULT_FOLLOW_REDIRECTS;
-    timeout = DEFAULT_TIMEOUT;
     connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     idleTimeout = DEFAULT_IDLE_TIMEOUT;
     traceOperation = null;
@@ -139,7 +132,6 @@ public class RequestOptions {
     setFollowRedirects(other.followRedirects);
     setIdleTimeout(other.idleTimeout);
     setConnectTimeout(other.connectTimeout);
-    setTimeout(other.timeout);
     if (other.headers != null) {
       setHeaders(MultiMap.caseInsensitiveMultiMap().setAll(other.headers));
     }
@@ -341,25 +333,6 @@ public class RequestOptions {
    */
   public RequestOptions setFollowRedirects(Boolean followRedirects) {
     this.followRedirects = followRedirects;
-    return this;
-  }
-
-  /**
-   * @see #setTimeout(long)
-   */
-  @Deprecated
-  public long getTimeout() {
-    return timeout;
-  }
-
-  /**
-   * Equivalent to setting the same timeout value with {@link #setConnectTimeout(long)} and {@link #setIdleTimeout(long)}.
-   *
-   * @deprecated instead use {@link #setConnectTimeout(long)} or/and {@link #setIdleTimeout(long)}
-   */
-  @Deprecated
-  public RequestOptions setTimeout(long timeout) {
-    this.timeout = timeout;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/WebSocketConnectOptions.java
+++ b/src/main/java/io/vertx/core/http/WebSocketConnectOptions.java
@@ -195,6 +195,11 @@ public class WebSocketConnectOptions extends RequestOptions {
     return (WebSocketConnectOptions) super.setURI(uri);
   }
 
+  @Override
+  public WebSocketConnectOptions setConnectTimeout(long timeout) {
+    return (WebSocketConnectOptions) super.setConnectTimeout(timeout);
+  }
+
   /**
    * Sets the amount of time after which if the WebSocket handshake does not happen within the timeout period an
    * {@link WebSocketHandshakeException} will be passed to the exception handler and the connection will be closed.
@@ -202,16 +207,6 @@ public class WebSocketConnectOptions extends RequestOptions {
    * @param timeout the amount of time in milliseconds.
    * @return a reference to this, so the API can be used fluently
    */
-  @Override
-  public WebSocketConnectOptions setTimeout(long timeout) {
-    return (WebSocketConnectOptions) super.setTimeout(timeout);
-  }
-
-  @Override
-  public WebSocketConnectOptions setConnectTimeout(long timeout) {
-    return (WebSocketConnectOptions) super.setConnectTimeout(timeout);
-  }
-
   @Override
   public WebSocketConnectOptions setIdleTimeout(long timeout) {
     return (WebSocketConnectOptions) super.setIdleTimeout(timeout);

--- a/src/main/java/io/vertx/core/http/WebSocketConnectOptions.java
+++ b/src/main/java/io/vertx/core/http/WebSocketConnectOptions.java
@@ -208,6 +208,16 @@ public class WebSocketConnectOptions extends RequestOptions {
   }
 
   @Override
+  public WebSocketConnectOptions setConnectTimeout(long timeout) {
+    return (WebSocketConnectOptions) super.setConnectTimeout(timeout);
+  }
+
+  @Override
+  public WebSocketConnectOptions setIdleTimeout(long timeout) {
+    return (WebSocketConnectOptions) super.setIdleTimeout(timeout);
+  }
+
+  @Override
   public WebSocketConnectOptions addHeader(String key, String value) {
     return (WebSocketConnectOptions) super.addHeader(key, value);
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -17,6 +17,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.http.*;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.NoStackTraceTimeoutException;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.net.HostAndPort;
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -132,7 +132,7 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   }
 
   @Override
-  public synchronized HttpClientRequest setTimeout(long timeout) {
+  public synchronized HttpClientRequest setIdleTimeout(long timeout) {
     cancelTimeout();
     currentTimeoutMs = timeout;
     currentTimeoutTimerId = context.setTimer(timeout, id -> handleTimeout(timeout));
@@ -196,7 +196,7 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
         if (timeSinceLastData < timeoutMs) {
           // reschedule
           lastDataReceived = 0;
-          setTimeout(timeoutMs - timeSinceLastData);
+          setIdleTimeout(timeoutMs - timeSinceLastData);
           return;
         }
       }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -131,10 +131,10 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   }
 
   @Override
-  public synchronized HttpClientRequest setTimeout(long timeoutMs) {
+  public synchronized HttpClientRequest setTimeout(long timeout) {
     cancelTimeout();
-    currentTimeoutMs = timeoutMs;
-    currentTimeoutTimerId = context.setTimer(timeoutMs, id -> handleTimeout(timeoutMs));
+    currentTimeoutMs = timeout;
+    currentTimeoutTimerId = context.setTimer(timeout, id -> handleTimeout(timeout));
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -326,7 +326,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
     endFuture.onComplete(ar -> {
       if (ar.succeeded()) {
         if (timeoutMs > 0) {
-          next.setTimeout(timeoutMs);
+          next.setIdleTimeout(timeoutMs);
         }
         next.end();
       } else {

--- a/src/main/java/io/vertx/core/http/impl/SharedClientHttpStreamEndpoint.java
+++ b/src/main/java/io/vertx/core/http/impl/SharedClientHttpStreamEndpoint.java
@@ -17,6 +17,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.NoStackTraceTimeoutException;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.net.impl.pool.ConnectResult;
 import io.vertx.core.net.impl.pool.ConnectionPool;

--- a/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
@@ -92,7 +92,7 @@ public class WebSocketClientImpl extends HttpClientBase implements WebSocketClie
             options,
             connectOptions.getVersion(),
             connectOptions.getSubProtocols(),
-            connectOptions.getTimeout(),
+            connectOptions.getIdleTimeout(),
             connectOptions.isRegisterWriteHandlers(),
             WebSocketClientImpl.this.options.getMaxFrameSize(),
             promise);

--- a/src/main/java/io/vertx/core/impl/NoStackTraceTimeoutException.java
+++ b/src/main/java/io/vertx/core/impl/NoStackTraceTimeoutException.java
@@ -8,16 +8,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.core.http.impl;
+package io.vertx.core.impl;
 
 import java.util.concurrent.TimeoutException;
 
-class NoStackTraceTimeoutException extends TimeoutException {
-  NoStackTraceTimeoutException(String message) {
+public class NoStackTraceTimeoutException extends TimeoutException {
+
+  public NoStackTraceTimeoutException(String message) {
     super(message);
   }
+
   @Override
   public synchronized Throwable fillInStackTrace() {
     return this;
   }
+
 }

--- a/src/main/java/io/vertx/core/impl/future/FutureBase.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureBase.java
@@ -11,12 +11,18 @@
 
 package io.vertx.core.impl.future;
 
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.GlobalEventExecutor;
+import io.netty.util.concurrent.OrderedEventExecutor;
+import io.netty.util.concurrent.ScheduledFuture;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.NoStackTraceTimeoutException;
 
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -130,5 +136,40 @@ public abstract class FutureBase<T> implements FutureInternal<T> {
     FixedOtherwise<T> operation = new FixedOtherwise<>(context, value);
     addListener(operation);
     return operation;
+  }
+
+  @Override
+  public Future<T> timeout(long delay, TimeUnit unit) {
+    if (isComplete()) {
+      return this;
+    }
+    OrderedEventExecutor instance;
+    Promise<T> promise;
+    if (context != null) {
+      instance = context.nettyEventLoop();
+      promise = context.promise();
+    } else {
+      instance = GlobalEventExecutor.INSTANCE;
+      promise = Promise.promise();
+    }
+    ScheduledFuture<?> task = instance.schedule(() -> {
+      String msg = "Timeout " + unit.toMillis(delay) + " (ms) fired";
+      promise.fail(new NoStackTraceTimeoutException(msg));
+    }, delay, unit);
+    addListener(new Listener<T>() {
+      @Override
+      public void onSuccess(T value) {
+        if (task.cancel(false)) {
+          promise.complete(value);
+        }
+      }
+      @Override
+      public void onFailure(Throwable failure) {
+        if (task.cancel(false)) {
+          promise.fail(failure);
+        }
+      }
+    });
+    return promise.future();
   }
 }

--- a/src/test/java/io/vertx/core/http/Http1xMetricsTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xMetricsTest.java
@@ -10,7 +10,6 @@
  */
 package io.vertx.core.http;
 
-import io.vertx.test.fakemetrics.FakeHttpClientMetrics;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -26,7 +25,7 @@ public class Http1xMetricsTest extends HttpMetricsTestBase {
     server.requestHandler(req -> {
       fail();
     });
-    startServer();
+    startServer(testAddress);
     CountDownLatch latch = new CountDownLatch(1);
     client = vertx.createHttpClient(createBaseClientOptions().setIdleTimeout(2));
     client.request(requestOptions).onComplete(onSuccess(req -> {

--- a/src/test/java/io/vertx/core/http/Http2ClientTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientTest.java
@@ -1068,7 +1068,7 @@ public class Http2ClientTest extends Http2TestBase {
       HttpConnection conn = req.connection();
       conn.goAwayHandler(ga -> {
         vertx.runOnContext(v -> {
-          client.request(new RequestOptions(requestOptions).setTimeout(5000))
+          client.request(new RequestOptions(requestOptions).setIdleTimeout(5000))
             .compose(HttpClientRequest::send)
             .onComplete(onSuccess(resp2 -> {
               assertEquals(2, connections.size());
@@ -1105,7 +1105,7 @@ public class Http2ClientTest extends Http2TestBase {
           .setHost(DEFAULT_HTTPS_HOST)
           .setPort(DEFAULT_HTTPS_PORT)
           .setURI("/somepath")
-          .setTimeout(5000)).onComplete(onSuccess(req2 -> {
+          .setIdleTimeout(5000)).onComplete(onSuccess(req2 -> {
             req2.send().onComplete(onSuccess(resp2 -> {
               testComplete();
             }));

--- a/src/test/java/io/vertx/core/http/Http2MetricsTest.java
+++ b/src/test/java/io/vertx/core/http/Http2MetricsTest.java
@@ -80,7 +80,7 @@ public class Http2MetricsTest extends HttpMetricsTestBase {
         });
       });
     });
-    startServer();
+    startServer(testAddress);
     client = vertx.createHttpClient(createBaseClientOptions());
     FakeHttpClientMetrics metrics = FakeMetricsBase.getMetrics(client);
     client.request(requestOptions).onComplete(onSuccess(req -> {

--- a/src/test/java/io/vertx/core/http/Http2Test.java
+++ b/src/test/java/io/vertx/core/http/Http2Test.java
@@ -474,7 +474,7 @@ public class Http2Test extends HttpTest {
         });
       })
       .build();
-    client.request(new RequestOptions(requestOptions).setTimeout(10000))
+    client.request(new RequestOptions(requestOptions).setIdleTimeout(10000))
       .compose(HttpClientRequest::send)
       .onComplete(onSuccess(resp -> complete()));
     await();
@@ -488,7 +488,7 @@ public class Http2Test extends HttpTest {
       req.response().end();
     });
     startServer(testAddress);
-    client.request(new RequestOptions(requestOptions).setTimeout(10000))
+    client.request(new RequestOptions(requestOptions).setIdleTimeout(10000))
       .compose(HttpClientRequest::send)
       .onComplete(onSuccess(resp -> {
         assertEquals(Integer.MAX_VALUE, resp.request().connection().remoteSettings().getMaxHeaderListSize());

--- a/src/test/java/io/vertx/core/http/Http2TestBase.java
+++ b/src/test/java/io/vertx/core/http/Http2TestBase.java
@@ -58,6 +58,11 @@ public class Http2TestBase extends HttpTestBase {
   }
 
   @Override
+  protected void configureDomainSockets() throws Exception {
+    // Nope
+  }
+
+  @Override
   protected void tearDown() throws Exception {
     super.tearDown();
     for (EventLoopGroup eventLoopGroup : eventLoopGroups) {

--- a/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
+++ b/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
@@ -41,6 +41,7 @@ import io.vertx.test.core.TestUtils;
 
 @RunWith(Parameterized.class)
 public class HttpBandwidthLimitingTest extends Http2TestBase {
+
   private static final int OUTBOUND_LIMIT = 64 * 1024;  // 64KB/s
   private static final int INBOUND_LIMIT = 64 * 1024;   // 64KB/s
   private static final int TEST_CONTENT_SIZE = 64 * 1024 * 4;   // 64 * 4 = 256KB

--- a/src/test/java/io/vertx/core/http/HttpClientConnectionTest.java
+++ b/src/test/java/io/vertx/core/http/HttpClientConnectionTest.java
@@ -12,35 +12,24 @@ package io.vertx.core.http;
 
 import io.netty.buffer.Unpooled;
 import io.vertx.core.MultiMap;
-import io.vertx.core.http.impl.CleanableHttpClient;
 import io.vertx.core.http.impl.HttpClientInternal;
 import io.vertx.core.http.impl.HttpRequestHead;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.net.HostAndPort;
-import io.vertx.core.net.SocketAddress;
-import io.vertx.test.core.TestUtils;
 import org.junit.Test;
 
-import java.io.File;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class HttpClientConnectionTest extends HttpTestBase {
 
-  protected HostAndPort peerAddress;
-  private File tmp;
   protected HttpClientInternal client;
+  protected HostAndPort peerAddress;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    peerAddress = HostAndPort.create(testAddress.host(), testAddress.port());
-    if (USE_DOMAIN_SOCKETS) {
-      assertTrue("Native transport not enabled", USE_NATIVE_TRANSPORT);
-      tmp = TestUtils.tmpFile(".sock");
-      testAddress = SocketAddress.domainSocketAddress(tmp.getAbsolutePath());
-      requestOptions.setServer(testAddress);
-    }
     this.client = (HttpClientInternal) super.client;
+    this.peerAddress = HostAndPort.create(requestOptions.getHost(), requestOptions.getPort());
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/HttpClientTimeoutTest.java
+++ b/src/test/java/io/vertx/core/http/HttpClientTimeoutTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.ThreadingModel;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.Utils;
+import io.vertx.core.net.NetServer;
+import io.vertx.test.core.TestUtils;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class HttpClientTimeoutTest extends HttpTestBase {
+
+  @Test
+  public void testConnectTimeoutDoesFire() throws Exception {
+    int timeout = 3000;
+    server.requestHandler(req -> {
+      req.response().end();
+    });
+    startServer(testAddress);
+    List<HttpClientRequest> requests = new ArrayList<>();
+    for (int i = 0;i < 5;i++) {
+      HttpClientRequest request = client.request(new RequestOptions(requestOptions)).toCompletionStage().toCompletableFuture().get();
+      requests.add(request);
+    }
+    long now = System.currentTimeMillis();
+    client.request(new RequestOptions(requestOptions).setConnectTimeout(timeout).setURI("/slow"))
+      .onComplete(onFailure(err -> {
+        assertTrue(System.currentTimeMillis() - now >= timeout);
+        testComplete();
+      }));
+    await();
+  }
+
+  @Test
+  public void testConnectTimeoutDoesNotFire() throws Exception {
+    int timeout = 3000;
+    int ratio = 80;
+    server.requestHandler(req -> {
+      req.response().end();
+    });
+    startServer(testAddress);
+    List<HttpClientRequest> requests = new ArrayList<>();
+    for (int i = 0;i < 5;i++) {
+      HttpClientRequest request = client.request(new RequestOptions(requestOptions)).toCompletionStage().toCompletableFuture().get();
+      requests.add(request);
+    }
+    vertx.setTimer(timeout * ratio / 100, id -> {
+      requests.forEach(req -> {
+        req.send().compose(HttpClientResponse::body);
+      });
+    });
+    long now = System.currentTimeMillis();
+    client.request(new RequestOptions(requestOptions).setConnectTimeout(timeout).setURI("/slow"))
+      .onComplete(onSuccess(req -> {
+        long elapsed = System.currentTimeMillis() - now;
+        assertTrue(elapsed >= timeout * ratio / 100);
+        assertTrue(elapsed <= timeout);
+        testComplete();
+      }));
+    await();
+  }
+
+  @Test
+  public void testTimedOutWaiterDoesNotConnect() throws Exception {
+    Assume.assumeTrue("Domain socket don't pass this test", testAddress.isInetSocket());
+    long responseDelay = 300;
+    int requests = 6;
+    CountDownLatch firstCloseLatch = new CountDownLatch(1);
+    server.close().onComplete(onSuccess(v -> firstCloseLatch.countDown()));
+    // Make sure server is closed before continuing
+    awaitLatch(firstCloseLatch);
+
+    client.close();
+    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(false), new PoolOptions().setHttp1MaxSize(1));
+    AtomicInteger requestCount = new AtomicInteger(0);
+    // We need a net server because we need to intercept the socket connection, not just full http requests
+    NetServer server = vertx.createNetServer();
+    server.connectHandler(socket -> {
+      Buffer content = Buffer.buffer();
+      AtomicBoolean closed = new AtomicBoolean();
+      socket.closeHandler(v -> closed.set(true));
+      socket.handler(buff -> {
+        content.appendBuffer(buff);
+        if (buff.toString().endsWith("\r\n\r\n")) {
+          // Delay and write a proper http response
+          vertx.setTimer(responseDelay, time -> {
+            if (!closed.get()) {
+              requestCount.incrementAndGet();
+              socket.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK");
+            }
+          });
+        }
+      });
+    });
+
+    CountDownLatch latch = new CountDownLatch(requests);
+
+    server.listen(testAddress)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(20, TimeUnit.SECONDS);
+
+    for(int count = 0; count < requests; count++) {
+
+      if (count % 2 == 0) {
+        client.request(requestOptions)
+          .compose(req -> req
+            .send()
+            .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+            .compose(HttpClientResponse::body))
+          .onComplete(onSuccess(buff -> {
+            assertEquals("OK", buff.toString());
+            latch.countDown();
+          }));
+      } else {
+        // Odd requests get a timeout less than the responseDelay, since we have a pool size of one and a delay all but
+        // the first request should end up in the wait queue, the odd numbered requests should time out so we should get
+        // (requests + 1 / 2) connect attempts
+        client
+          .request(new RequestOptions(requestOptions).setConnectTimeout(responseDelay / 2))
+          .onComplete(onFailure(err -> {
+            latch.countDown();
+          }));
+      }
+    }
+
+    awaitLatch(latch);
+
+    assertEquals("Incorrect number of connect attempts.", (requests + 1) / 2, requestCount.get());
+    server.close();
+  }
+
+  @Test
+  public void testRequestTimeoutIsNotDelayedAfterResponseIsReceived() throws Exception {
+    int n = 6;
+    waitFor(n);
+    server.requestHandler(req -> {
+      req.response().end();
+    });
+    startServer(testAddress);
+    vertx.deployVerticle(new AbstractVerticle() {
+      @Override
+      public void start() throws Exception {
+        client.close();
+        client = vertx.createHttpClient(new PoolOptions().setHttp1MaxSize(1));
+        for (int i = 0;i < n;i++) {
+          AtomicBoolean responseReceived = new AtomicBoolean();
+          client.request(requestOptions).onComplete(onSuccess(req -> {
+            req.setIdleTimeout(500);
+            req.send().onComplete(onSuccess(resp -> {
+              try {
+                Thread.sleep(150);
+              } catch (InterruptedException e) {
+                fail(e);
+              }
+              responseReceived.set(true);
+              // Complete later, if some timeout tasks have been queued, this will be executed after
+              vertx.runOnContext(v -> complete());
+            }));
+          }));
+        }
+      }
+    }, new DeploymentOptions().setThreadingModel(ThreadingModel.WORKER));
+    await();
+  }
+
+  @Test
+  public void testRequestTimeoutCanceledWhenRequestEndsNormally() throws Exception {
+    server.requestHandler(req -> req.response().end());
+    startServer(testAddress);
+    AtomicReference<Throwable> exception = new AtomicReference<>();
+    client.request(requestOptions).onComplete(onSuccess(req -> {
+      req
+        .exceptionHandler(exception::set)
+        .setIdleTimeout(500)
+        .end();
+      vertx.setTimer(1000, id -> {
+        assertNull("Did not expect any exception", exception.get());
+        testComplete();
+      });
+    }));
+    await();
+  }
+
+  @Test
+  public void testRequestTimeoutCanceledWhenRequestHasAnOtherError() {
+    Assume.assumeFalse(Utils.isWindows());
+    AtomicReference<Throwable> exception = new AtomicReference<>();
+    // There is no server running, should fail to connect
+    client.request(new RequestOptions().setPort(5000).setIdleTimeout(800))
+      .onComplete(onFailure(exception::set));
+    vertx.setTimer(1500, id -> {
+      assertNotNull("Expected an exception to be set", exception.get());
+      assertFalse("Expected to not end with timeout exception, but did: " + exception.get(), exception.get() instanceof TimeoutException);
+      testComplete();
+    });
+
+    await();
+  }
+
+  @Test
+  public void testHttpClientRequestTimeoutResetsTheConnection() throws Exception {
+    waitFor(3);
+    server.requestHandler(req -> {
+      AtomicBoolean errored = new AtomicBoolean();
+      req.exceptionHandler(err -> {
+        if (errored.compareAndSet(false, true)) {
+          complete();
+        }
+      });
+    });
+    startServer(testAddress);
+    client.request(requestOptions).onComplete(onSuccess(req -> {
+      req.response().onComplete(onFailure(err -> {
+        complete();
+      }));
+      req.setChunked(true).sendHead().onComplete(onSuccess(version -> req.setIdleTimeout(500)));
+      AtomicBoolean errored = new AtomicBoolean();
+      req.exceptionHandler(err -> {
+        if (errored.compareAndSet(false, true)) {
+          complete();
+        }
+      });
+    }));
+    await();
+  }
+
+  @Test
+  public void testResponseDataTimeout() throws Exception {
+    waitFor(2);
+    Buffer expected = TestUtils.randomBuffer(1000);
+    server.requestHandler(req -> {
+      req.response().setChunked(true).write(expected);
+    });
+    startServer(testAddress);
+    Buffer received = Buffer.buffer();
+    client.request(requestOptions).onComplete(onSuccess(req -> {
+      req.response().onComplete(onSuccess(resp -> {
+        AtomicInteger count = new AtomicInteger();
+        resp.exceptionHandler(t -> {
+          if (count.getAndIncrement() == 0) {
+            assertTrue(t instanceof TimeoutException);
+            assertEquals(expected, received);
+            complete();
+          }
+        });
+        resp.request().setIdleTimeout(500);
+        resp.handler(buff -> {
+          received.appendBuffer(buff);
+          // Force the internal timer to be rescheduled with the remaining amount of time
+          // e.g around 100 ms
+          try {
+            Thread.sleep(100);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        });
+      }));
+      AtomicInteger count = new AtomicInteger();
+      req.exceptionHandler(t -> {
+        if (count.getAndIncrement() == 0) {
+          assertTrue(t instanceof TimeoutException);
+          assertEquals(expected, received);
+          complete();
+        }
+      });
+      req.sendHead();
+    }));
+    await();
+  }
+
+  @Test
+  public void testRequestTimesOutWhenIndicatedPeriodExpiresWithoutAResponseFromRemoteServer() throws Exception {
+    server.requestHandler(noOpHandler()); // No response handler so timeout triggers
+    AtomicBoolean failed = new AtomicBoolean();
+    startServer(testAddress);
+    client.request(new RequestOptions(requestOptions).setIdleTimeout(1000))
+      .compose(HttpClientRequest::send).onComplete(onFailure(t -> {
+        // Catch the first, the second is going to be a connection closed exception when the
+        // server is shutdown on testComplete
+        if (failed.compareAndSet(false, true)) {
+          testComplete();
+        }
+      }));
+
+    await();
+  }
+
+  // Note : cannot pass for http/2 because flushing is not the same : investigate
+  @Test
+  public void testRequestTimeoutExtendedWhenResponseChunksReceived() throws Exception {
+    long timeout = 2000;
+    int numChunks = 100;
+    AtomicInteger count = new AtomicInteger(0);
+    long interval = timeout * 2 / numChunks;
+
+    server.requestHandler(req -> {
+      req.response().setChunked(true);
+      vertx.setPeriodic(interval, timerID -> {
+        req.response().write("foo");
+        if (count.incrementAndGet() == numChunks) {
+          req.response().end();
+          vertx.cancelTimer(timerID);
+        }
+      });
+    });
+
+    startServer(testAddress);
+
+    client.request(new RequestOptions(requestOptions).setIdleTimeout(timeout))
+      .compose(req -> req
+        .send()
+        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .compose(HttpClientResponse::end))
+      .onComplete(onSuccess(v -> testComplete()));
+
+    await();
+  }
+
+  @Test
+  public void testRequestsTimeoutInQueue() throws Exception {
+
+    server.requestHandler(req -> {
+      vertx.setTimer(1000, id -> {
+        HttpServerResponse resp = req.response();
+        if (!resp.closed()) {
+          resp.end();
+        }
+      });
+    });
+
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(false), new PoolOptions().setHttp1MaxSize(1));
+
+    startServer(testAddress);
+
+    // Add a few requests that should all timeout
+    for (int i = 0; i < 5; i++) {
+      client.request(new RequestOptions(requestOptions).setIdleTimeout(500))
+        .compose(HttpClientRequest::send)
+        .onComplete(onFailure(t -> assertTrue(t instanceof TimeoutException)));
+    }
+    // Now another request that should not timeout
+    client.request(new RequestOptions(requestOptions).setIdleTimeout(3000))
+      .compose(HttpClientRequest::send)
+      .onComplete(onSuccess(resp -> {
+        assertEquals(200, resp.statusCode());
+        testComplete();
+      }));
+
+    await();
+  }
+}

--- a/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
+++ b/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
@@ -105,7 +105,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
         });
       });
     });
-    startServer();
+    startServer(testAddress);
     CountDownLatch latch = new CountDownLatch(1);
     AtomicReference<HttpClientMetric> clientMetric = new AtomicReference<>();
     AtomicReference<SocketMetric> clientSocketMetric = new AtomicReference<>();
@@ -116,23 +116,20 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
     Context ctx = vertx.getOrCreateContext();
     ctx.runOnContext(v -> {
       assertEquals(Collections.emptySet(), metrics.endpoints());
-      client.request(new RequestOptions()
-        .setPort(DEFAULT_HTTP_PORT)
-        .setHost(DEFAULT_HTTP_HOST)
+      client.request(new RequestOptions(requestOptions)
         .setURI(TestUtils.randomAlphaString(16)))
         .onComplete(onSuccess(req -> {
           req
             .response().onComplete(onSuccess(resp -> {
-              clientSocketMetric.set(metrics.firstMetric(SocketAddress.inetSocketAddress(8080, "localhost")));
+              clientSocketMetric.set(metrics.firstMetric(testAddress));
               assertNotNull(clientSocketMetric.get());
-              assertEquals(Collections.singleton("localhost:8080"), metrics.endpoints());
+              assertEquals(Collections.singleton(testAddress.toString()), metrics.endpoints());
               clientMetric.set(metrics.getMetric(resp.request()));
               assertNotNull(clientMetric.get());
               assertEquals(contentLength, clientMetric.get().bytesWritten.get());
               // assertNotNull(clientMetric.get().socket);
               // assertTrue(clientMetric.get().socket.connected.get());
-              assertEquals((Integer) 1, metrics.connectionCount("localhost:8080"));
-              assertEquals((Integer) 1, metrics.connectionCount(SocketAddress.inetSocketAddress(8080, "localhost")));
+              assertEquals((Integer) 1, metrics.connectionCount(testAddress));
               resp.bodyHandler(buff -> {
                 assertEquals(contentLength, clientMetric.get().bytesRead.get());
                 assertNull(metrics.getMetric(resp.request()));
@@ -257,7 +254,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
     server.requestHandler(req -> {
       req.response().setChunked(true).write(Buffer.buffer("some-data"));
     });
-    startServer();
+    startServer(testAddress);
     client = vertx.createHttpClient(createBaseClientOptions().setIdleTimeout(2));
     FakeHttpClientMetrics metrics = FakeMetricsBase.getMetrics(client);
     client.request(requestOptions).onComplete(onSuccess(req -> {
@@ -292,7 +289,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
         testComplete();
       });
     });
-    startServer();
+    startServer(testAddress);
     client.request(new RequestOptions(requestOptions).setURI(TestUtils.randomAlphaString(16))).onComplete(onSuccess(HttpClientRequest::send));
     await();
   }
@@ -310,7 +307,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
       req.response().end();
       testComplete();
     });
-    startServer();
+    startServer(testAddress);
     client.request(new RequestOptions(requestOptions).setURI(TestUtils.randomAlphaString(16))).onComplete(onSuccess(HttpClientRequest::send));
     await();
   }
@@ -326,7 +323,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
       assertNull(metric.route.get());
       testComplete();
     });
-    startServer();
+    startServer(testAddress);
     client.request(new RequestOptions(requestOptions).setURI(TestUtils.randomAlphaString(16))).onComplete(onSuccess(HttpClientRequest::send));
     await();
   }
@@ -336,7 +333,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
     FakeHttpClientMetrics metrics = FakeMetricsBase.getMetrics(client);
     server.requestHandler(req -> {
     }).listen(testAddress).onComplete(onSuccess(v -> {
-      client.request(HttpMethod.GET, 8080, "localhost", "/somepath").onComplete(onSuccess(request -> {
+      client.request(requestOptions).onComplete(onSuccess(request -> {
         assertNull(metrics.getMetric(request));
         request.reset(0);
         vertx.setTimer(10, id -> {

--- a/src/test/java/io/vertx/core/http/HttpServerFileUploadTest.java
+++ b/src/test/java/io/vertx/core/http/HttpServerFileUploadTest.java
@@ -42,18 +42,11 @@ public abstract class HttpServerFileUploadTest extends HttpTestBase {
   public TemporaryFolder testFolder = new TemporaryFolder();
 
   protected File testDir;
-  private File tmp;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
     testDir = testFolder.newFolder();
-    if (USE_DOMAIN_SOCKETS) {
-      assertTrue("Native transport not enabled", USE_NATIVE_TRANSPORT);
-      tmp = TestUtils.tmpFile(".sock");
-      testAddress = SocketAddress.domainSocketAddress(tmp.getAbsolutePath());
-      requestOptions.setServer(testAddress);
-    }
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -95,7 +95,7 @@ public abstract class HttpTest extends HttpTestBase {
       assertNullPointerException(() -> req.end((String) null));
       assertNullPointerException(() -> req.end(null, "UTF-8"));
       assertNullPointerException(() -> req.end("someString", (String) null));
-      assertIllegalArgumentException(() -> req.setTimeout(0));
+      assertIllegalArgumentException(() -> req.setIdleTimeout(0));
       testComplete();
     }));
     await();
@@ -2373,89 +2373,6 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
-  public void testRequestTimesOutWhenIndicatedPeriodExpiresWithoutAResponseFromRemoteServer() throws Exception {
-    server.requestHandler(noOpHandler()); // No response handler so timeout triggers
-    AtomicBoolean failed = new AtomicBoolean();
-    startServer(testAddress);
-    client.request(new RequestOptions(requestOptions).setTimeout(1000))
-      .compose(HttpClientRequest::send).onComplete(onFailure(t -> {
-        // Catch the first, the second is going to be a connection closed exception when the
-        // server is shutdown on testComplete
-        if (failed.compareAndSet(false, true)) {
-          testComplete();
-        }
-      }));
-
-    await();
-  }
-
-  @Test
-  public void testRequestTimeoutCanceledWhenRequestHasAnOtherError() {
-    Assume.assumeFalse(Utils.isWindows());
-    AtomicReference<Throwable> exception = new AtomicReference<>();
-    // There is no server running, should fail to connect
-    client.request(new RequestOptions().setPort(5000).setTimeout(800))
-      .onComplete(onFailure(exception::set));
-
-    vertx.setTimer(1500, id -> {
-      assertNotNull("Expected an exception to be set", exception.get());
-      assertFalse("Expected to not end with timeout exception, but did: " + exception.get(), exception.get() instanceof TimeoutException);
-      testComplete();
-    });
-
-    await();
-  }
-
-  @Test
-  public void testRequestTimeoutCanceledWhenRequestEndsNormally() throws Exception {
-    server.requestHandler(req -> req.response().end());
-
-    startServer(testAddress);
-    AtomicReference<Throwable> exception = new AtomicReference<>();
-
-    client.request(requestOptions).onComplete(onSuccess(req -> {
-      req
-        .exceptionHandler(exception::set)
-        .setTimeout(500)
-        .end();
-
-      vertx.setTimer(1000, id -> {
-        assertNull("Did not expect any exception", exception.get());
-        testComplete();
-      });
-    }));
-
-    await();
-  }
-
-  @Test
-  public void testHttpClientRequestTimeoutResetsTheConnection() throws Exception {
-    waitFor(3);
-    server.requestHandler(req -> {
-      AtomicBoolean errored = new AtomicBoolean();
-      req.exceptionHandler(err -> {
-        if (errored.compareAndSet(false, true)) {
-          complete();
-        }
-      });
-    });
-    startServer(testAddress);
-    client.request(requestOptions).onComplete(onSuccess(req -> {
-      req.response().onComplete(onFailure(err -> {
-        complete();
-      }));
-      req.setChunked(true).sendHead().onComplete(onSuccess(version -> req.setTimeout(500)));
-      AtomicBoolean errored = new AtomicBoolean();
-      req.exceptionHandler(err -> {
-        if (errored.compareAndSet(false, true)) {
-          complete();
-        }
-      });
-    }));
-    await();
-  }
-
-  @Test
   public void testConnectInvalidPort() {
     client.request(HttpMethod.GET, 9998, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI).onComplete(onFailure(err -> complete()));
     await();
@@ -3061,50 +2978,6 @@ public abstract class HttpTest extends HttpTestBase {
         testComplete();
       }));
 
-    await();
-  }
-
-  @Test
-  public void testResponseDataTimeout() throws Exception {
-    waitFor(2);
-    Buffer expected = TestUtils.randomBuffer(1000);
-    server.requestHandler(req -> {
-      req.response().setChunked(true).write(expected);
-    });
-    startServer(testAddress);
-    Buffer received = Buffer.buffer();
-    client.request(requestOptions).onComplete(onSuccess(req -> {
-      req.response().onComplete(onSuccess(resp -> {
-        AtomicInteger count = new AtomicInteger();
-        resp.exceptionHandler(t -> {
-          if (count.getAndIncrement() == 0) {
-            assertTrue(t instanceof TimeoutException);
-            assertEquals(expected, received);
-            complete();
-          }
-        });
-        resp.request().setTimeout(500);
-        resp.handler(buff -> {
-          received.appendBuffer(buff);
-          // Force the internal timer to be rescheduled with the remaining amount of time
-          // e.g around 100 ms
-          try {
-            Thread.sleep(100);
-          } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-          }
-        });
-      }));
-      AtomicInteger count = new AtomicInteger();
-      req.exceptionHandler(t -> {
-        if (count.getAndIncrement() == 0) {
-          assertTrue(t instanceof TimeoutException);
-          assertEquals(expected, received);
-          complete();
-        }
-      });
-      req.sendHead();
-    }));
     await();
   }
 
@@ -4138,7 +4011,7 @@ public abstract class HttpTest extends HttpTestBase {
     startServer();
     AtomicBoolean done = new AtomicBoolean();
     client.request(new RequestOptions(requestOptions)
-      .setTimeout(500)).onComplete(onSuccess(req -> {
+      .setIdleTimeout(500)).onComplete(onSuccess(req -> {
       req
         .setFollowRedirects(true)
         .send()

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -4177,7 +4177,7 @@ public abstract class HttpTest extends HttpTestBase {
       public Future<Void> end() { throw new UnsupportedOperationException(); }
       public Future<Void> end(Buffer chunk) { throw new UnsupportedOperationException(); }
       public void end(Buffer chunk, Handler<AsyncResult<Void>> handler) { throw new UnsupportedOperationException(); }
-      public HttpClientRequest setTimeout(long timeoutMs) { throw new UnsupportedOperationException(); }
+      public HttpClientRequest setIdleTimeout(long timeoutMs) { throw new UnsupportedOperationException(); }
       public HttpClientRequest pushHandler(Handler<HttpClientRequest> handler) { throw new UnsupportedOperationException(); }
       public boolean reset(long code) { return false; }
       public boolean reset(long code, Throwable cause) { return false; }

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -70,18 +70,11 @@ public abstract class HttpTest extends HttpTestBase {
   public TemporaryFolder testFolder = TemporaryFolder.builder().assureDeletion().build();
 
   protected File testDir;
-  private File tmp;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
     testDir = testFolder.newFolder();
-    if (USE_DOMAIN_SOCKETS) {
-      assertTrue("Native transport not enabled", USE_NATIVE_TRANSPORT);
-      tmp = TestUtils.tmpFile(".sock");
-      testAddress = SocketAddress.domainSocketAddress(tmp.getAbsolutePath());
-      requestOptions.setServer(testAddress);
-    }
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/RequestOptionsTest.java
+++ b/src/test/java/io/vertx/core/http/RequestOptionsTest.java
@@ -36,6 +36,8 @@ public class RequestOptionsTest {
     assertEquals(RequestOptions.DEFAULT_URI, options.getURI());
     assertEquals(RequestOptions.DEFAULT_FOLLOW_REDIRECTS, options.getFollowRedirects());
     assertEquals(RequestOptions.DEFAULT_TIMEOUT, options.getTimeout());
+    assertEquals(RequestOptions.DEFAULT_CONNECT_TIMEOUT, options.getConnectTimeout());
+    assertEquals(RequestOptions.DEFAULT_IDLE_TIMEOUT, options.getIdleTimeout());
   }
 
   @Test
@@ -63,6 +65,8 @@ public class RequestOptionsTest {
       .addHeader("foo", Arrays.asList("bar", "baz"));
     JsonObject expected = new JsonObject()
       .put("timeout", RequestOptions.DEFAULT_TIMEOUT)
+      .put("connectTimeout", RequestOptions.DEFAULT_CONNECT_TIMEOUT)
+      .put("idleTimeout", RequestOptions.DEFAULT_IDLE_TIMEOUT)
       .put("uri", RequestOptions.DEFAULT_URI)
       .put("method", "PUT")
       .put("port", 8443)

--- a/src/test/java/io/vertx/core/http/RequestOptionsTest.java
+++ b/src/test/java/io/vertx/core/http/RequestOptionsTest.java
@@ -35,7 +35,6 @@ public class RequestOptionsTest {
     assertEquals(RequestOptions.DEFAULT_SSL, options.isSsl());
     assertEquals(RequestOptions.DEFAULT_URI, options.getURI());
     assertEquals(RequestOptions.DEFAULT_FOLLOW_REDIRECTS, options.getFollowRedirects());
-    assertEquals(RequestOptions.DEFAULT_TIMEOUT, options.getTimeout());
     assertEquals(RequestOptions.DEFAULT_CONNECT_TIMEOUT, options.getConnectTimeout());
     assertEquals(RequestOptions.DEFAULT_IDLE_TIMEOUT, options.getIdleTimeout());
   }
@@ -64,7 +63,6 @@ public class RequestOptionsTest {
       .addHeader("key", "value")
       .addHeader("foo", Arrays.asList("bar", "baz"));
     JsonObject expected = new JsonObject()
-      .put("timeout", RequestOptions.DEFAULT_TIMEOUT)
       .put("connectTimeout", RequestOptions.DEFAULT_CONNECT_TIMEOUT)
       .put("idleTimeout", RequestOptions.DEFAULT_IDLE_TIMEOUT)
       .put("uri", RequestOptions.DEFAULT_URI)

--- a/src/test/java/io/vertx/core/http/ResolvingHttpClientTest.java
+++ b/src/test/java/io/vertx/core/http/ResolvingHttpClientTest.java
@@ -291,7 +291,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
     }
     assertWaitUntil(() -> count.get() == 5);
     try {
-      awaitFuture(client.request(new RequestOptions().setServer(new FakeAddress("example.com")).setTimeout(100)));
+      awaitFuture(client.request(new RequestOptions().setServer(new FakeAddress("example.com")).setConnectTimeout(100)));
     } catch (RuntimeException e) {
       assertTrue(e.getMessage().contains("timeout"));
     }

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -1715,7 +1715,7 @@ public class WebSocketTest extends VertxTestBase {
         .setPort(1234)
         .setHost(DEFAULT_HTTP_HOST)
         .setURI("/")
-        .setTimeout(1000);
+        .setIdleTimeout(1000);
       client.connect(options).onComplete(onFailure(err -> {
         assertEquals(WebSocketHandshakeException.class, err.getClass());
         testComplete();


### PR DESCRIPTION
The way HTTP client timeouts does not meet all the expectations.

The `timeout` present on `RequestOptions` applies for the time to obtain a connection and then configures the idle timeout of the request.

It is preferable to remove `RequestOptions#timeout` property an `HttpClientRequest#setTimeout` because its naming is too broad and introduce a connect timeout and an idle timeout.

`RequestOptions` now has a `connectTimeout` applied when a request is obtained from the client pool and an `idleTimeout` applied to the `HttpClientRequest` after it has been obtained from the pool.

`HttpClientRequest` now has a `setIdleTimeout` method which is a bare rename of `setTimeout` and better carries the meaning of the method.

In addition it should be easier to define a global timeout when interacting with an HTTP server that is not captured by connect or idle timeout. The `Future` interface now has a `timeout` method allowing to define a timeout when obtaining a result, e.g. the result of an HTTP client interaction with a server.
