### PR TITLE
HTTP/2 server headers validation improvements

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -65,7 +65,6 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
   protected final Http2ServerResponse response;
   private final String serverOrigin;
   private final MultiMap headersMap;
-  private final String scheme;
 
   // Accessed on context thread
   private Charset paramsCharset = StandardCharsets.UTF_8;
@@ -83,17 +82,10 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
                      String serverOrigin,
                      Http2Headers headers,
                      String contentEncoding) {
-    String scheme = headers.get(":scheme") != null ? headers.get(":scheme").toString() : null;
-    headers.remove(":method");
-    headers.remove(":scheme");
-    headers.remove(":path");
-    headers.remove(":authority");
-
     this.context = stream.context;
     this.stream = stream;
     this.response = new Http2ServerResponse(stream.conn, stream, false, contentEncoding);
     this.serverOrigin = serverOrigin;
-    this.scheme = scheme;
     this.headersMap = new Http2HeadersAdaptor(headers);
   }
 
@@ -330,7 +322,7 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
 
   @Override
   public String scheme() {
-    return scheme;
+    return stream.scheme;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
@@ -37,9 +37,11 @@ import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
 class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
 
   protected final Http2Headers headers;
+  protected final String scheme;
   protected final HttpMethod method;
   protected final String uri;
   protected final String host; // deprecated
+  protected final boolean hasAuthority;
   protected final HostAndPort authority;
   private final TracingPolicy tracingPolicy;
   private Object metric;
@@ -60,26 +62,33 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
     this.headers = null;
     this.method = method;
     this.uri = uri;
+    this.scheme = null;
     this.host = null;
+    this.hasAuthority = false;
     this.authority = null;
     this.tracingPolicy = tracingPolicy;
     this.halfClosedRemote = halfClosedRemote;
   }
 
-  Http2ServerStream(Http2ServerConnection conn, ContextInternal context, Http2Headers headers, String serverOrigin, TracingPolicy tracingPolicy, boolean halfClosedRemote) {
+  Http2ServerStream(Http2ServerConnection conn,
+                    ContextInternal context,
+                    Http2Headers headers,
+                    String scheme,
+                    boolean hasAuthority,
+                    HostAndPort authority,
+                    HttpMethod method,
+                    String uri,
+                    TracingPolicy tracingPolicy,
+                    boolean halfClosedRemote) {
     super(conn, context);
 
-    String host = headers.get(":authority") != null ? headers.get(":authority").toString() : null;
-    if (host == null) {
-      int idx = serverOrigin.indexOf("://");
-      host = serverOrigin.substring(idx + 3);
-    }
-
+    this.scheme = scheme;
     this.headers = headers;
-    this.host =  host;
-    this.authority = HostAndPortImpl.parseHostAndPort(host, -1);
-    this.uri = headers.get(":path") != null ? headers.get(":path").toString() : null;
-    this.method = headers.get(":method") != null ? HttpMethod.valueOf(headers.get(":method").toString()) : null;
+    this.hasAuthority = hasAuthority;
+    this.authority = authority;
+    this.host = authority != null ? authority.toString() : null;
+    this.uri = uri;
+    this.method = method;
     this.tracingPolicy = tracingPolicy;
     this.halfClosedRemote = halfClosedRemote;
   }

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -1094,7 +1094,7 @@ public class Http2ServerTest extends Http2TestBase {
       assertEquals("GET", headers.method().toString());
       assertEquals("https", headers.scheme().toString());
       assertEquals("/wibble", headers.path().toString());
-      assertEquals(DEFAULT_HTTPS_HOST_AND_PORT, headers.authority().toString());
+      assertNull(headers.authority());
     });
   }
 
@@ -1302,8 +1302,18 @@ public class Http2ServerTest extends Http2TestBase {
   }
 
   @Test
-  public void testInvalidHost() throws Exception {
-    testMalformedRequestHeaders(new DefaultHttp2Headers().method("GET").scheme("http").authority(DEFAULT_HTTPS_HOST_AND_PORT).path("/").set("host", "something-else"));
+  public void testInvalidHost1() throws Exception {
+    testMalformedRequestHeaders(new DefaultHttp2Headers().method("GET").scheme("http").authority(DEFAULT_HTTPS_HOST_AND_PORT).path("/").set("host", "foo@" + DEFAULT_HTTPS_HOST_AND_PORT));
+  }
+
+  @Test
+  public void testInvalidHost2() throws Exception {
+    testMalformedRequestHeaders(new DefaultHttp2Headers().method("GET").scheme("http").authority(DEFAULT_HTTPS_HOST_AND_PORT).path("/").set("host", "another-host:" + DEFAULT_HTTPS_PORT));
+  }
+
+  @Test
+  public void testInvalidHost3() throws Exception {
+    testMalformedRequestHeaders(new DefaultHttp2Headers().method("GET").scheme("http").authority(DEFAULT_HTTPS_HOST_AND_PORT).path("/").set("host", DEFAULT_HTTP_HOST));
   }
 
   @Test


### PR DESCRIPTION
The HTTP/2 server request handling first validates the request headers and then creates the request object. This leads to un-necessary work since same headers are lookup several times for the validation and the request creation.

In addition the HTTP/2 server malformed request check uses java URI to validate the request authority. We can reuse the HostAndPort parse method to validate the authority and reuse the created HostAndPort instance to avoid doing the same again when the HTTP/2 server stream is created.

We can split the request creation into creation/initialization, allowing to move the validation phase in between. The new sequence is creation of the request from the headers, pseudo headers are sanitized from the headers object instead of being done in the HttpServerRequest implementation. Then the request is validated against the its own state instead of the headers state, finally the request is initialized (e.g.g registering the vertx stream as a payload of the netty stream).