### PR TITLE
Introduce a VertxBuilder API

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -679,15 +679,61 @@ Worker executors can be configured when created:
 
 NOTE: the configuration is set when the worker pool is created
 
-== Metrics SPI
+== Vert.x SPI
 
-By default Vert.x does not record any metrics. Instead it provides an SPI for others to implement which can be added
-to the classpath. The metrics SPI is an advanced feature which allows implementers to capture events from Vert.x in
-order to gather metrics. For more information on this, please consult the
-{@link io.vertx.core.spi.metrics.VertxMetrics API Documentation}.
+A Vert.x instance has a few extension points knows as _SPI_ (Service Provider Interface).
 
-You can also specify a metrics factory programmatically if embedding Vert.x using
-{@link io.vertx.core.metrics.MetricsOptions#setFactory(io.vertx.core.spi.VertxMetricsFactory)}.
+Such SPI are often loaded from the classpath using Java's `ServiceLoader` mechanism.
+
+=== Metrics and tracing SPI
+
+By default, Vert.x does not record any metrics nor does any tracing. Instead, it provides an SPI for others to implement which can be added
+to the classpath. The metrics SPI is a feature which allows implementers to capture events from Vert.x in order to
+collect and report metrics, likewise the tracing SPI does the same for traces.
+
+For more information on this, please consult https://vertx.io/docs/#monitoring
+
+[[cluster_manager_spi]]
+=== Cluster Manager SPI
+
+In Vert.x a cluster manager is used for various functions including:
+
+* Discovery and group membership of Vert.x nodes in a cluster
+* Maintaining cluster wide topic subscriber lists (so we know which nodes are interested in which event bus addresses)
+* Distributed Map support
+* Distributed Locks
+* Distributed Counters
+
+Cluster managers _do not_ handle the event bus inter-node transport, this is done directly by Vert.x with TCP connections.
+
+The default cluster manager used in the Vert.x distributions is one that uses http://hazelcast.com[Hazelcast] but this
+can be easily replaced by a different implementation as Vert.x cluster managers are pluggable.
+
+A cluster manager must implement the interface {@link io.vertx.core.spi.cluster.ClusterManager}. Vert.x locates
+cluster managers at run-time by using the Java https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html[Service Loader] functionality to locate instances of {@link io.vertx.core.spi.cluster.ClusterManager} on the classpath.
+
+If you are using Vert.x at the command line and you want to use clustering you should make sure the `lib` directory
+of the Vert.x installation contains your cluster manager jar.
+
+If you are using Vert.x from a Maven or Gradle project just add the cluster manager jar as a dependency of your project.
+
+For more information on this, please consult https://vertx.io/docs/#clustering
+
+=== Programmatic SPI selection and configuration
+
+The {@link io.vertx.core.VertxBuilder} gives you more control over the SPI selection and configuration.
+
+[source,$lang]
+----
+{@link examples.CoreExamples#vertxBuilder}
+----
+
+Clustered instances can also be created.
+
+[source,$lang]
+----
+{@link examples.CoreExamples#clusteredVertxBuilder}
+----
 
 == The 'vertx' command line
 
@@ -1031,8 +1077,7 @@ of the Vert.x installation contains your cluster manager jar.
 
 If you are using Vert.x from a Maven or Gradle project just add the cluster manager jar as a dependency of your project.
 
-You can also specify cluster managers programmatically if embedding Vert.x using
-{@link io.vertx.core.VertxOptions#setClusterManager(io.vertx.core.spi.cluster.ClusterManager)}.
+You can also specify cluster managers <<cluster_manager_spi, programmatically>> if embedding Vert.x.
 
 == Logging
 

--- a/src/main/java/examples/CoreExamples.java
+++ b/src/main/java/examples/CoreExamples.java
@@ -23,6 +23,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.VertxMetricsFactory;
+import io.vertx.core.spi.cluster.ClusterManager;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -107,6 +109,20 @@ public class CoreExamples {
     String blockingMethod(String str) {
       return str;
     }
+  }
+
+  public void vertxBuilder(VertxOptions options, VertxMetricsFactory metricsFactory) {
+    Vertx vertx = Vertx.builder()
+      .with(options)
+      .withMetrics(metricsFactory)
+      .build();
+  }
+
+  public void clusteredVertxBuilder(VertxOptions options, ClusterManager clusterManager) {
+    Future<Vertx> vertx = Vertx.builder()
+      .with(options)
+      .withClusterManager(clusterManager)
+      .buildClustered();
   }
 
   public void exampleFuture1(Vertx vertx, Handler<HttpServerRequest> requestHandler) {

--- a/src/main/java/io/vertx/core/VertxBuilder.java
+++ b/src/main/java/io/vertx/core/VertxBuilder.java
@@ -1,0 +1,112 @@
+package io.vertx.core;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.metrics.MetricsOptions;
+import io.vertx.core.spi.VertxMetricsFactory;
+import io.vertx.core.spi.VertxTracerFactory;
+import io.vertx.core.spi.cluster.ClusterManager;
+
+import java.util.Objects;
+
+/**
+ * A builder for creating Vert.x instances, allowing to configure Vert.x plugins:
+ *
+ * <ul>
+ *   <li>metrics</li>
+ *   <li>tracing</li>
+ *   <li>cluster manager</li>
+ * </ul>
+ *
+ * Example usage:
+ *
+ * <pre><code>
+ *   Vertx vertx = Vertx.builder().with(options).withMetrics(metricsFactory).build();
+ * </code></pre>
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface VertxBuilder {
+
+  /**
+   * Configure the Vert.x options.
+   * @param options the Vert.x options
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  VertxBuilder with(VertxOptions options);
+
+  /**
+   * Programmatically set the metrics factory to be used when metrics are enabled.
+   * <p>
+   * Only valid if {@link MetricsOptions#isEnabled} = true.
+   * <p>
+   * Normally Vert.x will look on the classpath for a metrics factory implementation, but if you want to set one
+   * programmatically you can use this method.
+   *
+   * @param factory the metrics factory
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  VertxBuilder withMetrics(VertxMetricsFactory factory);
+
+  /**
+   * Programmatically set the tracer factory to be used when tracing are enabled.
+   * <p>
+   * Normally Vert.x will look on the classpath for a tracer factory implementation, but if you want to set one
+   * programmatically you can use this method.
+   *
+   * @param factory the tracer factory
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  VertxBuilder withTracer(VertxTracerFactory factory);
+
+  /**
+   * Programmatically set the cluster manager to be used when clustering.
+   * <p>
+   * Only valid if clustered = true.
+   * <p>
+   * Normally Vert.x will look on the classpath for a cluster manager, but if you want to set one
+   * programmatically you can use this method.
+   *
+   * @param clusterManager the cluster manager
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  VertxBuilder withClusterManager(ClusterManager clusterManager);
+
+  /**
+   * Creates a non clustered instance.
+   *
+   * @return the instance
+   */
+  Vertx build();
+
+  /**
+   * Creates a clustered instance.
+   * <p>
+   * The instance is created asynchronously and the returned future is completed with the result when it is ready.
+   *
+   * @return a future completed with the clustered vertx
+   */
+  Future<Vertx> buildClustered();
+
+  /**
+   * Creates a clustered instance.
+   * <p>
+   * The instance is created asynchronously and the returned future is completed with the result when it is ready.
+   *
+   * @return a future completed with the clustered vertx
+   */
+  default void buildClustered(Handler<AsyncResult<Vertx>> handler) {
+    Objects.requireNonNull(handler);
+    Future<Vertx> fut = buildClustered();
+    fut.onComplete(handler);
+  }
+}

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -171,6 +171,7 @@ public class VertxOptions {
     this.warningExceptionTime = other.warningExceptionTime;
     this.eventBusOptions = new EventBusOptions(other.eventBusOptions);
     this.addressResolverOptions = other.addressResolverOptions != null ? new AddressResolverOptions(other.getAddressResolverOptions()) : null;
+    this.preferNativeTransport = other.preferNativeTransport;
     this.maxEventLoopExecuteTimeUnit = other.maxEventLoopExecuteTimeUnit;
     this.maxWorkerExecuteTimeUnit = other.maxWorkerExecuteTimeUnit;
     this.warningExceptionTimeUnit = other.warningExceptionTimeUnit;
@@ -354,7 +355,9 @@ public class VertxOptions {
    *
    * @param clusterManager the cluster manager
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link io.vertx.core.VertxBuilder#withClusterManager(ClusterManager)}
    */
+  @Deprecated
   public VertxOptions setClusterManager(ClusterManager clusterManager) {
     this.clusterManager = clusterManager;
     return this;

--- a/src/main/java/io/vertx/core/metrics/MetricsOptions.java
+++ b/src/main/java/io/vertx/core/metrics/MetricsOptions.java
@@ -14,6 +14,7 @@ package io.vertx.core.metrics;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.VertxMetricsFactory;
+import io.vertx.core.spi.cluster.ClusterManager;
 
 /**
  * Vert.x metrics base configuration, this class can be extended by provider implementations to configure
@@ -105,7 +106,9 @@ public class MetricsOptions {
    *
    * @param factory the metrics factory
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link io.vertx.core.VertxBuilder#withMetrics(VertxMetricsFactory)}
    */
+  @Deprecated
   public MetricsOptions setFactory(VertxMetricsFactory factory) {
     this.factory = factory;
     return this;

--- a/src/main/java/io/vertx/core/tracing/TracingOptions.java
+++ b/src/main/java/io/vertx/core/tracing/TracingOptions.java
@@ -14,6 +14,7 @@ package io.vertx.core.tracing;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.VertxTracerFactory;
+import io.vertx.core.spi.cluster.ClusterManager;
 
 /**
  * Vert.x tracing base configuration, this class can be extended by provider implementations to configure
@@ -75,7 +76,9 @@ public class TracingOptions {
    *
    * @param factory the tracer factory
    * @return a reference to this, so the API can be used fluently
+   * @deprecated instead use {@link io.vertx.core.VertxBuilder#withTracer(VertxTracerFactory)}
    */
+  @Deprecated
   public TracingOptions setFactory(VertxTracerFactory factory) {
     this.factory = factory;
     return this;

--- a/src/test/java/io/vertx/core/VertxBuilderTest.java
+++ b/src/test/java/io/vertx/core/VertxBuilderTest.java
@@ -1,0 +1,34 @@
+package io.vertx.core;
+
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.test.core.AsyncTestBase;
+import io.vertx.test.fakemetrics.FakeVertxMetrics;
+import io.vertx.test.faketracer.FakeTracer;
+import org.junit.Test;
+
+public class VertxBuilderTest extends AsyncTestBase {
+
+  @Test
+  public void testBuildVertx() {
+    Vertx vertx = Vertx.builder().build();
+    vertx.setTimer(10, id -> {
+      testComplete();
+    });
+    await();
+    vertx.close();
+  }
+
+  @Test
+  public void testTracerFactoryDoesNotRequireOptions() {
+    FakeTracer tracer = new FakeTracer();
+    Vertx vertx = Vertx.builder().withTracer(options -> tracer).build();
+    assertEquals(tracer, ((VertxInternal)vertx).tracer());
+  }
+
+  @Test
+  public void testMetricsFactoryDoesNotRequireOptions() {
+    FakeVertxMetrics metrics = new FakeVertxMetrics();
+    Vertx vertx = Vertx.builder().withMetrics(options -> metrics).build();
+    assertEquals(metrics, ((VertxInternal)vertx).metricsSPI());
+  }
+}


### PR DESCRIPTION
VertxOptions exposes services like the cluster manager, the metrics factory, the tracer factory which are not suited for options, since options should focus on configuration data.

This provides a `VertxBuilder` API that can be used to override the vertx services exposed in `VertxOptions`, `VertxOptions` related services have been deprecated.

```java
// Before
Future<Vertx> fut = Vertx.clusteredVertx(new VertxOptions().setClusterManager(clusterManager));

// After
Future<Vertx> fut = Vertx.builder().withClusterManager(clusterManager).buildClustered();
```