### PR TITLE
Duplicate context on periodic event notifications

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -430,7 +430,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   @Override
   public long setPeriodic(long initialDelay, long delay, Handler<Long> handler) {
     ContextInternal ctx = getOrCreateContext();
-    return scheduleTimeout(ctx, true, initialDelay, delay, TimeUnit.MILLISECONDS, ctx.isDeployment(), handler);
+    return scheduleTimeout(ctx.unwrap(), true, initialDelay, delay, TimeUnit.MILLISECONDS, ctx.isDeployment(), handler);
   }
 
   public long setTimer(long delay, Handler<Long> handler) {
@@ -977,7 +977,11 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
     @Override
     public void run() {
-      context.emit(this);
+      ContextInternal dispatcher = context;
+      if (periodic) {
+        dispatcher = dispatcher.duplicate();
+      }
+      dispatcher.emit(this);
     }
 
     public void handle(Void v) {


### PR DESCRIPTION
Periodic tasks will reuse any context to deliver timer events independantly of the context. Unlike timers (which reuse the current context whether it is a duplicate) a periodic should not capture duplicate context as they would extend the lifecycle of the duplicated context. Instead a periodic should duplicate the current context so each timer event will have its own independant lifecycle.

Update the implementation of internal schedule tasks to unwrap the context of the scheduler timer task and then duplicate it when an timer event is emitted.
