### PR TITLE
Generify HttpClientRequest stream reset exception remapping

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -60,12 +60,6 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
-  boolean reset(Throwable cause) {
-    stream.reset(cause);
-    return true;
-  }
-
-  @Override
   public boolean isChunked() {
     return false;
   }

--- a/src/test/java/io/vertx/core/http/Http2Test.java
+++ b/src/test/java/io/vertx/core/http/Http2Test.java
@@ -1072,4 +1072,24 @@ public class Http2Test extends HttpTest {
     }
     await();
   }
+
+  @Test
+  public void testStreamResetErrorMapping() throws Exception {
+    server.requestHandler(req -> {
+    });
+    startServer(testAddress);
+    client.request(requestOptions).onComplete(onSuccess(req -> {
+      req.exceptionHandler(err -> {
+        assertTrue(err instanceof StreamResetException);
+        StreamResetException sre = (StreamResetException) err;
+        assertEquals(10, sre.getCode());
+        testComplete();
+      });
+      // Force stream allocation
+      req.sendHead().onComplete(onSuccess(v -> {
+        req.reset(10);
+      }));
+    }));
+    await();
+  }
 }


### PR DESCRIPTION
The HttpClientRequest implementation does have a mapping of HTTP closed exception when a timeout occurs so the client is signaled with a stream exception for better usability. Actually we can generify this for the generic reset exception case instead of just being for idle timeouts.
