### PR TITLE
TCPSSLOptions keyCertOptions/trustOptions accessors overload deprecation

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
@@ -361,35 +361,41 @@ public class EventBusOptions extends TCPSSLOptions {
 
   @Override
   @GenIgnore
+  @Deprecated
   public EventBusOptions setKeyCertOptions(KeyCertOptions options) {
     super.setKeyCertOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public EventBusOptions setKeyStoreOptions(JksOptions options) {
     super.setKeyStoreOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public EventBusOptions setPemKeyCertOptions(PemKeyCertOptions options) {
     super.setPemKeyCertOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public EventBusOptions setPemTrustOptions(PemTrustOptions options) {
     super.setPemTrustOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public EventBusOptions setPfxKeyCertOptions(PfxOptions options) {
     super.setPfxKeyCertOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public EventBusOptions setPfxTrustOptions(PfxOptions options) {
     super.setPfxTrustOptions(options);
@@ -426,6 +432,7 @@ public class EventBusOptions extends TCPSSLOptions {
     return this;
   }
 
+  @Deprecated
   @Override
   public EventBusOptions setTrustStoreOptions(JksOptions options) {
     super.setTrustStoreOptions(options);
@@ -472,11 +479,13 @@ public class EventBusOptions extends TCPSSLOptions {
     return (EventBusOptions) super.setSslEngineOptions(sslEngineOptions);
   }
 
+  @Deprecated
   @Override
   public EventBusOptions setJdkSslEngineOptions(JdkSSLEngineOptions sslEngineOptions) {
     return (EventBusOptions) super.setJdkSslEngineOptions(sslEngineOptions);
   }
 
+  @Deprecated
   @Override
   public EventBusOptions setOpenSslEngineOptions(OpenSSLEngineOptions sslEngineOptions) {
     return (EventBusOptions) super.setOpenSslEngineOptions(sslEngineOptions);

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -482,18 +482,21 @@ public class HttpClientOptions extends ClientOptionsBase {
     return this;
   }
 
+  @Deprecated
   @Override
   public HttpClientOptions setKeyCertOptions(KeyCertOptions options) {
     super.setKeyCertOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public HttpClientOptions setKeyStoreOptions(JksOptions options) {
     super.setKeyStoreOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public HttpClientOptions setPfxKeyCertOptions(PfxOptions options) {
     return (HttpClientOptions) super.setPfxKeyCertOptions(options);
@@ -505,22 +508,26 @@ public class HttpClientOptions extends ClientOptionsBase {
     return this;
   }
 
+  @Deprecated
   @Override
   public HttpClientOptions setPemKeyCertOptions(PemKeyCertOptions options) {
     return (HttpClientOptions) super.setPemKeyCertOptions(options);
   }
 
+  @Deprecated
   @Override
   public HttpClientOptions setTrustStoreOptions(JksOptions options) {
     super.setTrustStoreOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public HttpClientOptions setPfxTrustOptions(PfxOptions options) {
     return (HttpClientOptions) super.setPfxTrustOptions(options);
   }
 
+  @Deprecated
   @Override
   public HttpClientOptions setPemTrustOptions(PemTrustOptions options) {
     return (HttpClientOptions) super.setPemTrustOptions(options);
@@ -1121,11 +1128,13 @@ public class HttpClientOptions extends ClientOptionsBase {
     return (HttpClientOptions) super.setSslEngineOptions(sslEngineOptions);
   }
 
+  @Deprecated
   @Override
   public HttpClientOptions setJdkSslEngineOptions(JdkSSLEngineOptions sslEngineOptions) {
     return (HttpClientOptions) super.setSslEngineOptions(sslEngineOptions);
   }
 
+  @Deprecated
   @Override
   public HttpClientOptions setOpenSslEngineOptions(OpenSSLEngineOptions sslEngineOptions) {
     return (HttpClientOptions) super.setSslEngineOptions(sslEngineOptions);

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -395,23 +395,27 @@ public class HttpServerOptions extends NetServerOptions {
     return this;
   }
 
+  @Deprecated
   @Override
   public HttpServerOptions setKeyCertOptions(KeyCertOptions options) {
     super.setKeyCertOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public HttpServerOptions setKeyStoreOptions(JksOptions options) {
     super.setKeyStoreOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public HttpServerOptions setPfxKeyCertOptions(PfxOptions options) {
     return (HttpServerOptions) super.setPfxKeyCertOptions(options);
   }
 
+  @Deprecated
   @Override
   public HttpServerOptions setPemKeyCertOptions(PemKeyCertOptions options) {
     return (HttpServerOptions) super.setPemKeyCertOptions(options);
@@ -423,17 +427,20 @@ public class HttpServerOptions extends NetServerOptions {
     return this;
   }
 
+  @Deprecated
   @Override
   public HttpServerOptions setTrustStoreOptions(JksOptions options) {
     super.setTrustStoreOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public HttpServerOptions setPemTrustOptions(PemTrustOptions options) {
     return (HttpServerOptions) super.setPemTrustOptions(options);
   }
 
+  @Deprecated
   @Override
   public HttpServerOptions setPfxTrustOptions(PfxOptions options) {
     return (HttpServerOptions) super.setPfxTrustOptions(options);
@@ -516,11 +523,13 @@ public class HttpServerOptions extends NetServerOptions {
     return this;
   }
 
+  @Deprecated
   @Override
   public HttpServerOptions setJdkSslEngineOptions(JdkSSLEngineOptions sslEngineOptions) {
     return (HttpServerOptions) super.setSslEngineOptions(sslEngineOptions);
   }
 
+  @Deprecated
   @Override
   public HttpServerOptions setOpenSslEngineOptions(OpenSSLEngineOptions sslEngineOptions) {
     return (HttpServerOptions) super.setSslEngineOptions(sslEngineOptions);

--- a/src/main/java/io/vertx/core/http/WebSocketClientOptions.java
+++ b/src/main/java/io/vertx/core/http/WebSocketClientOptions.java
@@ -497,21 +497,25 @@ public class WebSocketClientOptions extends ClientOptionsBase {
     return (WebSocketClientOptions)super.setSsl(ssl);
   }
 
+  @Deprecated
   @Override
   public WebSocketClientOptions setKeyCertOptions(KeyCertOptions options) {
     return (WebSocketClientOptions)super.setKeyCertOptions(options);
   }
 
+  @Deprecated
   @Override
   public WebSocketClientOptions setKeyStoreOptions(JksOptions options) {
     return (WebSocketClientOptions)super.setKeyStoreOptions(options);
   }
 
+  @Deprecated
   @Override
   public WebSocketClientOptions setPfxKeyCertOptions(PfxOptions options) {
     return (WebSocketClientOptions)super.setPfxKeyCertOptions(options);
   }
 
+  @Deprecated
   @Override
   public WebSocketClientOptions setPemKeyCertOptions(PemKeyCertOptions options) {
     return (WebSocketClientOptions)super.setPemKeyCertOptions(options);
@@ -522,16 +526,19 @@ public class WebSocketClientOptions extends ClientOptionsBase {
     return (WebSocketClientOptions)super.setTrustOptions(options);
   }
 
+  @Deprecated
   @Override
   public WebSocketClientOptions setTrustStoreOptions(JksOptions options) {
     return (WebSocketClientOptions)super.setTrustStoreOptions(options);
   }
 
+  @Deprecated
   @Override
   public WebSocketClientOptions setPfxTrustOptions(PfxOptions options) {
     return (WebSocketClientOptions)super.setPfxTrustOptions(options);
   }
 
+  @Deprecated
   @Override
   public WebSocketClientOptions setPemTrustOptions(PemTrustOptions options) {
     return (WebSocketClientOptions)super.setPemTrustOptions(options);
@@ -547,11 +554,13 @@ public class WebSocketClientOptions extends ClientOptionsBase {
     return (WebSocketClientOptions)super.setSslEngineOptions(sslEngineOptions);
   }
 
+  @Deprecated
   @Override
   public WebSocketClientOptions setJdkSslEngineOptions(JdkSSLEngineOptions sslEngineOptions) {
     return (WebSocketClientOptions)super.setJdkSslEngineOptions(sslEngineOptions);
   }
 
+  @Deprecated
   @Override
   public WebSocketClientOptions setOpenSslEngineOptions(OpenSSLEngineOptions sslEngineOptions) {
     return (WebSocketClientOptions)super.setOpenSslEngineOptions(sslEngineOptions);

--- a/src/main/java/io/vertx/core/net/ClientOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/ClientOptionsBase.java
@@ -287,21 +287,25 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
     return (ClientOptionsBase) super.setSsl(ssl);
   }
 
+  @Deprecated
   @Override
   public ClientOptionsBase setKeyCertOptions(KeyCertOptions options) {
     return (ClientOptionsBase) super.setKeyCertOptions(options);
   }
 
+  @Deprecated
   @Override
   public ClientOptionsBase setKeyStoreOptions(JksOptions options) {
     return (ClientOptionsBase) super.setKeyStoreOptions(options);
   }
 
+  @Deprecated
   @Override
   public ClientOptionsBase setPfxKeyCertOptions(PfxOptions options) {
     return (ClientOptionsBase) super.setPfxKeyCertOptions(options);
   }
 
+  @Deprecated
   @Override
   public ClientOptionsBase setPemKeyCertOptions(PemKeyCertOptions options) {
     return (ClientOptionsBase) super.setPemKeyCertOptions(options);
@@ -312,16 +316,19 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
     return (ClientOptionsBase) super.setTrustOptions(options);
   }
 
+  @Deprecated
   @Override
   public ClientOptionsBase setTrustStoreOptions(JksOptions options) {
     return (ClientOptionsBase) super.setTrustStoreOptions(options);
   }
 
+  @Deprecated
   @Override
   public ClientOptionsBase setPfxTrustOptions(PfxOptions options) {
     return (ClientOptionsBase) super.setPfxTrustOptions(options);
   }
 
+  @Deprecated
   @Override
   public ClientOptionsBase setPemTrustOptions(PemTrustOptions options) {
     return (ClientOptionsBase) super.setPemTrustOptions(options);
@@ -337,11 +344,13 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
     return (ClientOptionsBase) super.setSslEngineOptions(sslEngineOptions);
   }
 
+  @Deprecated
   @Override
   public ClientOptionsBase setJdkSslEngineOptions(JdkSSLEngineOptions sslEngineOptions) {
     return (ClientOptionsBase) super.setJdkSslEngineOptions(sslEngineOptions);
   }
 
+  @Deprecated
   @Override
   public ClientOptionsBase setOpenSslEngineOptions(OpenSSLEngineOptions sslEngineOptions) {
     return (ClientOptionsBase) super.setOpenSslEngineOptions(sslEngineOptions);

--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -183,23 +183,27 @@ public class NetClientOptions extends ClientOptionsBase {
     return this;
   }
 
+  @Deprecated
   @Override
   public NetClientOptions setKeyCertOptions(KeyCertOptions options) {
     super.setKeyCertOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public NetClientOptions setKeyStoreOptions(JksOptions options) {
     super.setKeyStoreOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public NetClientOptions setPfxKeyCertOptions(PfxOptions options) {
     return (NetClientOptions) super.setPfxKeyCertOptions(options);
   }
 
+  @Deprecated
   @Override
   public NetClientOptions setPemKeyCertOptions(PemKeyCertOptions options) {
     return (NetClientOptions) super.setPemKeyCertOptions(options);
@@ -211,17 +215,20 @@ public class NetClientOptions extends ClientOptionsBase {
     return this;
   }
 
+  @Deprecated
   @Override
   public NetClientOptions setTrustStoreOptions(JksOptions options) {
     super.setTrustStoreOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public NetClientOptions setPemTrustOptions(PemTrustOptions options) {
     return (NetClientOptions) super.setPemTrustOptions(options);
   }
 
+  @Deprecated
   @Override
   public NetClientOptions setPfxTrustOptions(PfxOptions options) {
     return (NetClientOptions) super.setPfxTrustOptions(options);
@@ -260,6 +267,7 @@ public class NetClientOptions extends ClientOptionsBase {
     return (NetClientOptions) super.setSslEngineOptions(sslEngineOptions);
   }
 
+  @Deprecated
   @Override
   public NetClientOptions setJdkSslEngineOptions(JdkSSLEngineOptions sslEngineOptions) {
     return (NetClientOptions) super.setJdkSslEngineOptions(sslEngineOptions);
@@ -280,6 +288,7 @@ public class NetClientOptions extends ClientOptionsBase {
     return (NetClientOptions) super.setTcpQuickAck(tcpQuickAck);
   }
 
+  @Deprecated
   @Override
   public ClientOptionsBase setOpenSslEngineOptions(OpenSSLEngineOptions sslEngineOptions) {
     return super.setOpenSslEngineOptions(sslEngineOptions);

--- a/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -230,33 +230,39 @@ public class NetServerOptions extends TCPSSLOptions {
     return this;
   }
 
+  @Deprecated
   @Override
   public NetServerOptions setJdkSslEngineOptions(JdkSSLEngineOptions sslEngineOptions) {
     return (NetServerOptions) super.setSslEngineOptions(sslEngineOptions);
   }
 
+  @Deprecated
   @Override
   public NetServerOptions setOpenSslEngineOptions(OpenSSLEngineOptions sslEngineOptions) {
     return (NetServerOptions) super.setSslEngineOptions(sslEngineOptions);
   }
 
+  @Deprecated
   @Override
   public NetServerOptions setKeyCertOptions(KeyCertOptions options) {
     super.setKeyCertOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public NetServerOptions setKeyStoreOptions(JksOptions options) {
     super.setKeyStoreOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public NetServerOptions setPfxKeyCertOptions(PfxOptions options) {
     return (NetServerOptions) super.setPfxKeyCertOptions(options);
   }
 
+  @Deprecated
   @Override
   public NetServerOptions setPemKeyCertOptions(PemKeyCertOptions options) {
     return (NetServerOptions) super.setPemKeyCertOptions(options);
@@ -268,17 +274,20 @@ public class NetServerOptions extends TCPSSLOptions {
     return this;
   }
 
+  @Deprecated
   @Override
   public NetServerOptions setTrustStoreOptions(JksOptions options) {
     super.setTrustStoreOptions(options);
     return this;
   }
 
+  @Deprecated
   @Override
   public NetServerOptions setPfxTrustOptions(PfxOptions options) {
     return (NetServerOptions) super.setPfxTrustOptions(options);
   }
 
+  @Deprecated
   @Override
   public NetServerOptions setPemTrustOptions(PemTrustOptions options) {
     return (NetServerOptions) super.setPemTrustOptions(options);

--- a/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -396,7 +396,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Get the key/cert options in jks format, aka Java keystore.
    *
    * @return the key/cert options in jks format, aka Java keystore.
+   * @deprecated instead use {@link #getKeyCertOptions()}
    */
+  @Deprecated
   public JksOptions getKeyStoreOptions() {
     KeyCertOptions keyCertOptions = sslOptions.getKeyCertOptions();
     return keyCertOptions instanceof JksOptions ? (JksOptions) keyCertOptions : null;
@@ -406,7 +408,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Set the key/cert options in jks format, aka Java keystore.
    * @param options the key store in jks format
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link #setKeyCertOptions(KeyCertOptions)}
    */
+  @Deprecated
   public TCPSSLOptions setKeyStoreOptions(JksOptions options) {
     return setKeyCertOptions(options);
   }
@@ -415,7 +419,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Get the key/cert options in pfx format.
    *
    * @return the key/cert options in pfx format.
+   * @deprecated instead use {@link #getKeyCertOptions()}
    */
+  @Deprecated
   public PfxOptions getPfxKeyCertOptions() {
     KeyCertOptions keyCertOptions = sslOptions.getKeyCertOptions();
     return keyCertOptions instanceof PfxOptions ? (PfxOptions) keyCertOptions : null;
@@ -425,7 +431,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Set the key/cert options in pfx format.
    * @param options the key cert options in pfx format
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link #setKeyCertOptions(KeyCertOptions)}
    */
+  @Deprecated
   public TCPSSLOptions setPfxKeyCertOptions(PfxOptions options) {
     return setKeyCertOptions(options);
   }
@@ -434,7 +442,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Get the key/cert store options in pem format.
    *
    * @return the key/cert store options in pem format.
+   * @deprecated instead use {@link #getKeyCertOptions()}
    */
+  @Deprecated
   public PemKeyCertOptions getPemKeyCertOptions() {
     KeyCertOptions keyCertOptions = sslOptions.getKeyCertOptions();
     return keyCertOptions instanceof PemKeyCertOptions ? (PemKeyCertOptions) keyCertOptions : null;
@@ -444,7 +454,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Set the key/cert store options in pem format.
    * @param options the options in pem format
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link #setKeyCertOptions(KeyCertOptions)}
    */
+  @Deprecated
   public TCPSSLOptions setPemKeyCertOptions(PemKeyCertOptions options) {
     return setKeyCertOptions(options);
   }
@@ -470,7 +482,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Get the trust options in jks format, aka Java truststore
    *
    * @return the trust options in jks format, aka Java truststore
+   * @deprecated instead use {@link #getTrustOptions()}
    */
+  @Deprecated
   public JksOptions getTrustStoreOptions() {
     TrustOptions trustOptions = sslOptions.getTrustOptions();
     return trustOptions instanceof JksOptions ? (JksOptions) trustOptions : null;
@@ -480,7 +494,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Set the trust options in jks format, aka Java truststore
    * @param options the trust options in jks format
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link #setTrustOptions(TrustOptions)}
    */
+  @Deprecated
   public TCPSSLOptions setTrustStoreOptions(JksOptions options) {
     return setTrustOptions(options);
   }
@@ -489,7 +505,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Get the trust options in pfx format
    *
    * @return the trust options in pfx format
+   * @deprecated instead use {@link #getTrustOptions()}
    */
+  @Deprecated
   public PfxOptions getPfxTrustOptions() {
     TrustOptions trustOptions = sslOptions.getTrustOptions();
     return trustOptions instanceof PfxOptions ? (PfxOptions) trustOptions : null;
@@ -499,7 +517,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Set the trust options in pfx format
    * @param options the trust options in pfx format
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link #setTrustOptions(TrustOptions)}
    */
+  @Deprecated
   public TCPSSLOptions setPfxTrustOptions(PfxOptions options) {
     return setTrustOptions(options);
   }
@@ -508,7 +528,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Get the trust options in pem format
    *
    * @return the trust options in pem format
+   * @deprecated instead use {@link #getTrustOptions()}
    */
+  @Deprecated
   public PemTrustOptions getPemTrustOptions() {
     TrustOptions trustOptions = sslOptions.getTrustOptions();
     return trustOptions instanceof PemTrustOptions ? (PemTrustOptions) trustOptions : null;
@@ -518,7 +540,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Set the trust options in pem format
    * @param options the trust options in pem format
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link #setTrustOptions(TrustOptions)}
    */
+  @Deprecated
   public TCPSSLOptions setPemTrustOptions(PemTrustOptions options) {
     return setTrustOptions(options);
   }
@@ -572,9 +596,8 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * Add a CRL path
    * @param crlPath  the path
    * @return a reference to this, so the API can be used fluently
-   * @throws NullPointerException
    */
-  public TCPSSLOptions addCrlPath(String crlPath) throws NullPointerException {
+  public TCPSSLOptions addCrlPath(String crlPath) {
     sslOptions.addCrlPath(crlPath);
     return this;
   }
@@ -593,9 +616,8 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    *
    * @param crlValue  the value
    * @return a reference to this, so the API can be used fluently
-   * @throws NullPointerException
    */
-  public TCPSSLOptions addCrlValue(Buffer crlValue) throws NullPointerException {
+  public TCPSSLOptions addCrlValue(Buffer crlValue) {
     sslOptions.addCrlValue(crlValue);
     return this;
   }
@@ -635,18 +657,34 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     return this;
   }
 
+  /**
+   * @deprecated instead use {@link #getSslEngineOptions()}
+   */
+  @Deprecated
   public JdkSSLEngineOptions getJdkSslEngineOptions() {
     return sslEngineOptions instanceof JdkSSLEngineOptions ? (JdkSSLEngineOptions) sslEngineOptions : null;
   }
 
+  /**
+   * @deprecated instead use {@link #setSslEngineOptions(SSLEngineOptions)}
+   */
+  @Deprecated
   public TCPSSLOptions setJdkSslEngineOptions(JdkSSLEngineOptions sslEngineOptions) {
     return setSslEngineOptions(sslEngineOptions);
   }
 
+  /**
+   * @deprecated instead use {@link #getSslEngineOptions()}
+   */
+  @Deprecated
   public OpenSSLEngineOptions getOpenSslEngineOptions() {
     return sslEngineOptions instanceof OpenSSLEngineOptions ? (OpenSSLEngineOptions) sslEngineOptions : null;
   }
 
+  /**
+   * @deprecated instead use {@link #setSslEngineOptions(SSLEngineOptions)}
+   */
+  @Deprecated
   public TCPSSLOptions setOpenSslEngineOptions(OpenSSLEngineOptions sslEngineOptions) {
     return setSslEngineOptions(sslEngineOptions);
   }


### PR DESCRIPTION
The TCPSSLOptions data object class has setters overload for keyCertOptions and trustOptions with different sub interfaces of the base interfaces, e.g. setPfxTrustOptions(PfxTrustOptions) for setTrustOptions(TrustOptions). This was initially done to let the JSON generated converter work since KeyCertOptions and TrustOptions are used through their implementations.

This deprecates those un-necessary. The corresponding methods are removed in Vert.x 5
