### PR TITLE
Speedup HTTP headers lowercase transformation

### DIFF
--- a/src/test/benchmarks/io/vertx/benchmarks/HttpUtilsAsciiToLowerCaseBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HttpUtilsAsciiToLowerCaseBenchmark.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.benchmarks;
+
+import io.netty.util.AsciiString;
+import io.vertx.core.http.impl.HttpUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 20, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 200, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(NANOSECONDS)
+@Fork(2)
+public class HttpUtilsAsciiToLowerCaseBenchmark {
+
+  @Param({"ascii", "string", "builder"})
+  public String type;
+
+  @Param({"false", "true"})
+  public boolean lowerCase;
+  private CharSequence sequence;
+
+  @Setup
+  public void init() {
+    sequence = create(type, lowerCase ? "content-length" : "Content-Length");
+  }
+
+  private CharSequence create(String type, String content) {
+
+    switch (type) {
+      case "ascii":
+        return new AsciiString(content);
+      case "string":
+        return content;
+      case "builder":
+        return new StringBuilder(content);
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  @Benchmark
+  public CharSequence toLowerCase() {
+    return HttpUtils.toLowerCase(sequence);
+  }
+
+}


### PR DESCRIPTION
In some simple HTTP 2 hello world benchmarks, `HttpUtils::toLowerCase` has pop-up due to how Quarkus handle HTTP headers using Jax-RS HTTP header name constants ie using capital letters in `String`s eg "Content-Type".

![image](https://github.com/eclipse-vertx/vert.x/assets/13125299/6762c254-d906-476a-bd75-117ab2403402)

This is speeding up the `String` lowercase transformation case improving the others, where possible.

baseline:
```
Benchmark                                       (lowerCase)   (type)  Mode  Cnt   Score   Error  Units
HttpUtilsAsciiToLowerCaseBenchmark.toLowerCase        false    ascii  avgt   20  29.698 ± 0.195  ns/op
HttpUtilsAsciiToLowerCaseBenchmark.toLowerCase        false   string  avgt   20  23.967 ± 0.791  ns/op
HttpUtilsAsciiToLowerCaseBenchmark.toLowerCase        false  builder  avgt   20  24.155 ± 0.905  ns/op
HttpUtilsAsciiToLowerCaseBenchmark.toLowerCase         true    ascii  avgt   20   6.625 ± 0.008  ns/op
HttpUtilsAsciiToLowerCaseBenchmark.toLowerCase         true   string  avgt   20   4.932 ± 0.015  ns/op
HttpUtilsAsciiToLowerCaseBenchmark.toLowerCase         true  builder  avgt   20   5.654 ± 0.021  ns/op
```

b2925a869146dc9a1fb7e0ba4e4086751da6934b :
```
Benchmark                                       (lowerCase)   (type)  Mode  Cnt   Score   Error  Units
HttpUtilsAsciiToLowerCaseBenchmark.toLowerCase        false    ascii  avgt   20  10.988 ± 0.258  ns/op
HttpUtilsAsciiToLowerCaseBenchmark.toLowerCase        false   string  avgt   20  13.255 ± 0.111  ns/op
HttpUtilsAsciiToLowerCaseBenchmark.toLowerCase        false  builder  avgt   20  24.846 ± 1.290  ns/op
HttpUtilsAsciiToLowerCaseBenchmark.toLowerCase         true    ascii  avgt   20   6.107 ± 0.007  ns/op
HttpUtilsAsciiToLowerCaseBenchmark.toLowerCase         true   string  avgt   20   5.078 ± 0.053  ns/op
HttpUtilsAsciiToLowerCaseBenchmark.toLowerCase         true  builder  avgt   20   5.619 ± 0.017  ns/op
```

This change is kind-of related to https://github.com/quarkusio/quarkus/pull/37619/files#diff-7cd9e11ea75ab750663bd15870c0749df275c32fd3d8eb2dfdc8eb706e4db540L499
which, instead, try to address it by forcing to use the same `AsciiString` of vertx, but introducing some ugly APIs which doesn't fit with the rest. 

That's why I think that improving on Vertx side is more beneficial for this