### PR TITLE
Future fix NPE, fast path for completed, fewer lines

### DIFF
--- a/src/main/java/io/vertx/core/impl/Utils.java
+++ b/src/main/java/io/vertx/core/impl/Utils.java
@@ -46,7 +46,7 @@ public class Utils {
   }
 
   @SuppressWarnings("unchecked")
-  public static <E extends Throwable> void throwAsUnchecked(Throwable t) throws E {
+  public static <E extends Throwable> RuntimeException throwAsUnchecked(Throwable t) throws E {
     throw (E) t;
   }
 }


### PR DESCRIPTION
1) ```
} catch (InterruptedException e) {
      Utils.throwAsUnchecked(e.getCause());
```
could cause NPE

2) if Future.isComplete() simply return result

3)
```
Utils.throwAsUnchecked(cause());
return null;
```
looks ugly, can be easily optimized
