### PR TITLE
HTTP/2 server response should sync on the connection when handling a writability change

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -556,9 +556,14 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   void handlerWritabilityChanged(boolean writable) {
-    if (!ended && writable && drainHandler != null) {
-      drainHandler.handle(null);
+    Handler<Void> handler;
+    synchronized (conn) {
+      handler = drainHandler;
+      if (ended || !writable || handler == null) {
+        return;
+      }
     }
+    handler.handle(null);
   }
 
   @Override


### PR DESCRIPTION
When the HTTP/2 server response is handled a writability change it should check the local request state under connection synchronization to avoid races from a non vertx thread. When on a vertx thread (even work) that is fine.
