### PR TITLE
 HTTP TLS tests improvements

### DIFF
--- a/src/test/java/io/vertx/core/http/Http1xTLSTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTLSTest.java
@@ -13,9 +13,7 @@ package io.vertx.core.http;
 
 import io.netty.buffer.ByteBufUtil;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.VertxOptions;
 import io.vertx.test.tls.Cert;
@@ -38,17 +36,20 @@ import java.util.stream.Collectors;
 public class Http1xTLSTest extends HttpTLSTest {
 
   @Override
-  HttpServer createHttpServer(HttpServerOptions options) {
-    return vertx.createHttpServer(options);
-  }
+  protected HttpServerOptions createBaseServerOptions() {
+    return new HttpServerOptions()
+      .setPort(HttpTestBase.DEFAULT_HTTPS_PORT)
+      .setSsl(true);
+  };
 
   @Override
-  HttpClient createHttpClient(HttpClientOptions options) {
-    return vertx.createHttpClient(options);
+  protected HttpClientOptions createBaseClientOptions() {
+    return new HttpClientOptions()
+      .setSsl(true)
+      .setProtocolVersion(HttpVersion.HTTP_1_1);
   }
 
-
-  // ALPN tests
+// ALPN tests
 
   @Test
   // Client and server uses ALPN

--- a/src/test/java/io/vertx/core/http/Http2TLSTest.java
+++ b/src/test/java/io/vertx/core/http/Http2TLSTest.java
@@ -20,13 +20,19 @@ import io.vertx.test.tls.Trust;
 public class Http2TLSTest extends HttpTLSTest {
 
   @Override
-  HttpServer createHttpServer(HttpServerOptions options) {
-    return vertx.createHttpServer(options.setUseAlpn(true));
+  protected HttpServerOptions createBaseServerOptions() {
+    return new HttpServerOptions()
+      .setPort(HttpTestBase.DEFAULT_HTTPS_PORT)
+      .setUseAlpn(true)
+      .setSsl(true);
   }
 
   @Override
-  HttpClient createHttpClient(HttpClientOptions options) {
-    return vertx.createHttpClient(options.setUseAlpn(true));
+  protected HttpClientOptions createBaseClientOptions() {
+    return new HttpClientOptions()
+      .setUseAlpn(true)
+      .setSsl(true)
+      .setProtocolVersion(HttpVersion.HTTP_2);
   }
 
   @Override


### PR DESCRIPTION
- creation of base options should be achieved in create base options methods for each protocol
- SSL options update tests are actually not configured for HTTP/2
