### PR TITLE
Vertx Builder API + remove cluster manager from VertxOptions

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -790,17 +790,21 @@ Worker executors can be configured when created:
 
 NOTE: the configuration is set when the worker pool is created
 
-== Metrics SPI
+== Vert.x SPI
 
-By default Vert.x does not record any metrics. Instead it provides an SPI for others to implement which can be added
-to the classpath. The metrics SPI is an advanced feature which allows implementers to capture events from Vert.x in
-order to gather metrics. For more information on this, please consult the
-{@link io.vertx.core.spi.metrics.VertxMetrics API Documentation}.
+A Vert.x instance has a few extension points knows as _SPI_ (Service Provider Interface).
 
-You can also specify a metrics factory programmatically if embedding Vert.x using
-{@link io.vertx.core.metrics.MetricsOptions#setFactory(io.vertx.core.spi.VertxMetricsFactory)}.
+Such SPI are often loaded from the classpath using Java's `ServiceLoader` mechanism.
 
-== Cluster Managers
+=== Metrics and tracing SPI
+
+By default, Vert.x does not record any metrics nor does any tracing. Instead, it provides an SPI for others to implement which can be added
+to the classpath. The metrics SPI is a feature which allows implementers to capture events from Vert.x in order to
+collect and report metrics, likewise the tracing SPI does the same for traces.
+
+For more information on this, please consult https://vertx.io/docs/#monitoring
+
+=== Cluster Manager SPI
 
 In Vert.x a cluster manager is used for various functions including:
 
@@ -816,17 +820,30 @@ The default cluster manager used in the Vert.x distributions is one that uses ht
 can be easily replaced by a different implementation as Vert.x cluster managers are pluggable.
 
 A cluster manager must implement the interface {@link io.vertx.core.spi.cluster.ClusterManager}. Vert.x locates
-cluster managers at run-time by using the Java
-https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html[Service Loader] functionality to locate
-instances of {@link io.vertx.core.spi.cluster.ClusterManager} on the classpath.
+cluster managers at run-time by using the Java https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html[Service Loader] functionality to locate instances of {@link io.vertx.core.spi.cluster.ClusterManager} on the classpath.
 
 If you are using Vert.x at the command line and you want to use clustering you should make sure the `lib` directory
 of the Vert.x installation contains your cluster manager jar.
 
 If you are using Vert.x from a Maven or Gradle project just add the cluster manager jar as a dependency of your project.
 
-You can also specify cluster managers programmatically if embedding Vert.x using
-{@link io.vertx.core.VertxOptions#setClusterManager(io.vertx.core.spi.cluster.ClusterManager)}.
+For more information on this, please consult https://vertx.io/docs/#clustering
+
+=== Programmatic SPI selection and configuration
+
+The {@link io.vertx.core.VertxBuilder} gives you more control over the SPI selection and configuration.
+
+[source,$lang]
+----
+{@link examples.CoreExamples#vertxBuilder}
+----
+
+Clustered instances can also be created.
+
+[source,$lang]
+----
+{@link examples.CoreExamples#clusteredVertxBuilder}
+----
 
 == Logging
 

--- a/src/main/java/examples/CoreExamples.java
+++ b/src/main/java/examples/CoreExamples.java
@@ -23,6 +23,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.VertxMetricsFactory;
+import io.vertx.core.spi.cluster.ClusterManager;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -107,6 +109,20 @@ public class CoreExamples {
     String blockingMethod(String str) {
       return str;
     }
+  }
+
+  public void vertxBuilder(VertxOptions options, VertxMetricsFactory metricsFactory) {
+    Vertx vertx = Vertx.builder()
+      .with(options)
+      .withMetrics(metricsFactory)
+      .build();
+  }
+
+  public void clusteredVertxBuilder(VertxOptions options, ClusterManager clusterManager) {
+    Future<Vertx> vertx = Vertx.builder()
+      .with(options)
+      .withClusterManager(clusterManager)
+      .buildClustered();
   }
 
   public void exampleFuture1(Vertx vertx, Handler<HttpServerRequest> requestHandler) {

--- a/src/main/java/io/vertx/core/VertxBuilder.java
+++ b/src/main/java/io/vertx/core/VertxBuilder.java
@@ -1,0 +1,98 @@
+package io.vertx.core;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.metrics.MetricsOptions;
+import io.vertx.core.spi.VertxMetricsFactory;
+import io.vertx.core.spi.VertxTracerFactory;
+import io.vertx.core.spi.cluster.ClusterManager;
+
+/**
+ * A builder for creating Vert.x instances, allowing to configure Vert.x plugins:
+ *
+ * <ul>
+ *   <li>metrics</li>
+ *   <li>tracing</li>
+ *   <li>cluster manager</li>
+ * </ul>
+ *
+ * Example usage:
+ *
+ * <pre><code>
+ *   Vertx vertx = Vertx.builder().with(options).withMetrics(metricsFactory).build();
+ * </code></pre>
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface VertxBuilder {
+
+  /**
+   * Configure the Vert.x options.
+   * @param options the Vert.x options
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  VertxBuilder with(VertxOptions options);
+
+  /**
+   * Programmatically set the metrics factory to be used when metrics are enabled.
+   * <p>
+   * Only valid if {@link MetricsOptions#isEnabled} = true.
+   * <p>
+   * Normally Vert.x will look on the classpath for a metrics factory implementation, but if you want to set one
+   * programmatically you can use this method.
+   *
+   * @param factory the metrics factory
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  VertxBuilder withMetrics(VertxMetricsFactory factory);
+
+  /**
+   * Programmatically set the tracer factory to be used when tracing are enabled.
+   * <p>
+   * Normally Vert.x will look on the classpath for a tracer factory implementation, but if you want to set one
+   * programmatically you can use this method.
+   *
+   * @param factory the tracer factory
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  VertxBuilder withTracer(VertxTracerFactory factory);
+
+  /**
+   * Programmatically set the cluster manager to be used when clustering.
+   * <p>
+   * Only valid if clustered = true.
+   * <p>
+   * Normally Vert.x will look on the classpath for a cluster manager, but if you want to set one
+   * programmatically you can use this method.
+   *
+   * @param clusterManager the cluster manager
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  VertxBuilder withClusterManager(ClusterManager clusterManager);
+
+  /**
+   * Creates a non clustered instance.
+   *
+   * @return the instance
+   */
+  Vertx build();
+
+  /**
+   * Creates a clustered instance.
+   * <p>
+   * The instance is created asynchronously and the returned future is completed with the result when it is ready.
+   *
+   * @return a future completed with the clustered vertx
+   */
+  Future<Vertx> buildClustered();
+
+}

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -18,7 +18,6 @@ import io.vertx.core.file.FileSystemOptions;
 import io.vertx.core.impl.cpu.CpuCoreSensor;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;
-import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.tracing.TracingOptions;
 
 import java.util.Objects;
@@ -126,7 +125,6 @@ public class VertxOptions {
   private long blockedThreadCheckInterval = DEFAULT_BLOCKED_THREAD_CHECK_INTERVAL;
   private long maxEventLoopExecuteTime = DEFAULT_MAX_EVENT_LOOP_EXECUTE_TIME;
   private long maxWorkerExecuteTime = DEFAULT_MAX_WORKER_EXECUTE_TIME;
-  private ClusterManager clusterManager;
   private boolean haEnabled = DEFAULT_HA_ENABLED;
   private int quorumSize = DEFAULT_QUORUM_SIZE;
   private String haGroup = DEFAULT_HA_GROUP;
@@ -162,7 +160,6 @@ public class VertxOptions {
     this.maxEventLoopExecuteTime = other.getMaxEventLoopExecuteTime();
     this.maxWorkerExecuteTime = other.getMaxWorkerExecuteTime();
     this.internalBlockingPoolSize = other.getInternalBlockingPoolSize();
-    this.clusterManager = other.getClusterManager();
     this.haEnabled = other.isHAEnabled();
     this.quorumSize = other.getQuorumSize();
     this.haGroup = other.getHAGroup();
@@ -171,6 +168,7 @@ public class VertxOptions {
     this.warningExceptionTime = other.warningExceptionTime;
     this.eventBusOptions = new EventBusOptions(other.eventBusOptions);
     this.addressResolverOptions = other.addressResolverOptions != null ? new AddressResolverOptions(other.getAddressResolverOptions()) : null;
+    this.preferNativeTransport = other.preferNativeTransport;
     this.maxEventLoopExecuteTimeUnit = other.maxEventLoopExecuteTimeUnit;
     this.maxWorkerExecuteTimeUnit = other.maxWorkerExecuteTimeUnit;
     this.warningExceptionTimeUnit = other.warningExceptionTimeUnit;
@@ -328,35 +326,6 @@ public class VertxOptions {
       throw new IllegalArgumentException("maxWorkerpExecuteTime must be > 0");
     }
     this.maxWorkerExecuteTime = maxWorkerExecuteTime;
-    return this;
-  }
-
-  /**
-   * Get the cluster manager to be used when clustering.
-   * <p>
-   * If the cluster manager has been programmatically set here, then that will be used when clustering.
-   * <p>
-   * Otherwise Vert.x attempts to locate a cluster manager on the classpath.
-   *
-   * @return the cluster manager.
-   */
-  public ClusterManager getClusterManager() {
-    return clusterManager;
-  }
-
-  /**
-   * Programmatically set the cluster manager to be used when clustering.
-   * <p>
-   * Only valid if clustered = true.
-   * <p>
-   * Normally Vert.x will look on the classpath for a cluster manager, but if you want to set one
-   * programmatically you can use this method.
-   *
-   * @param clusterManager the cluster manager
-   * @return a reference to this, so the API can be used fluently
-   */
-  public VertxOptions setClusterManager(ClusterManager clusterManager) {
-    this.clusterManager = clusterManager;
     return this;
   }
 
@@ -725,7 +694,6 @@ public class VertxOptions {
         ", maxEventLoopExecuteTime=" + maxEventLoopExecuteTime +
         ", maxWorkerExecuteTimeUnit=" + maxWorkerExecuteTimeUnit +
         ", maxWorkerExecuteTime=" + maxWorkerExecuteTime +
-        ", clusterManager=" + clusterManager +
         ", haEnabled=" + haEnabled +
         ", preferNativeTransport=" + preferNativeTransport +
         ", quorumSize=" + quorumSize +

--- a/src/main/java/io/vertx/core/metrics/MetricsOptions.java
+++ b/src/main/java/io/vertx/core/metrics/MetricsOptions.java
@@ -13,7 +13,6 @@ package io.vertx.core.metrics;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.spi.VertxMetricsFactory;
 
 /**
  * Vert.x metrics base configuration, this class can be extended by provider implementations to configure
@@ -31,7 +30,6 @@ public class MetricsOptions {
 
   private boolean enabled;
   private JsonObject json; // Keep a copy of the original json, so we don't lose info when building options subclasses
-  private VertxMetricsFactory factory;
 
   /**
    * Default constructor
@@ -47,7 +45,6 @@ public class MetricsOptions {
    */
   public MetricsOptions(MetricsOptions other) {
     enabled = other.isEnabled();
-    factory = other.factory;
   }
 
   /**
@@ -78,36 +75,6 @@ public class MetricsOptions {
    */
   public MetricsOptions setEnabled(boolean enable) {
     this.enabled = enable;
-    return this;
-  }
-
-  /**
-   * Get the metrics factory to be used when metrics are enabled.
-   * <p>
-   * If the metrics factory has been programmatically set here, then that will be used when metrics are enabled
-   * for creating the {@link io.vertx.core.spi.metrics.VertxMetrics} instance.
-   * <p>
-   * Otherwise Vert.x attempts to locate a metrics factory implementation on the classpath.
-   *
-   * @return the metrics factory
-   */
-  public VertxMetricsFactory getFactory() {
-    return factory;
-  }
-
-  /**
-   * Programmatically set the metrics factory to be used when metrics are enabled.
-   * <p>
-   * Only valid if {@link MetricsOptions#isEnabled} = true.
-   * <p>
-   * Normally Vert.x will look on the classpath for a metrics factory implementation, but if you want to set one
-   * programmatically you can use this method.
-   *
-   * @param factory the metrics factory
-   * @return a reference to this, so the API can be used fluently
-   */
-  public MetricsOptions setFactory(VertxMetricsFactory factory) {
-    this.factory = factory;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/spi/VertxMetricsFactory.java
+++ b/src/main/java/io/vertx/core/spi/VertxMetricsFactory.java
@@ -28,10 +28,7 @@ public interface VertxMetricsFactory extends VertxServiceProvider {
   default void init(VertxBuilder builder) {
     if (builder.metrics() == null) {
       VertxOptions vertxOptions = builder.options();
-      MetricsOptions metricsOptions = vertxOptions.getMetricsOptions();
-      if (metricsOptions != null && metricsOptions.isEnabled()) {
-        builder.metrics(metrics(vertxOptions));
-      }
+      builder.metrics(metrics(vertxOptions));
     }
   }
 

--- a/src/main/java/io/vertx/core/spi/VertxTracerFactory.java
+++ b/src/main/java/io/vertx/core/spi/VertxTracerFactory.java
@@ -33,9 +33,10 @@ public interface VertxTracerFactory extends VertxServiceProvider {
   default void init(VertxBuilder builder) {
     if (builder.tracer() == null) {
       TracingOptions tracingOptions = builder.options().getTracingOptions();
-      if (tracingOptions != null) {
-        builder.tracer(tracer(tracingOptions));
+      if (tracingOptions == null) {
+        tracingOptions = newOptions();
       }
+      builder.tracer(tracer(tracingOptions));
     }
   }
 

--- a/src/main/java/io/vertx/core/tracing/TracingOptions.java
+++ b/src/main/java/io/vertx/core/tracing/TracingOptions.java
@@ -25,7 +25,6 @@ import io.vertx.core.spi.VertxTracerFactory;
 public class TracingOptions {
 
   private JsonObject json; // Keep a copy of the original json, so we don't lose info when building options subclasses
-  private VertxTracerFactory factory;
 
   /**
    * Default constructor
@@ -39,7 +38,10 @@ public class TracingOptions {
    * @param other The other {@link TracingOptions} to copy when creating this
    */
   public TracingOptions(TracingOptions other) {
-    factory = other.factory;
+    json = other.json;
+    if (json != null) {
+      json = json.copy();
+    }
   }
 
   /**
@@ -51,34 +53,6 @@ public class TracingOptions {
     this();
     TracingOptionsConverter.fromJson(json, this);
     this.json = json.copy();
-  }
-
-  /**
-   * Get the tracer factory to be used when tracing are enabled.
-   * <p>
-   * If the tracer factory has been programmatically set here, then that will be used when tracing are enabled
-   * for creating the {@link io.vertx.core.spi.tracing.VertxTracer} instance.
-   * <p>
-   * Otherwise Vert.x attempts to locate a tracer factory implementation on the classpath.
-   *
-   * @return the tracer factory
-   */
-  public VertxTracerFactory getFactory() {
-    return factory;
-  }
-
-  /**
-   * Programmatically set the tracer factory to be used when tracing are enabled.
-   * <p>
-   * Normally Vert.x will look on the classpath for a tracer factory implementation, but if you want to set one
-   * programmatically you can use this method.
-   *
-   * @param factory the tracer factory
-   * @return a reference to this, so the API can be used fluently
-   */
-  public TracingOptions setFactory(VertxTracerFactory factory) {
-    this.factory = factory;
-    return this;
   }
 
   public TracingOptions copy() {

--- a/src/test/java/io/vertx/core/CreateVertxTest.java
+++ b/src/test/java/io/vertx/core/CreateVertxTest.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core;
 
+import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakecluster.FakeClusterManager;
 import org.junit.Test;
@@ -51,13 +52,13 @@ public class CreateVertxTest extends VertxTestBase {
 
   @Test
   public void testCreateClusteredVertxAsyncDetectJoinFailure() {
-    VertxOptions options = new VertxOptions().setClusterManager(new FakeClusterManager(){
+    ClusterManager clusterManager = new FakeClusterManager(){
       @Override
       public void join(Promise<Void> promise) {
         promise.fail("joinfailure");
       }
-    });
-    clusteredVertx(options, ar -> {
+    };
+    clusteredVertx(new VertxOptions(), clusterManager, ar -> {
       assertTrue(ar.failed());
       assertEquals("joinfailure", ar.cause().getMessage());
       testComplete();

--- a/src/test/java/io/vertx/core/HATest.java
+++ b/src/test/java/io/vertx/core/HATest.java
@@ -362,11 +362,8 @@ public class HATest extends VertxTestBase {
   }
 
   protected Vertx startVertx(String haGroup, int quorumSize, boolean ha) throws Exception {
-    VertxOptions options = new VertxOptions()
-      .setHAEnabled(ha)
-      .setClusterManager(getClusterManager());
-    options.getEventBusOptions()
-      .setHost("localhost");
+    VertxOptions options = new VertxOptions().setHAEnabled(ha);
+    options.getEventBusOptions().setHost("localhost");
     if (ha) {
       options.setQuorumSize(quorumSize);
       if (haGroup != null) {
@@ -375,10 +372,14 @@ public class HATest extends VertxTestBase {
     }
     CountDownLatch latch = new CountDownLatch(1);
     AtomicReference<Vertx> vertxRef = new AtomicReference<>();
-    clusteredVertx(options, onSuccess(vertx -> {
-      vertxRef.set(vertx);
-      latch.countDown();
-    }));
+    Vertx.builder()
+      .with(options)
+      .withClusterManager(getClusterManager())
+      .buildClustered()
+      .onComplete(onSuccess(vertx -> {
+        vertxRef.set(vertx);
+        latch.countDown();
+      }));
     latch.await(2, TimeUnit.MINUTES);
     return vertxRef.get();
   }

--- a/src/test/java/io/vertx/core/VertxBuilderTest.java
+++ b/src/test/java/io/vertx/core/VertxBuilderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core;
+
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.spi.VertxTracerFactory;
+import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingOptions;
+import io.vertx.test.core.AsyncTestBase;
+import io.vertx.test.fakemetrics.FakeVertxMetrics;
+import io.vertx.test.faketracer.FakeTracer;
+import org.junit.Test;
+
+public class VertxBuilderTest  extends AsyncTestBase {
+
+  @Test
+  public void testTracerFactoryDoesNotRequireOptions() {
+    FakeTracer tracer = new FakeTracer();
+    Vertx vertx = Vertx.builder().withTracer(options -> tracer).build();
+    assertEquals(tracer, ((VertxInternal)vertx).tracer());
+  }
+
+  @Test
+  public void testMetricsFactoryDoesNotRequireOptions() {
+    FakeVertxMetrics metrics = new FakeVertxMetrics();
+    Vertx vertx = Vertx.builder().withMetrics(options -> metrics).build();
+    assertEquals(metrics, ((VertxInternal)vertx).metricsSPI());
+  }
+}

--- a/src/test/java/io/vertx/core/VertxOptionsTest.java
+++ b/src/test/java/io/vertx/core/VertxOptionsTest.java
@@ -152,9 +152,6 @@ public class VertxOptionsTest extends VertxTestBase {
       // OK
     }
     ClusterManager mgr = new FakeClusterManager();
-    assertNull(options.getClusterManager());
-    assertEquals(options, options.setClusterManager(mgr));
-    assertSame(mgr, options.getClusterManager());
     assertFalse(options.isHAEnabled());
     assertEquals(options, options.setHAEnabled(true));
     assertTrue(options.isHAEnabled());
@@ -249,12 +246,8 @@ public class VertxOptionsTest extends VertxTestBase {
     options.setHAEnabled(haEnabled);
     options.setQuorumSize(quorumSize);
     options.setHAGroup(haGroup);
-    options.setMetricsOptions(
-        new MetricsOptions().
-            setEnabled(metricsEnabled));
-    options.setTracingOptions(
-        new TracingOptions().setFactory(new FakeTracerFactory())
-    );
+    options.setMetricsOptions(new MetricsOptions().setEnabled(metricsEnabled));
+    options.setTracingOptions(new TracingOptions());
     options.setWarningExceptionTime(warningExceptionTime);
     options.setMaxEventLoopExecuteTimeUnit(maxEventLoopExecuteTimeUnit);
     options.setMaxWorkerExecuteTimeUnit(maxWorkerExecuteTimeUnit);
@@ -283,7 +276,6 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(metricsEnabled, metricsOptions.isEnabled());
     TracingOptions tracingOptions = options.getTracingOptions();
     assertNotNull(tracingOptions);
-    assertTrue(tracingOptions.getFactory() instanceof FakeTracerFactory);
     assertEquals(warningExceptionTime, options.getWarningExceptionTime());
     assertEquals(maxEventLoopExecuteTimeUnit, options.getMaxEventLoopExecuteTimeUnit());
     assertEquals(maxWorkerExecuteTimeUnit, options.getMaxWorkerExecuteTimeUnit());
@@ -340,7 +332,6 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(1000, options.getBlockedThreadCheckInterval());
     assertNull(options.getEventBusOptions().getHost());
     assertNull(options.getEventBusOptions().getClusterPublicHost());
-    assertEquals(null, options.getClusterManager());
     assertEquals(2000l * 1000000, options.getMaxEventLoopExecuteTime());
     assertEquals(1l * 60 * 1000 * 1000000, options.getMaxWorkerExecuteTime());
     assertFalse(options.isHAEnabled());
@@ -424,7 +415,6 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(workerPoolSize, options.getWorkerPoolSize());
     assertEquals(blockedThreadCheckInterval, options.getBlockedThreadCheckInterval());
     assertEquals(clusterHost, options.getEventBusOptions().getHost());
-    assertEquals(null, options.getClusterManager());
     assertEquals(maxEventLoopExecuteTime, options.getMaxEventLoopExecuteTime());
     assertEquals(maxWorkerExecuteTime, options.getMaxWorkerExecuteTime());
     assertEquals(haEnabled, options.isHAEnabled());

--- a/src/test/java/io/vertx/core/eventbus/ClusterHostTest.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusterHostTest.java
@@ -33,7 +33,7 @@ public class ClusterHostTest extends VertxTestBase {
         return "127.0.0.3";
       }
     };
-    clusteredVertx(new VertxOptions().setClusterManager(clusterManager), onSuccess(clusteredVertx -> {
+    clusteredVertx(new VertxOptions(), clusterManager, onSuccess(clusteredVertx -> {
       assertEquals("127.0.0.3", clusterManager.getNodeInfo().host());
     }));
   }
@@ -51,7 +51,7 @@ public class ClusterHostTest extends VertxTestBase {
         return "127.0.0.3";
       }
     };
-    clusteredVertx(new VertxOptions().setClusterManager(clusterManager), onSuccess(clusteredVertx -> {
+    clusteredVertx(new VertxOptions(), clusterManager, onSuccess(clusteredVertx -> {
       assertEquals("127.0.0.3", clusterManager.getNodeInfo().host());
     }));
   }
@@ -69,9 +69,9 @@ public class ClusterHostTest extends VertxTestBase {
         return "127.0.0.3";
       }
     };
-    VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+    VertxOptions options = new VertxOptions();
     options.getEventBusOptions().setHost("127.0.0.4");
-    clusteredVertx(options, onSuccess(clusteredVertx -> {
+    clusteredVertx(options, clusterManager, onSuccess(clusteredVertx -> {
       assertEquals("127.0.0.4", clusterManager.getNodeInfo().host());
     }));
   }

--- a/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/ClusteredEventBusTest.java
@@ -395,7 +395,7 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
   @Test
   public void testSendWriteHandler() throws Exception {
     CountDownLatch updateLatch = new CountDownLatch(3);
-    Supplier<VertxOptions> options = () -> getOptions().setClusterManager(new WrappedClusterManager(getClusterManager()) {
+    startNodes(2, () -> new WrappedClusterManager(getClusterManager()) {
       @Override
       public void init(Vertx vertx, NodeSelector nodeSelector) {
         super.init(vertx, new WrappedNodeSelector(nodeSelector) {
@@ -414,7 +414,6 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
         });
       }
     });
-    startNodes(options.get(), options.get());
     waitFor(2);
     vertices[1]
       .eventBus()
@@ -487,16 +486,15 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
   }
 
   @Test
-  public void testSelectorWantsUpdates() throws Exception {
+  public void testSelectorWantsUpdates() {
     AtomicReference<NodeSelector> nodeSelectorRef = new AtomicReference<>();
-    VertxOptions options = getOptions().setClusterManager(new WrappedClusterManager(getClusterManager()) {
+    startNodes(1, () -> new WrappedClusterManager(getClusterManager()) {
       @Override
       public void init(Vertx vertx, NodeSelector nodeSelector) {
         nodeSelectorRef.set(nodeSelector);
         super.init(vertx, nodeSelector);
       }
     });
-    startNodes(options);
     assertNotNull(nodeSelectorRef.get());
     vertices[0].eventBus().consumer(ADDRESS1, msg -> {
       assertTrue(nodeSelectorRef.get().wantsUpdatesFor(ADDRESS1));
@@ -506,16 +504,15 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
   }
 
   @Test
-  public void testSelectorDoesNotWantUpdates() throws Exception {
+  public void testSelectorDoesNotWantUpdates() {
     AtomicReference<NodeSelector> nodeSelectorRef = new AtomicReference<>();
-    VertxOptions options = getOptions().setClusterManager(new WrappedClusterManager(getClusterManager()) {
+    startNodes(1, () -> new WrappedClusterManager(getClusterManager()) {
       @Override
       public void init(Vertx vertx, NodeSelector nodeSelector) {
         nodeSelectorRef.set(nodeSelector);
         super.init(vertx, nodeSelector);
       }
     });
-    startNodes(options);
     assertNotNull(nodeSelectorRef.get());
     assertFalse(nodeSelectorRef.get().wantsUpdatesFor(ADDRESS1));
   }

--- a/src/test/java/io/vertx/core/eventbus/EventBusRegistrationRaceTest.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusRegistrationRaceTest.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.eventbus;
 
+import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.spi.VertxMetricsFactory;
@@ -38,33 +39,26 @@ public class EventBusRegistrationRaceTest extends VertxTestBase {
   private final AtomicInteger count = new AtomicInteger();
 
   @Override
-  protected VertxOptions getOptions() {
-    VertxOptions options = super.getOptions();
-    options.setMetricsOptions(new MetricsOptions().setEnabled(true).setFactory(new VertxMetricsFactory() {
+  protected VertxMetricsFactory getMetrics() {
+    return o -> new VertxMetrics() {
       @Override
-      public VertxMetrics metrics(VertxOptions options) {
-        return new VertxMetrics() {
+      public EventBusMetrics<Void> createEventBusMetrics() {
+        return new EventBusMetrics<>() {
           @Override
-          public EventBusMetrics<Void> createEventBusMetrics() {
-            return new EventBusMetrics<Void>() {
-              @Override
-              public void scheduleMessage(Void handler, boolean local) {
-                count.incrementAndGet();
-              }
-              @Override
-              public void messageDelivered(Void handler, boolean local) {
-                count.decrementAndGet();
-              }
-              @Override
-              public void discardMessage(Void handler, boolean local, Message<?> msg) {
-                count.decrementAndGet();
-              }
-            };
+          public void scheduleMessage(Void handler, boolean local) {
+            count.incrementAndGet();
+          }
+          @Override
+          public void messageDelivered(Void handler, boolean local) {
+            count.decrementAndGet();
+          }
+          @Override
+          public void discardMessage(Void handler, boolean local, Message<?> msg) {
+            count.decrementAndGet();
           }
         };
       }
-    }));
-    return options;
+    };
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
+++ b/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
@@ -11,9 +11,7 @@
 
 package io.vertx.core.http;
 
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.VertxOptions;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.impl.HttpClientInternal;
 import io.vertx.core.http.impl.HttpServerRequestInternal;
@@ -60,8 +58,15 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
   @Override
   protected VertxOptions getOptions() {
     VertxOptions options = super.getOptions();
-    options.setMetricsOptions(new MetricsOptions().setEnabled(true).setFactory(new FakeMetricsFactory()));
+    options.setMetricsOptions(new MetricsOptions().setEnabled(true));
     return options;
+  }
+
+  @Override
+  protected Vertx createVertx(VertxOptions options) {
+    return Vertx.builder().with(options)
+      .withMetrics(new FakeMetricsFactory())
+      .build();
   }
 
   @Test

--- a/src/test/java/io/vertx/core/impl/VertxFactoryTest.java
+++ b/src/test/java/io/vertx/core/impl/VertxFactoryTest.java
@@ -89,11 +89,11 @@ public class VertxFactoryTest {
   @Test
   public void testFactoryMetricsFactoryOverridesOptions() {
     FakeVertxMetrics metrics = new FakeVertxMetrics();
-    MetricsOptions metricsOptions = new MetricsOptions().setEnabled(true).setFactory(options -> {
+    VertxBuilder factory = new VertxBuilder(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    factory.metrics(metrics);
+    factory.metricsFactory(options -> {
       throw new AssertionError();
     });
-    VertxBuilder factory = new VertxBuilder(new VertxOptions().setMetricsOptions(metricsOptions));
-    factory.metrics(metrics);
     factory.init();
     Vertx vertx = factory.vertx();
     assertSame(metrics, ((VertxInternal)vertx).metricsSPI());
@@ -115,13 +115,10 @@ public class VertxFactoryTest {
   @Test
   public void testFactoryTracerFactoryOverridesOptions() {
     FakeTracer tracer = new FakeTracer();
-    TracingOptions tracingOptions = new TracingOptions().setFactory(new VertxTracerFactory() {
-      @Override
-      public VertxTracer tracer(TracingOptions options) {
+    VertxBuilder factory = new VertxBuilder(new VertxOptions().setTracingOptions(new TracingOptions()))
+      .tracerFactory(options -> {
         throw new AssertionError();
-      }
-    });
-    VertxBuilder factory = new VertxBuilder(new VertxOptions().setTracingOptions(tracingOptions));
+      });
     factory.tracer(tracer);
     factory.init();
     Vertx vertx = factory.vertx();

--- a/src/test/java/io/vertx/core/spi/tracing/EventBusTracingTestBase.java
+++ b/src/test/java/io/vertx/core/spi/tracing/EventBusTracingTestBase.java
@@ -32,8 +32,14 @@ public abstract class EventBusTracingTestBase extends VertxTestBase {
   FakeTracer tracer;
 
   @Override
+  public void setUp() throws Exception {
+    tracer = new FakeTracer();
+    super.setUp();
+  }
+
+  @Override
   protected VertxTracer getTracer() {
-    return tracer = new FakeTracer();
+    return tracer;
   }
 
   @Test


### PR DESCRIPTION
- Vertx has an internal builder API that is used by the launcher
- VertxOptions exposes services like the cluster manager, the metrics instance, the tracer instance which are not suited for options, since options should focus on configuration data

This PR provides a `VertxBuilder` API that can be used to override the the vertx services exposed in `VertxOptions`, `VertxOptions` related services have been removed.


```java
// Before
Future<Vertx> fut = Vertx.clusteredVertx(new VertxOptions().setClusterManager(clusterManager));

// After
Future<Vertx> fut = Vertx.builder().withClusterManager(clusterManager).buildClustered();
```

This should be back-ported to 4.x branches.

