### PR TITLE
TCP SslOptions update force option

### DIFF
--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -640,7 +640,11 @@ implement certificate rotation).
 {@link examples.NetExamples#updateSSLOptions}
 ----
 
-When the update succeeds the new SSL configuration is used, otherwise the previous configuration is kept.
+When the update succeeds the new SSL configuration is used, otherwise the previous configuration is preserved.
+
+NOTE: The options object is compared (using `equals`) against the existing options to prevent an update when the objects
+are equals since loading options can be costly. When object are equals, you can use the `force` parameter to force
+the update.
 
 ==== Self-signed certificates for testing and development purposes
 

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -512,7 +512,7 @@ public class NetExamples {
   }
 
   public void updateSSLOptions(HttpServer server) {
-    Future<Void> fut = server.updateSSLOptions(new SSLOptions()
+    Future<Boolean> fut = server.updateSSLOptions(new SSLOptions()
       .setKeyCertOptions(
         new JksOptions()
           .setPath("/path/to/your/server-keystore.jks").

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -196,14 +196,17 @@ public interface HttpClient extends Measured {
   Future<WebSocket> webSocketAbs(String url, MultiMap headers, WebsocketVersion version, List<String> subProtocols);
 
   /**
-   * Update the client SSL options.
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
    *
-   * Update only happens if the SSL options is valid.
+   * <p>The boolean succeeded future result indicates whether the update occurred.
    *
    * @param options the new SSL options
    * @return a future signaling the update success
    */
-  Future<Void> updateSSLOptions(SSLOptions options);
+  default Future<Boolean> updateSSLOptions(SSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
 
   /**
    * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
@@ -212,8 +215,39 @@ public interface HttpClient extends Measured {
    * @param options the new SSL options
    * @param handler the update handler
    */
-  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Void>> handler) {
-    Future<Void> fut = updateSSLOptions(options);
+  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> fut = updateSSLOptions(options);
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
+  }
+
+  /**
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(SSLOptions options, boolean force);
+
+  /**
+   * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
+   * happened (or has failed).
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @param handler the update handler
+   */
+  default void updateSSLOptions(SSLOptions options, boolean force, Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> fut = updateSSLOptions(options, force);
     if (handler != null) {
       fut.onComplete(handler);
     }

--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -125,14 +125,17 @@ public interface HttpServer extends Measured {
   Handler<ServerWebSocket> webSocketHandler();
 
   /**
-   * Update the server SSL options.
+   * Update the server with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
    *
-   * Update only happens if the SSL options is valid.
+   * <p>The boolean succeeded future result indicates whether the update occurred.
    *
    * @param options the new SSL options
    * @return a future signaling the update success
    */
-  Future<Void> updateSSLOptions(SSLOptions options);
+  default Future<Boolean> updateSSLOptions(SSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
 
   /**
    * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
@@ -141,8 +144,39 @@ public interface HttpServer extends Measured {
    * @param options the new SSL options
    * @param handler the update handler
    */
-  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Void>> handler) {
-    Future<Void> fut = updateSSLOptions(options);
+  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> fut = updateSSLOptions(options);
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
+  }
+
+  /**
+   * <p>Update the server with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(SSLOptions options, boolean force);
+
+  /**
+   * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
+   * happened (or has failed).
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @param handler the update handler
+   */
+  default void updateSSLOptions(SSLOptions options, boolean force, Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> fut = updateSSLOptions(options, force);
     if (handler != null) {
       fut.onComplete(handler);
     }

--- a/src/main/java/io/vertx/core/http/WebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/WebSocketClient.java
@@ -102,14 +102,15 @@ public interface WebSocketClient extends Measured {
   Future<WebSocket> connect(WebSocketConnectOptions options);
 
   /**
-   * Update the client SSL options.
-   *
-   * Update only happens if the SSL options is valid.
+   * Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
    *
    * @param options the new SSL options
    * @return a future signaling the update success
    */
-  Future<Void> updateSSLOptions(SSLOptions options);
+  default Future<Boolean> updateSSLOptions(SSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
 
   /**
    * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
@@ -118,8 +119,37 @@ public interface WebSocketClient extends Measured {
    * @param options the new SSL options
    * @param handler the update handler
    */
-  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Void>> handler) {
-    Future<Void> fut = updateSSLOptions(options);
+  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> fut = updateSSLOptions(options);
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
+  }
+
+  /**
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(SSLOptions options, boolean force);
+
+  /**
+   * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
+   * happened (or has failed).
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @param handler the update handler
+   */
+  default void updateSSLOptions(SSLOptions options, boolean force, Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> fut = updateSSLOptions(options, force);
     if (handler != null) {
       fut.onComplete(handler);
     }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -316,8 +316,8 @@ public class HttpClientBase implements MetricsProvider, Closeable {
   }
 
 //  @Override
-  public Future<Void> updateSSLOptions(SSLOptions options) {
-    return netClient.updateSSLOptions(options);
+  public Future<Boolean> updateSSLOptions(SSLOptions options, boolean force) {
+    return netClient.updateSSLOptions(options, force);
   }
 
   public HttpClientBase proxyFilter(Predicate<SocketAddress> filter) {

--- a/src/main/java/io/vertx/core/http/impl/SharedHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/SharedHttpClient.java
@@ -145,8 +145,8 @@ public class SharedHttpClient implements HttpClientInternal {
   }
 
   @Override
-  public Future<Void> updateSSLOptions(SSLOptions options) {
-    return delegate.updateSSLOptions(options);
+  public Future<Boolean> updateSSLOptions(SSLOptions options, boolean force) {
+    return delegate.updateSSLOptions(options, force);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/SharedWebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/impl/SharedWebSocketClient.java
@@ -69,13 +69,8 @@ public class SharedWebSocketClient implements WebSocketClient {
   }
 
   @Override
-  public Future<Void> updateSSLOptions(SSLOptions options) {
-    return delegate.updateSSLOptions(options);
-  }
-
-  @Override
-  public void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Void>> handler) {
-    delegate.updateSSLOptions(options, handler);
+  public Future<Boolean> updateSSLOptions(SSLOptions options, boolean force) {
+    return delegate.updateSSLOptions(options, force);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/NetClient.java
+++ b/src/main/java/io/vertx/core/net/NetClient.java
@@ -115,14 +115,17 @@ public interface NetClient extends Measured {
   Future<Void> close();
 
   /**
-   * Update the client SSL options.
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
    *
-   * Update only happens if the SSL options is valid.
+   * <p>The boolean succeeded future result indicates whether the update occurred.
    *
    * @param options the new SSL options
    * @return a future signaling the update success
    */
-  Future<Void> updateSSLOptions(SSLOptions options);
+  default Future<Boolean> updateSSLOptions(SSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
 
   /**
    * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
@@ -131,8 +134,39 @@ public interface NetClient extends Measured {
    * @param options the new SSL options
    * @param handler the update handler
    */
-  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Void>> handler) {
-    Future<Void> fut = updateSSLOptions(options);
+  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> fut = updateSSLOptions(options);
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
+  }
+
+  /**
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(SSLOptions options, boolean force);
+
+  /**
+   * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
+   * happened (or has failed).
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @param handler the update handler
+   */
+  default void updateSSLOptions(SSLOptions options, boolean force, Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> fut = updateSSLOptions(options, force);
     if (handler != null) {
       fut.onComplete(handler);
     }

--- a/src/main/java/io/vertx/core/net/NetServer.java
+++ b/src/main/java/io/vertx/core/net/NetServer.java
@@ -200,14 +200,17 @@ public interface NetServer extends Measured {
   int actualPort();
 
   /**
-   * Update the server SSL options.
+   * <p>Update the server with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
    *
-   * Update only happens if the SSL options is valid.
+   * <p>The boolean succeeded future result indicates whether the update occurred.
    *
    * @param options the new SSL options
    * @return a future signaling the update success
    */
-  Future<Void> updateSSLOptions(SSLOptions options);
+  default Future<Boolean> updateSSLOptions(SSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
 
   /**
    * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
@@ -216,9 +219,41 @@ public interface NetServer extends Measured {
    * @param options the new SSL options
    * @param handler the update handler
    */
-  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Void>> handler) {
-    Future<Void> fut = updateSSLOptions(options);
+  default void updateSSLOptions(SSLOptions options, Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> fut = updateSSLOptions(options);
     if (handler != null) {
       fut.onComplete(handler);
     }
-  }}
+  }
+
+  /**
+   * <p>Update the server with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(SSLOptions options, boolean force);
+
+  /**
+   * Like {@link #updateSSLOptions(SSLOptions)}  but supplying a handler that will be called when the update
+   * happened (or has failed).
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @param handler the update handler
+   */
+  default void updateSSLOptions(SSLOptions options, boolean force, Handler<AsyncResult<Boolean>> handler) {
+    Future<Boolean> fut = updateSSLOptions(options, force);
+    if (handler != null) {
+      fut.onComplete(handler);
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/net/impl/SslContextUpdate.java
+++ b/src/main/java/io/vertx/core/net/impl/SslContextUpdate.java
@@ -16,10 +16,12 @@ package io.vertx.core.net.impl;
 public class SslContextUpdate {
 
   private final SslChannelProvider sslChannelProvider;
+  private final boolean updated;
   private final Throwable error;
 
-  SslContextUpdate(SslChannelProvider sslChannelProvider, Throwable error) {
+  SslContextUpdate(SslChannelProvider sslChannelProvider, boolean updated, Throwable error) {
     this.sslChannelProvider = sslChannelProvider;
+    this.updated = updated;
     this.error = error;
   }
 
@@ -28,6 +30,13 @@ public class SslContextUpdate {
    */
   public SslChannelProvider sslChannelProvider() {
     return sslChannelProvider;
+  }
+
+  /**
+   * @return whether the update occurred
+   */
+  public boolean isUpdated() {
+    return updated;
   }
 
   /**

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -1637,52 +1637,92 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Test
   public void testUpdateSSLOptions() throws Exception {
-    testUpdateSSLOptions(false);
+    testUpdateSSLOptions(idx -> {
+      switch (idx) {
+        case 0:
+          return Cert.SERVER_JKS.get();
+        case 1:
+          return Cert.SERVER_JKS_ROOT_CA.get();
+      }
+      return null;
+    }, idx -> {
+      switch (idx) {
+        case 0:
+          return Trust.SERVER_JKS.get();
+        case 1:
+          return Trust.SERVER_JKS_ROOT_CA.get();
+      }
+      return null;
+    }, false, true);
   }
 
   @Test
-  public void testUpdateSSLOptionsWithScaledServer() throws Exception {
-    testUpdateSSLOptions(true);
+  public void testUpdateSSLOptionsSamePath() throws Exception {
+    testUpdateSSLOptionsSamePath(false);
   }
 
-  private void testUpdateSSLOptions(boolean scaled) throws Exception {
-    server = vertx.createHttpServer(createBaseServerOptions().setSsl(true).setKeyCertOptions(Cert.SERVER_JKS.get()))
+  @Test
+  public void testUpdateSSLOptionsSamePathAndForce() throws Exception {
+    testUpdateSSLOptionsSamePath(true);
+  }
+
+  private void testUpdateSSLOptionsSamePath(boolean force) throws Exception {
+    Path cert = Files.createTempFile("vertx", ".jks").toAbsolutePath();
+    Buffer serverJks = vertx.fileSystem().readFileBlocking(Cert.SERVER_JKS.get().getPath());
+    Buffer serverJksRootCA = vertx.fileSystem().readFileBlocking(Cert.SERVER_JKS_ROOT_CA.get().getPath());
+    testUpdateSSLOptions(idx -> {
+      try {
+        switch (idx) {
+          case 0:
+            Files.write(cert, serverJks.getBytes());
+            return Cert.SERVER_JKS.get().copy().setPath(cert.toFile().getAbsolutePath());
+          case 1:
+            Files.write(cert, serverJksRootCA.getBytes());
+            return Cert.SERVER_JKS.get().copy().setPath(cert.toFile().getAbsolutePath());
+        }
+      } catch (IOException e) {
+        fail(e);
+      }
+      return null;
+    }, idx -> {
+      switch (idx) {
+        case 0:
+          return Trust.SERVER_JKS.get();
+        case 1:
+          return Trust.SERVER_JKS_ROOT_CA.get();
+      }
+      return null;
+    }, force, force);
+  }
+
+  private void testUpdateSSLOptions(Function<Integer, JksOptions> blah, Function<Integer, JksOptions> bluh, boolean force, boolean updateTrust) throws Exception {
+    server = vertx.createHttpServer(createBaseServerOptions().setKeyCertOptions(blah.apply(0)))
       .requestHandler(req -> {
         req.response().end("Hello World");
       });
     startServer(testAddress);
-    if (scaled) {
-      CountDownLatch latch = new CountDownLatch(1);
-      vertx.deployVerticle(new AbstractVerticle() {
-        private HttpServer server;
-        @Override
-        public void start(Promise<Void> startPromise) {
-          server = vertx.createHttpServer(createBaseServerOptions().setKeyCertOptions(Cert.SERVER_JKS.get()))
-            .requestHandler(req -> {
-              req.response().end("Hello World");
-            });
-          server
-            .listen(testAddress)
-            .<Void>mapEmpty()
-            .onComplete(startPromise);
-        }
-      }).onComplete(onSuccess(v -> latch.countDown()));
-      awaitLatch(latch);
-    }
     Function<HttpClient, Future<Buffer>> request = client -> client.request(requestOptions).compose(req -> req.send().compose(HttpClientResponse::body));
-    HttpClient client1 = vertx.createHttpClient(createBaseClientOptions().setVerifyHost(false).setTrustOptions(Trust.SERVER_JKS.get()));
-    HttpClient client2 = vertx.createHttpClient(createBaseClientOptions().setVerifyHost(false).setTrustOptions(Trust.SERVER_JKS.get()));
+    HttpClient client1 = vertx.createHttpClient(createBaseClientOptions().setVerifyHost(false).setTrustOptions(bluh.apply(0)));
+    HttpClient client2 = vertx.createHttpClient(createBaseClientOptions().setVerifyHost(false).setTrustOptions(bluh.apply(0)));
     request.apply(client1).onComplete(onSuccess(body1 -> {
       assertEquals("Hello World", body1.toString());
-      server.updateSSLOptions(createBaseServerOptions().setKeyCertOptions(Cert.SERVER_JKS_ROOT_CA.get()).getSslOptions()).onComplete(onSuccess(v -> {
-        request.apply(client2).onComplete(onFailure(err -> {
-          client2.updateSSLOptions(createBaseClientOptions().setTrustOptions(Trust.SERVER_JKS_ROOT_CA.get()).getSslOptions()).onComplete(onSuccess(v2 -> {
-            request.apply(client2).onComplete(onSuccess(body2 -> {
-              assertEquals("Hello World", body2.toString());
-              testComplete();
+      server.updateSSLOptions(createBaseServerOptions().setKeyCertOptions(blah.apply(1)).getSslOptions(), force, onSuccess(updateOccurred -> {
+        request.apply(client2).onComplete(ar -> {
+          assertEquals(!updateTrust, ar.succeeded());
+          if (updateTrust) {
+            assertTrue(updateOccurred);
+            client2.updateSSLOptions(createBaseClientOptions().setTrustOptions(bluh.apply(1)).getSslOptions(), force, onSuccess(v2 -> {
+              request.apply(client2).onComplete(onSuccess(body2 -> {
+                assertEquals("Hello World", body2.toString());
+                testComplete();
+              }));
             }));
-          }));
-        }));
+          } else {
+            // Same trust options since update did not occur
+            assertFalse(updateOccurred);
+            testComplete();
+          }
+        });
       }));
     }));
     await();
@@ -1696,7 +1736,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
       });
     startServer(testAddress);
     client = vertx.createHttpClient(createBaseClientOptions().setVerifyHost(false).setTrustOptions(Trust.SERVER_JKS.get()));
-    Future<Void> last = server.updateSSLOptions(createBaseServerOptions()
+    Future<Boolean> last = server.updateSSLOptions(createBaseServerOptions()
       .setKeyCertOptions(new JksOptions().setValue(TestUtils.randomBuffer(20)).setPassword("invalid"))
       .getSslOptions());
     last.onComplete(onFailure(err -> {
@@ -1718,14 +1758,14 @@ public abstract class HttpTLSTest extends HttpTestBase {
         req.response().end("Hello World");
       });
     startServer(testAddress);
-    client = vertx.createHttpClient(createBaseClientOptions().setKeepAlive(false).setVerifyHost(false).setTrustOptions(Trust.SERVER_JKS_ROOT_CA.get()));
+    client = vertx.createHttpClient(createBaseClientOptions().setVerifyHost(false).setTrustOptions(Trust.SERVER_JKS_ROOT_CA.get()));
     List<KeyCertOptions> list = Arrays.asList(
       Cert.SERVER_PKCS12.get(),
       Cert.SERVER_PEM.get(),
       Cert.SERVER_PEM.get(),
       Cert.SERVER_JKS_ROOT_CA.get());
     AtomicInteger seq = new AtomicInteger();
-    Future<Void> last = null;
+    Future<Boolean> last = null;
     for (int i = 0;i < list.size();i++) {
       int val = i;
       last = server.updateSSLOptions(createBaseServerOptions().setKeyCertOptions(list.get(i)).getSslOptions());


### PR DESCRIPTION
The TCP server/client updateSslOptions method does not update the options when the comparison using equals against the previous options returns true. Sometimes this behavior is not desirable, e.g. when the path to the certificate does not change and such certificates has been overwritten.
