### PR TITLE
HTTP/2 pseudo header lookup optimisations

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -13,6 +13,7 @@ package io.vertx.core.http;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.util.AsciiString;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
@@ -426,6 +427,36 @@ public interface HttpHeaders {
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   CharSequence VARY = createOptimized("vary");
+
+  /**
+   * HTTP/2 {@code :path} pseudo header
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence PSEUDO_PATH = Http2Headers.PseudoHeaderName.PATH.value();
+
+  /**
+   * HTTP/2 {@code :authority} pseudo header
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence PSEUDO_AUTHORITY = Http2Headers.PseudoHeaderName.AUTHORITY.value();
+
+  /**
+   * HTTP/2 {@code :scheme} pseudo header
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence PSEUDO_SCHEME = Http2Headers.PseudoHeaderName.SCHEME.value();
+
+  /**
+   * HTTP/2 {@code :status} pseudo header
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence PSEUDO_STATUS = Http2Headers.PseudoHeaderName.STATUS.value();
+
+  /**
+   * HTTP/2 {@code :method} pseudo hedaer
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence PSEUDO_METHOD = Http2Headers.PseudoHeaderName.METHOD.value();
 
   /**
    * Create an optimized {@link CharSequence} which can be used as header name or value.

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -357,7 +357,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
     }
 
     private void removeStatusHeaders(Http2Headers headers) {
-      headers.remove(":status");
+      headers.remove(HttpHeaders.PSEUDO_STATUS);
     }
 
     @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -130,16 +130,16 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
   }
 
   private Http2ServerStream createStream(Http2Headers headers, boolean streamEnded) {
-    CharSequence schemeHeader = headers.getAndRemove(":scheme");
+    CharSequence schemeHeader = headers.getAndRemove(HttpHeaders.PSEUDO_SCHEME);
     HostAndPort authority = null;
-    String authorityHeaderAsString = null;
-    CharSequence authorityHeader = headers.getAndRemove(":authority");
+    String authorityHeaderAsString;
+    CharSequence authorityHeader = headers.getAndRemove(HttpHeaders.PSEUDO_AUTHORITY);
     if (authorityHeader != null) {
       authorityHeaderAsString = authorityHeader.toString();
       authority = HostAndPortImpl.parseHostAndPort(authorityHeaderAsString, -1);
     }
-    CharSequence pathHeader = headers.getAndRemove(":path");
-    CharSequence methodHeader = headers.getAndRemove(":method");
+    CharSequence pathHeader = headers.getAndRemove(HttpHeaders.PSEUDO_PATH);
+    CharSequence methodHeader = headers.getAndRemove(HttpHeaders.PSEUDO_METHOD);
     return new Http2ServerStream(
       this,
       streamContextSupplier.get(),


### PR DESCRIPTION
Define in HttpHeaders constants for HTTP/2 pseudo headers and use them instead of mere strings to optimise headers lookup
