### PR TITLE
Fail SSL handshake when ALPN protocol selection fails and document better HTTP server protocol selection

### DIFF
--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -59,6 +59,24 @@ The settings define how the client can use the connection, the default initial s
 - {@link io.vertx.core.http.Http2Settings#getMaxConcurrentStreams}: `100` as recommended by the HTTP/2 RFC
 - the default HTTP/2 settings values for the others
 
+=== Configuring server supported HTTP versions
+
+Default supported HTTP versions depends on the server configuration.
+
+- when TLS is disabled
+  - HTTP/1.1, HTTP/1.0
+  - HTTP/2 when {@link io.vertx.core.http.HttpServerOptions#isHttp2ClearTextEnabled} is `true`
+- when TLS is enabled and ALPN disabled
+  - HTTP/1.1 and HTTP/1.0
+- when TLS is enabled and ALPN enabled
+  - the protocols defined by {@link io.vertx.core.http.HttpServerOptions#getAlpnVersions}: by default HTTP/1.1 and HTTP/2
+
+If you want to disable HTTP/2 on the server
+- when TLS is disabled, set {@link io.vertx.core.http.HttpServerOptions#setHttp2ClearTextEnabled} to `false`
+- when TLS is enabled
+  - set ({@link io.vertx.core.http.HttpServerOptions#isUseAlpn}) to `false`
+  - _or_ remove HTTP/2 from the {@link io.vertx.core.http.HttpServerOptions#getAlpnVersions} list
+
 === Logging network server activity
 
 For debugging purposes, network activity can be logged.

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -107,6 +107,11 @@ public class HttpServerOptions extends NetServerOptions {
   public static final List<HttpVersion> DEFAULT_ALPN_VERSIONS = Collections.unmodifiableList(Arrays.asList(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1));
 
   /**
+   * Default H2C is enabled = {@code true}
+   */
+  public static final boolean DEFAULT_HTTP2_CLEAR_TEXT_ENABLED = true;
+
+  /**
    * The default initial settings max concurrent stream for an HTTP/2 server = 100
    */
   public static final long DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS = 100;
@@ -199,6 +204,7 @@ public class HttpServerOptions extends NetServerOptions {
   private int maxFormAttributeSize;
   private Http2Settings initialSettings;
   private List<HttpVersion> alpnVersions;
+  private boolean http2ClearTextEnabled;
   private int http2ConnectionWindowSize;
   private boolean decompressionSupported;
   private boolean acceptUnmaskedFrames;
@@ -244,6 +250,7 @@ public class HttpServerOptions extends NetServerOptions {
     this.maxFormAttributeSize = other.getMaxFormAttributeSize();
     this.initialSettings = other.initialSettings != null ? new Http2Settings(other.initialSettings) : null;
     this.alpnVersions = other.alpnVersions != null ? new ArrayList<>(other.alpnVersions) : null;
+    this.http2ClearTextEnabled = other.http2ClearTextEnabled;
     this.http2ConnectionWindowSize = other.http2ConnectionWindowSize;
     this.decompressionSupported = other.isDecompressionSupported();
     this.acceptUnmaskedFrames = other.isAcceptUnmaskedFrames();
@@ -296,6 +303,7 @@ public class HttpServerOptions extends NetServerOptions {
     maxFormAttributeSize = DEFAULT_MAX_FORM_ATTRIBUTE_SIZE;
     initialSettings = new Http2Settings().setMaxConcurrentStreams(DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS);
     alpnVersions = new ArrayList<>(DEFAULT_ALPN_VERSIONS);
+    http2ClearTextEnabled = DEFAULT_HTTP2_CLEAR_TEXT_ENABLED;
     http2ConnectionWindowSize = DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE;
     decompressionSupported = DEFAULT_DECOMPRESSION_SUPPORTED;
     acceptUnmaskedFrames = DEFAULT_ACCEPT_UNMASKED_FRAMES;
@@ -856,6 +864,24 @@ public class HttpServerOptions extends NetServerOptions {
    */
   public HttpServerOptions setAlpnVersions(List<HttpVersion> alpnVersions) {
     this.alpnVersions = alpnVersions;
+    return this;
+  }
+
+  /**
+   * @return whether the server accepts HTTP/2 over clear text connections
+   */
+  public boolean isHttp2ClearTextEnabled() {
+    return http2ClearTextEnabled;
+  }
+
+  /**
+   * Set whether HTTP/2 over clear text is enabled or disabled, default is enabled.
+   *
+   * @param http2ClearTextEnabled whether to accept HTTP/2 over clear text
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setHttp2ClearTextEnabled(boolean http2ClearTextEnabled) {
+    this.http2ClearTextEnabled = http2ClearTextEnabled;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http1xUpgradeToH2CHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xUpgradeToH2CHandler.java
@@ -120,7 +120,7 @@ public class Http1xUpgradeToH2CHandler extends ChannelInboundHandlerAdapter {
           ctx.writeAndFlush(res);
         }
       } else {
-        initializer.configureHttp1(ctx.pipeline(), sslChannelProvider);
+        initializer.configureHttp1Handler(ctx.pipeline(), sslChannelProvider);
         ctx.fireChannelRead(msg);
         ctx.pipeline().remove(this);
       }
@@ -140,7 +140,7 @@ public class Http1xUpgradeToH2CHandler extends ChannelInboundHandlerAdapter {
                 pipeline.remove(handler.getKey());
               }
             }
-            initializer.configureHttp2(pipeline);
+            initializer.configureHttp2Pipeline(pipeline);
           }
         } else {
           // We might have left over buffer sent when removing the HTTP decoder that needs to be propagated to the HTTP handler

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -45,13 +45,11 @@ public class HttpServerImpl extends TCPServerBase implements HttpServer, Closeab
 
   private static final String FLASH_POLICY_HANDLER_PROP_NAME = "vertx.flashPolicyHandler";
   private static final String DISABLE_WEBSOCKETS_PROP_NAME = "vertx.disableWebsockets";
-  private static final String DISABLE_H2C_PROP_NAME = "vertx.disableH2c";
 
   static final boolean USE_FLASH_POLICY_HANDLER = Boolean.getBoolean(FLASH_POLICY_HANDLER_PROP_NAME);
   static final boolean DISABLE_WEBSOCKETS = Boolean.getBoolean(DISABLE_WEBSOCKETS_PROP_NAME);
 
   final HttpServerOptions options;
-  private final boolean disableH2c;
   private final HttpStreamHandler<ServerWebSocket> wsStream = new HttpStreamHandler<>();
   private final HttpStreamHandler<HttpServerRequest> requestStream = new HttpStreamHandler<>();
   private Handler<HttpServerRequest> invalidRequestHandler;
@@ -62,7 +60,6 @@ public class HttpServerImpl extends TCPServerBase implements HttpServer, Closeab
   public HttpServerImpl(VertxInternal vertx, HttpServerOptions options) {
     super(vertx, options);
     this.options = new HttpServerOptions(options);
-    this.disableH2c = Boolean.getBoolean(DISABLE_H2C_PROP_NAME) || options.isSsl();
   }
 
   @Override
@@ -156,7 +153,6 @@ public class HttpServerImpl extends TCPServerBase implements HttpServer, Closeab
       vertx,
       options,
       serverOrigin,
-      disableH2c,
       hello,
       hello.exceptionHandler,
       trafficShapingHandler);

--- a/src/main/java/io/vertx/core/http/impl/HttpServerWorker.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerWorker.java
@@ -139,12 +139,14 @@ public class HttpServerWorker implements BiConsumer<Channel, SslChannelProvider>
             SslHandler sslHandler = pipeline.get(SslHandler.class);
             String protocol = sslHandler.applicationProtocol();
             if ("h2".equals(protocol)) {
-              handleHttp2(ch);
+              configureHttp2(ch.pipeline());
             } else {
-              handleHttp1(ch, sslChannelProvider);
+              configureHttp1Pipeline(ch.pipeline());
+              configureHttp1Handler(ch.pipeline(), sslChannelProvider);
             }
           } else {
-            handleHttp1(ch, sslChannelProvider);
+            configureHttp1Pipeline(ch.pipeline());
+            configureHttp1Handler(ch.pipeline(), sslChannelProvider);
           }
         } else {
           handleException(future.cause());
@@ -152,7 +154,8 @@ public class HttpServerWorker implements BiConsumer<Channel, SslChannelProvider>
       });
     } else {
       if (disableH2C) {
-        handleHttp1(ch, sslChannelProvider);
+        configureHttp1Pipeline(ch.pipeline());
+        configureHttp1Handler(ch.pipeline(), sslChannelProvider);
       } else {
         IdleStateHandler idle;
         int idleTimeout = options.getIdleTimeout();
@@ -174,9 +177,10 @@ public class HttpServerWorker implements BiConsumer<Channel, SslChannelProvider>
               pipeline.remove(idle);
             }
             if (h2c) {
-              handleHttp2(ctx.channel());
+              configureHttp2(ctx.pipeline());
             } else {
-              handleHttp1(ch, sslChannelProvider);
+              configureHttp1Pipeline(ctx.pipeline());
+              configureHttp1OrH2CUpgradeHandler(ctx.pipeline(), sslChannelProvider);
             }
           }
 
@@ -204,10 +208,6 @@ public class HttpServerWorker implements BiConsumer<Channel, SslChannelProvider>
     context.emit(cause, exceptionHandler);
   }
 
-  private void handleHttp1(Channel ch, SslChannelProvider sslChannelProvider) {
-    configureHttp1OrH2C(ch.pipeline(), sslChannelProvider);
-  }
-
   private void sendServiceUnavailable(Channel ch) {
     ch.writeAndFlush(
       Unpooled.copiedBuffer("HTTP/1.1 503 Service Unavailable\r\n" +
@@ -216,13 +216,17 @@ public class HttpServerWorker implements BiConsumer<Channel, SslChannelProvider>
       .addListener(ChannelFutureListener.CLOSE);
   }
 
-  private void handleHttp2(Channel ch) {
-    VertxHttp2ConnectionHandler<Http2ServerConnection> handler = buildHttp2ConnectionHandler(context, connectionHandler);
-    ch.pipeline().addLast("handler", handler);
-    configureHttp2(ch.pipeline());
+  private void configureHttp2(ChannelPipeline pipeline) {
+    configureHttp2Handler(pipeline);
+    configureHttp2Pipeline(pipeline);
   }
 
-  void configureHttp2(ChannelPipeline pipeline) {
+  private void configureHttp2Handler(ChannelPipeline pipeline) {
+    VertxHttp2ConnectionHandler<Http2ServerConnection> handler = buildHttp2ConnectionHandler(context, connectionHandler);
+    pipeline.addLast("handler", handler);
+  }
+
+  void configureHttp2Pipeline(ChannelPipeline pipeline) {
     if (!server.requestAccept()) {
       // That should send an HTTP/2 go away
       pipeline.channel().close();
@@ -264,7 +268,11 @@ public class HttpServerWorker implements BiConsumer<Channel, SslChannelProvider>
     return handler;
   }
 
-  private void configureHttp1OrH2C(ChannelPipeline pipeline, SslChannelProvider sslChannelProvider) {
+  private void configureHttp1OrH2CUpgradeHandler(ChannelPipeline pipeline, SslChannelProvider sslChannelProvider) {
+    pipeline.addLast("h2c", new Http1xUpgradeToH2CHandler(this, sslChannelProvider, options.isCompressionSupported(), options.isDecompressionSupported()));
+  }
+
+  private void configureHttp1Pipeline(ChannelPipeline pipeline) {
     if (logEnabled) {
       pipeline.addLast("logging", new LoggingHandler(options.getActivityLogDataFormat()));
     }
@@ -289,14 +297,9 @@ public class HttpServerWorker implements BiConsumer<Channel, SslChannelProvider>
     if (idleTimeout > 0 || readIdleTimeout > 0 || writeIdleTimeout > 0) {
       pipeline.addLast("idle", new IdleStateHandler(readIdleTimeout, writeIdleTimeout, idleTimeout, options.getIdleTimeoutUnit()));
     }
-    if (disableH2C) {
-      configureHttp1(pipeline, sslChannelProvider);
-    } else {
-      pipeline.addLast("h2c", new Http1xUpgradeToH2CHandler(this, sslChannelProvider, options.isCompressionSupported(), options.isDecompressionSupported()));
-    }
   }
 
-  void configureHttp1(ChannelPipeline pipeline, SslChannelProvider sslChannelProvider) {
+  void configureHttp1Handler(ChannelPipeline pipeline, SslChannelProvider sslChannelProvider) {
     if (!server.requestAccept()) {
       sendServiceUnavailable(pipeline.channel());
       return;

--- a/src/main/java/io/vertx/core/spi/tls/DefaultSslContextFactory.java
+++ b/src/main/java/io/vertx/core/spi/tls/DefaultSslContextFactory.java
@@ -143,10 +143,20 @@ public class DefaultSslContextFactory implements SslContextFactory {
       builder.ciphers(cipherSuites);
     }
     if (useAlpn && applicationProtocols != null && applicationProtocols.size() > 0) {
+      ApplicationProtocolConfig.SelectorFailureBehavior sfb;
+      ApplicationProtocolConfig.SelectedListenerFailureBehavior slfb;
+      if (sslProvider == SslProvider.JDK) {
+        sfb = ApplicationProtocolConfig.SelectorFailureBehavior.FATAL_ALERT;
+        slfb = ApplicationProtocolConfig.SelectedListenerFailureBehavior.FATAL_ALERT;
+      } else {
+        // Fatal alert not supportd by OpenSSL
+        sfb = ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE;
+        slfb = ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT;
+      }
       builder.applicationProtocolConfig(new ApplicationProtocolConfig(
         ApplicationProtocolConfig.Protocol.ALPN,
-        ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
-        ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+        sfb,
+        slfb,
         applicationProtocols
       ));
     }

--- a/src/test/java/io/vertx/core/http/Http2ClientTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientTest.java
@@ -1672,71 +1672,61 @@ public class Http2ClientTest extends Http2TestBase {
 
   @Test
   public void testRejectClearTextUpgrade() throws Exception {
-    System.setProperty("vertx.disableH2c", "true");
-    try {
-      server.close();
-      server = vertx.createHttpServer(serverOptions.setUseAlpn(false).setSsl(false));
-      AtomicBoolean first = new AtomicBoolean(true);
-      server.requestHandler(req -> {
-        MultiMap headers = req.headers();
-        String upgrade = headers.get("upgrade");
-        if (first.getAndSet(false)) {
-          assertEquals("h2c", upgrade);
-        } else {
-          assertNull(upgrade);
-        }
-        assertEquals(DEFAULT_HTTPS_HOST + ":" + DEFAULT_HTTPS_PORT, req.host());
-        assertEquals(DEFAULT_HTTPS_HOST, req.authority().host());
-        assertEquals(DEFAULT_HTTPS_PORT, req.authority().port());
-        req.response().end("wibble");
-        assertEquals(HttpVersion.HTTP_1_1, req.version());
-      });
-      startServer(testAddress);
-      client.close();
-      client = vertx.createHttpClient(clientOptions.setUseAlpn(false).setSsl(false).setMaxPoolSize(1));
-      waitFor(5);
-      for (int i = 0;i < 5;i++) {
-        client.request(requestOptions).onComplete(onSuccess(req -> {
-          req.send(onSuccess(resp -> {
-            Http2UpgradeClientConnection connection = (Http2UpgradeClientConnection) resp.request().connection();
-            Channel ch = connection.channel();
-            ChannelPipeline pipeline = ch.pipeline();
-            for (Map.Entry<String, ?> entry : pipeline) {
-              assertTrue("Was not expecting pipeline handler " + entry.getValue().getClass(), entry.getKey().equals("codec") || entry.getKey().equals("handler"));
-            }
-            assertEquals(200, resp.statusCode());
-            assertEquals(HttpVersion.HTTP_1_1, resp.version());
-            resp.bodyHandler(body -> {
-              complete();
-            });
-          }));
-        }));
+    server.close();
+    server = vertx.createHttpServer(serverOptions.setUseAlpn(false).setSsl(false).setHttp2ClearTextEnabled(false));
+    AtomicBoolean first = new AtomicBoolean(true);
+    server.requestHandler(req -> {
+      MultiMap headers = req.headers();
+      String upgrade = headers.get("upgrade");
+      if (first.getAndSet(false)) {
+        assertEquals("h2c", upgrade);
+      } else {
+        assertNull(upgrade);
       }
-      await();
-    } finally {
-      System.clearProperty("vertx.disableH2c");
+      assertEquals(DEFAULT_HTTPS_HOST + ":" + DEFAULT_HTTPS_PORT, req.host());
+      assertEquals(DEFAULT_HTTPS_HOST, req.authority().host());
+      assertEquals(DEFAULT_HTTPS_PORT, req.authority().port());
+      req.response().end("wibble");
+      assertEquals(HttpVersion.HTTP_1_1, req.version());
+    });
+    startServer(testAddress);
+    client.close();
+    client = vertx.createHttpClient(clientOptions.setUseAlpn(false).setSsl(false).setMaxPoolSize(1));
+    waitFor(5);
+    for (int i = 0;i < 5;i++) {
+      client.request(requestOptions).onComplete(onSuccess(req -> {
+        req.send(onSuccess(resp -> {
+          Http2UpgradeClientConnection connection = (Http2UpgradeClientConnection) resp.request().connection();
+          Channel ch = connection.channel();
+          ChannelPipeline pipeline = ch.pipeline();
+          for (Map.Entry<String, ?> entry : pipeline) {
+            assertTrue("Was not expecting pipeline handler " + entry.getValue().getClass(), entry.getKey().equals("codec") || entry.getKey().equals("handler"));
+          }
+          assertEquals(200, resp.statusCode());
+          assertEquals(HttpVersion.HTTP_1_1, resp.version());
+          resp.bodyHandler(body -> {
+            complete();
+          });
+        }));
+      }));
     }
+    await();
   }
 
   @Test
   public void testRejectClearTextDirect() throws Exception {
-    System.setProperty("vertx.disableH2c", "true");
-    try {
-      server.close();
-      server = vertx.createHttpServer(serverOptions.setUseAlpn(false).setSsl(false));
-      server.requestHandler(req -> {
-        fail();
-      });
-      startServer(testAddress);
-      client.close();
-      client = vertx.createHttpClient(clientOptions.setUseAlpn(false).setSsl(false).setHttp2ClearTextUpgrade(false));
-      client.request(requestOptions).onComplete(onFailure(err -> {
-        testComplete();
-      }));
-      await();
-    } finally {
-      System.clearProperty("vertx.disableH2c");
-    }
+    server.close();
+    server = vertx.createHttpServer(serverOptions.setUseAlpn(false).setSsl(false).setHttp2ClearTextEnabled(false));
+    server.requestHandler(req -> {
+      fail();
+    });
+    startServer(testAddress);
+    client.close();
+    client = vertx.createHttpClient(clientOptions.setUseAlpn(false).setSsl(false).setHttp2ClearTextUpgrade(false));
+    client.request(requestOptions).onComplete(onFailure(err -> {
+      testComplete();
+    }));
+    await();
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -1220,6 +1220,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
       client = vertx.createHttpClient(options);
       HttpServerOptions serverOptions = createBaseServerOptions();
       serverOptions.setTrustOptions(serverTrust);
+      serverOptions.setAlpnVersions(Arrays.asList(version));
       serverOptions.setKeyCertOptions(serverCert);
       if (requiresClientAuth) {
         serverOptions.setClientAuth(ClientAuth.REQUIRED);


### PR DESCRIPTION
When the server cannot select a protocol sent by the ALPN extension sent by the client, we should fail the SSL handshake immediately instead of having a successful handshake.

This also documents the HTTP server protocol selection according to the TLS configuration and explains how to disable HTTP/2 on the server accordingly.