### PR TITLE
Deprecate pump for pipe

### DIFF
--- a/src/main/java/io/vertx/core/streams/Pump.java
+++ b/src/main/java/io/vertx/core/streams/Pump.java
@@ -37,7 +37,9 @@ import io.vertx.core.streams.impl.PumpImpl;
  * Please see the documentation for more information.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
+ * @deprecated instead use {@link ReadStream#pipe()} or {@link ReadStream#pipeTo(WriteStream)}
  */
+@Deprecated
 @VertxGen
 public interface Pump {
 


### PR DESCRIPTION
 Stream Pump has been superseded by io.vertx.core.streams.Pipe since Vert.x 4. The documentation does not reference Pump since 4.0.0, only the vertx-examples were still merely referring to it.
