### PR TITLE
- allows for local only codec lookup when in clustered mode

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -119,14 +119,18 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
 
   @Override
   public EventBus send(String address, Object message, DeliveryOptions options) {
-    MessageImpl msg = createMessage(true, address, options.getHeaders(), message, options.getCodecName());
+    MessageImpl msg = createMessage(true, options.isLocalOnly(), address, options.getHeaders(), message, options.getCodecName());
     sendOrPubInternal(msg, options, null);
     return this;
   }
 
   @Override
   public <T> Future<Message<T>> request(String address, Object message, DeliveryOptions options) {
-    MessageImpl msg = createMessage(true, address, options.getHeaders(), message, options.getCodecName());
+    boolean local = false;
+    if (vertx.isClustered() && options.isLocalOnly()) {
+      local = true;
+    }
+    MessageImpl msg = createMessage(options.isLocalOnly(), local, address, options.getHeaders(), message, options.getCodecName());
     ReplyHandler<T> handler = createReplyHandler(msg, true, options);
     sendOrPubInternal(msg, options, handler);
     return handler.result();
@@ -165,7 +169,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
 
   @Override
   public EventBus publish(String address, Object message, DeliveryOptions options) {
-    sendOrPubInternal(createMessage(false, address, options.getHeaders(), message, options.getCodecName()), options, null);
+    sendOrPubInternal(createMessage(false, options.isLocalOnly(), address, options.getHeaders(), message, options.getCodecName()), options, null);
     return this;
   }
 
@@ -253,9 +257,13 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     return metrics;
   }
 
