### PR TITLE
Fix flaky testSetAll

### DIFF
--- a/src/test/java/io/vertx/core/http/headers/VertxHttpHeadersTest.java
+++ b/src/test/java/io/vertx/core/http/headers/VertxHttpHeadersTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.Set;
 
 import static io.vertx.core.http.HttpUtilsTest.HEADER_NAME_ALLOWED_CHARS;
 import static org.junit.Assert.*;
@@ -129,7 +130,8 @@ public class VertxHttpHeadersTest extends HeadersTestBase {
     assertNotNull(result);
     assertFalse(result.isEmpty());
     assertEquals(2, result.size());
-    assertEquals("=\naaa=bbb\n", result.toString());
+    String actual = result.toString();
+    assertTrue(Set.of("=\naaa=bbb\n", "aaa=bbb\n=\n").contains(actual));
   }
 
   @Test


### PR DESCRIPTION
Motivation:

**Problem**
The `testSetAll` unit test checks output of `MultiMap` which compares output of `MultiMap` and unintentionally checks for the order of the elements of output of `MultiMap.toString()` method. This may cause the following tests to sometimes fail even though the code under test may be working as expected -
- 
**Solution**
The idea is to sort the MultiMap output so that we have a deterministic test assertion. I have used the function defined in the test class itself, to sort the mmap output lines.
https://github.com/eclipse-vertx/vert.x/blob/b4fd4d691cfa802189c5a5d25688ea739440bf4a/src/test/java/io/vertx/core/http/headers/HeadersTestBase.java#L476-L485
There are 4 unit tests which can be fixed with this change -
```
io.vertx.core.http.headers.Http2HeadersAdaptorsTest#testAddAll2
io.vertx.core.http.headers.CaseInsensitiveHeadersTest#testAddAll2
io.vertx.core.http.headers.VertxHttpHeadersTest#testAddAll2
io.vertx.core.http.headers.HttpHeadersAdaptorTest#testAddAll2
```
## Reproduction of Bug
Setup the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool and run
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex  -Dtest=io.vertx.core.http.headers.VertxHttpHeadersTest#testAddAll2 -DnondexRuns=10
```
**Error Message**
```html
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.117 sec <<< FAILURE! - in io.vertx.core.http.headers.VertxHttpHeadersTest
testAddAll2(io.vertx.core.http.headers.VertxHttpHeadersTest)  Time elapsed: 0.116 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[a=b
c=d]
> but was:<[c=d
a=b]
>
```


