### PR TITLE
More robust Json types deserialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
   ~
   ~ This program and the accompanying materials are made available under the
   ~ terms of the Eclipse Public License 2.0 which is available at
-  ~
   ~ http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
   ~ which is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-  ~
   --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -634,6 +632,22 @@
                 <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-core</classpathDependencyExclude>
                 <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-databind</classpathDependencyExclude>
               </classpathDependencyExcludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>customized-jackson-databind</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>io/vertx/it/CustomObjectMapperTest.java</include>
+              </includes>
+              <systemProperties>
+                <vertx-test-alpn-jdk>false</vertx-test-alpn-jdk>
+                <vertx-test-alpn-openssl>false</vertx-test-alpn-openssl>
+              </systemProperties>
             </configuration>
           </execution>
           <execution>

--- a/src/main/java/io/vertx/core/buffer/Buffer.java
+++ b/src/main/java/io/vertx/core/buffer/Buffer.java
@@ -129,7 +129,7 @@ public interface Buffer extends ClusterSerializable, Shareable {
    */
   @GenIgnore
   default Object toJson() {
-    return Json.CODEC.fromBuffer(this);
+    return Json.CODEC.fromBuffer(this, true);
   }
 
   /**

--- a/src/main/java/io/vertx/core/buffer/Buffer.java
+++ b/src/main/java/io/vertx/core/buffer/Buffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,6 @@ package io.vertx.core.buffer;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.buffer.impl.BufferInternal;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
@@ -112,12 +111,16 @@ public interface Buffer extends ClusterSerializable, Shareable {
   /**
    * Returns a Json object representation of the Buffer.
    */
-  JsonObject toJsonObject();
+  default JsonObject toJsonObject() {
+    return (JsonObject) toJson();
+  }
 
   /**
    * Returns a Json array representation of the Buffer.
    */
-  JsonArray toJsonArray();
+  default JsonArray toJsonArray() {
+    return (JsonArray) toJson();
+  }
 
   /**
    * Returns a Json representation of the Buffer.
@@ -126,7 +129,7 @@ public interface Buffer extends ClusterSerializable, Shareable {
    */
   @GenIgnore
   default Object toJson() {
-    return Json.CODEC.fromBuffer(this, Object.class);
+    return Json.CODEC.fromBuffer(this);
   }
 
   /**

--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,8 +17,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.Arguments;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -78,17 +76,6 @@ public class BufferImpl implements BufferInternal {
 
   public String toString(Charset enc) {
     return buffer.toString(enc);
-  }
-
-
-  @Override
-  public JsonObject toJsonObject() {
-    return new JsonObject(this);
-  }
-
-  @Override
-  public JsonArray toJsonArray() {
-    return new JsonArray(this);
   }
 
   public byte getByte(int pos) {

--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,9 +11,7 @@
 
 package io.vertx.core.json;
 
-import io.vertx.core.ServiceHelper;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.jackson.JacksonFactory;
 import io.vertx.core.spi.JsonFactory;
 import io.vertx.core.spi.json.JsonCodec;
 
@@ -32,7 +30,7 @@ public class Json {
    * using Jackson will be returned.
    * <br/>
    * When {@code jackson-databind} is available then a codec using it will be used otherwise
-   * the codec will only use {@code jackson-core} and provide best effort mapping.
+   * the codec will only use {@code jackson-core} and provide best-effort mapping.
    */
   public static io.vertx.core.spi.JsonFactory load() {
     return JsonFactory.load();
@@ -92,7 +90,7 @@ public class Json {
    * @throws DecodeException when there is a parsing or invalid mapping.
    */
   public static Object decodeValue(String str) throws DecodeException {
-    return decodeValue(str, Object.class);
+    return CODEC.fromString(str);
   }
 
   /**
@@ -104,7 +102,7 @@ public class Json {
    * @throws DecodeException when there is a parsing or invalid mapping.
    */
   public static Object decodeValue(Buffer buf) throws DecodeException {
-    return decodeValue(buf, Object.class);
+    return CODEC.fromBuffer(buf);
   }
 
   /**

--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -90,7 +90,7 @@ public class Json {
    * @throws DecodeException when there is a parsing or invalid mapping.
    */
   public static Object decodeValue(String str) throws DecodeException {
-    return CODEC.fromString(str);
+    return CODEC.fromString(str, true);
   }
 
   /**
@@ -102,7 +102,7 @@ public class Json {
    * @throws DecodeException when there is a parsing or invalid mapping.
    */
   public static Object decodeValue(Buffer buf) throws DecodeException {
-    return CODEC.fromBuffer(buf);
+    return CODEC.fromBuffer(buf, true);
   }
 
   /**

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -53,6 +53,9 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
       throw new NullPointerException();
     }
     fromJson(json);
+    if (list == null) {
+      throw new DecodeException("Invalid JSON array: " + json);
+    }
   }
 
   /**
@@ -84,6 +87,9 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
       throw new NullPointerException();
     }
     fromBuffer(buf);
+    if (list == null) {
+      throw new DecodeException("Invalid JSON array: " + buf);
+    }
   }
 
   /**
@@ -702,20 +708,14 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
     return pos + length + 4;
   }
 
+  @SuppressWarnings("unchecked")
   private void fromJson(String json) {
-    JsonArray decoded = (JsonArray) Json.CODEC.fromString(json);
-    if (decoded == null) {
-      throw new DecodeException("Invalid JSON array: " + json);
-    }
-    list = decoded.list;
+    list = (List<Object>) Json.CODEC.fromString(json, false);
   }
 
+  @SuppressWarnings("unchecked")
   private void fromBuffer(Buffer buf) {
-    JsonArray decoded = (JsonArray) Json.CODEC.fromBuffer(buf);
-    if (decoded == null) {
-      throw new DecodeException("Invalid JSON array: " + buf);
-    }
-    list = decoded.list;
+    list = (List<Object>) Json.CODEC.fromBuffer(buf, false);
   }
 
   private static class Iter implements Iterator<Object> {

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -53,9 +53,6 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
       throw new NullPointerException();
     }
     fromJson(json);
-    if (list == null) {
-      throw new DecodeException("Invalid JSON array: " + json);
-    }
   }
 
   /**
@@ -87,9 +84,6 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
       throw new NullPointerException();
     }
     fromBuffer(buf);
-    if (list == null) {
-      throw new DecodeException("Invalid JSON array: " + buf);
-    }
   }
 
   /**
@@ -709,11 +703,19 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
   }
 
   private void fromJson(String json) {
-    list = Json.CODEC.fromString(json, List.class);
+    JsonArray decoded = (JsonArray) Json.CODEC.fromString(json);
+    if (decoded == null) {
+      throw new DecodeException("Invalid JSON array: " + json);
+    }
+    list = decoded.list;
   }
 
   private void fromBuffer(Buffer buf) {
-    list = Json.CODEC.fromBuffer(buf, List.class);
+    JsonArray decoded = (JsonArray) Json.CODEC.fromBuffer(buf);
+    if (decoded == null) {
+      throw new DecodeException("Invalid JSON array: " + buf);
+    }
+    list = decoded.list;
   }
 
   private static class Iter implements Iterator<Object> {

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -49,6 +49,9 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
       throw new NullPointerException();
     }
     fromJson(json);
+    if (map == null) {
+      throw new DecodeException("Invalid JSON object: " + json);
+    }
   }
 
   /**
@@ -80,6 +83,9 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
       throw new NullPointerException();
     }
     fromBuffer(buf);
+    if (map == null) {
+      throw new DecodeException("Invalid JSON object: " + buf);
+    }
   }
 
   /**
@@ -1240,20 +1246,14 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
     return pos + length + 4;
   }
 
+  @SuppressWarnings("unchecked")
   private void fromJson(String json) {
-    JsonObject decoded = (JsonObject) Json.CODEC.fromString(json);
-    if (decoded == null) {
-      throw new DecodeException("Invalid JSON object: " + json);
-    }
-    map = decoded.map;
+    map = (Map<String, Object>) Json.CODEC.fromString(json, false);
   }
 
+  @SuppressWarnings("unchecked")
   private void fromBuffer(Buffer buf) {
-    JsonObject decoded = (JsonObject) Json.CODEC.fromBuffer(buf);
-    if (decoded == null) {
-      throw new DecodeException("Invalid JSON object: " + buf);
-    }
-    map = decoded.map;
+    map = (Map<String, Object>) Json.CODEC.fromBuffer(buf, false);
   }
 
   private static class Iter implements Iterator<Map.Entry<String, Object>> {

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -49,9 +49,6 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
       throw new NullPointerException();
     }
     fromJson(json);
-    if (map == null) {
-      throw new DecodeException("Invalid JSON object: " + json);
-    }
   }
 
   /**
@@ -83,9 +80,6 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
       throw new NullPointerException();
     }
     fromBuffer(buf);
-    if (map == null) {
-      throw new DecodeException("Invalid JSON object: " + buf);
-    }
   }
 
   /**
@@ -1247,11 +1241,19 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   }
 
   private void fromJson(String json) {
-    map = Json.CODEC.fromString(json, Map.class);
+    JsonObject decoded = (JsonObject) Json.CODEC.fromString(json);
+    if (decoded == null) {
+      throw new DecodeException("Invalid JSON object: " + json);
+    }
+    map = decoded.map;
   }
 
   private void fromBuffer(Buffer buf) {
-    map = Json.CODEC.fromBuffer(buf, Map.class);
+    JsonObject decoded = (JsonObject) Json.CODEC.fromBuffer(buf);
+    if (decoded == null) {
+      throw new DecodeException("Invalid JSON object: " + buf);
+    }
+    map = decoded.map;
   }
 
   private static class Iter implements Iterator<Map.Entry<String, Object>> {

--- a/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -89,9 +89,9 @@ public class DatabindCodec extends JacksonCodec {
     return fromParser(createParser(buf), typeRef);
   }
 
-  public static JsonParser createParser(BufferInternal buf) {
+  public static JsonParser createParser(Buffer buf) {
     try {
-      return DatabindCodec.mapper.getFactory().createParser((InputStream) new ByteBufInputStream(buf.getByteBuf()));
+      return DatabindCodec.mapper.getFactory().createParser((InputStream) new ByteBufInputStream(((BufferInternal) buf).getByteBuf()));
     } catch (IOException e) {
       throw new DecodeException("Failed to decode:" + e.getMessage(), e);
     }
@@ -103,6 +103,16 @@ public class DatabindCodec extends JacksonCodec {
     } catch (IOException e) {
       throw new DecodeException("Failed to decode:" + e.getMessage(), e);
     }
+  }
+
+  @Override
+  public Object fromString(String str) throws DecodeException {
+    return JacksonCodec.fromParser(createParser(str), Object.class);
+  }
+
+  @Override
+  public Object fromBuffer(Buffer buf) throws DecodeException {
+    return JacksonCodec.fromParser(createParser(buf), Object.class);
   }
 
   public static <T> T fromParser(JsonParser parser, Class<T> type) throws DecodeException {

--- a/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,12 +25,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.json.JsonCodec;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.StringWriter;
-import java.io.Writer;
+import java.io.*;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -42,8 +37,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static io.vertx.core.json.impl.JsonUtil.BASE64_DECODER;
+import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
 /**
@@ -184,10 +179,12 @@ public class JacksonCodec implements JsonCodec {
     }
   }
 
+  @Override
   public Object fromString(String str) throws DecodeException {
     return fromParser(createParser(str), Object.class);
   }
 
+  @Override
   public Object fromBuffer(Buffer buf) throws DecodeException {
     return fromParser(createParser(buf), Object.class);
   }
@@ -232,7 +229,7 @@ public class JacksonCodec implements JsonCodec {
     }
   }
 
-  private static Map<String, Object> parseObject(JsonParser parser) throws IOException {
+  public static Map<String, Object> parseObject(JsonParser parser) throws IOException {
     String key1 = parser.nextFieldName();
     if (key1 == null) {
       return new LinkedHashMap<>(2);
@@ -267,7 +264,7 @@ public class JacksonCodec implements JsonCodec {
     return obj;
   }
 
-  private static List<Object> parseArray(JsonParser parser) throws IOException {
+  public static List<Object> parseArray(JsonParser parser) throws IOException {
     List<Object> array = new ArrayList<>();
     while (true) {
       parser.nextToken();

--- a/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -180,13 +180,15 @@ public class JacksonCodec implements JsonCodec {
   }
 
   @Override
-  public Object fromString(String str) throws DecodeException {
-    return fromParser(createParser(str), Object.class);
+  public Object fromString(String str, boolean wrap) throws DecodeException {
+    Object value = fromParser(createParser(str), Object.class);
+    return wrap ? wrap(value) : value;
   }
 
   @Override
-  public Object fromBuffer(Buffer buf) throws DecodeException {
-    return fromParser(createParser(buf), Object.class);
+  public Object fromBuffer(Buffer buf, boolean wrap) throws DecodeException {
+    Object value = fromParser(createParser(buf), Object.class);
+    return wrap ? wrap(value) : value;
   }
 
   public static <T> T fromParser(JsonParser parser, Class<T> type) throws DecodeException {
@@ -414,16 +416,10 @@ public class JacksonCodec implements JsonCodec {
       if (!clazz.isAssignableFrom(Map.class)) {
         throw new DecodeException("Failed to decode");
       }
-      if (clazz == Object.class) {
-        o = new JsonObject((Map) o);
-      }
       return clazz.cast(o);
     } else if (o instanceof List) {
       if (!clazz.isAssignableFrom(List.class)) {
         throw new DecodeException("Failed to decode");
-      }
-      if (clazz == Object.class) {
-        o = new JsonArray((List) o);
       }
       return clazz.cast(o);
     } else if (o instanceof String) {
@@ -461,9 +457,7 @@ public class JacksonCodec implements JsonCodec {
         o = number.byteValue();
       } else if (clazz == Short.class) {
         o = number.shortValue();
-      } else if (clazz == Object.class || clazz.isAssignableFrom(Number.class)) {
-        // Nothing
-      } else {
+      } else if (clazz != Object.class && !clazz.isAssignableFrom(Number.class)) {
         throw new DecodeException("Failed to decode");
       }
       return clazz.cast(o);

--- a/src/main/java/io/vertx/core/json/jackson/JsonArrayDeserializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/JsonArrayDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,11 +16,16 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.vertx.core.json.JsonArray;
 
 import java.io.IOException;
-import java.util.List;
 
 class JsonArrayDeserializer extends JsonDeserializer<JsonArray> {
+
+  @Override
+  public boolean isCachable() {
+    return true;
+  }
+
   @Override
   public JsonArray deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-    return new JsonArray(p.readValueAs(List.class));
+    return new JsonArray(JacksonCodec.parseArray(p));
   }
 }

--- a/src/main/java/io/vertx/core/json/jackson/JsonObjectDeserializer.java
+++ b/src/main/java/io/vertx/core/json/jackson/JsonObjectDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,20 +11,21 @@
 package io.vertx.core.json.jackson;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.vertx.core.json.JsonObject;
 
 import java.io.IOException;
-import java.util.Map;
 
 class JsonObjectDeserializer extends JsonDeserializer<JsonObject> {
 
-  private static final TypeReference<Map<String, Object>> TYPE_REF = new TypeReference<>() {
-  };
+  @Override
+  public boolean isCachable() {
+    return true;
+  }
 
+  @Override
   public JsonObject deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-    return new JsonObject(p.<Map<String, Object>>readValueAs(TYPE_REF));
+    return new JsonObject(JacksonCodec.parseObject(p));
   }
 }

--- a/src/main/java/io/vertx/core/spi/json/JsonCodec.java
+++ b/src/main/java/io/vertx/core/spi/json/JsonCodec.java
@@ -17,6 +17,9 @@ import io.vertx.core.json.EncodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -26,11 +29,28 @@ public interface JsonCodec {
    * Decode a given JSON string.
    *
    * @param json the JSON string.
+   * @param wrap
    * @return a JSON element which can be a {@link JsonArray}, {@link JsonObject}, {@link String}, ...etc. if the string contains an array, object, string, ...etc
    * @throws DecodeException when there is a parsing or invalid mapping.
    */
-  default Object fromString(String json) throws DecodeException {
-    return fromString(json, Object.class);
+  default Object fromString(String json, boolean wrap) throws DecodeException {
+    Object value = fromString(json, Object.class);
+    return wrap ? wrap(value) : value;
+  }
+
+  /**
+   * Wrap Java {@link Map} in a {@link JsonObject},{@link List} in {@link JsonArray}.
+   * Otherwise, return the {@code value} unchanged.
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  default Object wrap(Object value) {
+    if (value instanceof Map) {
+      return new JsonObject((Map<String, Object>) value);
+    }
+    if (value instanceof List) {
+      return new JsonArray((List) value);
+    }
+    return value;
   }
 
   /**
@@ -44,10 +64,11 @@ public interface JsonCodec {
   <T> T fromString(String json, Class<T> clazz) throws DecodeException;
 
   /**
-   * Like {@link #fromString(String)} but with a json {@link Buffer}
+   * Like {@link #fromString(String, boolean)} but with a json {@link Buffer}
    */
-  default Object fromBuffer(Buffer json) throws DecodeException {
-    return fromBuffer(json, Object.class);
+  default Object fromBuffer(Buffer json, boolean wrap) throws DecodeException {
+    Object value = fromBuffer(json, Object.class);
+    return wrap ? wrap(value) : value;
   }
 
   /**

--- a/src/main/java/io/vertx/core/spi/json/JsonCodec.java
+++ b/src/main/java/io/vertx/core/spi/json/JsonCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,11 +14,24 @@ package io.vertx.core.spi.json;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.EncodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public interface JsonCodec {
+
+  /**
+   * Decode a given JSON string.
+   *
+   * @param json the JSON string.
+   * @return a JSON element which can be a {@link JsonArray}, {@link JsonObject}, {@link String}, ...etc. if the string contains an array, object, string, ...etc
+   * @throws DecodeException when there is a parsing or invalid mapping.
+   */
+  default Object fromString(String json) throws DecodeException {
+    return fromString(json, Object.class);
+  }
 
   /**
    * Decode the provide {@code json} string to an object extending {@code clazz}.
@@ -29,6 +42,13 @@ public interface JsonCodec {
    * @throws DecodeException anything preventing the decoding
    */
   <T> T fromString(String json, Class<T> clazz) throws DecodeException;
+
+  /**
+   * Like {@link #fromString(String)} but with a json {@link Buffer}
+   */
+  default Object fromBuffer(Buffer json) throws DecodeException {
+    return fromBuffer(json, Object.class);
+  }
 
   /**
    * Like {@link #fromString(String, Class)} but with a json {@link Buffer}

--- a/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -106,11 +106,15 @@ public class JacksonDatabindTest extends VertxTestBase {
   @Test
   public void testJsonArrayDeserializer() throws JsonProcessingException {
 
-    String jsonArrayString = "[1, 2, 3]";
+    String jsonArrayString = "[[1, 2, 3], 2, {\"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"value3\"}]";
     JsonArray jsonArray = DatabindCodec.mapper().readValue(jsonArrayString, JsonArray.class);
 
     assertEquals(3, jsonArray.size());
-    assertEquals(new JsonArray().add(1).add(2).add(3), jsonArray);
+    JsonArray expected = new JsonArray()
+      .add(new JsonArray().add(1).add(2).add(3))
+      .add(2)
+      .add(new JsonObject().put("key1", "value1").put("key2", "value2").put("key3", "value3"));
+    assertEquals(expected, jsonArray);
 
   }
 
@@ -118,12 +122,12 @@ public class JacksonDatabindTest extends VertxTestBase {
   @Test
   public void testJsonObjectDeserializer() throws JsonProcessingException {
 
-    String jsonObjectString = "{\"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"value3\"}";
+    String jsonObjectString = "{\"key1\": \"value1\", \"key2\": [1, 2, 3], \"key3\": \"value3\"}";
 
     JsonObject jsonObject = DatabindCodec.mapper().readValue(jsonObjectString, JsonObject.class);
 
     assertEquals("value1", jsonObject.getString("key1"));
-    assertEquals("value2", jsonObject.getString("key2"));
+    assertEquals(new JsonArray().add(1).add(2).add(3), jsonObject.getJsonArray("key2"));
 
   }
 

--- a/src/test/java/io/vertx/core/json/JsonCodecTest.java
+++ b/src/test/java/io/vertx/core/json/JsonCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,24 +28,12 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Collection;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class JsonCodecTest {
@@ -479,29 +467,29 @@ public class JsonCodecTest {
 
   private void testDecodeUnknowContent(boolean asBuffer) {
     String number = String.valueOf(1);
-    assertEquals(1, asBuffer ? mapper.fromBuffer(Buffer.buffer(number)) : mapper.fromString(number));
+    assertEquals(1, asBuffer ? mapper.fromBuffer(Buffer.buffer(number), true) : mapper.fromString(number, true));
 
     String bool = Boolean.TRUE.toString();
-    assertEquals(true, asBuffer ?mapper.fromBuffer(Buffer.buffer(bool)) : mapper.fromString(bool));
+    assertEquals(true, asBuffer ? mapper.fromBuffer(Buffer.buffer(bool), true) : mapper.fromString(bool, true));
 
     String text = "\"whatever\"";
-    assertEquals("whatever", asBuffer ? mapper.fromBuffer(Buffer.buffer(text)) : mapper.fromString(text));
+    assertEquals("whatever", asBuffer ? mapper.fromBuffer(Buffer.buffer(text), true) : mapper.fromString(text, true));
 
     String nullText = "null";
-    assertNull(asBuffer ? mapper.fromBuffer(Buffer.buffer(nullText)) : mapper.fromString(nullText));
+    assertNull(asBuffer ? mapper.fromBuffer(Buffer.buffer(nullText), true) : mapper.fromString(nullText, true));
 
     JsonObject obj = new JsonObject().put("foo", "bar");
-    assertEquals(obj, asBuffer ? mapper.fromBuffer(obj.toBuffer()) : mapper.fromString(obj.toString()));
+    assertEquals(obj, asBuffer ? mapper.fromBuffer(obj.toBuffer(), true) : mapper.fromString(obj.toString(), true));
 
     JsonArray arr = new JsonArray().add(1).add(false).add("whatever").add(obj);
-    assertEquals(arr, asBuffer ? mapper.fromBuffer(arr.toBuffer()) : mapper.fromString(arr.toString()));
+    assertEquals(arr, asBuffer ? mapper.fromBuffer(arr.toBuffer(), true) : mapper.fromString(arr.toString(), true));
 
     String invalidText = "\"invalid";
     try {
       if (asBuffer) {
-        mapper.fromBuffer(Buffer.buffer(invalidText));
+        mapper.fromBuffer(Buffer.buffer(invalidText), true);
       } else {
-        mapper.fromString(invalidText);
+        mapper.fromString(invalidText, true);
       }
       fail();
     } catch (DecodeException ignore) {

--- a/src/test/java/io/vertx/it/CustomObjectMapperTest.java
+++ b/src/test/java/io/vertx/it/CustomObjectMapperTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.it;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.databind.type.MapType;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.jackson.DatabindCodec;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.Assert.*;
+
+/**
+ * This test verifies that, even when the user registers a Jackson Databind module that modifies container types,
+ * such as the Scala module, Vert.x can properly deserialize {@link JsonObject}, {@link JsonArray},
+ * or a POJO with fields having one these types.
+ */
+public class CustomObjectMapperTest {
+
+  private static final MyBeanDeserializerModifier DESERIALIZER_MODIFIER = new MyBeanDeserializerModifier();
+
+  @BeforeClass
+  public static void beforeClass() {
+    DatabindCodec.mapper().registerModule(new SimpleModule().setDeserializerModifier(DESERIALIZER_MODIFIER));
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    DESERIALIZER_MODIFIER.reset();
+  }
+
+  @Test
+  public void testDecodeJsonArray() {
+    String jsonArrayString = "[[1, 2, 3], 2, {\"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"value3\"}]";
+
+    JsonArray jsonArray = (JsonArray) Json.decodeValue(jsonArrayString);
+
+    assertEquals(3, jsonArray.size());
+    JsonArray expected = new JsonArray()
+      .add(new JsonArray().add(1).add(2).add(3))
+      .add(2)
+      .add(new JsonObject().put("key1", "value1").put("key2", "value2").put("key3", "value3"));
+    assertEquals(expected, jsonArray);
+  }
+
+  @Test
+  public void testDecodeJsonObject() {
+    String jsonObjectString = "{\"key1\": \"value1\", \"key2\": [1, 2, 3], \"key3\": \"value3\"}";
+
+    JsonObject jsonObject = (JsonObject) Json.decodeValue(jsonObjectString);
+
+    assertEquals("value1", jsonObject.getString("key1"));
+    assertEquals(new JsonArray().add(1).add(2).add(3), jsonObject.getJsonArray("key2"));
+  }
+
+  @Test
+  public void testDecodePojo() {
+    String jsonString = "{" +
+                        "\"str\": \"foo\"," +
+                        "\"when\": \"2011-12-03T10:15:30Z\"," +
+                        "\"nil\": null," +
+                        "\"obj\": {\"key1\": \"value1\", \"key2\": [1, false, 3], \"key3\": \"value3\"}," +
+                        "\"arr\": [[1, 2, 3], 2, {\"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"value3\"}]" +
+                        "}";
+
+    PojoWithEmbeddedJson pojo = Json.decodeValue(jsonString, PojoWithEmbeddedJson.class);
+
+    assertEquals("foo", pojo.str);
+    assertEquals(LocalDateTime.of(2011, 12, 3, 10, 15, 30).toInstant(ZoneOffset.UTC), pojo.when);
+    assertNull("foo", pojo.nil);
+    JsonArray expectedArr = new JsonArray()
+      .add(new JsonArray().add(1).add(2).add(3))
+      .add(2)
+      .add(new JsonObject().put("key1", "value1").put("key2", "value2").put("key3", "value3"));
+    assertEquals(expectedArr, pojo.arr);
+    JsonObject expectedObj = new JsonObject()
+      .put("key1", "value1")
+      .put("key2", new JsonArray().add(1).add(false).add(3))
+      .put("key3", "value3");
+    assertEquals(expectedObj, pojo.obj);
+
+
+    assertTrue(DESERIALIZER_MODIFIER.collectionDeserializerModified);
+    assertTrue(DESERIALIZER_MODIFIER.mapDeserializerModified);
+  }
+
+  @SuppressWarnings("unused")
+  public static class PojoWithEmbeddedJson {
+
+    private String str;
+    private Instant when;
+    private Object nil;
+    private JsonObject obj;
+    private JsonArray arr;
+
+    public String getStr() {
+      return str;
+    }
+
+    public void setStr(String str) {
+      this.str = str;
+    }
+
+    public Instant getWhen() {
+      return when;
+    }
+
+    public void setWhen(Instant when) {
+      this.when = when;
+    }
+
+    public Object getNil() {
+      return nil;
+    }
+
+    public void setNil(Object nil) {
+      this.nil = nil;
+    }
+
+    public JsonObject getObj() {
+      return obj;
+    }
+
+    public void setObj(JsonObject obj) {
+      this.obj = obj;
+    }
+
+    public JsonArray getArr() {
+      return arr;
+    }
+
+    public void setArr(JsonArray arr) {
+      this.arr = arr;
+    }
+  }
+
+  private static class MyBeanDeserializerModifier extends BeanDeserializerModifier {
+
+    boolean collectionDeserializerModified = true;
+    boolean mapDeserializerModified = true;
+
+    @Override
+    public JsonDeserializer<?> modifyCollectionDeserializer(DeserializationConfig config, CollectionType type, BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
+      collectionDeserializerModified = true;
+      return new CustomDeserializer();
+    }
+
+    @Override
+    public JsonDeserializer<?> modifyMapDeserializer(DeserializationConfig config, MapType type, BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
+      mapDeserializerModified = true;
+      return new CustomDeserializer();
+    }
+
+    public void reset() {
+      collectionDeserializerModified = mapDeserializerModified = false;
+    }
+  }
+
+  private static class CustomDeserializer extends JsonDeserializer<Object> {
+    @Override
+    public Object deserialize(JsonParser parser, DeserializationContext ctx) {
+      throw new AssertionError("Should not be used");
+    }
+  }
+}


### PR DESCRIPTION
Possible fix for #5058 

Users can register a Jackson Databind module that modifies container types, such as the Scala module. In this case, Vert.x wasn't able to deserialize properly a `JsonObject`, `JsonArray`, or a POJO with fields having one these types. The reason is that Vert.x expected instances of `Map` and `List` before wrapping to `JsonObject` and `JsonArray`, respectively.

In this change, we introduce two methods on the `JsonCodec` type, which allow to decode a JSON string or buffer without prior knowledge of the expected Java type. For backwards compatibility, the default implementation delegates to the existing method, using the `Object` type. In the `DatabindCodec` implementation, these new methods delegate parsing to the `JacksonCodec`. Consequently, we can be sure no Jackson Databind module can interfere with the deserialization of `JsonObject` and `JsonArray`.

Similarly, the `JsonArrayDeserializer` and `JsonObjectDeserializer` now delegate parsing to the `JacksonCodec`. This is required to properly deserialize Vert.x Json objects embedded in a POJO.

Side fix: the `DatabindCodec.createParser` method takes a `Buffer` parameter again, instead of a `BufferInternal.` The method was no longer used. Instead, the `createParser` method of the `JacksonCodec` parent class was used.