-  public MessageImpl createMessage(boolean send, String address, MultiMap headers, Object body, String codecName) {
+  public MessageImpl createMessage(boolean send, boolean localOnly, String address, MultiMap headers, Object body, String codecName) {
     Objects.requireNonNull(address, "no null address accepted");
-    MessageCodec codec = codecManager.lookupCodec(body, codecName, true);
+    boolean local = true;
+    if (vertx.isClustered()) {
+      local = localOnly;
+    }
+    MessageCodec codec = codecManager.lookupCodec(body, codecName, local);
     @SuppressWarnings("unchecked")
     MessageImpl msg = new MessageImpl(address, headers, body, codec, send, this);
     return msg;

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -119,18 +119,14 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
 
   @Override
   public EventBus send(String address, Object message, DeliveryOptions options) {
-    MessageImpl msg = createMessage(true, options.isLocalOnly(), address, options.getHeaders(), message, options.getCodecName());
+    MessageImpl msg = createMessage(true, isLocalOnly(options), address, options.getHeaders(), message, options.getCodecName());
     sendOrPubInternal(msg, options, null);
     return this;
   }
 
   @Override
   public <T> Future<Message<T>> request(String address, Object message, DeliveryOptions options) {
-    boolean local = false;
-    if (vertx.isClustered() && options.isLocalOnly()) {
-      local = true;
-    }
-    MessageImpl msg = createMessage(options.isLocalOnly(), local, address, options.getHeaders(), message, options.getCodecName());
+    MessageImpl msg = createMessage(true, isLocalOnly(options), address, options.getHeaders(), message, options.getCodecName());
     ReplyHandler<T> handler = createReplyHandler(msg, true, options);
     sendOrPubInternal(msg, options, handler);
     return handler.result();
@@ -169,7 +165,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
 
   @Override
   public EventBus publish(String address, Object message, DeliveryOptions options) {
-    sendOrPubInternal(createMessage(false, options.isLocalOnly(), address, options.getHeaders(), message, options.getCodecName()), options, null);
+    sendOrPubInternal(createMessage(false, isLocalOnly(options), address, options.getHeaders(), message, options.getCodecName()), options, null);
     return this;
   }
 
@@ -177,7 +173,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   public <T> MessageConsumer<T> consumer(String address) {
     checkStarted();
     Objects.requireNonNull(address, "address");
-    return new MessageConsumerImpl<>(vertx.getOrCreateContext(), this, address,  false);
+    return new MessageConsumerImpl<>(vertx.getOrCreateContext(), this, address, false);
   }
 
   @Override
@@ -192,7 +188,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   public <T> MessageConsumer<T> localConsumer(String address) {
     checkStarted();
     Objects.requireNonNull(address, "address");
-    return new MessageConsumerImpl<>(vertx.getOrCreateContext(), this, address,  true);
+    return new MessageConsumerImpl<>(vertx.getOrCreateContext(), this, address, true);
   }
 
   @Override
@@ -259,11 +255,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
 
   public MessageImpl createMessage(boolean send, boolean localOnly, String address, MultiMap headers, Object body, String codecName) {
     Objects.requireNonNull(address, "no null address accepted");
-    boolean local = true;
-    if (vertx.isClustered()) {
-      local = localOnly;
-    }
-    MessageCodec codec = codecManager.lookupCodec(body, codecName, local);
+    MessageCodec codec = codecManager.lookupCodec(body, codecName, localOnly);
     @SuppressWarnings("unchecked")
     MessageImpl msg = new MessageImpl(address, headers, body, codec, send, this);
     return msg;
@@ -390,7 +382,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
         if (metrics != null) {
           metrics.messageReceived(msg.address(), !msg.isSend(), messageLocal, handlers.size());
         }
-        for (HandlerHolder holder: handlers) {
+        for (HandlerHolder holder : handlers) {
           if (messageLocal || !holder.isLocalOnly()) {
             holder.handler.receive(msg.copyBeforeReceive());
           }
@@ -420,8 +412,8 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   }
 
   <T> ReplyHandler<T> createReplyHandler(MessageImpl message,
-                                                 boolean src,
-                                                 DeliveryOptions options) {
+                                         boolean src,
+                                         DeliveryOptions options) {
     long timeout = options.getSendTimeout();
     String replyAddress = generateReplyAddress();
     message.setReplyAddress(replyAddress);
@@ -431,7 +423,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   }
 
   public <T> OutboundDeliveryContext<T> newSendContext(MessageImpl message, DeliveryOptions options,
-                                               ReplyHandler<T> handler) {
+                                                       ReplyHandler<T> handler) {
     return new OutboundDeliveryContext<>(vertx.getOrCreateContext(), message, options, handler);
   }
 
@@ -443,7 +435,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   }
 
   public <T> Future<Void> sendOrPubInternal(MessageImpl message, DeliveryOptions options,
-                                    ReplyHandler<T> handler) {
+                                            ReplyHandler<T> handler) {
     checkStarted();
     OutboundDeliveryContext<T> ctx = newSendContext(message, options, handler);
     sendOrPubInternal(ctx);
@@ -486,7 +478,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     while (true) {
       Handler[] interceptors = updater.get(this);
       int idx = -1;
-      for (int i = 0;i < interceptors.length;i++) {
+      for (int i = 0; i < interceptors.length; i++) {
         if (interceptors[i].equals(interceptor)) {
           idx = i;
           break;
@@ -502,6 +494,13 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
         break;
       }
     }
+  }
+
+  private boolean isLocalOnly(DeliveryOptions options) {
+    if (vertx.isClustered()) {
+      return options.isLocalOnly();
+    }
+    return true;
   }
 }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -119,7 +119,7 @@ public class MessageImpl<U, V> implements Message<V> {
   }
 
   protected MessageImpl createReply(Object message, DeliveryOptions options) {
-    MessageImpl reply = bus.createMessage(true, replyAddress, options.getHeaders(), message, options.getCodecName());
+    MessageImpl reply = bus.createMessage(true, options.isLocalOnly(),replyAddress, options.getHeaders(), message, options.getCodecName());
     reply.trace = trace;
     return reply;
   }

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -119,7 +119,7 @@ public class MessageImpl<U, V> implements Message<V> {
   }
 
   protected MessageImpl createReply(Object message, DeliveryOptions options) {
-    MessageImpl reply = bus.createMessage(true, options.isLocalOnly(),replyAddress, options.getHeaders(), message, options.getCodecName());
+    MessageImpl reply = bus.createMessage(true, isLocal(), replyAddress, options.getHeaders(), message, options.getCodecName());
     reply.trace = trace;
     return reply;
   }

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
@@ -45,7 +45,7 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
 
   @Override
   public Future<Void> write(T body) {
-    MessageImpl msg = bus.createMessage(send, address, options.getHeaders(), body, options.getCodecName());
+    MessageImpl msg = bus.createMessage(send, options.isLocalOnly(), address, options.getHeaders(), body, options.getCodecName());
     return bus.sendOrPubInternal(msg, options, null);
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
@@ -12,11 +12,9 @@
 package io.vertx.core.eventbus.impl;
 
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.*;
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.impl.VertxInternal;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -27,6 +25,7 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
   private final EventBusImpl bus;
   private final boolean send;
   private final String address;
+  private final boolean localOnly;
   private DeliveryOptions options;
 
   public MessageProducerImpl(Vertx vertx, String address, boolean send, DeliveryOptions options) {
@@ -35,6 +34,7 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
     this.address = address;
     this.send = send;
     this.options = options;
+    this.localOnly = vertx.isClustered() ? options.isLocalOnly() : true;
   }
 
   @Override
@@ -45,7 +45,7 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
 
   @Override
   public Future<Void> write(T body) {
-    MessageImpl msg = bus.createMessage(send, options.isLocalOnly(), address, options.getHeaders(), body, options.getCodecName());
+    MessageImpl msg = bus.createMessage(send, localOnly, address, options.getHeaders(), body, options.getCodecName());
     return bus.sendOrPubInternal(msg, options, null);
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -145,9 +145,9 @@ public class ClusteredEventBus extends EventBusImpl {
   }
 
   @Override
-  public MessageImpl createMessage(boolean send, String address, MultiMap headers, Object body, String codecName) {
+  public MessageImpl createMessage(boolean send, boolean local, String address, MultiMap headers, Object body, String codecName) {
     Objects.requireNonNull(address, "no null address accepted");
-    MessageCodec codec = codecManager.lookupCodec(body, codecName, false);
+    MessageCodec codec = codecManager.lookupCodec(body, codecName, local);
     @SuppressWarnings("unchecked")
     ClusteredMessage msg = new ClusteredMessage(nodeId, address, headers, body, codec, send, this);
     return msg;


### PR DESCRIPTION
Motivation:

When operating in clustered mode I want to allow local messages to perform the codec lookup as local.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
