### PR TITLE
Emit tags suitable for OpenTelemetry 1.18 Semantic Conventions

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/MessageTagExtractor.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageTagExtractor.java
@@ -27,21 +27,31 @@ class MessageTagExtractor implements TagExtractor<Message<?>> {
 
   @Override
   public int len(Message<?> obj) {
-    return 1;
+    return 3;
   }
 
   @Override
   public String name(Message<?> obj, int index) {
-    if (index == 0) {
-      return "message_bus.destination";
+    switch (index) {
+      case 0:
+        return "message_bus.destination";
+      case 1:
+        return "messaging.system";
+      case 2:
+        return "messaging.operation";
     }
     throw new IndexOutOfBoundsException("Invalid tag index " + index);
   }
 
   @Override
   public String value(Message<?> obj, int index) {
-    if (index == 0) {
-      return obj.address();
+    switch (index) {
+      case 0:
+        return obj.address();
+      case 1:
+        return "vertx-eventbus";
+      case 2:
+        return "publish";
     }
     throw new IndexOutOfBoundsException("Invalid tag index " + index);
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -70,7 +70,7 @@ public final class HttpUtils {
   static final TagExtractor<HttpServerRequest> SERVER_REQUEST_TAG_EXTRACTOR = new TagExtractor<HttpServerRequest>() {
     @Override
     public int len(HttpServerRequest req) {
-      return 2;
+      return 4;
     }
     @Override
     public String name(HttpServerRequest req, int index) {
@@ -79,6 +79,10 @@ public final class HttpUtils {
           return "http.url";
         case 1:
           return "http.method";
+        case 2:
+          return "http.scheme";
+        case 3:
+          return "http.target";
       }
       throw new IndexOutOfBoundsException("Invalid tag index " + index);
     }
@@ -89,6 +93,10 @@ public final class HttpUtils {
           return req.absoluteURI();
         case 1:
           return req.method().name();
+        case 2:
+          return req.scheme();
+        case 3:
+          return req.uri();
       }
       throw new IndexOutOfBoundsException("Invalid tag index " + index);
     }

--- a/src/test/java/io/vertx/core/spi/tracing/EventBusTracingTestBase.java
+++ b/src/test/java/io/vertx/core/spi/tracing/EventBusTracingTestBase.java
@@ -164,6 +164,8 @@ public abstract class EventBusTracingTestBase extends VertxTestBase {
     assertSingleTrace(finishedSpans);
     finishedSpans.forEach(span -> {
       assertEquals("send", span.operation);
+      assertEquals("vertx-eventbus", span.getTags().get("messaging.system"));
+      assertEquals("publish", span.getTags().get("messaging.operation"));
     });
   }
 

--- a/src/test/java/io/vertx/core/spi/tracing/HttpTracingTestBase.java
+++ b/src/test/java/io/vertx/core/spi/tracing/HttpTracingTestBase.java
@@ -108,7 +108,7 @@ public abstract class HttpTracingTestBase extends HttpTestBase {
       switch (serverReq.path()) {
         case "/1": {
           vertx.setTimer(10, id -> {
-            client.request(HttpMethod.GET, 8080, "localhost", "/2", onSuccess(clientReq -> {
+            client.request(HttpMethod.GET, 8080, "localhost", "/2?q=true", onSuccess(clientReq -> {
               clientReq.send(onSuccess(resp -> {
                 serverReq.response().end();
               }));
@@ -156,9 +156,11 @@ public abstract class HttpTracingTestBase extends HttpTestBase {
 
     String scheme = createBaseServerOptions().isSsl() ? "https" : "http";
     for (Span server2Span: lastServerSpans) {
+      assertEquals(scheme, server2Span.getTags().get("http.scheme"));
+      assertEquals("/2?q=true", server2Span.getTags().get("http.target"));
       Span client2Span = spanMap.get(server2Span.parentId);
       assertEquals("GET", client2Span.operation);
-      assertEquals(scheme + "://localhost:8080/2", client2Span.getTags().get("http.url"));
+      assertEquals(scheme + "://localhost:8080/2?q=true", client2Span.getTags().get("http.url"));
       assertEquals("200", client2Span.getTags().get("http.status_code"));
       assertEquals("client", client2Span.getTags().get("span_kind"));
       Span server1Span = spanMap.get(client2Span.parentId);


### PR DESCRIPTION
### Motivation:
Ensure that spans have the right attributes to be classified correctly in an OpenTelemetry backend. OpenTelemetry conventions should override OpenTracing conventions eventually since OpenTracing has been absorbed into OpenTelemetry.

### Approach:
Semantic conventions for [HTTP](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.18.0/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions) & [Messaging](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.18.0/specification/trace/semantic_conventions/messaging.md#messaging-attributes) show some required attributes for OpenTelemetry spans. Extra tags have been added and none removed to ensure backwards compatibility. Added tags seems to be satisfactory for telemetry backends like Uptrace.

This is an upstream fix for https://github.com/eclipse-vertx/vertx-tracing/issues/67
