### PR TITLE
- allows for local codec lookup when in clustered mode.

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -119,7 +119,7 @@ public class MessageImpl<U, V> implements Message<V> {
   }
 
   protected MessageImpl createReply(Object message, DeliveryOptions options) {
-    MessageImpl reply = bus.createMessage(true, replyAddress, options.getHeaders(), message, options.getCodecName());
+    MessageImpl reply = bus.createMessage(true, isLocal(), replyAddress, options.getHeaders(), message, options.getCodecName());
     reply.trace = trace;
     return reply;
   }

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
@@ -29,6 +29,7 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
   private final EventBusImpl bus;
   private final boolean send;
   private final String address;
+  private final boolean localOnly;
   private DeliveryOptions options;
 
   public MessageProducerImpl(Vertx vertx, String address, boolean send, DeliveryOptions options) {
@@ -37,6 +38,7 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
     this.address = address;
     this.send = send;
     this.options = options;
+    this.localOnly = vertx.isClustered() ? options.isLocalOnly() : true;
   }
 
   @Override
@@ -62,7 +64,7 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
   }
 
   private void write(T data, Promise<Void> handler) {
-    MessageImpl msg = bus.createMessage(send, address, options.getHeaders(), data, options.getCodecName());
+    MessageImpl msg = bus.createMessage(send, localOnly, address, options.getHeaders(), data, options.getCodecName());
     bus.sendOrPubInternal(msg, options, null, handler);
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -147,9 +147,9 @@ public class ClusteredEventBus extends EventBusImpl {
   }
 
   @Override
-  public MessageImpl createMessage(boolean send, String address, MultiMap headers, Object body, String codecName) {
+  public MessageImpl createMessage(boolean send, boolean isLocal, String address, MultiMap headers, Object body, String codecName) {
     Objects.requireNonNull(address, "no null address accepted");
-    MessageCodec codec = codecManager.lookupCodec(body, codecName, false);
+    MessageCodec codec = codecManager.lookupCodec(body, codecName, isLocal);
     @SuppressWarnings("unchecked")
     ClusteredMessage msg = new ClusteredMessage(nodeId, address, headers, body, codec, send, this);
     return msg;


### PR DESCRIPTION
Motivation:

Allows for local codec lookup when in clustered mode. 

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
