### PR TITLE
Improve the new client shutdown mechanism

### DIFF
--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -183,6 +183,16 @@ This handler will then be called when the close has fully completed.
 {@link examples.NetExamples#example9}
 ----
 
+=== Client socket shutdown
+
+When a client is closed with a grace period, each socket opened by the client will be notified with a shutdown event, to
+let the opportunity to perform a protocol level close before the actual socket close.
+
+[source,$lang]
+----
+{@link examples.NetExamples#shutdownHandler}
+----
+
 === Automatic clean-up in verticles
 
 If you're creating TCP servers and clients from inside verticles, those servers and clients will be automatically closed

--- a/src/main/generated/io/vertx/core/http/RequestOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/RequestOptionsConverter.java
@@ -40,6 +40,11 @@ public class RequestOptionsConverter {
             obj.setSsl((Boolean)member.getValue());
           }
           break;
+        case "sslOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setSslOptions(new io.vertx.core.net.ClientSSLOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
         case "uri":
           if (member.getValue() instanceof String) {
             obj.setURI((String)member.getValue());
@@ -95,6 +100,9 @@ public class RequestOptionsConverter {
     }
     if (obj.isSsl() != null) {
       json.put("ssl", obj.isSsl());
+    }
+    if (obj.getSslOptions() != null) {
+      json.put("sslOptions", obj.getSslOptions().toJson());
     }
     if (obj.getURI() != null) {
       json.put("uri", obj.getURI());

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -24,6 +24,7 @@ import io.vertx.core.net.*;
 
 import java.security.cert.CertificateException;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by tim on 19/01/15.
@@ -126,6 +127,19 @@ public class NetExamples {
           System.out.println("close failed");
         }
       });
+  }
+
+  public void shutdownHandler(NetClient client, SocketAddress server) {
+    client
+      .connect(server)
+      .onSuccess(so -> {
+      so.shutdownHandler(timeout -> {
+        // Notified when the client is closing
+      });
+    });
+
+    // A few moments later
+    client.close(30, TimeUnit.SECONDS);
   }
 
   public void example9_1(NetSocket socket) {

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -12,11 +12,8 @@
 package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.VertxGen;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.net.ClientSSLOptions;
-import io.vertx.core.net.SSLOptions;
 
 import java.util.concurrent.TimeUnit;
 
@@ -96,21 +93,12 @@ public interface HttpClient extends io.vertx.core.metrics.Measured {
   }
 
   /**
-   * Close the client immediately ({@code close(0, TimeUnit.SECONDS}).
+   * Close the client immediately ({@code shutdown(0, TimeUnit.SECONDS}).
    *
    * @return a future notified when the client is closed
    */
   default Future<Void> close() {
-    return shutdown(0, TimeUnit.SECONDS);
-  }
-
-  /**
-   * Initiate the close sequence with a 30 seconds timeout.
-   *
-   * see {@link #shutdown(long, TimeUnit)}
-   */
-  default Future<Void> shutdown() {
-    return shutdown(30, TimeUnit.SECONDS);
+    return close(0, TimeUnit.SECONDS);
   }
 
   /**
@@ -127,7 +115,7 @@ public interface HttpClient extends io.vertx.core.metrics.Measured {
    *
    * @return a future notified when the client is closed
    */
-  Future<Void> shutdown(long timeout, TimeUnit timeUnit);
+  Future<Void> close(long timeout, TimeUnit timeUnit);
 
   /**
    * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different

--- a/src/main/java/io/vertx/core/http/WebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/WebSocketClient.java
@@ -82,16 +82,7 @@ public interface WebSocketClient extends Measured {
    * @return a future notified when the client is closed
    */
   default Future<Void> close() {
-    return shutdown(0, TimeUnit.SECONDS);
-  }
-
-  /**
-   * Initiate the close sequence with a 30 seconds timeout.
-   *
-   * see {@link #shutdown(long, TimeUnit)}
-   */
-  default Future<Void> shutdown() {
-    return shutdown(30, TimeUnit.SECONDS);
+    return close(0, TimeUnit.SECONDS);
   }
 
   /**
@@ -122,17 +113,8 @@ public interface WebSocketClient extends Measured {
   /**
    * Initiate the client close sequence.
    *
-   * <p> Connections are taken out of service and closed when all inflight requests are processed, client connection are
-   * immediately removed from the pool. When all connections are closed the client is closed. When the timeout
-   * expires, all unclosed connections are immediately closed.
-   *
-   * <ul>
-   *   <li>HTTP/2 connections will send a go away frame immediately to signal the other side the connection will close</li>
-   *   <li>HTTP/1.x client connection will be closed after the current response is received</li>
-   * </ul>
-   *
    * @return a future notified when the client is closed
    */
-  Future<Void> shutdown(long timeout, TimeUnit timeUnit);
+  Future<Void> close(long timeout, TimeUnit timeUnit);
 
 }

--- a/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -67,7 +67,7 @@ public class CleanableHttpClient implements HttpClientInternal {
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
+  public Future<Void> close(long timeout, TimeUnit timeUnit) {
     if (timeout < 0L) {
       throw new IllegalArgumentException();
     }

--- a/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
@@ -69,7 +69,7 @@ public class CleanableWebSocketClient implements WebSocketClient, MetricsProvide
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
+  public Future<Void> close(long timeout, TimeUnit timeUnit) {
     if (timeout < 0L) {
       throw new IllegalArgumentException();
     }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -174,7 +174,7 @@ public class HttpClientBase implements MetricsProvider, Closeable {
     netClient.close().onComplete(p);
   }
 
-  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
+  public Future<Void> close(long timeout, TimeUnit timeUnit) {
     this.closeTimeout = timeout;
     this.closeTimeoutUnit = timeUnit;
     return closeSequence.close();

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBuilderImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBuilderImpl.java
@@ -104,7 +104,7 @@ public class HttpClientBuilderImpl implements HttpClientBuilder {
     } else {
       HttpClientImpl impl = new HttpClientImpl(vertx, _addressResolver, _loadBalancer, co, po);
       closeable = impl;
-      client = new CleanableHttpClient(impl, vertx.cleaner(), impl::shutdown);
+      client = new CleanableHttpClient(impl, vertx.cleaner(), impl::close);
     }
     cf.add(closeable);
     if (redirectHandler != null) {

--- a/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
@@ -22,6 +22,7 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.ConnectionBase;
+import io.vertx.core.net.impl.NetSocketInternal;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 
@@ -235,6 +236,12 @@ class HttpNetSocket implements NetSocket {
     synchronized (conn) {
       closeHandler = handler;
     }
+    return this;
+  }
+
+  @Override
+  public NetSocket shutdownHandler(@Nullable Handler<Long> handler) {
+    // Not sure, we can do something here
     return this;
   }
 

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -401,7 +401,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     } else {
       WebSocketClientImpl impl = new WebSocketClientImpl(this, o, options);
       closeable = impl;
-      client = new CleanableWebSocketClient(impl, cleaner, impl::shutdown);
+      client = new CleanableWebSocketClient(impl, cleaner, impl::close);
     }
     cf.add(closeable);
     return client;

--- a/src/main/java/io/vertx/core/net/NetClient.java
+++ b/src/main/java/io/vertx/core/net/NetClient.java
@@ -17,6 +17,8 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
 import io.vertx.core.metrics.Measured;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * A TCP client.
  * <p>
@@ -93,7 +95,17 @@ public interface NetClient extends Measured {
    * complete until some time after the method has returned.
    * @return a future notified when the client is closed
    */
-  Future<Void> close();
+  default Future<Void> close() {
+    return close(0L, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Initiate the client close sequence.
+   *
+   * <p> Connections are taken out of service and notified the close sequence has started through {@link NetSocket#shutdownHandler(Handler)}.
+   * When all connections are closed the client is closed. When the timeout expires, all unclosed connections are immediately closed.
+   */
+  Future<Void> close(long timeout, TimeUnit unit);
 
   /**
    * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different

--- a/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/src/main/java/io/vertx/core/net/NetSocket.java
@@ -190,6 +190,17 @@ public interface NetSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
   NetSocket closeHandler(@Nullable Handler<Void> handler);
 
   /**
+   * Set a handler that will be called when the NetSocket is shutdown: the client or server will close the connection
+   * within a certain amount of time. This gives the opportunity to the handler to close the socket gracefully before
+   * the socket is closed.
+   *
+   * @param handler  the handler notified with the remaining shutdown time in milliseconds
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  NetSocket shutdownHandler(@Nullable Handler<Long> handler);
+
+  /**
    * Upgrade channel to use SSL/TLS. Be aware that for this to work SSL must be configured.
    *
    * @return a future completed when the connection has been upgraded to SSL

--- a/src/main/java/io/vertx/core/net/impl/NetClientInternal.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientInternal.java
@@ -32,23 +32,17 @@ public interface NetClientInternal extends NetClient, MetricsProvider, Closeable
                        Promise<NetSocket> connectHandler,
                        ContextInternal context);
 
-  @Override
-  default Future<Void> close() {
-    return close(0L, TimeUnit.SECONDS);
-  }
-
   Future<Void> closeFuture();
 
   /**
    * Shutdown the client, a {@link ShutdownEvent} is broadcast to all channels. The operation completes
-   * when all channels are closed or the timeout expires.
+   * when all channels are closed or the timeout expires. This method does not close the remaining connections
+   * forcibly.
    *
    * @param timeout the shutdown timeout
    * @param timeUnit the shutdown timeout unit
    * @return a future completed when all channels are closed or the timeout expires.
    */
   Future<Void> shutdown(long timeout, TimeUnit timeUnit);
-
-  Future<Void> close(long timeout, TimeUnit timeUnit);
 
 }

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCounted;
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
@@ -61,6 +62,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
   private Handler<Buffer> handler;
   private Handler<Object> messageHandler;
   private Handler<Object> eventHandler;
+  private Handler<Long> shutdownHandler;
 
   public NetSocketImpl(ContextInternal context,
                        ChannelHandlerContext channel,
@@ -362,6 +364,19 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
     } else {
       super.handleEvent(evt);
     }
+    if (evt instanceof ShutdownEvent) {
+      Handler<Long> shutdownHandler = this.shutdownHandler;
+      if (shutdownHandler != null) {
+        ShutdownEvent shutdown = (ShutdownEvent) evt;
+        context.emit(shutdown.timeUnit().toMillis(shutdown.timeout()), shutdownHandler);
+      }
+    }
+  }
+
+  @Override
+  public NetSocket shutdownHandler(@Nullable Handler<Long> handler) {
+    shutdownHandler = handler;
+    return this;
   }
 
   private class DataMessageHandler implements Handler<Object> {

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -5302,7 +5302,7 @@ public class Http1xTest extends HttpTest {
   }
 
   @Test
-  public void testShutdown() throws Exception {
+  public void testShutdownClose() throws Exception {
     int num = 4;
     waitFor(num);
     AtomicReference<HttpServerRequest> ref = new AtomicReference<>();
@@ -5330,7 +5330,7 @@ public class Http1xTest extends HttpTest {
         assertWaitUntil(() -> ref.get() != null);
       }
     }
-    Future<Void> shutdown = client.shutdown(10, TimeUnit.SECONDS);
+    Future<Void> shutdown = client.close(10, TimeUnit.SECONDS);
     ref.get().response().end("hello");
     awaitFuture(shutdown);
     await();

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -4348,4 +4348,48 @@ public class NetTest extends VertxTestBase {
     }));
     await();
   }
+
+  @Test
+  public void testInternalShutdown() throws Exception {
+    server.connectHandler(so -> {
+    });
+    startServer();
+    int num = 2;
+    AtomicBoolean[] closed = new AtomicBoolean[num];
+    for (int i = 0;i < num;i++) {
+      closed[i] = new AtomicBoolean();
+      int idx = i;
+      client.connect(testAddress).onComplete(onSuccess(so -> {
+        NetSocketInternal soi = (NetSocketInternal) so;
+        soi.shutdownHandler(timeout -> {
+          if (idx == 0) {
+            soi.close();
+          }
+        });
+        soi.closeHandler(v -> {
+          closed[idx].set(true);
+        });
+        if (idx == num - 1) {
+          ((NetClientInternal)client).shutdown(2, TimeUnit.SECONDS).onComplete(ar -> {
+            client.connect(testAddress).onComplete(onFailure(expected -> {
+              for (int j = 0;j < num;j++) {
+                assertEquals(j == 0, closed[j].get());
+              }
+              // Hard close override
+              client.close().onComplete(onSuccess(v -> {
+                for (int j = 0;j < num;j++) {
+                  assertTrue(closed[j].get());
+                }
+                testComplete();
+              }));
+            }));
+          });
+        }
+      }));
+    }
+
+
+    await();
+  }
+
 }


### PR DESCRIPTION
- Rename shutdown to close to avoid confusion since shutdown is used internally and does not have the same effect
- Add a NetSocket shutdown handler so protocol can be aware of client shutdown
