### PR TITLE
Deprecate DatabindCodec pretty mapper

### DIFF
--- a/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.netty.buffer.ByteBufInputStream;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
@@ -26,7 +25,6 @@ import io.vertx.core.json.JsonObject;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -63,7 +61,9 @@ public class DatabindCodec extends JacksonCodec {
 
   /**
    * @return the {@link ObjectMapper} used for data binding configured for indenting output.
+   * @deprecated as of 4.5.2, use {@link ObjectMapper#writerWithDefaultPrettyPrinter()} instead
    */
+  @Deprecated
   public static ObjectMapper prettyMapper() {
     return prettyMapper;
   }

--- a/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
@@ -22,7 +22,9 @@ import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
@@ -38,6 +40,7 @@ public class JacksonDatabindTest extends VertxTestBase {
     assertNotNull(mapper);
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void testGetPrettyMapper() {
     ObjectMapper mapper = DatabindCodec.prettyMapper();


### PR DESCRIPTION
There is no need to keep two object mappers if a single one can be used to encode json in compact and pretty form. This change relieves users from configuring two object mappers if they have customizations.