### PR TITLE
RecordParser may grow the initial buffer until the first event is emitted

### DIFF
--- a/src/main/java/io/vertx/core/parsetools/impl/RecordParserImpl.java
+++ b/src/main/java/io/vertx/core/parsetools/impl/RecordParserImpl.java
@@ -280,6 +280,11 @@ public class RecordParserImpl implements RecordParser {
   public void handle(Buffer buffer) {
     if (buffer.length() != 0) {
       if (buff == EMPTY_BUFFER) {
+        // Copy the initial buffer instead of growing it.
+        // We cannot assume that we can modify the input,
+        // or that the buffer has enough capacity.
+        // For example, an HTTP client response sent over an encrypted connection
+        // emits un-pooled buffers with limited capacity.
         buff = buffer.getBuffer(0, buffer.length());
       } else {
         buff.appendBuffer(buffer);

--- a/src/main/java/io/vertx/core/parsetools/impl/RecordParserImpl.java
+++ b/src/main/java/io/vertx/core/parsetools/impl/RecordParserImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -278,10 +278,12 @@ public class RecordParserImpl implements RecordParser {
    * @param buffer  a chunk of data
    */
   public void handle(Buffer buffer) {
-    if (buff.length() == 0) {
-      buff = buffer;
-    } else {
-      buff.appendBuffer(buffer);
+    if (buffer.length() != 0) {
+      if (buff == EMPTY_BUFFER) {
+        buff = buffer.getBuffer(0, buffer.length());
+      } else {
+        buff.appendBuffer(buffer);
+      }
     }
     handleParsing();
     if (buff != null && maxRecordSize > 0 && buff.length() > maxRecordSize) {

--- a/src/test/java/io/vertx/core/http/ClientResponseParserTest.java
+++ b/src/test/java/io/vertx/core/http/ClientResponseParserTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.http;
+
+import io.vertx.core.net.SelfSignedCertificate;
+import io.vertx.core.parsetools.RecordParser;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public abstract class ClientResponseParserTest extends HttpTestBase {
+
+  private SelfSignedCertificate selfSignedCertificate;
+
+  @Override
+  public void setUp() throws Exception {
+    selfSignedCertificate = SelfSignedCertificate.create();
+    super.setUp();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    super.tearDown();
+    selfSignedCertificate.delete();
+  }
+
+  @Override
+  protected HttpServerOptions createBaseServerOptions() {
+    return super.createBaseServerOptions()
+      .setSsl(true)
+      .setKeyCertOptions(selfSignedCertificate.keyCertOptions());
+  }
+
+  @Override
+  protected HttpClientOptions createBaseClientOptions() {
+    return super.createBaseClientOptions()
+      .setSsl(true)
+      .setTrustOptions(selfSignedCertificate.trustOptions());
+  }
+
+  @Test
+  public void shouldParseHttpsStream() throws Exception {
+    vertx.exceptionHandler(this::fail);
+
+    char[] firstLine = new char[1024 * 32];
+    Arrays.fill(firstLine, 'a');
+    char[] secondLine = new char[1024 * 64];
+    Arrays.fill(secondLine, 'b');
+
+    server.requestHandler(req -> {
+      HttpServerResponse response = req.response();
+      response.setChunked(true);
+      response.write(new String(firstLine), UTF_8.name());
+      response.write("\n");
+      response.end(new String(secondLine), UTF_8.name());
+    });
+    startServer();
+
+    List<String> lines = Collections.synchronizedList(new ArrayList<>());
+    waitFor(3);
+    client.request(requestOptions.setPort(server.actualPort())).onComplete(onSuccess(req -> {
+      req.send().onComplete(onSuccess(resp -> {
+        resp.exceptionHandler(this::fail);
+        RecordParser.newDelimited("\n", resp).endHandler(v -> complete()).handler(buff -> {
+          lines.add(buff.toString(UTF_8));
+          complete();
+        });
+      }));
+    }));
+
+    await();
+
+    assertEquals(2, lines.size());
+    assertEquals(new String(firstLine), lines.get(0));
+    assertEquals(new String(secondLine), lines.get(1));
+  }
+}

--- a/src/test/java/io/vertx/core/http/ClientResponseParserTest.java
+++ b/src/test/java/io/vertx/core/http/ClientResponseParserTest.java
@@ -11,8 +11,9 @@
 
 package io.vertx.core.http;
 
-import io.vertx.core.net.SelfSignedCertificate;
 import io.vertx.core.parsetools.RecordParser;
+import io.vertx.test.tls.Cert;
+import io.vertx.test.tls.Trust;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -24,32 +25,18 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public abstract class ClientResponseParserTest extends HttpTestBase {
 
-  private SelfSignedCertificate selfSignedCertificate;
-
-  @Override
-  public void setUp() throws Exception {
-    selfSignedCertificate = SelfSignedCertificate.create();
-    super.setUp();
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-    super.tearDown();
-    selfSignedCertificate.delete();
-  }
-
   @Override
   protected HttpServerOptions createBaseServerOptions() {
     return super.createBaseServerOptions()
       .setSsl(true)
-      .setKeyCertOptions(selfSignedCertificate.keyCertOptions());
+      .setKeyCertOptions(Cert.SERVER_PEM.get());
   }
 
   @Override
   protected HttpClientOptions createBaseClientOptions() {
     return super.createBaseClientOptions()
       .setSsl(true)
-      .setTrustOptions(selfSignedCertificate.trustOptions());
+      .setTrustOptions(Trust.SERVER_PEM.get());
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/Http1xClientResponseParserTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xClientResponseParserTest.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.http;
+
+public class Http1xClientResponseParserTest extends ClientResponseParserTest {
+}

--- a/src/test/java/io/vertx/core/http/Http2ClientResponseParserTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientResponseParserTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.http;
+
+public class Http2ClientResponseParserTest extends ClientResponseParserTest {
+
+  @Override
+  protected HttpServerOptions createBaseServerOptions() {
+    return super.createBaseServerOptions()
+      .setUseAlpn(true);
+  }
+
+  @Override
+  protected HttpClientOptions createBaseClientOptions() {
+    return super.createBaseClientOptions()
+      .setUseAlpn(true)
+      .setProtocolVersion(HttpVersion.HTTP_2);
+  }
+}

--- a/src/test/java/io/vertx/core/parsetools/RecordParserTest.java
+++ b/src/test/java/io/vertx/core/parsetools/RecordParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -473,5 +473,20 @@ public class RecordParserTest {
     });
     recordParser.handle(Buffer.buffer("foo\n"));
     latch.await();
+  }
+
+  @Test
+  public void shouldCopyInitialBuffer() {
+    RecordParser parser = RecordParser.newFixed(150, buff -> {
+    });
+    List<Buffer> inputBuffers = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      Buffer buffer = TestUtils.randomBuffer(12);
+      parser.handle(buffer);
+      inputBuffers.add(buffer);
+    }
+    for (int i = 0; i < 20; i++) {
+      assertEquals(12, inputBuffers.get(i).length());
+    }
   }
 }


### PR DESCRIPTION
See #4811

This can be a problem if the received [Buffer](url) is backed by a Netty `ByteBuff` with low capacity.

Also, we shouldn't assume we can modify input.