### PR TITLE
File resolver supports custom jar URL connection

### DIFF
--- a/src/main/java/io/vertx/core/file/impl/FileCache.java
+++ b/src/main/java/io/vertx/core/file/impl/FileCache.java
@@ -197,7 +197,7 @@ class FileCache {
   void cacheFile(String fileName, InputStream is, boolean overwrite) throws IOException {
     File cacheFile = new File(getCacheDir(), fileName);
     fileNameCheck(cacheFile);
-    cacheFile.getParentFile().mkdirs();
+    boolean created = cacheFile.getParentFile().mkdirs();
     if (!overwrite) {
       try {
         Files.copy(is, cacheFile.toPath());

--- a/src/main/java/io/vertx/core/file/impl/FileCache.java
+++ b/src/main/java/io/vertx/core/file/impl/FileCache.java
@@ -197,7 +197,7 @@ class FileCache {
   void cacheFile(String fileName, InputStream is, boolean overwrite) throws IOException {
     File cacheFile = new File(getCacheDir(), fileName);
     fileNameCheck(cacheFile);
-    boolean created = cacheFile.getParentFile().mkdirs();
+    cacheFile.getParentFile().mkdirs();
     if (!overwrite) {
       try {
         Files.copy(is, cacheFile.toPath());

--- a/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
@@ -20,6 +20,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.JarURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -298,11 +299,8 @@ public class FileResolverImpl implements FileResolver {
       List<String> listOfEntries = listOfEntries(url);
       switch (listOfEntries.size()) {
         case 1:
-          String path = url.getPath();
-          int to = path.length() - listOfEntries.get(0).length() - 2;
-          String sub = path.substring(5, to);
-          File file = new File(decodeURIComponent(sub, false));
-          zip = new ZipFile(file);
+          JarURLConnection conn = (JarURLConnection) url.openConnection();
+          zip = conn.getJarFile();
           break;
         case 2:
           zip = new ZipFile(resolveFile(listOfEntries.get(1)));

--- a/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
@@ -222,7 +222,7 @@ public class FileResolverImpl implements FileResolver {
       case "file":
         return unpackFromFileURL(url, fileName, cl);
       case "jar":
-        return unpackFromJarURL(url, fileName, cl);
+        return unpackFromJarURL(url, fileName);
       case "bundle": // Apache Felix, Knopflerfish
       case "bundleentry": // Equinox
       case "bundleresource": // Equinox
@@ -261,7 +261,7 @@ public class FileResolverImpl implements FileResolver {
     return cacheFile;
   }
 
-  private File unpackFromJarURL(URL url, String fileName, ClassLoader cl) {
+  private File unpackFromJarURL(URL url, String fileName) {
     ZipFile zip = null;
     try {
       String path = url.getPath();

--- a/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
@@ -14,6 +14,7 @@ package io.vertx.core.file.impl;
 import io.netty.util.internal.PlatformDependent;
 import io.vertx.core.VertxException;
 import io.vertx.core.file.FileSystemOptions;
+import io.vertx.core.impl.Utils;
 import io.vertx.core.spi.file.FileResolver;
 
 import java.io.File;
@@ -355,12 +356,18 @@ public class FileResolverImpl implements FileResolver {
     while (entries.hasMoreElements()) {
       ZipEntry entry = entries.nextElement();
       String name = entry.getName();
-      if (name.startsWith(entryFilter)) {
-        if (name.endsWith("/")) {
-          cache.cacheDir(name);
-        } else {
-          try (InputStream is = zip.getInputStream(entry)) {
-            cache.cacheFile(name, is, !enableCaching);
+      int len = name.length();
+      if (len == 0) {
+        return;
+      }
+      if (name.charAt(len - 1) != ' ' || !Utils.isWindows()) {
+        if (name.startsWith(entryFilter)) {
+          if (name.charAt(len - 1) == '/') {
+            cache.cacheDir(name);
+          } else {
+            try (InputStream is = zip.getInputStream(entry)) {
+              cache.cacheFile(name, is, !enableCaching);
+            }
           }
         }
       }

--- a/src/test/java/io/vertx/core/file/CustomJarFileResolverTest.java
+++ b/src/test/java/io/vertx/core/file/CustomJarFileResolverTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.file;
+
+import io.vertx.test.core.TestUtils;
+import org.junit.Assert;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.*;
+import java.nio.file.Files;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+
+/**
+ * Custom jar file resolution test, à la spring boot nested URLs: https://docs.spring.io/spring-boot/docs/current/reference/html/executable-jar.html#appendix.executable-jar.nested-jars
+ *
+ * what we are trying to resolve:
+ * - BOOT-INF/classes -> jar:file:/path/to/file.jar!/BOOT-INF/classes/
+ * - webroot/hello.txt -> jar:nested:/path/to/file.jar/!BOOT-INF/classes/!/webroot/hello.txt
+ */
+public class CustomJarFileResolverTest extends FileResolverTestBase {
+
+  static File getFiles(File baseDir) throws Exception {
+    File file = Files.createTempFile(TestUtils.MAVEN_TARGET_DIR.toPath(), "", "files.custom").toFile();
+    Assert.assertTrue(file.delete());
+    return ZipFileResolverTest.getFiles(
+      baseDir,
+      file,
+      out -> {
+        try {
+          return new JarOutputStream(out);
+        } catch (IOException e) {
+          throw new AssertionError(e);
+        }
+      }, JarEntry::new);
+  }
+
+  @Override
+  protected ClassLoader resourcesLoader(File baseDir) throws Exception {
+    File files = getFiles(baseDir);
+    return new ClassLoader() {
+      @Override
+      public URL getResource(String name) {
+        try {
+          try (JarFile jf = new JarFile(files)) {
+            if (jf.getJarEntry(name) == null) {
+              return super.getResource(name);
+            }
+          }
+          return new URL("jar", "null" , -1, "custom:/whatever!/" + name, new URLStreamHandler() {
+            @Override
+            protected URLConnection openConnection(URL u) throws IOException {
+              // Use file protocol here on purpose otherwise we would need to register the protocol
+              return new JarURLConnection(new URL("jar:file:/whatever!/" + name)) {
+                @Override
+                public JarFile getJarFile() throws IOException {
+                  return new JarFile(files);
+                }
+                @Override
+                public void connect() throws IOException {
+                }
+              };
+            }
+          });
+        } catch (Exception e) {
+          return null;
+        }
+      }
+    };
+  }
+}

--- a/src/test/java/io/vertx/core/file/NestedJarFileResolverTest.java
+++ b/src/test/java/io/vertx/core/file/NestedJarFileResolverTest.java
@@ -47,11 +47,11 @@ public class NestedJarFileResolverTest extends FileResolverTestBase {
           } else if (name.startsWith("webroot")) {
             return new URL("jar:" + webrootURL + "!/lib/nested.jar!/" + name.substring(7));
           } else if (name.equals("afile.html")) {
-            return new URL("jar:" + webrootURL + "!/lib/nested.jar!afile.html/");
+            return new URL("jar:" + webrootURL + "!/lib/nested.jar!/afile.html");
           } else if (name.equals("afile with spaces.html")) {
-            return new URL("jar:" + webrootURL + "!/lib/nested.jar!afile with spaces.html/");
+            return new URL("jar:" + webrootURL + "!/lib/nested.jar!/afile with spaces.html");
           } else if (name.equals("afilewithspaceatend ")) {
-            return new URL("jar:" + webrootURL + "!/lib/nested.jar!afilewithspaceatend /");
+            return new URL("jar:" + webrootURL + "!/lib/nested.jar!/afilewithspaceatend ");
           }
         } catch (MalformedURLException e) {
           throw new AssertionError(e);

--- a/src/test/java/io/vertx/core/file/NestedRootJarResolverTest.java
+++ b/src/test/java/io/vertx/core/file/NestedRootJarResolverTest.java
@@ -12,16 +12,24 @@
 package io.vertx.core.file;
 
 import io.vertx.test.core.TestUtils;
+import junit.framework.AssertionFailedError;
 import org.junit.Assert;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.function.Function;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 /**
+ * what we are trying to resolve:
+ * - webroot/hello.txt -> jar:file:/path/to/file.jar!/BOOT-INF/classes!/webroot/hello.txt
+ * - BOOT-INF/classes -> jar:file:/path/to/file.jar!/BOOT-INF/classes
+ *
  * @author Thomas Segismont
  */
 public class NestedRootJarResolverTest extends FileResolverTestBase {
@@ -30,13 +38,27 @@ public class NestedRootJarResolverTest extends FileResolverTestBase {
   protected ClassLoader resourcesLoader(File baseDir) throws Exception {
     File nestedFiles = Files.createTempFile(TestUtils.MAVEN_TARGET_DIR.toPath(), "", "nestedroot.jar").toFile();
     Assert.assertTrue(nestedFiles.delete());
-    ZipFileResolverTest.getFiles(baseDir, nestedFiles, ZipOutputStream::new, name -> new ZipEntry("nested-inf/classes/" + name));
+    ZipFileResolverTest.getFiles(baseDir, nestedFiles, new Function<OutputStream, ZipOutputStream>() {
+      @Override
+      public ZipOutputStream apply(OutputStream outputStream) {
+        ZipOutputStream zip = new ZipOutputStream(outputStream);
+        try {
+          zip.putNextEntry(new ZipEntry("nested-inf/classes/"));
+          zip.closeEntry();
+        } catch (IOException e) {
+          throw new AssertionFailedError();
+        }
+        return zip;
+      }
+    }, name -> new ZipEntry("nested-inf/classes/" + name));
     URL webrootURL = nestedFiles.toURI().toURL();
     return new ClassLoader(Thread.currentThread().getContextClassLoader()) {
       @Override
       public URL getResource(String name) {
         try {
-          if (name.startsWith("webroot")) {
+          if (name.equals("nested-inf/classes")) {
+            return new URL("jar:" + webrootURL + "!/nested-inf/classes");
+          } else if (name.startsWith("webroot")) {
             return new URL("jar:" + webrootURL + "!/nested-inf/classes!/" + name);
           } else if (name.equals("afile.html") || name.equals("afile with spaces.html") || name.equals("afilewithspaceatend ")) {
             return new URL("jar:" + webrootURL + "!/nested-inf/classes!/" + name);

--- a/src/test/java/io/vertx/core/file/NestedZipFileResolverTest.java
+++ b/src/test/java/io/vertx/core/file/NestedZipFileResolverTest.java
@@ -47,11 +47,11 @@ public class NestedZipFileResolverTest extends FileResolverTestBase {
           } else if (name.startsWith("webroot")) {
             return new URL("jar:" + webrootURL + "!/lib/nested.zip!/" + name.substring(7));
           } else if (name.equals("afile.html")) {
-            return new URL("jar:" + webrootURL + "!/lib/nested.zip!afile.html/");
+            return new URL("jar:" + webrootURL + "!/lib/nested.zip!/afile.html");
           } else if (name.equals("afile with spaces.html")) {
-            return new URL("jar:" + webrootURL + "!/lib/nested.zip!afile with spaces.html/");
+            return new URL("jar:" + webrootURL + "!/lib/nested.zip!/afile with spaces.html");
           } else if (name.equals("afilewithspaceatend ")) {
-            return new URL("jar:" + webrootURL + "!/lib/nested.zip!afilewithspaceatend /");
+            return new URL("jar:" + webrootURL + "!/lib/nested.zip!/afilewithspaceatend ");
           }
         } catch (MalformedURLException e) {
           throw new AssertionError(e);


### PR DESCRIPTION
Best effort in Vert.x file resolver to support jar file resolution for simple jar file entries without recursion when the URL to resolve provides a custom protocol that provides a valid jar url connection to a jar file. The file resolver unpacking mechanism is changed to get the jar file to unpack from the jar url connection instead of reconstructing the jar URL deduced from the initial URL to resolve (according to what the classloader resolved).

The extraction of the list of jar entries from the URL has been rewritten in a more generic fashion with a relaxed parsing to accommodate URL with a file that use custom conventions which actually seems fine with the jar url documentation.

This provides a *best* effort support for Spring boot `nested` custom protocol https://docs.spring.io/spring-boot/docs/current/reference/html/executable-jar.html#appendix.executable-jar.nested-jars