### PR TITLE
HostAndPort fails to parse a nip host

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/HostAndPortImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/HostAndPortImpl.java
@@ -30,7 +30,7 @@ public class HostAndPortImpl implements HostAndPort {
         return -1;
       }
     }
-    return from;
+    return from < to && (from + 1 == s.length() || s.charAt(from + 1) != ':') ? -1 : from;
   }
 
   static int parseDecOctet(String s, int from, int to) {

--- a/src/test/java/io/vertx/core/net/impl/HostAndPortTest.java
+++ b/src/test/java/io/vertx/core/net/impl/HostAndPortTest.java
@@ -34,6 +34,10 @@ public class HostAndPortTest {
     assertEquals(7, HostAndPortImpl.parseIPv4Address("0.0.0.0", 0, 7));
     assertEquals(11, HostAndPortImpl.parseIPv4Address("192.168.0.0", 0, 11));
     assertEquals(-1, HostAndPortImpl.parseIPv4Address("011.168.0.0", 0, 11));
+    assertEquals(-1, HostAndPortImpl.parseIPv4Address("10.0.0.1.nip.io", 0, 15));
+    assertEquals(-1, HostAndPortImpl.parseIPv4Address("10.0.0.1.nip.io", 0, 9));
+    assertEquals(8, HostAndPortImpl.parseIPv4Address("10.0.0.1.nip.io", 0, 8));
+    assertEquals(-1, HostAndPortImpl.parseIPv4Address("10.0.0.1:", 0, 9));
   }
 
   @Test
@@ -42,6 +46,7 @@ public class HostAndPortTest {
     assertEquals(5, HostAndPortImpl.parseRegName("abcdef:1234", 0, 5));
     assertEquals(11, HostAndPortImpl.parseRegName("example.com", 0, 11));
     assertEquals(14, HostAndPortImpl.parseRegName("example-fr.com", 0, 14));
+    assertEquals(15, HostAndPortImpl.parseRegName("10.0.0.1.nip.io", 0, 15));
   }
 
   @Test
@@ -49,10 +54,14 @@ public class HostAndPortTest {
     assertEquals(14, HostAndPortImpl.parseHost("example-fr.com", 0, 14));
     assertEquals(5, HostAndPortImpl.parseHost("[0::]", 0, 5));
     assertEquals(7, HostAndPortImpl.parseHost("0.0.0.0", 0, 7));
+    assertEquals(8, HostAndPortImpl.parseHost("10.0.0.1.nip.io", 0, 8));
+    assertEquals(15, HostAndPortImpl.parseHost("10.0.0.1.nip.io", 0, 15));
   }
 
   @Test
   public void testParseHostAndPort() {
+    assertHostAndPort("10.0.0.1.nip.io", -1, "10.0.0.1.nip.io");
+    assertHostAndPort("10.0.0.1.nip.io", 8443, "10.0.0.1.nip.io:8443");
     assertHostAndPort("example.com", 8080, "example.com:8080");
     assertHostAndPort("example.com", -1, "example.com");
     assertHostAndPort("0.1.2.3", -1, "0.1.2.3");
@@ -60,6 +69,7 @@ public class HostAndPortTest {
     assertHostAndPort("", -1, "");
     assertHostAndPort("", 8080, ":8080");
     assertNull(HostAndPortImpl.parseHostAndPort("/", -1));
+    assertNull(HostAndPortImpl.parseHostAndPort("10.0.0.1:x", -1));
   }
 
   private void assertHostAndPort(String expectedHost, int expectedPort, String actual) {


### PR DESCRIPTION
See #4947

If `parseIPv4Address` finds an IP address, and the string still has characters which do not begin with `:`, then this is not an IP address.

In other words, `10.0.0.1.nip.io` should not be parsed as an IP address.