### PR TITLE
Core system properties cleanup

### DIFF
--- a/src/main/java/io/vertx/core/Context.java
+++ b/src/main/java/io/vertx/core/Context.java
@@ -167,7 +167,7 @@ public interface Context {
    * Is the current context an event loop context?
    * <p>
    * NOTE! when running blocking code using {@link io.vertx.core.Vertx#executeBlocking(Callable)} from a
-   * standard (not worker) verticle, the context will still an event loop context and this {@link this#isEventLoopContext()}
+   * standard (not worker) verticle, the context will still an event loop context and this {@link #isEventLoopContext()}
    * will return true.
    *
    * @return {@code true} if the current context is an event-loop context, {@code false} otherwise

--- a/src/main/java/io/vertx/core/ServiceHelper.java
+++ b/src/main/java/io/vertx/core/ServiceHelper.java
@@ -38,11 +38,11 @@ public class ServiceHelper {
   }
 
 
-  public static <T> Collection<T> loadFactories(Class<T> clazz) {
+  public static <T> List<T> loadFactories(Class<T> clazz) {
     return loadFactories(clazz, null);
   }
 
-  public static <T> Collection<T> loadFactories(Class<T> clazz, ClassLoader classLoader) {
+  public static <T> List<T> loadFactories(Class<T> clazz, ClassLoader classLoader) {
     List<T> list = new ArrayList<>();
     ServiceLoader<T> factories;
     if (classLoader != null) {

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -111,7 +111,10 @@ public class VertxOptions {
    */
   public static final TimeUnit DEFAULT_WARNING_EXCEPTION_TIME_UNIT = TimeUnit.NANOSECONDS;
 
-  public static final boolean DEFAULT_DISABLE_TCCL = SysProps.DISABLE_TCCL.getBoolean();
+  /**
+   * The default value of thread context classloader disabling = {@code false}
+   */
+  public static final boolean DEFAULT_DISABLE_TCCL = false;
 
   /**
    * Set default value to false for aligning with the old behavior

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -16,6 +16,7 @@ import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.eventbus.EventBusOptions;
 import io.vertx.core.file.FileSystemOptions;
+import io.vertx.core.impl.SysProps;
 import io.vertx.core.impl.cpu.CpuCoreSensor;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;
@@ -32,8 +33,6 @@ import java.util.concurrent.TimeUnit;
 @DataObject
 @JsonGen(publicConverter = false)
 public class VertxOptions {
-
-  private static final String DISABLE_TCCL_PROP_NAME = "vertx.disableTCCL";
 
   /**
    * The default number of event loop threads to be used  = 2 * number of cores on the machine
@@ -112,7 +111,7 @@ public class VertxOptions {
    */
   public static final TimeUnit DEFAULT_WARNING_EXCEPTION_TIME_UNIT = TimeUnit.NANOSECONDS;
 
-  public static final boolean DEFAULT_DISABLE_TCCL = Boolean.getBoolean(DISABLE_TCCL_PROP_NAME);
+  public static final boolean DEFAULT_DISABLE_TCCL = SysProps.DISABLE_TCCL.getBoolean();
 
   /**
    * Set default value to false for aligning with the old behavior

--- a/src/main/java/io/vertx/core/file/FileSystemOptions.java
+++ b/src/main/java/io/vertx/core/file/FileSystemOptions.java
@@ -15,6 +15,7 @@ package io.vertx.core.file;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.file.impl.FileResolverImpl;
+import io.vertx.core.impl.SysProps;
 import io.vertx.core.json.JsonObject;
 
 import java.io.File;
@@ -30,24 +31,19 @@ public class FileSystemOptions {
   /**
    * The default behavior for caching files for class path resolution = {@code false} if and only if the system property {@code "vertx.disableFileCaching"} exists and is set to the string {@code "false"}
    */
-  public static final boolean DEFAULT_FILE_CACHING_ENABLED = !Boolean.getBoolean(FileResolverImpl.DISABLE_FILE_CACHING_PROP_NAME);
+  public static final boolean DEFAULT_FILE_CACHING_ENABLED = !SysProps.DISABLE_FILE_CACHING.getBoolean();
 
   /**
    * The default behavior to cache or not class path resolution = {@code false} if and only if the system property {@code "vertx.disableFileCPResolving"} exists and is set to the string {@code "false"}
    */
-  public static final boolean DEFAULT_CLASS_PATH_RESOLVING_ENABLED = !Boolean.getBoolean(FileResolverImpl.DISABLE_CP_RESOLVING_PROP_NAME);
+  public static final boolean DEFAULT_CLASS_PATH_RESOLVING_ENABLED = !SysProps.DISABLE_FILE_CP_RESOLVING.getBoolean();
 
-
-  // get the system default temp dir location (can be overriden by using the standard java system property)
-  // if not present default to the process start CWD
-  private static final String TMPDIR = System.getProperty("java.io.tmpdir", ".");
-  private static final String DEFAULT_CACHE_DIR_BASE = "vertx-cache";
 
   /**
    * The default file caching dir. If the system property {@code "vertx.cacheDirBase"} is set, then this is the value
    * If not, then the system property {@code java.io.tmpdir} is taken or {code .} if not set. suffixed with {@code vertx-cache}.
    */
-  public static final String DEFAULT_FILE_CACHING_DIR = System.getProperty(FileResolverImpl.CACHE_DIR_BASE_PROP_NAME, TMPDIR + File.separator + DEFAULT_CACHE_DIR_BASE);
+  public static final String DEFAULT_FILE_CACHING_DIR = SysProps.FILE_CACHE_DIR.get();
 
   private boolean classPathResolvingEnabled = DEFAULT_CLASS_PATH_RESOLVING_ENABLED;
   private boolean fileCachingEnabled = DEFAULT_FILE_CACHING_ENABLED;

--- a/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
@@ -53,9 +53,6 @@ import static io.vertx.core.net.impl.URIDecoder.decodeURIComponent;
  */
 public class FileResolverImpl implements FileResolver {
 
-  public static final String DISABLE_FILE_CACHING_PROP_NAME = "vertx.disableFileCaching";
-  public static final String DISABLE_CP_RESOLVING_PROP_NAME = "vertx.disableFileCPResolving";
-  public static final String CACHE_DIR_BASE_PROP_NAME = "vertx.cacheDirBase";
   private static final boolean NON_UNIX_FILE_SEP = File.separatorChar != '/';
   private static final String JAR_URL_SEP = "!/";
 

--- a/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -19,6 +19,7 @@ import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import io.vertx.core.impl.SysProps;
 
 /**
  * Contains a bunch of useful HTTP headers stuff:
@@ -35,10 +36,10 @@ import io.vertx.core.http.impl.headers.HeadersMultiMap;
 public interface HttpHeaders {
 
   /** JVM system property that disables HTTP headers validation, don't use this in production. */
-  String DISABLE_HTTP_HEADERS_VALIDATION_PROP_NAME = "vertx.disableHttpHeadersValidation";
+  String DISABLE_HTTP_HEADERS_VALIDATION_PROP_NAME = SysProps.DISABLE_HTTP_HEADERS_VALIDATION.name;
 
   /** Constant that disables HTTP headers validation, this is a constant so the JIT can eliminate validation code. */
-  boolean DISABLE_HTTP_HEADERS_VALIDATION = Boolean.getBoolean(DISABLE_HTTP_HEADERS_VALIDATION_PROP_NAME);
+  boolean DISABLE_HTTP_HEADERS_VALIDATION = SysProps.DISABLE_HTTP_HEADERS_VALIDATION.getBoolean();
 
   /**
    * Accept header name

--- a/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -36,9 +36,11 @@ import io.vertx.core.impl.SysProps;
 public interface HttpHeaders {
 
   /** JVM system property that disables HTTP headers validation, don't use this in production. */
+  @Deprecated
   String DISABLE_HTTP_HEADERS_VALIDATION_PROP_NAME = SysProps.DISABLE_HTTP_HEADERS_VALIDATION.name;
 
   /** Constant that disables HTTP headers validation, this is a constant so the JIT can eliminate validation code. */
+  @Deprecated
   boolean DISABLE_HTTP_HEADERS_VALIDATION = SysProps.DISABLE_HTTP_HEADERS_VALIDATION.getBoolean();
 
   /**

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -11,15 +11,11 @@
 
 package io.vertx.core.http.impl;
 
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
-import io.netty.handler.ssl.SslHandler;
-import io.netty.handler.traffic.GlobalTrafficShapingHandler;
 import io.vertx.core.*;
 import io.vertx.core.http.*;
 import io.vertx.core.impl.CloseSequence;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.SysProps;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
@@ -28,9 +24,7 @@ import io.vertx.core.net.impl.*;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -46,9 +40,7 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
 
   private static final Handler<Throwable> DEFAULT_EXCEPTION_HANDLER = t -> log.trace("Connection failure", t);
 
-  private static final String DISABLE_WEBSOCKETS_PROP_NAME = "vertx.disableWebsockets";
-
-  static final boolean DISABLE_WEBSOCKETS = Boolean.getBoolean(DISABLE_WEBSOCKETS_PROP_NAME);
+  static final boolean DISABLE_WEBSOCKETS = SysProps.DISABLE_WEBSOCKETS.getBoolean();
 
   private final VertxInternal vertx;
   final HttpServerOptions options;

--- a/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -32,8 +32,7 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
 
   private static final Logger log = LoggerFactory.getLogger(ContextImpl.class);
 
-  private static final String DISABLE_TIMINGS_PROP_NAME = "vertx.disableContextTimings";
-  static final boolean DISABLE_TIMINGS = Boolean.getBoolean(DISABLE_TIMINGS_PROP_NAME);
+  static final boolean DISABLE_TIMINGS = SysProps.DISABLE_CONTEXT_TIMINGS.getBoolean();
 
   private final ThreadingModel threadingModel;
   private final VertxInternal owner;

--- a/src/main/java/io/vertx/core/impl/SysProps.java
+++ b/src/main/java/io/vertx/core/impl/SysProps.java
@@ -48,16 +48,19 @@ public enum SysProps {
 
   /**
    * Default value of {@link io.vertx.core.file.FileSystemOptions#DEFAULT_FILE_CACHING_ENABLED}
+   *
    */
   DISABLE_FILE_CACHING("vertx.disableFileCaching"),
 
   /**
    * Default value of {@link io.vertx.core.file.FileSystemOptions#DEFAULT_CLASS_PATH_RESOLVING_ENABLED}
+   *
    */
   DISABLE_FILE_CP_RESOLVING("vertx.disableFileCPResolving"),
 
   /**
    * Default value of {@link io.vertx.core.file.FileSystemOptions#DEFAULT_FILE_CACHING_DIR}
+   *
    */
   FILE_CACHE_DIR("vertx.cacheDirBase") {
     @Override

--- a/src/main/java/io/vertx/core/impl/SysProps.java
+++ b/src/main/java/io/vertx/core/impl/SysProps.java
@@ -1,0 +1,110 @@
+package io.vertx.core.impl;
+
+import java.io.File;
+
+public enum SysProps {
+
+  /**
+   * Defines a mode for base64 JSON conversions that is compatible with Vert.x 3
+   */
+  JSON_BASE_64("vertx.json.base64"),
+
+  /**
+   * Cluster manager to use class FQN.
+   *
+   * It does not seem tested, it is not documented, but we can find evidence of it on the web (mailing list).
+   */
+  CLUSTER_MANAGER_CLASS("vertx.cluster.managerClass"),
+
+  /**
+   * Duplicate of {@link io.vertx.core.http.HttpHeaders#DISABLE_HTTP_HEADERS_VALIDATION}
+   */
+  DISABLE_HTTP_HEADERS_VALIDATION("vertx.disableHttpHeadersValidation"),
+
+  /**
+   * Internal property that disables websockets benchmarking purpose.
+   */
+  DISABLE_WEBSOCKETS("vertx.disableWebsockets"),
+
+  /**
+   * Internal property that disables metrics for benchmarking purpose.
+   */
+  DISABLE_METRICS("vertx.disableMetrics"),
+
+  /**
+   * Internal property that disables the context task execution measures for benchmarking purpose.
+   */
+  DISABLE_CONTEXT_TIMINGS("vertx.disableContextTimings"),
+
+  /**
+   * Disable Netty DNS resolver usage.
+   *
+   * Documented and (not much) tested.
+   */
+  DISABLE_DNS_RESOLVER("vertx.disableDnsResolver"),
+
+  /**
+   * Default value of {@link io.vertx.core.VertxOptions#DEFAULT_DISABLE_TCCL}
+   */
+  DISABLE_TCCL("vertx.disableTCCL"),
+
+  /**
+   * Default value of {@link io.vertx.core.file.FileSystemOptions#DEFAULT_FILE_CACHING_ENABLED}
+   */
+  DISABLE_FILE_CACHING("vertx.disableFileCaching"),
+
+  /**
+   * Default value of {@link io.vertx.core.file.FileSystemOptions#DEFAULT_CLASS_PATH_RESOLVING_ENABLED}
+   */
+  DISABLE_FILE_CP_RESOLVING("vertx.disableFileCPResolving"),
+
+  /**
+   * Default value of {@link io.vertx.core.file.FileSystemOptions#DEFAULT_FILE_CACHING_DIR}
+   */
+  FILE_CACHE_DIR("vertx.cacheDirBase") {
+    @Override
+    public String get() {
+      String val = super.get();
+      if (val == null) {
+        // get the system default temp dir location (can be overriden by using the standard java system property)
+        // if not present default to the process start CWD
+        String tmpDir = System.getProperty("java.io.tmpdir", ".");
+        String cacheDirBase = "vertx-cache";
+        val = tmpDir + File.separator + cacheDirBase;
+      }
+      return val;
+    }
+  },
+
+  /**
+   * Configure the Vert.x logger.
+   *
+   * Documented and tested.
+   */
+  LOGGER_DELEGATE_FACTORY_CLASS_NAME("vertx.logger-delegate-factory-class-name"),
+
+  /**
+   * Pass options to the Java compiler when a .java verticle is compiled by Vert.x when deploying a source code verticle. The
+   * value should be a comma separated list of options.
+   *
+   * Not documented nor tested.
+   */
+  JAVA_COMPILER_OPTIONS_PROP_NAME("vertx.javaCompilerOptions")
+
+  ;
+
+  public final String name;
+
+  SysProps(String name) {
+    this.name = name;
+  }
+
+  public String get() {
+    return System.getProperty(name);
+  }
+
+  public boolean getBoolean() {
+    return Boolean.getBoolean(name);
+  }
+
+}

--- a/src/main/java/io/vertx/core/impl/SysProps.java
+++ b/src/main/java/io/vertx/core/impl/SysProps.java
@@ -5,11 +5,6 @@ import java.io.File;
 public enum SysProps {
 
   /**
-   * Defines a mode for base64 JSON conversions that is compatible with Vert.x 3
-   */
-  JSON_BASE_64("vertx.json.base64"),
-
-  /**
    * Cluster manager to use class FQN.
    *
    * It does not seem tested, it is not documented, but we can find evidence of it on the web (mailing list).

--- a/src/main/java/io/vertx/core/impl/SysProps.java
+++ b/src/main/java/io/vertx/core/impl/SysProps.java
@@ -1,7 +1,22 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.core.impl;
 
 import java.io.File;
 
+/**
+ * Vert.x known system properties.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
 public enum SysProps {
 
   /**

--- a/src/main/java/io/vertx/core/impl/SysProps.java
+++ b/src/main/java/io/vertx/core/impl/SysProps.java
@@ -71,14 +71,6 @@ public enum SysProps {
    */
   LOGGER_DELEGATE_FACTORY_CLASS_NAME("vertx.logger-delegate-factory-class-name"),
 
-  /**
-   * Pass options to the Java compiler when a .java verticle is compiled by Vert.x when deploying a source code verticle. The
-   * value should be a comma separated list of options.
-   *
-   * Not documented nor tested.
-   */
-  JAVA_COMPILER_OPTIONS_PROP_NAME("vertx.javaCompilerOptions")
-
   ;
 
   public final String name;

--- a/src/main/java/io/vertx/core/impl/SysProps.java
+++ b/src/main/java/io/vertx/core/impl/SysProps.java
@@ -32,11 +32,6 @@ public enum SysProps {
   DISABLE_DNS_RESOLVER("vertx.disableDnsResolver"),
 
   /**
-   * Default value of {@link io.vertx.core.VertxOptions#DEFAULT_DISABLE_TCCL}
-   */
-  DISABLE_TCCL("vertx.disableTCCL"),
-
-  /**
    * Default value of {@link io.vertx.core.file.FileSystemOptions#DEFAULT_FILE_CACHING_ENABLED}
    */
   DISABLE_FILE_CACHING("vertx.disableFileCaching"),

--- a/src/main/java/io/vertx/core/impl/SysProps.java
+++ b/src/main/java/io/vertx/core/impl/SysProps.java
@@ -5,13 +5,6 @@ import java.io.File;
 public enum SysProps {
 
   /**
-   * Cluster manager to use class FQN.
-   *
-   * It does not seem tested, it is not documented, but we can find evidence of it on the web (mailing list).
-   */
-  CLUSTER_MANAGER_CLASS("vertx.cluster.managerClass"),
-
-  /**
    * Duplicate of {@link io.vertx.core.http.HttpHeaders#DISABLE_HTTP_HEADERS_VALIDATION}
    */
   DISABLE_HTTP_HEADERS_VALIDATION("vertx.disableHttpHeadersValidation"),

--- a/src/main/java/io/vertx/core/impl/VertxBuilder.java
+++ b/src/main/java/io/vertx/core/impl/VertxBuilder.java
@@ -315,7 +315,7 @@ public class VertxBuilder {
   }
 
   private static void initClusterManager(Collection<VertxServiceProvider> providers) {
-    String clusterManagerClassName = System.getProperty("vertx.cluster.managerClass");
+    String clusterManagerClassName = SysProps.CLUSTER_MANAGER_CLASS.get();
     if (clusterManagerClassName != null) {
       // We allow specify a sys prop for the cluster manager factory which overrides ServiceLoader
       try {

--- a/src/main/java/io/vertx/core/impl/VertxBuilder.java
+++ b/src/main/java/io/vertx/core/impl/VertxBuilder.java
@@ -32,9 +32,9 @@ import io.vertx.core.spi.cluster.impl.DefaultNodeSelector;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Vertx builder for creating vertx instances with SPI overrides.
@@ -279,9 +279,7 @@ public class VertxBuilder {
     initTransport();
     initMetrics();
     initTracing();
-    Collection<VertxServiceProvider> providers = new ArrayList<>();
-    initClusterManager(providers);
-    providers.addAll(ServiceHelper.loadFactories(VertxServiceProvider.class));
+    List<VertxServiceProvider> providers = ServiceHelper.loadFactories(VertxServiceProvider.class);
     initProviders(providers);
     initThreadFactory();
     initExecutorServiceFactory();
@@ -311,20 +309,6 @@ public class VertxBuilder {
     VertxTracerFactory provider = tracerFactory;
     if (provider != null) {
       provider.init(this);
-    }
-  }
-
-  private static void initClusterManager(Collection<VertxServiceProvider> providers) {
-    String clusterManagerClassName = SysProps.CLUSTER_MANAGER_CLASS.get();
-    if (clusterManagerClassName != null) {
-      // We allow specify a sys prop for the cluster manager factory which overrides ServiceLoader
-      try {
-        Class<?> clazz = Class.forName(clusterManagerClassName);
-        ClusterManager clusterManager = (ClusterManager) clazz.getDeclaredConstructor().newInstance();
-        providers.add(clusterManager);
-      } catch (Exception e) {
-        throw new IllegalStateException("Failed to instantiate " + clusterManagerClassName, e);
-      }
     }
   }
 

--- a/src/main/java/io/vertx/core/impl/logging/LoggerFactory.java
+++ b/src/main/java/io/vertx/core/impl/logging/LoggerFactory.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.impl.logging;
 
+import io.vertx.core.impl.SysProps;
 import io.vertx.core.logging.JULLogDelegateFactory;
 import io.vertx.core.spi.logging.LogDelegate;
 import io.vertx.core.spi.logging.LogDelegateFactory;
@@ -21,8 +22,6 @@ import io.vertx.core.spi.logging.LogDelegateFactory;
  * @author Thomas Segismont
  */
 public class LoggerFactory {
-
-  public static final String LOGGER_DELEGATE_FACTORY_CLASS_NAME = "vertx.logger-delegate-factory-class-name";
 
   private static volatile LogDelegateFactory delegateFactory;
 
@@ -37,7 +36,7 @@ public class LoggerFactory {
     ClassLoader loader = Thread.currentThread().getContextClassLoader();
     String className;
     try {
-      className = System.getProperty(LOGGER_DELEGATE_FACTORY_CLASS_NAME);
+      className = SysProps.LOGGER_DELEGATE_FACTORY_CLASS_NAME.get();
     } catch (Exception ignore) {
       className = null;
     }

--- a/src/main/java/io/vertx/core/impl/verticle/CompilingClassLoader.java
+++ b/src/main/java/io/vertx/core/impl/verticle/CompilingClassLoader.java
@@ -41,24 +41,6 @@ public class CompilingClassLoader extends ClassLoader {
 
   private static final Logger log = LoggerFactory.getLogger(CompilingClassLoader.class);
 
-
-  private final static List<String> COMPILER_OPTIONS;
-
-  static {
-    String props = SysProps.JAVA_COMPILER_OPTIONS_PROP_NAME.get();
-    if (props != null) {
-      String[] array = props.split(",");
-      List<String> compilerProps = new ArrayList<>(array.length);
-
-      for (String prop :array) {
-        compilerProps.add(prop.trim());
-      }
-      COMPILER_OPTIONS = Collections.unmodifiableList(compilerProps);
-    } else {
-      COMPILER_OPTIONS = null;
-    }
-  }
-
   private final JavaSourceContext javaSourceContext;
   private final MemoryFileManager fileManager;
   public CompilingClassLoader(ClassLoader loader, String sourceName) {
@@ -90,7 +72,7 @@ public class CompilingClassLoader extends ClassLoader {
       // other .java resources from other modules
 
       JavaFileObject javaFile = standardFileManager.getJavaFileForInput(StandardLocation.SOURCE_PATH, resolveMainClassName(), Kind.SOURCE);
-      JavaCompiler.CompilationTask task = javaCompiler.getTask(null, fileManager, diagnostics, COMPILER_OPTIONS, null, Collections.singleton(javaFile));
+      JavaCompiler.CompilationTask task = javaCompiler.getTask(null, fileManager, diagnostics, null, null, Collections.singleton(javaFile));
       boolean valid = task.call();
       if (valid) {
         for (Diagnostic<?> d : diagnostics.getDiagnostics()) {

--- a/src/main/java/io/vertx/core/impl/verticle/CompilingClassLoader.java
+++ b/src/main/java/io/vertx/core/impl/verticle/CompilingClassLoader.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.impl.verticle;
 
+import io.vertx.core.impl.SysProps;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 
@@ -41,11 +42,10 @@ public class CompilingClassLoader extends ClassLoader {
   private static final Logger log = LoggerFactory.getLogger(CompilingClassLoader.class);
 
 
-  private static final String JAVA_COMPILER_OPTIONS_PROP_NAME = "vertx.javaCompilerOptions";
   private final static List<String> COMPILER_OPTIONS;
 
   static {
-    String props = System.getProperty(JAVA_COMPILER_OPTIONS_PROP_NAME);
+    String props = SysProps.JAVA_COMPILER_OPTIONS_PROP_NAME.get();
     if (props != null) {
       String[] array = props.split(",");
       List<String> compilerProps = new ArrayList<>(array.length);

--- a/src/main/java/io/vertx/core/json/impl/JsonUtil.java
+++ b/src/main/java/io/vertx/core/json/impl/JsonUtil.java
@@ -11,6 +11,7 @@
 package io.vertx.core.json.impl;
 
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.SysProps;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.Shareable;
@@ -40,7 +41,7 @@ public final class JsonUtil {
      * Users who might need to interop with Vert.x 3.x applications should set the system property
      * {@code vertx.json.base64} to {@code legacy}.
      */
-    if ("legacy".equalsIgnoreCase(System.getProperty("vertx.json.base64"))) {
+    if ("legacy".equalsIgnoreCase(SysProps.JSON_BASE_64.get())) {
       BASE64_ENCODER = Base64.getEncoder();
       BASE64_DECODER = Base64.getDecoder();
     } else {

--- a/src/main/java/io/vertx/core/json/impl/JsonUtil.java
+++ b/src/main/java/io/vertx/core/json/impl/JsonUtil.java
@@ -11,7 +11,6 @@
 package io.vertx.core.json.impl;
 
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.impl.SysProps;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.Shareable;
@@ -32,23 +31,8 @@ import static java.time.format.DateTimeFormatter.ISO_INSTANT;
  */
 public final class JsonUtil {
 
-  public static final Base64.Encoder BASE64_ENCODER;
-  public static final Base64.Decoder BASE64_DECODER;
-
-  static {
-    /*
-     * Vert.x 3.x Json supports RFC-7493, however the JSON encoder/decoder format was incorrect.
-     * Users who might need to interop with Vert.x 3.x applications should set the system property
-     * {@code vertx.json.base64} to {@code legacy}.
-     */
-    if ("legacy".equalsIgnoreCase(SysProps.JSON_BASE_64.get())) {
-      BASE64_ENCODER = Base64.getEncoder();
-      BASE64_DECODER = Base64.getDecoder();
-    } else {
-      BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
-      BASE64_DECODER = Base64.getUrlDecoder();
-    }
-  }
+  public static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
+  public static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
 
   /**
    * Wraps well known java types to adhere to the Json expected types.

--- a/src/main/java/io/vertx/core/spi/dns/AddressResolverProvider.java
+++ b/src/main/java/io/vertx/core/spi/dns/AddressResolverProvider.java
@@ -16,6 +16,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
 import io.vertx.core.dns.AddressResolverOptions;
+import io.vertx.core.impl.SysProps;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.dns.impl.DnsAddressResolverProvider;
 import io.vertx.core.dns.impl.DefaultAddressResolverProvider;
@@ -29,13 +30,11 @@ import java.net.InetSocketAddress;
  */
 public interface AddressResolverProvider {
 
-  String DISABLE_DNS_RESOLVER_PROP_NAME = "vertx.disableDnsResolver";
-
   static AddressResolverProvider factory(Vertx vertx, AddressResolverOptions options) {
     // For now not really plugable, we just want to not fail when we can't load the async provider
     // that use an unstable API and fallback on the default (blocking) provider
     try {
-      if (!Boolean.getBoolean(DISABLE_DNS_RESOLVER_PROP_NAME)) {
+      if (!SysProps.DISABLE_DNS_RESOLVER.getBoolean()) {
         return DnsAddressResolverProvider.create((VertxInternal) vertx, options);
       }
     } catch (Throwable e) {

--- a/src/main/java/io/vertx/core/spi/metrics/Metrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/Metrics.java
@@ -11,6 +11,8 @@
 
 package io.vertx.core.spi.metrics;
 
+import io.vertx.core.impl.SysProps;
+
 /**
  * The metrics interface is implemented by metrics providers that wants to provide monitoring of
  * Vert.x core.
@@ -19,9 +21,7 @@ package io.vertx.core.spi.metrics;
  */
 public interface Metrics {
 
-  String DISABLE_METRICS_PROPERTY_NAME = "vertx.disableMetrics";
-
-  boolean METRICS_ENABLED = !Boolean.getBoolean(DISABLE_METRICS_PROPERTY_NAME);
+  boolean METRICS_ENABLED = !SysProps.DISABLE_METRICS.getBoolean();
 
   /**
    * Used to close out the metrics, for example when an http server/client has been closed.<p/>

--- a/src/test/benchmarks/io/vertx/benchmarks/ContextBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/ContextBenchmark.java
@@ -13,6 +13,7 @@ package io.vertx.benchmarks;
 
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.impl.BenchmarkContext;
 import io.vertx.core.impl.ContextInternal;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -41,7 +42,7 @@ public class ContextBenchmark extends BenchmarkBase {
 
     @Setup
     public void setup() {
-      vertx = Vertx.vertx();
+      vertx = Vertx.vertx(new VertxOptions().setDisableTCCL(true));
       context = BenchmarkContext.create(vertx);
       task = v -> consume("the-string");
     }
@@ -53,7 +54,7 @@ public class ContextBenchmark extends BenchmarkBase {
   }
 
   @Benchmark
-  @Fork(jvmArgsAppend = { "-Dvertx.threadChecks=false", "-Dvertx.disableContextTimings=true", "-Dvertx.disableTCCL=true" })
+  @Fork(jvmArgsAppend = { "-Dvertx.threadChecks=false", "-Dvertx.disableContextTimings=true" })
   public void runOnContextNoChecks(BaselineState state) {
     state.context.runOnContext(state.task);
   }

--- a/src/test/benchmarks/io/vertx/core/http/impl/HttpServerHandlerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/core/http/impl/HttpServerHandlerBenchmark.java
@@ -37,6 +37,7 @@ import io.vertx.benchmarks.BenchmarkBase;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
@@ -204,7 +205,7 @@ public class HttpServerHandlerBenchmark extends BenchmarkBase {
 
   @Setup
   public void setup() {
-    vertx = (VertxInternal) Vertx.vertx();
+    vertx = (VertxInternal) Vertx.vertx(new VertxOptions().setDisableTCCL(true));
     HttpServerOptions options = new HttpServerOptions();
     vertxChannel = new EmbeddedChannel(
         new VertxHttpRequestDecoder(options),
@@ -329,7 +330,6 @@ public class HttpServerHandlerBenchmark extends BenchmarkBase {
   @Fork(value = 1, jvmArgsAppend = {
       "-Dvertx.threadChecks=false",
       "-Dvertx.disableContextTimings=true",
-      "-Dvertx.disableTCCL=true",
       "-Dvertx.disableHttpHeadersValidation=true",
       "-Dvertx.disableMetrics=true"
   })
@@ -343,7 +343,6 @@ public class HttpServerHandlerBenchmark extends BenchmarkBase {
   @Fork(value = 1, jvmArgsAppend = {
     "-Dvertx.threadChecks=false",
     "-Dvertx.disableContextTimings=true",
-    "-Dvertx.disableTCCL=true",
     "-Dvertx.disableHttpHeadersValidation=true",
     "-Dvertx.disableMetrics=false"
   })

--- a/src/test/java/io/vertx/core/impl/logging/LoggingBackendSelectionTest.java
+++ b/src/test/java/io/vertx/core/impl/logging/LoggingBackendSelectionTest.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.impl.logging;
 
+import io.vertx.core.impl.SysProps;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,7 +25,6 @@ import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 
-import static io.vertx.core.impl.logging.LoggerFactory.LOGGER_DELEGATE_FACTORY_CLASS_NAME;
 import static org.junit.Assert.assertEquals;
 
 
@@ -46,12 +46,12 @@ public class LoggingBackendSelectionTest {
   @After
   public void tearDown() {
     Thread.currentThread().setContextClassLoader(originalTccl);
-    System.clearProperty(LOGGER_DELEGATE_FACTORY_CLASS_NAME);
+    System.clearProperty(SysProps.LOGGER_DELEGATE_FACTORY_CLASS_NAME.name);
   }
 
   @Test
   public void syspropPriority() throws Exception {
-    System.setProperty(LOGGER_DELEGATE_FACTORY_CLASS_NAME, "io.vertx.core.logging.Log4j2LogDelegateFactory");
+    System.setProperty(SysProps.LOGGER_DELEGATE_FACTORY_CLASS_NAME.name, "io.vertx.core.logging.Log4j2LogDelegateFactory");
     assertEquals("Log4j2", loggingBackend());
   }
 

--- a/src/test/java/io/vertx/core/impl/logging/NoExceptionInInitializerErrorTest.java
+++ b/src/test/java/io/vertx/core/impl/logging/NoExceptionInInitializerErrorTest.java
@@ -12,6 +12,7 @@
 package io.vertx.core.impl.logging;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.SysProps;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.pattern.ConverterKeys;
@@ -19,8 +20,6 @@ import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
 import org.apache.logging.log4j.core.pattern.PatternConverter;
 import org.junit.After;
 import org.junit.Test;
-
-import static io.vertx.core.impl.logging.LoggerFactory.LOGGER_DELEGATE_FACTORY_CLASS_NAME;
 
 /**
  * Must be separated from {@link LoggingBackendSelectionTest}.
@@ -32,12 +31,12 @@ public class NoExceptionInInitializerErrorTest {
 
   @After
   public void tearDown() {
-    System.clearProperty(LOGGER_DELEGATE_FACTORY_CLASS_NAME);
+    System.clearProperty(SysProps.LOGGER_DELEGATE_FACTORY_CLASS_NAME.name);
   }
 
   @Test
   public void doTest() throws Exception {
-    System.setProperty(LOGGER_DELEGATE_FACTORY_CLASS_NAME, "io.vertx.core.logging.Log4j2LogDelegateFactory");
+    System.setProperty(SysProps.LOGGER_DELEGATE_FACTORY_CLASS_NAME.name, "io.vertx.core.logging.Log4j2LogDelegateFactory");
     // Will fail if:
     //  - the logging impl uses Vertx static methods (e.g. currentContext in a converter)
     //  - io.vertx.core.logging.LoggerFactory logs something before being fully initialized


### PR DESCRIPTION
- [x] introduce an enum representing core system properties that can be accounted for
- [x] `vertx.json.base64` removal
- [x] remove cluster manager system property
- [x] remove properties having a corresponding option which are not documented
  - [x] `vertx.javaCompilerOptions`
  - [x] `vertx.disableTCCL`
- [x] deprecate system properties  having a corresponding option which are documented
  - [x] discuss with @tsegismont the handling of file system properties as explained in the documentation
- [x] consider reifying system properties as env variable like `vertxweb.environment`
- [x] remaining properties analysis