### PR TITLE
Timer task as a Vert.x future

### DIFF
--- a/src/main/java/io/vertx/core/Timer.java
+++ b/src/main/java/io/vertx/core/Timer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * A timer task that can be used as a future.
+ *
+ * The future is completed when the timeout expires, when the task is cancelled the future is failed
+ * with a {@link java.util.concurrent.CancellationException}.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface Timer extends Future<Void> {
+
+  /**
+   * Attempt to cancel the timer task, when the timer is cancelled, the timer is
+   * failed with a {@link java.util.concurrent.CancellationException}.
+   *
+   * @return {@code true} when the future was cancelled and the timeout didn't fire.
+   */
+  boolean cancel();
+
+}

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -372,6 +372,24 @@ public interface Vertx extends Measured {
   SharedData sharedData();
 
   /**
+   * Like {@link #timer(long, TimeUnit)} with a unit in millis.
+   */
+  default Timer timer(long delay) {
+    return timer(delay, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Create a timer task configured with the specified {@code delay}, when the timeout fires the timer future
+   * is succeeded, when the timeout is cancelled the timer future is failed with a {@link java.util.concurrent.CancellationException}
+   * instance.
+   *
+   * @param delay the delay
+   * @param unit the delay unit
+   * @return the timer object
+   */
+  Timer timer(long delay, TimeUnit unit);
+
+  /**
    * Set a one-shot timer to fire after {@code delay} milliseconds, at which point {@code handler} will be called with
    * the id of the timer.
    *

--- a/src/main/java/io/vertx/core/impl/TimerImpl.java
+++ b/src/main/java/io/vertx/core/impl/TimerImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl;
+
+import io.netty.util.concurrent.FutureListener;
+import io.vertx.core.Timer;
+import io.vertx.core.impl.future.FutureImpl;
+
+/**
+ * A timer task as a vertx future.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+class TimerImpl extends FutureImpl<Void> implements FutureListener<Void>, Timer {
+
+  private final io.netty.util.concurrent.ScheduledFuture<Void> delegate;
+
+  TimerImpl(ContextInternal ctx, io.netty.util.concurrent.ScheduledFuture<Void> delegate) {
+    super(ctx);
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean cancel() {
+    return delegate.cancel(false);
+  }
+
+  @Override
+  public void operationComplete(io.netty.util.concurrent.Future<Void> future) {
+    if (future.isSuccess()) {
+      tryComplete(null);
+    } else {
+      tryFail(future.cause());
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/impl/VertxWrapper.java
+++ b/src/main/java/io/vertx/core/impl/VertxWrapper.java
@@ -13,15 +13,7 @@ package io.vertx.core.impl;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.resolver.AddressResolverGroup;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Closeable;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
-import io.vertx.core.TimeoutStream;
-import io.vertx.core.Verticle;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.dns.DnsClient;
@@ -131,6 +123,11 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public SharedData sharedData() {
     return delegate.sharedData();
+  }
+
+  @Override
+  public Timer timer(long delay, TimeUnit unit) {
+    return delegate.timer(delay, unit);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/future/FutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureImpl.java
@@ -25,7 +25,7 @@ import java.util.Objects;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-class FutureImpl<T> extends FutureBase<T> {
+public class FutureImpl<T> extends FutureBase<T> {
 
   private static final Object NULL_VALUE = new Object();
 
@@ -35,14 +35,14 @@ class FutureImpl<T> extends FutureBase<T> {
   /**
    * Create a future that hasn't completed yet
    */
-  FutureImpl() {
+  protected FutureImpl() {
     super();
   }
 
   /**
    * Create a future that hasn't completed yet
    */
-  FutureImpl(ContextInternal context) {
+  protected FutureImpl(ContextInternal context) {
     super(context);
   }
 


### PR DESCRIPTION
A timer task that extends a vertx future and can be used as a starting point in future chain or can be used within future compositions. This task is also more suitable for being awaited by a virtual thread.

When the context/vertx instance is disposed or the timer is cancelled, the future is signalled with a failure.