### PR TITLE
Deprecate AddressResolverOptions#DEFAULT_SEACH_DOMAINS (typo)

### DIFF
--- a/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
+++ b/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
@@ -77,8 +77,16 @@ public class AddressResolverOptions {
 
   /**
    * The default value of search domains = null
+   *
+   * @deprecated instead use {@link #DEFAULT_SEARCH_DOMAINS}
    */
+  @Deprecated
   public static final List<String> DEFAULT_SEACH_DOMAINS = null;
+
+  /**
+   * The default value of search domains = null
+   */
+  public static final List<String> DEFAULT_SEARCH_DOMAINS = null;
 
   /**
    * The default ndots value = loads the value from the OS on Linux otherwise use the value 1
@@ -120,7 +128,7 @@ public class AddressResolverOptions {
     queryTimeout = DEFAULT_QUERY_TIMEOUT;
     maxQueries = DEFAULT_MAX_QUERIES;
     rdFlag = DEFAULT_RD_FLAG;
-    searchDomains = DEFAULT_SEACH_DOMAINS;
+    searchDomains = DEFAULT_SEARCH_DOMAINS;
     ndots = DEFAULT_NDOTS;
     rotateServers = DEFAULT_ROTATE_SERVERS;
     roundRobinInetAddress = DEFAULT_ROUND_ROBIN_INET_ADDRESS;

--- a/src/test/java/io/vertx/core/dns/HostnameResolutionTest.java
+++ b/src/test/java/io/vertx/core/dns/HostnameResolutionTest.java
@@ -190,7 +190,7 @@ public class HostnameResolutionTest extends VertxTestBase {
     assertEquals(AddressResolverOptions.DEFAULT_MAX_QUERIES, options.getMaxQueries());
     assertEquals(AddressResolverOptions.DEFAULT_RD_FLAG, options.getRdFlag());
     assertEquals(AddressResolverOptions.DEFAULT_NDOTS, options.getNdots());
-    assertEquals(AddressResolverOptions.DEFAULT_SEACH_DOMAINS, options.getSearchDomains());
+    assertEquals(AddressResolverOptions.DEFAULT_SEARCH_DOMAINS, options.getSearchDomains());
 
     boolean optResourceEnabled = TestUtils.randomBoolean();
     List<String> servers = Arrays.asList("1.2.3.4", "5.6.7.8");
@@ -280,7 +280,7 @@ public class HostnameResolutionTest extends VertxTestBase {
     options.setMaxQueries(AddressResolverOptions.DEFAULT_MAX_QUERIES);
     options.setRdFlag(AddressResolverOptions.DEFAULT_RD_FLAG);
     options.setNdots(AddressResolverOptions.DEFAULT_NDOTS);
-    options.setSearchDomains(AddressResolverOptions.DEFAULT_SEACH_DOMAINS);
+    options.setSearchDomains(AddressResolverOptions.DEFAULT_SEARCH_DOMAINS);
 
     assertEquals(optResourceEnabled, copy.isOptResourceEnabled());
     assertEquals(servers, copy.getServers());
@@ -316,7 +316,7 @@ public class HostnameResolutionTest extends VertxTestBase {
     assertEquals(AddressResolverOptions.DEFAULT_QUERY_TIMEOUT, options.getQueryTimeout());
     assertEquals(AddressResolverOptions.DEFAULT_MAX_QUERIES, options.getMaxQueries());
     assertEquals(AddressResolverOptions.DEFAULT_RD_FLAG, options.getRdFlag());
-    assertEquals(AddressResolverOptions.DEFAULT_SEACH_DOMAINS, options.getSearchDomains());
+    assertEquals(AddressResolverOptions.DEFAULT_SEARCH_DOMAINS, options.getSearchDomains());
     assertEquals(AddressResolverOptions.DEFAULT_NDOTS, options.getNdots());
   }
 


### PR DESCRIPTION
instead AddressResolverOptions#DEFAULT_SEARCH_DOMAINS shall be used
