### PR TITLE
pply the queueing pattern to the initial message written by the HTTP client connection to preserve ordering of subsequent messages 

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -38,7 +38,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
 
   private static final MultiMap EMPTY = new Http2HeadersAdaptor(EmptyHttp2Headers.INSTANCE);
 
-  private final OutboundMessageQueue<MessageWrite> messageQueue;
+  protected final OutboundMessageQueue<MessageWrite> messageQueue;
   protected final C conn;
   protected final VertxInternal vertx;
   protected final ContextInternal context;


### PR DESCRIPTION
The HTTP client connection handle buffer writes from a non vertx thread and will re-schedule any message sent by the event-loop thread to preserve ordering. However this is not applied to the initial message is sent and therefore it is possible to have the initial message written after the subsequent HTTP messages.
