### PR TITLE
Fix flaky test in JsonPOJOMapperTest

### DIFF
--- a/src/test/java/io/vertx/core/json/JsonPOJOMapperTest.java
+++ b/src/test/java/io/vertx/core/json/JsonPOJOMapperTest.java
@@ -11,7 +11,9 @@
 
 package io.vertx.core.json;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.buffer.Buffer;
 import org.junit.Test;
 
@@ -39,7 +41,7 @@ public class JsonPOJOMapperTest {
   }
 
   @Test
-  public void testSerialization() {
+  public void testSerialization() throws JsonProcessingException{
     MyType myObj0 = new MyType() {{
       a = -1;
       b = "obj0";
@@ -57,9 +59,10 @@ public class JsonPOJOMapperTest {
 
     JsonObject jsonObject1 = JsonObject.mapFrom(myObj1);
     String jsonStr1 = jsonObject1.encode();
-    assertEquals("{\"a\":5,\"b\":\"obj1\",\"c\":{\"x\":\"1\",\"y\":2},\"d\":["
+    ObjectMapper mapper = new ObjectMapper();
+    assertEquals(mapper.readTree("{\"a\":5,\"b\":\"obj1\",\"c\":{\"x\":\"1\",\"y\":2},\"d\":["
         +"{\"a\":-1,\"b\":\"obj0\",\"c\":{\"z\":[7,8]},\"d\":[],\"e\":[9]}"
-        + "],\"e\":[3]}", jsonStr1);
+        + "],\"e\":[3]}"), mapper.readTree(jsonStr1));
 
     MyType myObj1Roundtrip = jsonObject1.mapTo(MyType.class);
     assertEquals(myObj1Roundtrip.a, 5);


### PR DESCRIPTION
## Motivation
### Problem
There is a test in `JsonPOJOMapperTest` class which compares json strings and unintentionally checks for the order of JSON elements as well. Converting a JSON to a string may return different orderings for the key-value pairs. 
### Solution
Using Jackson we can compare 2 JSON objects correctly as is explained here https://www.baeldung.com/jackson-compare-two-json-objects

**Reproducing the flaky test**
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=io.vertx.core.json.JsonPOJOMapperTest#testSerialization
```
**Error Message**
```java
Running io.vertx.core.json.JsonPOJOMapperTest
Tests run: 8, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.014 sec <<< FAILURE! - in io.vertx.core.json.JsonPOJOMapperTest
testSerialization(io.vertx.core.json.JsonPOJOMapperTest)  Time elapsed: 0.01 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<{"[a":5,"b":"obj1","c":{"x":"1","y":2},"d":[{"a":-1,"b":"obj0","c":{"z":[7,8]},"d":[],"e":[9]}]],"e":[3]}> but was:<{"[d":[{"e":[9],"d":[],"a":-1,"c":{"z":[7,8]},"b":"obj0"}],"a":5,"c":{"y":2,"x":"1"},"b":"obj1"],"e":[3]}>

```


