### PR TITLE
HTTP/2 server headers validation improvements

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -15,12 +15,8 @@ import io.netty.channel.EventLoop;
 import io.netty.handler.codec.compression.CompressionOptions;
 import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http2.DefaultHttp2Headers;
-import io.netty.handler.codec.http2.Http2CodecUtil;
-import io.netty.handler.codec.http2.Http2Error;
-import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.*;
 import io.netty.handler.codec.http2.Http2Settings;
-import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.vertx.core.Handler;
@@ -29,10 +25,9 @@ import io.vertx.core.Promise;
 import io.vertx.core.http.*;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.impl.HostAndPortImpl;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayDeque;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -85,41 +80,28 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
     return metrics;
   }
 
-  private static boolean isMalformedRequest(Http2Headers headers) {
-    if (headers.method() == null) {
+  private static boolean isMalformedRequest(Http2ServerStream request) {
+    if (request.method == null) {
       return true;
     }
-    String method = headers.method().toString();
-    if (method.equals("CONNECT")) {
-      if (headers.scheme() != null || headers.path() != null || headers.authority() == null) {
+
+    if (request.method == HttpMethod.CONNECT) {
+      if (request.scheme != null || request.uri != null || request.authority == null) {
         return true;
       }
     } else {
-      if (headers.method() == null || headers.scheme() == null || headers.path() == null || headers.path().length() == 0) {
+      if (request.scheme == null || request.uri == null || request.uri.length() == 0) {
         return true;
       }
     }
-    if (headers.authority() != null) {
-      URI uri;
-      try {
-        uri = new URI(null, headers.authority().toString(), null, null, null);
-      } catch (URISyntaxException e) {
+    if (request.hasAuthority) {
+      if (request.authority == null) {
         return true;
       }
-      if (uri.getRawUserInfo() != null) {
-        return true;
-      }
-      CharSequence host = headers.get(HttpHeaders.HOST);
-      if (host != null) {
-        URI hostURI;
-        try {
-          hostURI = new URI(null, host.toString(), null, null, null);
-        } catch (URISyntaxException e) {
-          return true;
-        }
-        if (uri.getRawUserInfo() != null || !uri.getAuthority().equals(hostURI.getAuthority())) {
-          return true;
-        }
+      CharSequence hostHeader = request.headers.get(HttpHeaders.HOST);
+      if (hostHeader != null) {
+        HostAndPort host = HostAndPortImpl.parseHostAndPort(hostHeader.toString(), -1);
+        return host == null || (!request.authority.host().equals(host.host()) || request.authority.port() != host.port());
       }
     }
     return false;
@@ -146,15 +128,36 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
     return null;
   }
 
-  private Http2ServerStream createStream(int streamId, Http2Headers headers, boolean streamEnded) {
-    Http2Stream stream = handler.connection().stream(streamId);
-    String contentEncoding = options.isCompressionSupported() ? determineContentEncoding(headers) : null;
-    Http2ServerStream vertxStream = new Http2ServerStream(this, streamContextSupplier.get(), headers, serverOrigin, options.getTracingPolicy(), streamEnded);
-    Http2ServerRequest request = new Http2ServerRequest(vertxStream, serverOrigin, headers, contentEncoding);
+  private Http2ServerStream createStream(Http2Headers headers, boolean streamEnded) {
+    CharSequence schemeHeader = headers.getAndRemove(":scheme");
+    HostAndPort authority = null;
+    String authorityHeaderAsString = null;
+    CharSequence authorityHeader = headers.getAndRemove(":authority");
+    if (authorityHeader != null) {
+      authorityHeaderAsString = authorityHeader.toString();
+      authority = HostAndPortImpl.parseHostAndPort(authorityHeaderAsString, -1);
+    }
+    CharSequence pathHeader = headers.getAndRemove(":path");
+    CharSequence methodHeader = headers.getAndRemove(":method");
+    return new Http2ServerStream(
+      this,
+      streamContextSupplier.get(),
+      headers,
+      schemeHeader != null ? schemeHeader.toString() : null,
+      authorityHeader != null,
+      authority,
+      methodHeader != null ? HttpMethod.valueOf(methodHeader.toString()) : null,
+      pathHeader != null ? pathHeader.toString() : null,
+      options.getTracingPolicy(), streamEnded);
+  }
+
+  private void initStream(int streamId, Http2ServerStream vertxStream) {
+    String contentEncoding = options.isCompressionSupported() ? determineContentEncoding(vertxStream.headers) : null;
+    Http2ServerRequest request = new Http2ServerRequest(vertxStream, serverOrigin, vertxStream.headers, contentEncoding);
     vertxStream.request = request;
     vertxStream.isConnect = request.method() == HttpMethod.CONNECT;
+    Http2Stream stream = handler.connection().stream(streamId);
     vertxStream.init(stream);
-    return vertxStream;
   }
 
   VertxHttp2Stream<?> stream(int id) {
@@ -167,18 +170,19 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
 
   @Override
   protected synchronized void onHeadersRead(int streamId, Http2Headers headers, StreamPriority streamPriority, boolean endOfStream) {
-    VertxHttp2Stream stream = stream(streamId);
+    Http2ServerStream stream = (Http2ServerStream) stream(streamId);
     if (stream == null) {
-      if (isMalformedRequest(headers)) {
+      if (streamId == 1 && handler.upgraded) {
+        stream = createStream(headers, true);
+        upgraded = stream;
+      } else {
+        stream = createStream(headers, endOfStream);
+      }
+      if (isMalformedRequest(stream)) {
         handler.writeReset(streamId, Http2Error.PROTOCOL_ERROR.code());
         return;
       }
-      if (streamId == 1 && handler.upgraded) {
-        stream = createStream(streamId, headers, true);
-        upgraded = stream;
-      } else {
-        stream = createStream(streamId, headers, endOfStream);
-      }
+      initStream(streamId, stream);
       stream.onHeaders(headers, streamPriority);
     } else {
       // Http server request trailer - not implemented yet (in api)

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -66,7 +66,6 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
   protected final Http2ServerResponse response;
   private final String serverOrigin;
   private final MultiMap headersMap;
-  private final String scheme;
 
   // Accessed on context thread
   private Charset paramsCharset = StandardCharsets.UTF_8;
@@ -84,17 +83,10 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
                      String serverOrigin,
                      Http2Headers headers,
                      String contentEncoding) {
-    String scheme = headers.get(":scheme") != null ? headers.get(":scheme").toString() : null;
-    headers.remove(":method");
-    headers.remove(":scheme");
-    headers.remove(":path");
-    headers.remove(":authority");
-
     this.context = stream.context;
     this.stream = stream;
     this.response = new Http2ServerResponse(stream.conn, stream, false, contentEncoding);
     this.serverOrigin = serverOrigin;
-    this.scheme = scheme;
     this.headersMap = new Http2HeadersAdaptor(headers);
   }
 
@@ -331,7 +323,7 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
 
   @Override
   public String scheme() {
-    return scheme;
+    return stream.scheme;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
@@ -36,8 +36,10 @@ import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
 class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
 
   protected final Http2Headers headers;
+  protected final String scheme;
   protected final HttpMethod method;
   protected final String uri;
+  protected final boolean hasAuthority;
   protected final HostAndPort authority;
   private final TracingPolicy tracingPolicy;
   private Object metric;
@@ -58,24 +60,31 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
     this.headers = null;
     this.method = method;
     this.uri = uri;
+    this.scheme = null;
+    this.hasAuthority = false;
     this.authority = null;
     this.tracingPolicy = tracingPolicy;
     this.halfClosedRemote = halfClosedRemote;
   }
 
-  Http2ServerStream(Http2ServerConnection conn, ContextInternal context, Http2Headers headers, String serverOrigin, TracingPolicy tracingPolicy, boolean halfClosedRemote) {
+  Http2ServerStream(Http2ServerConnection conn,
+                    ContextInternal context,
+                    Http2Headers headers,
+                    String scheme,
+                    boolean hasAuthority,
+                    HostAndPort authority,
+                    HttpMethod method,
+                    String uri,
+                    TracingPolicy tracingPolicy,
+                    boolean halfClosedRemote) {
     super(conn, context);
 
-    String host = headers.get(":authority") != null ? headers.get(":authority").toString() : null;
-    if (host == null) {
-      int idx = serverOrigin.indexOf("://");
-      host = serverOrigin.substring(idx + 3);
-    }
-
+    this.scheme = scheme;
     this.headers = headers;
-    this.authority = HostAndPortImpl.parseHostAndPort(host, -1);
-    this.uri = headers.get(":path") != null ? headers.get(":path").toString() : null;
-    this.method = headers.get(":method") != null ? HttpMethod.valueOf(headers.get(":method").toString()) : null;
+    this.hasAuthority = hasAuthority;
+    this.authority = authority;
+    this.uri = uri;
+    this.method = method;
     this.tracingPolicy = tracingPolicy;
     this.halfClosedRemote = halfClosedRemote;
   }

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -1091,7 +1091,7 @@ public class Http2ServerTest extends Http2TestBase {
       assertEquals("GET", headers.method().toString());
       assertEquals("https", headers.scheme().toString());
       assertEquals("/wibble", headers.path().toString());
-      assertEquals(DEFAULT_HTTPS_HOST_AND_PORT, headers.authority().toString());
+      assertNull(headers.authority());
     });
   }
 
@@ -1294,8 +1294,18 @@ public class Http2ServerTest extends Http2TestBase {
   }
 
   @Test
-  public void testInvalidHost() throws Exception {
-    testMalformedRequestHeaders(new DefaultHttp2Headers().method("GET").scheme("http").authority(DEFAULT_HTTPS_HOST_AND_PORT).path("/").set("host", "something-else"));
+  public void testInvalidHost1() throws Exception {
+    testMalformedRequestHeaders(new DefaultHttp2Headers().method("GET").scheme("http").authority(DEFAULT_HTTPS_HOST_AND_PORT).path("/").set("host", "foo@" + DEFAULT_HTTPS_HOST_AND_PORT));
+  }
+
+  @Test
+  public void testInvalidHost2() throws Exception {
+    testMalformedRequestHeaders(new DefaultHttp2Headers().method("GET").scheme("http").authority(DEFAULT_HTTPS_HOST_AND_PORT).path("/").set("host", "another-host:" + DEFAULT_HTTPS_PORT));
+  }
+
+  @Test
+  public void testInvalidHost3() throws Exception {
+    testMalformedRequestHeaders(new DefaultHttp2Headers().method("GET").scheme("http").authority(DEFAULT_HTTPS_HOST_AND_PORT).path("/").set("host", DEFAULT_HTTP_HOST));
   }
 
   @Test


### PR DESCRIPTION
The HTTP/2 server request handling first validates the request headers and then creates the request object. This leads to un-necessary work since same headers are lookup several times for the validation and the request creation.

In addition the HTTP/2 server malformed request check uses java URI to validate the request authority. We can reuse the HostAndPort parse method to validate the authority and reuse the created HostAndPort instance to avoid doing the same again when the HTTP/2 server stream is created.

We can split the request creation into creation/initialization, allowing to move the validation phase in between. The new sequence is creation of the request from the headers, pseudo headers are sanitized from the headers object instead of being done in the HttpServerRequest implementation. Then the request is validated against the its own state instead of the headers state, finally the request is initialized (e.g.g registering the vertx stream as a payload of the netty stream).
