### PR TITLE
The Buffer type becomes a data object instead of a generated type.

### DIFF
--- a/src/main/java/io/vertx/core/buffer/Buffer.java
+++ b/src/main/java/io/vertx/core/buffer/Buffer.java
@@ -12,6 +12,7 @@
 package io.vertx.core.buffer;
 
 
+import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
@@ -35,7 +36,7 @@ import java.nio.charset.Charset;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-@VertxGen
+@DataObject
 public interface Buffer extends ClusterSerializable, Shareable {
 
   /**
@@ -123,6 +124,7 @@ public interface Buffer extends ClusterSerializable, Shareable {
    *
    * @return a JSON element which can be a {@link JsonArray}, {@link JsonObject}, {@link String}, ...etc if the buffer contains an array, object, string, ...etc
    */
+  @GenIgnore
   default Object toJson() {
     return Json.CODEC.fromBuffer(this, Object.class);
   }


### PR DESCRIPTION
`io.vertx.core.buffer.Buffer` has historically been part of the API as an async generated type, annotated by `@VertxGen`. It it has always been wrapped/unwrapped with reactive stream based like generators.

In Vert.x 5 this type becomes a data object since it does not have asynchronous methods and actually wraps a byte array. As consequence reactive streams like generators will not need anymore to wrap/unwrap this type which avoids un-necessary allocation, as trade of for a breaking change.
