### PR TITLE
sortByLine MultiMap output - fixes 4 flaky unit tests

### DIFF
--- a/src/test/java/io/vertx/core/http/headers/HeadersTestBase.java
+++ b/src/test/java/io/vertx/core/http/headers/HeadersTestBase.java
@@ -69,7 +69,7 @@ public abstract class HeadersTestBase {
     HashMap<String, String> map = new HashMap<>();
     map.put("a", "b");
     map.put("c", "d");
-    assertEquals("a=b\nc=d\n", mmap.addAll(map).toString());
+    assertEquals("a=b\nc=d\n", sortByLine(mmap.addAll(map).toString()));
   }
 
   @Test


### PR DESCRIPTION
## Motivation:

**Problem**
The `testAddAll2` function checks the output of MultiMap against a hard-coded test string. This causes the unit test to fail sometimes, even though the code under test works as expected. 
**Solution**
The idea is to sort the MultiMap output so that we have a deterministic test assertion. I have used the function defined in the test class itself, to sort the mmap output lines.
https://github.com/eclipse-vertx/vert.x/blob/b4fd4d691cfa802189c5a5d25688ea739440bf4a/src/test/java/io/vertx/core/http/headers/HeadersTestBase.java#L476-L485
There are 4 unit tests which can be fixed with this change -
```
io.vertx.core.http.headers.Http2HeadersAdaptorsTest#testAddAll2
io.vertx.core.http.headers.CaseInsensitiveHeadersTest#testAddAll2
io.vertx.core.http.headers.VertxHttpHeadersTest#testAddAll2
io.vertx.core.http.headers.HttpHeadersAdaptorTest#testAddAll2
```
## Reproduction of Bug
Setup the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool and run
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex  -Dtest=io.vertx.core.http.headers.VertxHttpHeadersTest#testAddAll2 -DnondexRuns=10
```
**Error Message**
```html
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.117 sec <<< FAILURE! - in io.vertx.core.http.headers.VertxHttpHeadersTest
testAddAll2(io.vertx.core.http.headers.VertxHttpHeadersTest)  Time elapsed: 0.116 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[a=b
c=d]
> but was:<[c=d
a=b]
>
```
## Conformance:

I have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
