### PR TITLE
Proposal for HttpClientOptions ConnectTimeout to be used in connection acquisition.

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -312,6 +312,9 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     }
     long connectTimeout = 0L;
     long idleTimeout = 0L;
+    if (options.getConnectTimeout() >= 0) {
+      connectTimeout = options.getConnectTimeout();
+    }
     if (request.getTimeout() >= 0L) {
       connectTimeout = request.getTimeout();
       idleTimeout = request.getTimeout();

--- a/src/test/java/io/vertx/core/http/HttpClientTimeoutTest.java
+++ b/src/test/java/io/vertx/core/http/HttpClientTimeoutTest.java
@@ -88,7 +88,7 @@ public abstract class HttpClientTimeoutTest extends HttpTestBase {
     }
 
     long now = System.currentTimeMillis();
-    client.request(HttpMethod.GET, 8080, "localhost", "/slow")
+    client.request(HttpMethod.GET, requestOptions.getPort(), requestOptions.getHost(), "/slow")
       .onComplete(onFailure(err -> {
         assertTrue(System.currentTimeMillis() - now < connectTimeout + 5000);
 //        assertEquals(err.getMessage(), "The timeout of 1000 ms has been exceeded when getting a connection to localhost:8080");


### PR DESCRIPTION
Motivation:

This PR proposes using HttpClientOptions.connectTimeout for connection acquisition when RequestOptions.connectTimeout is not set.

Background:

AFAIR in vert.x 3 request timeout started ticking before connection acquisition.
In vert.x 4 it has changed. Request timeout starts ticking only after connection is sent. Hence, understandably there is need for explicit connectTimeout parameter.
I can see vert.x 4.5.0 introduced new connectTimeout parameter in RequestOptions so separate from request timeout value is used for connection acquisition.
I can see the connectTimeout also exists in  HttpClientOptions but it's not used in HttpClientImpl.

Curently the only way to impose connectTimeout is to set it explicitly on RequestOptions for every request.
However, there is no way to pass connectTimeout to client.request methods that take parameters other than RequestOptions.

Caveat:
I can see ConnectTimeout exists in HttpClientOptions for a long time, at least from vert.x 3.x, and I might not be fully aware of it's purpose if its used deeper i.e. Netty code. 

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
