### PR TITLE
Reduce garbage with small jackson encoded data (Fixes #4977)

### DIFF
--- a/src/main/java/io/vertx/core/buffer/impl/VertxHeapByteBuf.java
+++ b/src/main/java/io/vertx/core/buffer/impl/VertxHeapByteBuf.java
@@ -13,15 +13,24 @@ package io.vertx.core.buffer.impl;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledHeapByteBuf;
-import io.netty.buffer.UnpooledUnsafeHeapByteBuf;
 
 /**
  * An un-releasable, un-pooled, un-instrumented heap {@code ByteBuf}.
  */
 final class VertxHeapByteBuf extends UnpooledHeapByteBuf {
 
+  private static final byte[] EMPTY = new byte[0];
+
   public VertxHeapByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
     super(alloc, initialCapacity, maxCapacity);
+  }
+
+  @Override
+  protected byte[] allocateArray(int initialCapacity) {
+    if (initialCapacity == 0) {
+      return EMPTY;
+    }
+    return super.allocateArray(initialCapacity);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/buffer/impl/VertxUnsafeHeapByteBuf.java
+++ b/src/main/java/io/vertx/core/buffer/impl/VertxUnsafeHeapByteBuf.java
@@ -19,8 +19,18 @@ import io.netty.buffer.UnpooledUnsafeHeapByteBuf;
  */
 final class VertxUnsafeHeapByteBuf extends UnpooledUnsafeHeapByteBuf {
 
+  private static final byte[] EMPTY = new byte[0];
+
   public VertxUnsafeHeapByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
     super(alloc, initialCapacity, maxCapacity);
+  }
+
+  @Override
+  protected byte[] allocateArray(int initialCapacity) {
+    if (initialCapacity == 0) {
+      return EMPTY;
+    }
+    return super.allocateArray(initialCapacity);
   }
 
   @Override

--- a/src/test/benchmarks/io/vertx/benchmarks/JsonEncodeBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/JsonEncodeBenchmark.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class JsonEncodeBenchmark extends BenchmarkBase {
-
+  private JsonObject tiny;
   private JsonObject small;
   private JsonObject wide;
   private JsonObject deep;
@@ -51,6 +51,7 @@ public class JsonEncodeBenchmark extends BenchmarkBase {
   @Setup
   public void setup() {
     ClassLoader classLoader = getClass().getClassLoader();
+    tiny = new JsonObject(Map.of("message", "Hello, World!"));
     small = loadJson(classLoader.getResource("small_bench.json"));
     wide = loadJson(classLoader.getResource("wide_bench.json"));
     deep = loadJson(classLoader.getResource("deep_bench.json"));
@@ -104,6 +105,11 @@ public class JsonEncodeBenchmark extends BenchmarkBase {
   @CompilerControl(INLINE)
   private String stringDatabind(JsonObject jsonObject) {
     return databindCodec.toString(jsonObject);
+  }
+
+  @Benchmark
+  public Buffer tinyBufferJackson() {
+    return bufferJackson(tiny);
   }
 
   @Benchmark

--- a/src/test/benchmarks/io/vertx/benchmarks/JsonEncodeBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/JsonEncodeBenchmark.java
@@ -12,23 +12,34 @@
 package io.vertx.benchmarks;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.core.json.jackson.JacksonCodec;
 import io.vertx.core.spi.json.JsonCodec;
-import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import static org.openjdk.jmh.annotations.CompilerControl.Mode.INLINE;
+import static org.openjdk.jmh.annotations.Mode.*;
 
 import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Thomas Segismont
  * @author slinkydeveloper
  */
 @State(Scope.Thread)
-@BenchmarkMode(Mode.AverageTime)
+@BenchmarkMode(AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class JsonEncodeBenchmark extends BenchmarkBase {
 
   private JsonObject small;
@@ -56,78 +67,82 @@ public class JsonEncodeBenchmark extends BenchmarkBase {
   }
 
   @Benchmark
-  public void smallStringJackson(Blackhole blackhole) throws Exception {
-    stringJackson(small, blackhole);
+  public String smallStringJackson() {
+    return stringJackson(small);
   }
 
   @Benchmark
-  public void smallStringDatabind(Blackhole blackhole) throws Exception {
-    stringDatabind(small, blackhole);
+  public String smallStringDatabind() {
+    return stringDatabind(small);
   }
 
   @Benchmark
-  public void wideStringJackson(Blackhole blackhole) throws Exception {
-    stringJackson(wide, blackhole);
+  public String wideStringJackson() {
+    return stringJackson(wide);
   }
 
   @Benchmark
-  public void wideStringDatabind(Blackhole blackhole) throws Exception {
-    stringDatabind(wide, blackhole);
+  public String wideStringDatabind() {
+    return stringDatabind(wide);
   }
 
   @Benchmark
-  public void deepStringJackson(Blackhole blackhole) throws Exception {
-    stringJackson(deep, blackhole);
+  public String deepStringJackson() {
+    return stringJackson(deep);
   }
 
   @Benchmark
-  public void deepStringDatabind(Blackhole blackhole) throws Exception {
-    stringDatabind(deep, blackhole);
+  public String deepStringDatabind() {
+    return stringDatabind(deep);
   }
 
-  private void stringJackson(JsonObject jsonObject, Blackhole blackhole) throws Exception {
-    blackhole.consume(jsonObject.encode());
+  @CompilerControl(INLINE)
+  private String stringJackson(JsonObject jsonObject) {
+    return jacksonCodec.toString(jsonObject);
   }
 
-  private void stringDatabind(JsonObject jsonObject, Blackhole blackhole) throws Exception {
-    blackhole.consume(databindCodec.toString(jsonObject));
-  }
-
-  @Benchmark
-  public void smallBufferJackson(Blackhole blackhole) throws Exception {
-    bufferJackson(small, blackhole);
+  @CompilerControl(INLINE)
+  private String stringDatabind(JsonObject jsonObject) {
+    return databindCodec.toString(jsonObject);
   }
 
   @Benchmark
-  public void smallBufferDatabind(Blackhole blackhole) throws Exception {
-    bufferDatabind(small, blackhole);
+  public Buffer smallBufferJackson() {
+    return bufferJackson(small);
   }
 
   @Benchmark
-  public void deepBufferJackson(Blackhole blackhole) throws Exception {
-    bufferJackson(deep, blackhole);
+  public Buffer smallBufferDatabind() {
+    return bufferDatabind(small);
   }
 
   @Benchmark
-  public void deepBufferDatabind(Blackhole blackhole) throws Exception {
-    bufferDatabind(deep, blackhole);
+  public Buffer deepBufferJackson() {
+    return bufferJackson(deep);
   }
 
   @Benchmark
-  public void wideBufferJackson(Blackhole blackhole) throws Exception {
-    bufferJackson(wide, blackhole);
+  public Buffer deepBufferDatabind() {
+    return bufferDatabind(deep);
   }
 
   @Benchmark
-  public void wideBufferDatabind(Blackhole blackhole) throws Exception {
-    bufferDatabind(wide, blackhole);
+  public Buffer wideBufferJackson() {
+    return bufferJackson(wide);
   }
 
-  private void bufferJackson(JsonObject jsonObject, Blackhole blackhole) throws Exception {
-    blackhole.consume(jsonObject.toBuffer());
+  @Benchmark
+  public Buffer wideBufferDatabind() {
+    return bufferDatabind(wide);
   }
 
-  private void bufferDatabind(JsonObject jsonObject, Blackhole blackhole) throws Exception {
-    blackhole.consume(jacksonCodec.toBuffer(jsonObject));
+  @CompilerControl(INLINE)
+  private Buffer bufferJackson(JsonObject jsonObject) {
+    return jacksonCodec.toBuffer(jsonObject);
+  }
+
+  @CompilerControl(INLINE)
+  private Buffer bufferDatabind(JsonObject jsonObject) {
+    return databindCodec.toBuffer(jsonObject);
   }
 }


### PR DESCRIPTION
Some numbers:

baseline:
```
Benchmark                                                  Mode  Cnt     Score    Error   Units
JsonEncodeBenchmark.tinyBufferJackson                      avgt   10     0.363 ±  0.001   us/op
JsonEncodeBenchmark.tinyBufferJackson:·gc.alloc.rate.norm  avgt   10   704.000 ±  0.001    B/op
```
With ba66dfa628ada94d9dac1d589255b0bcd080fdd0:
```
Benchmark                                                  Mode  Cnt     Score    Error   Units
JsonEncodeBenchmark.tinyBufferJackson                      avgt   10     0.350 ±  0.001   us/op
JsonEncodeBenchmark.tinyBufferJackson:·gc.alloc.rate.norm  avgt   10   512.000 ±  0.001    B/op
```
Performance is slightly increased (and will get better with highly concurrent allocations), but most importantly,
the GC pressure is highly decreased. 
It's not a case I've used the same json content we use for Techempower's JSON tests.