### PR TITLE
TCP SslOptions update force option

### DIFF
--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -638,7 +638,11 @@ implement certificate rotation).
 {@link examples.NetExamples#updateSSLOptions}
 ----
 
-When the update succeeds the new SSL configuration is used, otherwise the previous configuration is kept.
+When the update succeeds the new SSL configuration is used, otherwise the previous configuration is preserved.
+
+NOTE: The options object is compared (using `equals`) against the existing options to prevent an update when the objects
+are equals since loading options can be costly. When object are equals, you can use the `force` parameter to force
+the update.
 
 ==== Self-signed certificates for testing and development purposes
 

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -512,7 +512,7 @@ public class NetExamples {
   }
 
   public void updateSSLOptions(HttpServer server) {
-    Future<Void> fut = server.updateSSLOptions(new ServerSSLOptions()
+    Future<Boolean> fut = server.updateSSLOptions(new ServerSSLOptions()
       .setKeyCertOptions(
         new JksOptions()
           .setPath("/path/to/your/server-keystore.jks").

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -12,8 +12,11 @@
 package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.net.ClientSSLOptions;
+import io.vertx.core.net.SSLOptions;
 
 import java.util.concurrent.TimeUnit;
 
@@ -127,12 +130,31 @@ public interface HttpClient extends io.vertx.core.metrics.Measured {
   Future<Void> shutdown(long timeout, TimeUnit timeUnit);
 
   /**
-   * Update the client SSL options.
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
    *
-   * Update only happens if the SSL options is valid.
+   * <p>The boolean succeeded future result indicates whether the update occurred.
    *
    * @param options the new SSL options
    * @return a future signaling the update success
    */
-  Future<Void> updateSSLOptions(ClientSSLOptions options);
+  default Future<Boolean> updateSSLOptions(ClientSSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
+
+  /**
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force);
 }

--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -12,11 +12,13 @@
 package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.metrics.Measured;
+import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.SocketAddressImpl;
@@ -100,14 +102,33 @@ public interface HttpServer extends Measured {
   Handler<ServerWebSocket> webSocketHandler();
 
   /**
-   * Update the server SSL options.
+   * Update the server with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
    *
-   * Update only happens if the SSL options is valid.
+   * <p>The boolean succeeded future result indicates whether the update occurred.
    *
    * @param options the new SSL options
    * @return a future signaling the update success
    */
-  Future<Void> updateSSLOptions(ServerSSLOptions options);
+  default Future<Boolean> updateSSLOptions(ServerSSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
+
+  /**
+   * <p>Update the server with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(ServerSSLOptions options, boolean force);
 
   /**
    * Tell the server to start listening. The server will listen on the port and host specified in the

--- a/src/main/java/io/vertx/core/http/WebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/WebSocketClient.java
@@ -13,6 +13,7 @@ package io.vertx.core.http;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.metrics.Measured;
+import io.vertx.core.net.ClientSSLOptions;
 
 import java.util.concurrent.TimeUnit;
 
@@ -92,6 +93,31 @@ public interface WebSocketClient extends Measured {
   default Future<Void> shutdown() {
     return shutdown(30, TimeUnit.SECONDS);
   }
+
+  /**
+   * Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * @param options the new SSL options
+   * @return a future signaling the update success
+   */
+  default Future<Boolean> updateSSLOptions(ClientSSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
+
+  /**
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force);
 
   /**
    * Initiate the client close sequence.

--- a/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -62,8 +62,8 @@ public class CleanableHttpClient implements HttpClientInternal {
   }
 
   @Override
-  public Future<Void> updateSSLOptions(ClientSSLOptions options) {
-    return delegate.updateSSLOptions(options);
+  public Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force) {
+    return delegate.updateSSLOptions(options, force);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
@@ -14,6 +14,7 @@ import io.vertx.core.Closeable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.http.*;
+import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 
@@ -60,6 +61,11 @@ public class CleanableWebSocketClient implements WebSocketClient, MetricsProvide
 
   public Future<WebSocket> connect(WebSocketConnectOptions options) {
     return delegate.connect(options);
+  }
+
+  @Override
+  public Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force) {
+    return delegate.updateSSLOptions(options, force);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -180,11 +180,12 @@ public class HttpClientBase implements MetricsProvider, Closeable {
     return metrics;
   }
 
-  public Future<Void> updateSSLOptions(ClientSSLOptions options) {
+  public Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force) {
     sslOptions = options
       .copy()
       .setHostnameVerificationAlgorithm(this.options.isVerifyHost() ? "HTTPS" : "")
-      .setApplicationLayerProtocols(alpnVersions.stream().map(HttpVersion::alpnName).collect(Collectors.toList()));;    return Future.succeededFuture();
+      .setApplicationLayerProtocols(alpnVersions.stream().map(HttpVersion::alpnName).collect(Collectors.toList()));;
+    return Future.succeededFuture(true);
   }
 
   public HttpClientBase proxyFilter(Predicate<SocketAddress> filter) {

--- a/src/main/java/io/vertx/core/net/NetClient.java
+++ b/src/main/java/io/vertx/core/net/NetClient.java
@@ -11,8 +11,10 @@
 
 package io.vertx.core.net;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
 import io.vertx.core.metrics.Measured;
 
 /**
@@ -94,13 +96,31 @@ public interface NetClient extends Measured {
   Future<Void> close();
 
   /**
-   * Update the client SSL options.
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
    *
-   * Update only happens if the SSL options is valid.
+   * <p>The boolean succeeded future result indicates whether the update occurred.
    *
    * @param options the new SSL options
    * @return a future signaling the update success
    */
-  Future<Void> updateSSLOptions(ClientSSLOptions options);
+  default Future<Boolean> updateSSLOptions(ClientSSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
 
+  /**
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force);
 }

--- a/src/main/java/io/vertx/core/net/NetServer.java
+++ b/src/main/java/io/vertx/core/net/NetServer.java
@@ -119,13 +119,31 @@ public interface NetServer extends Measured {
   int actualPort();
 
   /**
-   * Update the server SSL options.
+   * <p>Update the server with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
    *
-   * Update only happens if the SSL options is valid.
+   * <p>The boolean succeeded future result indicates whether the update occurred.
    *
    * @param options the new SSL options
    * @return a future signaling the update success
    */
-  Future<Void> updateSSLOptions(ServerSSLOptions options);
+  default Future<Boolean> updateSSLOptions(ServerSSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
 
+  /**
+   * <p>Update the server with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(ServerSSLOptions options, boolean force);
 }

--- a/src/main/java/io/vertx/core/net/impl/CleanableNetClient.java
+++ b/src/main/java/io/vertx/core/net/impl/CleanableNetClient.java
@@ -88,8 +88,8 @@ public class CleanableNetClient implements NetClientInternal {
   }
 
   @Override
-  public Future<Void> updateSSLOptions(ClientSSLOptions options) {
-    return client.updateSSLOptions(options);
+  public Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force) {
+    return client.updateSSLOptions(options, force);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -229,12 +229,12 @@ class NetClientImpl implements NetClientInternal {
   }
 
   @Override
-  public Future<Void> updateSSLOptions(ClientSSLOptions options) {
+  public Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force) {
     ContextInternal ctx = vertx.getOrCreateContext();
     synchronized (this) {
       this.sslOptions = options;
     }
-    return ctx.succeededFuture();
+    return ctx.succeededFuture(true);
   }
 
   private void connectInternal(ConnectOptions connectOptions,

--- a/src/main/java/io/vertx/core/net/impl/SslContextUpdate.java
+++ b/src/main/java/io/vertx/core/net/impl/SslContextUpdate.java
@@ -16,10 +16,12 @@ package io.vertx.core.net.impl;
 public class SslContextUpdate {
 
   private final SslChannelProvider sslChannelProvider;
+  private final boolean updated;
   private final Throwable error;
 
-  SslContextUpdate(SslChannelProvider sslChannelProvider, Throwable error) {
+  SslContextUpdate(SslChannelProvider sslChannelProvider, boolean updated, Throwable error) {
     this.sslChannelProvider = sslChannelProvider;
+    this.updated = updated;
     this.error = error;
   }
 
@@ -28,6 +30,13 @@ public class SslContextUpdate {
    */
   public SslChannelProvider sslChannelProvider() {
     return sslChannelProvider;
+  }
+
+  /**
+   * @return whether the update occurred
+   */
+  public boolean isUpdated() {
+    return updated;
   }
 
   /**

--- a/src/test/java/io/vertx/core/net/impl/SSLHelperTest.java
+++ b/src/test/java/io/vertx/core/net/impl/SSLHelperTest.java
@@ -43,7 +43,7 @@ public class SSLHelperTest extends VertxTestBase {
     String[] expected = engine.getEnabledCipherSuites();
     SSLHelper helper = new SSLHelper(SSLHelper.resolveEngineOptions(null, false));
     helper
-      .buildContextProvider(new SSLOptions().setKeyCertOptions(Cert.CLIENT_JKS.get()).setTrustOptions(Trust.SERVER_JKS.get()), null, ClientAuth.NONE, null, (ContextInternal) vertx.getOrCreateContext())
+      .buildContextProvider(new SSLOptions().setKeyCertOptions(Cert.CLIENT_JKS.get()).setTrustOptions(Trust.SERVER_JKS.get()), null, ClientAuth.NONE, null, false, (ContextInternal) vertx.getOrCreateContext())
       .onComplete(onSuccess(provider -> {
         SslContext ctx = provider.createClientContext(null, false, false);
         assertEquals(new HashSet<>(Arrays.asList(expected)), new HashSet<>(ctx.cipherSuites()));
@@ -56,7 +56,7 @@ public class SSLHelperTest extends VertxTestBase {
   public void testUseOpenSSLCiphersWhenNotSpecified() throws Exception {
     Set<String> expected = OpenSsl.availableOpenSslCipherSuites();
     SSLHelper helper = new SSLHelper(new OpenSSLEngineOptions());
-    helper.buildContextProvider(new SSLOptions().setKeyCertOptions(Cert.CLIENT_PEM.get()).setTrustOptions(Trust.SERVER_PEM.get()), null, ClientAuth.NONE, null, (ContextInternal) vertx.getOrCreateContext()).onComplete(onSuccess(provider -> {
+    helper.buildContextProvider(new SSLOptions().setKeyCertOptions(Cert.CLIENT_PEM.get()).setTrustOptions(Trust.SERVER_PEM.get()), null, ClientAuth.NONE, null, false, (ContextInternal) vertx.getOrCreateContext()).onComplete(onSuccess(provider -> {
       SslContext ctx = provider.createClientContext(null, false, false);
       assertEquals(expected, new HashSet<>(ctx.cipherSuites()));
       testComplete();
@@ -89,7 +89,7 @@ public class SSLHelperTest extends VertxTestBase {
     sslOptions.setKeyCertOptions(Cert.SERVER_PEM.get()).setTrustOptions(Trust.SERVER_PEM.get());
 
     defaultHelper
-      .buildContextProvider(sslOptions, null, ClientAuth.NONE, null, (ContextInternal) vertx.getOrCreateContext())
+      .buildContextProvider(sslOptions, null, ClientAuth.NONE, null, false, (ContextInternal) vertx.getOrCreateContext())
       .onComplete(onSuccess(provider -> {
         SslContext ctx = provider.createServerContext(false);
 
@@ -119,7 +119,7 @@ public class SSLHelperTest extends VertxTestBase {
     assertEquals(new ArrayList<>(new HttpServerOptions(json).getEnabledCipherSuites()), Arrays.asList(engine.getEnabledCipherSuites()));
     SSLHelper helper = new SSLHelper(SSLHelper.resolveEngineOptions(null, false));
     helper
-      .buildContextProvider(options, null, ClientAuth.NONE, null, (ContextInternal) vertx.getOrCreateContext())
+      .buildContextProvider(options, null, ClientAuth.NONE, null, false, (ContextInternal) vertx.getOrCreateContext())
       .onComplete(onSuccess(sslContextProvider -> {
         assertEquals(new HashSet<>(Arrays.asList(createEngine(sslContextProvider).getEnabledCipherSuites())), new HashSet<>(Arrays.asList(engine.getEnabledCipherSuites())));
         testComplete();
@@ -191,7 +191,7 @@ public class SSLHelperTest extends VertxTestBase {
   private void testTLSVersions(SSLOptions options, Consumer<SSLEngine> check) {
     SSLHelper helper = new SSLHelper(SSLHelper.resolveEngineOptions(null, false));
     helper
-      .buildContextProvider(options, null, ClientAuth.NONE, null, (ContextInternal) vertx.getOrCreateContext())
+      .buildContextProvider(options, null, ClientAuth.NONE, null, false, (ContextInternal) vertx.getOrCreateContext())
       .onComplete(onSuccess(sslContextProvider -> {
         SSLEngine engine = createEngine(sslContextProvider);
         check.accept(engine);


### PR DESCRIPTION
The TCP server/client updateSslOptions method does not update the options when the comparison using equals against the previous options returns true. Sometimes this behavior is not desirable, e.g. when the path to the certificate does not change and such certificates has been overwritten.
