### PR TITLE
Expose the high level EndpointResolver as SPI as it is more convenient for some integration levels

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
@@ -21,7 +21,7 @@ import io.vertx.core.http.HttpFrame;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.StreamPriority;
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.net.impl.resolver.EndpointRequest;
+import io.vertx.core.spi.resolver.endpoint.EndpointRequest;
 import io.vertx.core.streams.WriteStream;
 
 /**

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -419,7 +419,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public HttpClientBuilder httpClientBuilder() {
-    return new HttpClientBuilderImpl(this);
+    return new HttpClientBuilderInternal(this);
   }
 
   public EventBus eventBus() {

--- a/src/main/java/io/vertx/core/net/impl/resolver/EndpointResolverImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/resolver/EndpointResolverImpl.java
@@ -21,6 +21,9 @@ import io.vertx.core.net.impl.endpoint.Endpoint;
 import io.vertx.core.net.impl.endpoint.EndpointProvider;
 import io.vertx.core.spi.loadbalancing.EndpointSelector;
 import io.vertx.core.spi.resolver.address.AddressResolver;
+import io.vertx.core.spi.resolver.endpoint.EndpointLookup;
+import io.vertx.core.spi.resolver.endpoint.EndpointRequest;
+import io.vertx.core.spi.resolver.endpoint.EndpointResolver;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -32,14 +35,14 @@ import java.util.function.BiFunction;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class EndpointResolverManager<S, A extends Address, E> {
+public class EndpointResolverImpl<S, A extends Address, E> implements EndpointResolver<A> {
 
   private final LoadBalancer loadBalancer;
   private final AddressResolver<A, E, S, io.vertx.core.spi.loadbalancing.Endpoint<E>> addressResolver;
   private final EndpointManager<A, EndpointImpl> connectionManager;
   private final long expirationMillis;
 
-  public EndpointResolverManager(AddressResolver<A, E, S, ?> addressResolver, LoadBalancer loadBalancer, long expirationMillis) {
+  public EndpointResolverImpl(AddressResolver<A, E, S, ?> addressResolver, LoadBalancer loadBalancer, long expirationMillis) {
 
     if (loadBalancer == null) {
       loadBalancer = LoadBalancer.ROUND_ROBIN;
@@ -54,8 +57,8 @@ public class EndpointResolverManager<S, A extends Address, E> {
   /**
    * @return whether the resolver accepts the {@code address}
    */
-  public boolean accepts(Address address) {
-    return addressResolver.tryCast(address) != null;
+  public A accepts(Address address) {
+    return addressResolver.tryCast(address);
   }
 
   /**

--- a/src/main/java/io/vertx/core/spi/resolver/endpoint/EndpointLookup.java
+++ b/src/main/java/io/vertx/core/spi/resolver/endpoint/EndpointLookup.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.core.net.impl.resolver;
+package io.vertx.core.spi.resolver.endpoint;
 
 import io.vertx.core.net.SocketAddress;
 

--- a/src/main/java/io/vertx/core/spi/resolver/endpoint/EndpointRequest.java
+++ b/src/main/java/io/vertx/core/spi/resolver/endpoint/EndpointRequest.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.core.net.impl.resolver;
+package io.vertx.core.spi.resolver.endpoint;
 
 /**
  * Request interaction with an endpoint, mostly callbacks to gather statistics

--- a/src/main/java/io/vertx/core/spi/resolver/endpoint/EndpointResolver.java
+++ b/src/main/java/io/vertx/core/spi/resolver/endpoint/EndpointResolver.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.spi.resolver.endpoint;
+
+import io.vertx.core.Future;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.net.Address;
+
+/**
+ *  A resolver for endpoints.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface EndpointResolver<A extends Address> {
+
+  /**
+   * Check whether the resolver accepts the {@code Address} and returns the cast address.
+   *
+   * @param address the addrss to check
+   * @return the cast address
+   */
+  A accepts(Address address);
+
+  /**
+   * Lookup an endpoint for the specified {@code address}
+   * @param ctx the vertx context
+   * @param address the address to lookup
+   * @return the endpoint lookup result
+   */
+  Future<EndpointLookup> lookupEndpoint(ContextInternal ctx, A address);
+
+  /**
+   * Check expired endpoints, this method is called by the client periodically to give the opportunity to trigger eviction
+   * or refreshes.
+   */
+  void checkExpired();
+
+}


### PR DESCRIPTION
Expose the high level EndpointResolver as SPI as it is more convenient for some integration levels.
