### PR TITLE
Implementation of an HTTP client connection API.

### DIFF
--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -1581,6 +1581,8 @@ The {@link io.vertx.core.http.HttpClientConnection} can create {@link io.vertx.c
 {@link examples.HTTPExamples#connectAndGet}
 ----
 
+A client connection can handle a certain amount of concurrent requests. When the max number of connection is reached, any subsequent request is queued until a slot is available.
+
 === HTTP connections
 
 The {@link io.vertx.core.http.HttpConnection} offers the API for dealing with HTTP connection events, lifecycle

--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -1564,7 +1564,7 @@ connections not used within this timeout will be closed. Please note the idle ti
 
 ==== Un-pooled client connections
 
-Most HTTP interactions are performed using {@code HttpClient} request/response API: the client obtains
+Most HTTP interactions are performed using {@code HttpClientAgent} request/response API: the client obtains
 a connection from its pool of connections to perform a request.
 
 Alternatively, you can connect directly to a server (bypassing the connection pool) and get an HTTP client connection.

--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -1562,6 +1562,25 @@ or close the client instance.
 Alternatively you can set idle timeout using {@link io.vertx.core.http.HttpClientOptions#setIdleTimeout(int)} - any
 connections not used within this timeout will be closed. Please note the idle timeout value is in seconds not milliseconds.
 
+==== Un-pooled client connections
+
+Most HTTP interactions are performed using {@code HttpClient} request/response API: the client obtains
+a connection from its pool of connections to perform a request.
+
+Alternatively, you can connect directly to a server (bypassing the connection pool) and get an HTTP client connection.
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#connect}
+----
+
+The {@link io.vertx.core.http.HttpClientConnection} can create {@link io.vertx.core.http.HttpClientRequest}:
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#connectAndGet}
+----
+
 === HTTP connections
 
 The {@link io.vertx.core.http.HttpConnection} offers the API for dealing with HTTP connection events, lifecycle

--- a/src/main/generated/io/vertx/core/http/HttpConnectOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpConnectOptionsConverter.java
@@ -1,0 +1,79 @@
+package io.vertx.core.http;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+/**
+ * Converter and mapper for {@link io.vertx.core.http.HttpConnectOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.core.http.HttpConnectOptions} original class using Vert.x codegen.
+ */
+public class HttpConnectOptionsConverter {
+
+
+  private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+  private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+   static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, HttpConnectOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "proxyOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setProxyOptions(new io.vertx.core.net.ProxyOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+        case "host":
+          if (member.getValue() instanceof String) {
+            obj.setHost((String)member.getValue());
+          }
+          break;
+        case "port":
+          if (member.getValue() instanceof Number) {
+            obj.setPort(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "ssl":
+          if (member.getValue() instanceof Boolean) {
+            obj.setSsl((Boolean)member.getValue());
+          }
+          break;
+        case "sslOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setSslOptions(new io.vertx.core.net.ClientSSLOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+        case "connectTimeout":
+          if (member.getValue() instanceof Number) {
+            obj.setConnectTimeout(((Number)member.getValue()).longValue());
+          }
+          break;
+      }
+    }
+  }
+
+   static void toJson(HttpConnectOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+   static void toJson(HttpConnectOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getProxyOptions() != null) {
+      json.put("proxyOptions", obj.getProxyOptions().toJson());
+    }
+    if (obj.getHost() != null) {
+      json.put("host", obj.getHost());
+    }
+    if (obj.getPort() != null) {
+      json.put("port", obj.getPort());
+    }
+    if (obj.isSsl() != null) {
+      json.put("ssl", obj.isSsl());
+    }
+    if (obj.getSslOptions() != null) {
+      json.put("sslOptions", obj.getSslOptions().toJson());
+    }
+    json.put("connectTimeout", obj.getConnectTimeout());
+  }
+}

--- a/src/main/generated/io/vertx/core/http/RequestOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/RequestOptionsConverter.java
@@ -20,31 +20,6 @@ public class RequestOptionsConverter {
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, RequestOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "proxyOptions":
-          if (member.getValue() instanceof JsonObject) {
-            obj.setProxyOptions(new io.vertx.core.net.ProxyOptions((io.vertx.core.json.JsonObject)member.getValue()));
-          }
-          break;
-        case "host":
-          if (member.getValue() instanceof String) {
-            obj.setHost((String)member.getValue());
-          }
-          break;
-        case "port":
-          if (member.getValue() instanceof Number) {
-            obj.setPort(((Number)member.getValue()).intValue());
-          }
-          break;
-        case "ssl":
-          if (member.getValue() instanceof Boolean) {
-            obj.setSsl((Boolean)member.getValue());
-          }
-          break;
-        case "sslOptions":
-          if (member.getValue() instanceof JsonObject) {
-            obj.setSslOptions(new io.vertx.core.net.ClientSSLOptions((io.vertx.core.json.JsonObject)member.getValue()));
-          }
-          break;
         case "uri":
           if (member.getValue() instanceof String) {
             obj.setURI((String)member.getValue());
@@ -58,11 +33,6 @@ public class RequestOptionsConverter {
         case "timeout":
           if (member.getValue() instanceof Number) {
             obj.setTimeout(((Number)member.getValue()).longValue());
-          }
-          break;
-        case "connectTimeout":
-          if (member.getValue() instanceof Number) {
-            obj.setConnectTimeout(((Number)member.getValue()).longValue());
           }
           break;
         case "idleTimeout":
@@ -89,21 +59,6 @@ public class RequestOptionsConverter {
   }
 
    static void toJson(RequestOptions obj, java.util.Map<String, Object> json) {
-    if (obj.getProxyOptions() != null) {
-      json.put("proxyOptions", obj.getProxyOptions().toJson());
-    }
-    if (obj.getHost() != null) {
-      json.put("host", obj.getHost());
-    }
-    if (obj.getPort() != null) {
-      json.put("port", obj.getPort());
-    }
-    if (obj.isSsl() != null) {
-      json.put("ssl", obj.isSsl());
-    }
-    if (obj.getSslOptions() != null) {
-      json.put("sslOptions", obj.getSslOptions().toJson());
-    }
     if (obj.getURI() != null) {
       json.put("uri", obj.getURI());
     }
@@ -111,7 +66,6 @@ public class RequestOptionsConverter {
       json.put("followRedirects", obj.getFollowRedirects());
     }
     json.put("timeout", obj.getTimeout());
-    json.put("connectTimeout", obj.getConnectTimeout());
     json.put("idleTimeout", obj.getIdleTimeout());
     if (obj.getTraceOperation() != null) {
       json.put("traceOperation", obj.getTraceOperation());

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -1320,4 +1320,22 @@ public class HTTPExamples {
       .withLoadBalancer(LoadBalancer.ROUND_ROBIN)
       .build();
   }
+
+  public static void connect(HttpClient client) {
+    HttpConnectOptions connectOptions = new HttpConnectOptions()
+      .setHost("example.com")
+      .setPort(80);
+
+    Future<HttpClientConnection> fut = client.connect(connectOptions);
+  }
+
+  public static void connectAndGet(HttpClientConnection connection) {
+    connection
+      .createRequest()
+      .onSuccess(request -> {
+        request.setMethod(HttpMethod.GET);
+        request.setURI("/some-uri");
+        Future<HttpClientResponse> response = request.send();
+      });
+  }
 }

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -322,27 +322,27 @@ public class HTTPExamples {
   }
 
   public void example28(Vertx vertx) {
-    HttpClient client = vertx.createHttpClient();
+    HttpClientAgent client = vertx.createHttpClient();
   }
 
   public void example29(Vertx vertx) {
     HttpClientOptions options = new HttpClientOptions().setKeepAlive(false);
-    HttpClient client = vertx.createHttpClient(options);
+    HttpClientAgent client = vertx.createHttpClient(options);
   }
 
   public void examplePoolConfiguration(Vertx vertx) {
     PoolOptions options = new PoolOptions().setHttp1MaxSize(10);
-    HttpClient client = vertx.createHttpClient(options);
+    HttpClientAgent client = vertx.createHttpClient(options);
   }
 
   public void exampleClientLogging(Vertx vertx) {
     HttpClientOptions options = new HttpClientOptions().setLogActivity(true);
-    HttpClient client = vertx.createHttpClient(options);
+    HttpClientAgent client = vertx.createHttpClient(options);
   }
 
   public void exampleClientBuilder01(Vertx vertx, HttpClientOptions options) {
     // Pretty much like vertx.createHttpClient(options)
-    HttpClient build = vertx
+    HttpClientAgent build = vertx
       .httpClientBuilder()
       .with(options)
       .build();
@@ -364,7 +364,7 @@ public class HTTPExamples {
     HttpClientOptions options = new HttpClientOptions().setDefaultHost("wibble.com");
 
     // Can also set default port if you want...
-    HttpClient client = vertx.createHttpClient(options);
+    HttpClientAgent client = vertx.createHttpClient(options);
     client
       .request(HttpMethod.GET, "/some-uri")
       .onComplete(ar1 -> {
@@ -384,7 +384,7 @@ public class HTTPExamples {
 
   public void example32(Vertx vertx) {
 
-    HttpClient client = vertx.createHttpClient();
+    HttpClientAgent client = vertx.createHttpClient();
 
     // Write some headers using the headers multi-map
     MultiMap headers = HttpHeaders.set("content-type", "application/json").set("other-header", "foo");
@@ -490,7 +490,7 @@ public class HTTPExamples {
       });
   }
   public void example34(Vertx vertx, String body) {
-    HttpClient client = vertx.createHttpClient();
+    HttpClientAgent client = vertx.createHttpClient();
 
     client.request(HttpMethod.POST, "some-uri")
       .onSuccess(request -> {
@@ -815,7 +815,7 @@ public class HTTPExamples {
 
   public void exampleFollowRedirect02(Vertx vertx) {
 
-    HttpClient client = vertx.createHttpClient(
+    HttpClientAgent client = vertx.createHttpClient(
         new HttpClientOptions()
             .setMaxRedirects(32));
 
@@ -844,7 +844,7 @@ public class HTTPExamples {
   }
 
   public void exampleFollowRedirect03(Vertx vertx) {
-    HttpClient client = vertx.httpClientBuilder()
+    HttpClientAgent client = vertx.httpClientBuilder()
       .withRedirectHandler(response -> {
 
         // Only follow 301 code
@@ -1127,7 +1127,7 @@ public class HTTPExamples {
         .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTP)
             .setHost("localhost").setPort(3128)
             .setUsername("username").setPassword("secret"));
-    HttpClient client = vertx.createHttpClient(options);
+    HttpClientAgent client = vertx.createHttpClient(options);
 
   }
 
@@ -1137,7 +1137,7 @@ public class HTTPExamples {
         .setProxyOptions(new ProxyOptions().setType(ProxyType.SOCKS5)
             .setHost("localhost").setPort(1080)
             .setUsername("username").setPassword("secret"));
-    HttpClient client = vertx.createHttpClient(options);
+    HttpClientAgent client = vertx.createHttpClient(options);
 
   }
 
@@ -1149,7 +1149,7 @@ public class HTTPExamples {
         .setUsername("username").setPassword("secret"))
       .addNonProxyHost("*.foo.com")
       .addNonProxyHost("localhost");
-    HttpClient client = vertx.createHttpClient(options);
+    HttpClientAgent client = vertx.createHttpClient(options);
 
   }
 
@@ -1170,7 +1170,7 @@ public class HTTPExamples {
 
     HttpClientOptions options = new HttpClientOptions()
         .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTP));
-    HttpClient client = vertx.createHttpClient(options);
+    HttpClientAgent client = vertx.createHttpClient(options);
     client
       .request(HttpMethod.GET, "ftp://ftp.gnu.org/gnu/")
       .onComplete(ar -> {
@@ -1281,7 +1281,7 @@ public class HTTPExamples {
   }
 
   public static void httpClientSharing1(Vertx vertx) {
-    HttpClient client = vertx.createHttpClient(new HttpClientOptions().setShared(true));
+    HttpClientAgent client = vertx.createHttpClient(new HttpClientOptions().setShared(true));
     vertx.deployVerticle(() -> new AbstractVerticle() {
       @Override
       public void start() throws Exception {
@@ -1292,7 +1292,7 @@ public class HTTPExamples {
 
   public static void httpClientSharing2(Vertx vertx) {
     vertx.deployVerticle(() -> new AbstractVerticle() {
-      HttpClient client;
+      HttpClientAgent client;
       @Override
       public void start() {
         // Get or create a shared client
@@ -1305,7 +1305,7 @@ public class HTTPExamples {
 
   public static void httpClientSharing3(Vertx vertx) {
     vertx.deployVerticle(() -> new AbstractVerticle() {
-      HttpClient client;
+      HttpClientAgent client;
       @Override
       public void start() {
         // The client creates and use two event-loops for 4 instances
@@ -1315,13 +1315,13 @@ public class HTTPExamples {
   }
 
   public static void httpClientSideLoadBalancing(Vertx vertx) {
-    HttpClient client = vertx
+    HttpClientAgent client = vertx
       .httpClientBuilder()
       .withLoadBalancer(LoadBalancer.ROUND_ROBIN)
       .build();
   }
 
-  public static void connect(HttpClient client) {
+  public static void connect(HttpClientAgent client) {
     HttpConnectOptions connectOptions = new HttpConnectOptions()
       .setHost("example.com")
       .setPort(80);

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -1331,7 +1331,7 @@ public class HTTPExamples {
 
   public static void connectAndGet(HttpClientConnection connection) {
     connection
-      .createRequest()
+      .request()
       .onSuccess(request -> {
         request.setMethod(HttpMethod.GET);
         request.setURI("/some-uri");

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -139,7 +139,7 @@ public class NetExamples {
     });
 
     // A few moments later
-    client.close(30, TimeUnit.SECONDS);
+    client.shutdown(30, TimeUnit.SECONDS);
   }
 
   public void example9_1(NetSocket socket) {

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -248,7 +248,7 @@ public interface Vertx extends Measured {
    * @param poolOptions  the pool options to use
    * @return the client
    */
-  default HttpClient createHttpClient(HttpClientOptions clientOptions, PoolOptions poolOptions) {
+  default HttpClientAgent createHttpClient(HttpClientOptions clientOptions, PoolOptions poolOptions) {
     return httpClientBuilder().with(clientOptions).with(poolOptions).build();
   }
 
@@ -258,7 +258,7 @@ public interface Vertx extends Measured {
    * @param clientOptions  the options to use
    * @return the client
    */
-  default HttpClient createHttpClient(HttpClientOptions clientOptions) {
+  default HttpClientAgent createHttpClient(HttpClientOptions clientOptions) {
     return createHttpClient(clientOptions, new PoolOptions());
   }
 
@@ -268,7 +268,7 @@ public interface Vertx extends Measured {
    * @param poolOptions  the pool options to use
    * @return the client
    */
-  default HttpClient createHttpClient(PoolOptions poolOptions) {
+  default HttpClientAgent createHttpClient(PoolOptions poolOptions) {
     return createHttpClient(new HttpClientOptions(), poolOptions);
   }
 
@@ -277,9 +277,10 @@ public interface Vertx extends Measured {
    *
    * @return the client
    */
-  default HttpClient createHttpClient() {
+  default HttpClientAgent createHttpClient() {
     return createHttpClient(new HttpClientOptions(), new PoolOptions());
   }
+
   /**
    * Create a datagram socket using the specified options
    *

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -13,10 +13,6 @@ package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
-import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.net.ClientSSLOptions;
-import io.vertx.core.net.HostAndPort;
-import io.vertx.core.net.SocketAddress;
 
 import java.util.concurrent.TimeUnit;
 
@@ -82,12 +78,21 @@ public interface HttpClient {
   }
 
   /**
-   * Close the client immediately ({@code close(0, TimeUnit.SECONDS}).
+   * Shutdown with a delay of 30 seconds ({@code shutdown(30, TimeUnit.SECONDS)}).
+   *
+   * @return a future completed when shutdown has completed
+   */
+  default Future<Void> shutdown() {
+    return shutdown(30, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Close immediately ({@code shutdown(0, TimeUnit.SECONDS}).
    *
    * @return a future notified when the client is closed
    */
   default Future<Void> close() {
-    return close(0, TimeUnit.SECONDS);
+    return shutdown(0, TimeUnit.SECONDS);
   }
 
   /**
@@ -104,6 +109,6 @@ public interface HttpClient {
    *
    * @return a future notified when the client is closed
    */
-  Future<Void> close(long timeout, TimeUnit timeUnit);
+  Future<Void> shutdown(long timeout, TimeUnit timeUnit);
 
 }

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -14,6 +14,8 @@ package io.vertx.core.http;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.net.ClientSSLOptions;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.SocketAddress;
 
 import java.util.concurrent.TimeUnit;
 
@@ -145,4 +147,12 @@ public interface HttpClient extends io.vertx.core.metrics.Measured {
    * @return a future signaling the update success
    */
   Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force);
+
+  /**
+   * Connect to a remote HTTP server.
+   *
+   * @param options the server connect options
+   */
+  Future<HttpClientConnection> connect(HttpConnectOptions options);
+
 }

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -78,7 +78,7 @@ public interface HttpClient {
   }
 
   /**
-   * Shutdown with a delay of 30 seconds ({@code shutdown(30, TimeUnit.SECONDS)}).
+   * Shutdown with a 30 seconds timeout ({@code shutdown(30, TimeUnit.SECONDS)}).
    *
    * @return a future completed when shutdown has completed
    */
@@ -96,10 +96,10 @@ public interface HttpClient {
   }
 
   /**
-   * Initiate the client close sequence.
+   * Initiate the client shutdown sequence.
    *
    * <p> Connections are taken out of service and closed when all inflight requests are processed, client connection are
-   * immediately removed from the pool. When all connections are closed the client is closed. When the timeout
+   * immediately removed from the pool. When all connections are closed the client is closed. When the {@code timeout}
    * expires, all unclosed connections are immediately closed.
    *
    * <ul>
@@ -107,8 +107,10 @@ public interface HttpClient {
    *   <li>HTTP/1.x client connection will be closed after the current response is received</li>
    * </ul>
    *
+   * @param timeout the amount of time after which all resources are forcibly closed
+   * @param unit the of the timeout
    * @return a future notified when the client is closed
    */
-  Future<Void> shutdown(long timeout, TimeUnit timeUnit);
+  Future<Void> shutdown(long timeout, TimeUnit unit);
 
 }

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -13,6 +13,7 @@ package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
@@ -20,35 +21,21 @@ import io.vertx.core.net.SocketAddress;
 import java.util.concurrent.TimeUnit;
 
 /**
- * An asynchronous HTTP client.
- * <p>
- * It allows you to make requests to HTTP servers, and a single client can make requests to any server.
- * <p>
- * It also allows you to open WebSockets to servers.
- * <p>
- * The client can also pool HTTP connections.
- * <p>
- * For pooling to occur, keep-alive must be true on the {@link io.vertx.core.http.HttpClientOptions} (default is true).
- * In this case connections will be pooled and re-used if there are pending HTTP requests waiting to get a connection,
- * otherwise they will be closed.
- * <p>
- * This gives the benefits of keep alive when the client is loaded but means we don't keep connections hanging around
- * unnecessarily when there would be no benefits anyway.
- * <p>
- * The client also supports pipe-lining of requests. Pipe-lining means another request is sent on the same connection
- * before the response from the preceding one has returned. Pipe-lining is not appropriate for all requests.
- * <p>
- * To enable pipe-lining, it must be enabled on the {@link io.vertx.core.http.HttpClientOptions} (default is false).
- * <p>
- * When pipe-lining is enabled the connection will be automatically closed when all in-flight responses have returned
- * and there are no outstanding pending requests to write.
- * <p>
- * The client is designed to be reused between requests.
+ * The API to interacts with an HTTP server.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-@VertxGen
-public interface HttpClient extends io.vertx.core.metrics.Measured {
+@VertxGen(concrete = false)
+public interface HttpClient {
+
+  /**
+   * Create an HTTP request to send to the server with the default host and port of the client.
+   *
+   * @return a future notified when the request is ready to be sent
+   */
+  default Future<HttpClientRequest> request() {
+    return request(new RequestOptions());
+  }
 
   /**
    * Create an HTTP request to send to the server.
@@ -95,7 +82,7 @@ public interface HttpClient extends io.vertx.core.metrics.Measured {
   }
 
   /**
-   * Close the client immediately ({@code shutdown(0, TimeUnit.SECONDS}).
+   * Close the client immediately ({@code close(0, TimeUnit.SECONDS}).
    *
    * @return a future notified when the client is closed
    */
@@ -118,42 +105,5 @@ public interface HttpClient extends io.vertx.core.metrics.Measured {
    * @return a future notified when the client is closed
    */
   Future<Void> close(long timeout, TimeUnit timeUnit);
-
-  /**
-   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
-   * from the existing options object.
-   *
-   * <p>The boolean succeeded future result indicates whether the update occurred.
-   *
-   * @param options the new SSL options
-   * @return a future signaling the update success
-   */
-  default Future<Boolean> updateSSLOptions(ClientSSLOptions options) {
-    return updateSSLOptions(options, false);
-  }
-
-  /**
-   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
-   * from the existing options object.
-   *
-   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
-   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
-   * When object are equals, setting {@code force} to {@code true} forces the update.
-   *
-   * <p>The boolean succeeded future result indicates whether the update occurred.
-   *
-   * @param options the new SSL options
-   * @param force force the update when options are equals
-   * @return a future signaling the update success
-   */
-  Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force);
-
-  /**
-   * Connect to a remote HTTP server with the specific {@code options.
-   *
-   * @param options the server connect options
-   * @return a future notified when the connection is available
-   */
-  Future<HttpClientConnection> connect(HttpConnectOptions options);
 
 }

--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -149,9 +149,10 @@ public interface HttpClient extends io.vertx.core.metrics.Measured {
   Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force);
 
   /**
-   * Connect to a remote HTTP server.
+   * Connect to a remote HTTP server with the specific {@code options.
    *
    * @param options the server connect options
+   * @return a future notified when the connection is available
    */
   Future<HttpClientConnection> connect(HttpConnectOptions options);
 

--- a/src/main/java/io/vertx/core/http/HttpClientAgent.java
+++ b/src/main/java/io/vertx/core/http/HttpClientAgent.java
@@ -1,0 +1,75 @@
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.metrics.Measured;
+import io.vertx.core.net.ClientSSLOptions;
+
+/**
+ * An asynchronous HTTP client.
+ * <p>
+ * It allows you to make requests to HTTP servers, and a single client can make requests to any server.
+ * <p>
+ * The client can also pool HTTP connections.
+ * <p>
+ * For pooling to occur, keep-alive must be true on the {@link io.vertx.core.http.HttpClientOptions} (default is true).
+ * In this case connections will be pooled and re-used if there are pending HTTP requests waiting to get a connection,
+ * otherwise they will be closed.
+ * <p>
+ * This gives the benefits of keep alive when the client is loaded but means we don't keep connections hanging around
+ * unnecessarily when there would be no benefits anyway.
+ * <p>
+ * The client also supports pipe-lining of requests. Pipe-lining means another request is sent on the same connection
+ * before the response from the preceding one has returned. Pipe-lining is not appropriate for all requests.
+ * <p>
+ * To enable pipe-lining, it must be enabled on the {@link io.vertx.core.http.HttpClientOptions} (default is false).
+ * <p>
+ * When pipe-lining is enabled the connection will be automatically closed when all in-flight responses have returned
+ * and there are no outstanding pending requests to write.
+ * <p>
+ * The client is designed to be reused between requests.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface HttpClientAgent extends HttpClient, Measured {
+
+  /**
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @return a future signaling the update success
+   */
+  default Future<Boolean> updateSSLOptions(ClientSSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
+
+  /**
+   * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   *
+   * <p>The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equals since loading options can be costly, this can happen for share TCP servers.
+   * When object are equals, setting {@code force} to {@code true} forces the update.
+   *
+   * <p>The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equals
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force);
+
+  /**
+   * Connect to a remote HTTP server with the specific {@code options}, the connection is un-pooled and the management
+   * of the connection is left to the user.
+   *
+   * @param options the server connect options
+   * @return a future notified when the connection is available
+   */
+  Future<HttpClientConnection> connect(HttpConnectOptions options);
+
+}

--- a/src/main/java/io/vertx/core/http/HttpClientBuilder.java
+++ b/src/main/java/io/vertx/core/http/HttpClientBuilder.java
@@ -94,6 +94,6 @@ public interface HttpClientBuilder {
    * Build and return the client.
    * @return the client as configured by this builder
    */
-  HttpClient build();
+  HttpClientAgent build();
 
 }

--- a/src/main/java/io/vertx/core/http/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpClientConnection.java
@@ -22,7 +22,7 @@ import io.vertx.core.Future;
 public interface HttpClientConnection extends HttpConnection {
 
   /**
-   * Like {@link #createRequest(RequestOptions)} but with null options.
+   * Like {@link #createRequest(RequestOptions)} but without options.
    */
   Future<HttpClientRequest> createRequest();
 

--- a/src/main/java/io/vertx/core/http/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpClientConnection.java
@@ -22,19 +22,29 @@ import io.vertx.core.Future;
 public interface HttpClientConnection extends HttpConnection {
 
   /**
+   * @return the number of active request/response (streams)
+   */
+  long activeStreams();
+
+  /**
+   * @return the max number of active streams this connection can handle concurrently
+   */
+  long concurrency();
+
+  /**
    * Like {@link #createRequest(RequestOptions)} but without options.
    */
   Future<HttpClientRequest> createRequest();
 
   /**
-   * Create an HTTP request initialized with the specified request {@code options}
+   * Create an HTTP request (stream) initialized with the specified request {@code options}.
    *
-   * This enqueues a request in the client connection queue, the resulting future is notified when the connection can satisfy
-   * the request.
+   * No more than {@link #concurrency()} streams can be handled concurrently, when the number of {@link #activeStreams()} has
+   * reached {@link #concurrency()} the future is failed.
    *
    * Pooled HTTP connection will return an error, since requests should be made against the pool instead the connection itself.
    *
-   * @return a future notified with the created request
+   * @return a future notified with the created stream
    */
   Future<HttpClientRequest> createRequest(RequestOptions options);
 

--- a/src/main/java/io/vertx/core/http/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpClientConnection.java
@@ -32,9 +32,9 @@ public interface HttpClientConnection extends HttpConnection {
   long concurrency();
 
   /**
-   * Like {@link #createRequest(RequestOptions)} but without options.
+   * Like {@link #request(RequestOptions)} but without options.
    */
-  Future<HttpClientRequest> createRequest();
+  Future<HttpClientRequest> request();
 
   /**
    * Create an HTTP request (stream) initialized with the specified request {@code options}.
@@ -46,6 +46,6 @@ public interface HttpClientConnection extends HttpConnection {
    *
    * @return a future notified with the created stream
    */
-  Future<HttpClientRequest> createRequest(RequestOptions options);
+  Future<HttpClientRequest> request(RequestOptions options);
 
 }

--- a/src/main/java/io/vertx/core/http/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpClientConnection.java
@@ -42,7 +42,7 @@ public interface HttpClientConnection extends HttpConnection, HttpClient {
   Future<Void> shutdown();
 
   @Override
-  Future<Void> shutdown(long delay, TimeUnit timeUnit);
+  Future<Void> shutdown(long timeout, TimeUnit unit);
 
   @Override
   Future<Void> close();

--- a/src/main/java/io/vertx/core/http/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpClientConnection.java
@@ -17,6 +17,11 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Represents an HTTP client connection.
+ * <p>
+ * You can use this connection to create requests to the connected server.
+ * <p>
+ * Depending on the nature of the connection, requests might just be sent to the server or might be queued until
+ * a connection request is available.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -29,9 +34,9 @@ public interface HttpClientConnection extends HttpConnection, HttpClient {
   long activeStreams();
 
   /**
-   * @return the max number of active streams this connection can handle concurrently
+   * @return the max number of concurrent active streams this connection can handle
    */
-  long concurrency();
+  long maxActiveStreams();
 
   @Override
   default Future<Void> close(long timeout, TimeUnit timeUnit) {

--- a/src/main/java/io/vertx/core/http/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpClientConnection.java
@@ -39,14 +39,10 @@ public interface HttpClientConnection extends HttpConnection, HttpClient {
   long maxActiveStreams();
 
   @Override
-  default Future<Void> shutdown() {
-    return HttpConnection.super.shutdown();
-  }
+  Future<Void> shutdown();
 
   @Override
-  default Future<Void> shutdown(long delay, TimeUnit timeUnit) {
-    return shutdown(timeUnit.toMillis(delay));
-  }
+  Future<Void> shutdown(long delay, TimeUnit timeUnit);
 
   @Override
   Future<Void> close();

--- a/src/main/java/io/vertx/core/http/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpClientConnection.java
@@ -13,13 +13,15 @@ package io.vertx.core.http;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Represents an HTTP client connection.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 @VertxGen
-public interface HttpClientConnection extends HttpConnection {
+public interface HttpClientConnection extends HttpConnection, HttpClient {
 
   /**
    * @return the number of active request/response (streams)
@@ -31,21 +33,11 @@ public interface HttpClientConnection extends HttpConnection {
    */
   long concurrency();
 
-  /**
-   * Like {@link #request(RequestOptions)} but without options.
-   */
-  Future<HttpClientRequest> request();
+  @Override
+  default Future<Void> close(long timeout, TimeUnit timeUnit) {
+    return shutdown(timeUnit.toMillis(timeout));
+  }
 
-  /**
-   * Create an HTTP request (stream) initialized with the specified request {@code options}.
-   *
-   * No more than {@link #concurrency()} streams can be handled concurrently, when the number of {@link #activeStreams()} has
-   * reached {@link #concurrency()} the future is failed.
-   *
-   * Pooled HTTP connection will return an error, since requests should be made against the pool instead the connection itself.
-   *
-   * @return a future notified with the created stream
-   */
-  Future<HttpClientRequest> request(RequestOptions options);
-
+  @Override
+  Future<Void> close();
 }

--- a/src/main/java/io/vertx/core/http/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpClientConnection.java
@@ -39,8 +39,13 @@ public interface HttpClientConnection extends HttpConnection, HttpClient {
   long maxActiveStreams();
 
   @Override
-  default Future<Void> close(long timeout, TimeUnit timeUnit) {
-    return shutdown(timeUnit.toMillis(timeout));
+  default Future<Void> shutdown() {
+    return HttpConnection.super.shutdown();
+  }
+
+  @Override
+  default Future<Void> shutdown(long delay, TimeUnit timeUnit) {
+    return shutdown(timeUnit.toMillis(delay));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpClientConnection.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+
+/**
+ * Represents an HTTP client connection.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface HttpClientConnection extends HttpConnection {
+
+  /**
+   * Like {@link #createRequest(RequestOptions)} but with null options.
+   */
+  Future<HttpClientRequest> createRequest();
+
+  /**
+   * Create an HTTP request initialized with the specified request {@code options}
+   *
+   * This enqueues a request in the client connection queue, the resulting future is notified when the connection can satisfy
+   * the request.
+   *
+   * Pooled HTTP connection will return an error, since requests should be made against the pool instead the connection itself.
+   *
+   * @return a future notified with the created request
+   */
+  Future<HttpClientRequest> createRequest(RequestOptions options);
+
+}

--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -478,7 +478,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    * @return the {@link HttpConnection} associated with this request
    */
   @CacheReturn
-  HttpConnection connection();
+  HttpClientConnection connection();
 
   /**
    * Write an HTTP/2 frame to the request, allowing to extend the HTTP/2 protocol.<p>

--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -478,7 +478,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    * @return the {@link HttpConnection} associated with this request
    */
   @CacheReturn
-  HttpClientConnection connection();
+  HttpConnection connection();
 
   /**
    * Write an HTTP/2 frame to the request, allowing to extend the HTTP/2 protocol.<p>

--- a/src/main/java/io/vertx/core/http/HttpConnectOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpConnectOptions.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.json.annotations.JsonGen;
+import io.vertx.core.VertxException;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.Address;
+import io.vertx.core.net.ClientSSLOptions;
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.SocketAddress;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Options describing how an {@link HttpClient} will connect to a server.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@DataObject
+@JsonGen(publicConverter = false)
+public class HttpConnectOptions {
+
+  /**
+   * The default value for proxy options = {@code null}
+   */
+  public static final ProxyOptions DEFAULT_PROXY_OPTIONS = null;
+
+  /**
+   * The default value for server method = {@code null}
+   */
+  public static final SocketAddress DEFAULT_SERVER = null;
+
+  /**
+   * The default value for host name = {@code null}
+   */
+  public static final String DEFAULT_HOST = null;
+
+  /**
+   * The default value for port = {@code null}
+   */
+  public static final Integer DEFAULT_PORT = null;
+
+  /**
+   * The default value for SSL = {@code null}
+   */
+  public static final Boolean DEFAULT_SSL = null;
+
+  /**
+   * The default connect timeout = {@code -1L} (disabled)
+   */
+  public static final long DEFAULT_CONNECT_TIMEOUT = -1L;
+
+  private ProxyOptions proxyOptions;
+  private Address server;
+  private String host;
+  private Integer port;
+  private Boolean ssl;
+  private ClientSSLOptions sslOptions;;
+  private long connectTimeout;
+
+  /**
+   * Default constructor
+   */
+  public HttpConnectOptions() {
+    init();
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param other  the options to copy
+   */
+  public HttpConnectOptions(HttpConnectOptions other) {
+    init();
+    setProxyOptions(other.proxyOptions);
+    setServer(other.server);
+    setHost(other.host);
+    setPort(other.port);
+    setSsl(other.ssl);
+    sslOptions = other.sslOptions != null ? new ClientSSLOptions(other.sslOptions) : null;
+    setConnectTimeout(other.connectTimeout);
+  }
+
+  /**
+   * Create options from JSON
+   *
+   * @param json the JSON
+   */
+  public HttpConnectOptions(JsonObject json) {
+    init();
+    HttpConnectOptionsConverter.fromJson(json, this);
+    JsonObject server = json.getJsonObject("server");
+    if (server != null) {
+      this.server = SocketAddress.fromJson(server);
+    }
+  }
+
+  protected void init() {
+    proxyOptions = DEFAULT_PROXY_OPTIONS;
+    server = DEFAULT_SERVER;
+    host = DEFAULT_HOST;
+    port = DEFAULT_PORT;
+    ssl = DEFAULT_SSL;
+    sslOptions = null;
+    connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+  }
+
+  /**
+   * Get the proxy options override for connections
+   *
+   * @return proxy options override
+   */
+  public ProxyOptions getProxyOptions() {
+    return proxyOptions;
+  }
+
+  /**
+   * Override the {@link HttpClientOptions#setProxyOptions(ProxyOptions)} proxy options
+   * for connections.
+   *
+   * @param proxyOptions proxy options override object
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpConnectOptions setProxyOptions(ProxyOptions proxyOptions) {
+    this.proxyOptions = proxyOptions;
+    return this;
+  }
+
+  /**
+   * Get the server address to be used by the client request.
+   *
+   * @return the server address
+   */
+  public Address getServer() {
+    return server;
+  }
+
+  /**
+   * Set the server address to be used by the client request.
+   *
+   * <p> When the server address is {@code null}, the address will be resolved after the {@code host}
+   * property by the Vert.x resolver.
+   *
+   * <p> Use this when you want to connect to a specific server address without name resolution.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpConnectOptions setServer(Address server) {
+    this.server = server;
+    return this;
+  }
+
+  /**
+   * Get the host name to be used by the client request.
+   *
+   * @return  the host name
+   */
+  public String getHost() {
+    return host;
+  }
+
+  /**
+   * Set the host name to be used by the client request.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpConnectOptions setHost(String host) {
+    this.host = host;
+    return this;
+  }
+
+  /**
+   * Get the port to be used by the client request.
+   *
+   * @return  the port
+   */
+  public Integer getPort() {
+    return port;
+  }
+
+  /**
+   * Set the port to be used by the client request.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpConnectOptions setPort(Integer port) {
+    this.port = port;
+    return this;
+  }
+
+  /**
+   * @return is SSL/TLS enabled?
+   */
+  public Boolean isSsl() {
+    return ssl;
+  }
+
+  /**
+   * Set whether SSL/TLS is enabled.
+   *
+   * @param ssl  true if enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpConnectOptions setSsl(Boolean ssl) {
+    this.ssl = ssl;
+    return this;
+  }
+
+  /**
+   * @return the SSL options
+   */
+  public ClientSSLOptions getSslOptions() {
+    return sslOptions;
+  }
+
+  /**
+   * Set the SSL options to use.
+   * <p>
+   * When none is provided, the client SSL options will be used instead.
+   * @param sslOptions the SSL options to use
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpConnectOptions setSslOptions(ClientSSLOptions sslOptions) {
+    this.sslOptions = sslOptions;
+    return this;
+  }
+
+  /**
+   * @return the amount of time after which, if the request is not obtained from the client within the timeout period,
+   *         the {@code Future<HttpClientRequest>} obtained from the client is failed with a {@link java.util.concurrent.TimeoutException}
+   */
+  public long getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  /**
+   * Sets the amount of time after which, if the request is not obtained from the client within the timeout period,
+   * the {@code Future<HttpClientRequest>} obtained from the client is failed with a {@link java.util.concurrent.TimeoutException}.
+   *
+   * Note this is not related to the TCP {@link HttpClientOptions#setConnectTimeout(int)} option, when a request is made against
+   * a pooled HTTP client, the timeout applies to the duration to obtain a connection from the pool to serve the request, the timeout
+   * might fire because the server does not respond in time or the pool is too busy to serve a request.
+   *
+   * @param timeout the amount of time in milliseconds.
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpConnectOptions setConnectTimeout(long timeout) {
+    this.connectTimeout = timeout;
+    return this;
+  }
+
+  private URL parseUrl(String surl) {
+    // Note - parsing a URL this way is slower than specifying host, port and relativeURI
+    try {
+      return new URL(surl);
+    } catch (MalformedURLException e) {
+      throw new VertxException("Invalid url: " + surl, e);
+    }
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    HttpConnectOptionsConverter.toJson(this, json);
+    Address serverAddr = this.server;
+    if (serverAddr instanceof SocketAddress) {
+      SocketAddress socketAddr = (SocketAddress) serverAddr;
+      json.put("server", socketAddr.toJson());
+    }
+    return json;
+  }
+}

--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Represents an HTTP connection.
  * <p/>
- * HTTP/1.x connection provides an limited implementation, the following methods are implemented:
+ * HTTP/1.x connection provides a limited implementation, the following methods are implemented:
  * <ul>
  *   <li>{@link #close}</li>
  *   <li>{@link #closeHandler}</li>

--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -119,7 +119,7 @@ public interface HttpConnection {
   HttpConnection shutdownHandler(@Nullable  Handler<Void> handler);
 
   /**
-   * Shutdown with a delay of 30 seconds ({@code shutdown(30, TimeUnit.SECONDS)}).
+   * Shutdown a 30 seconds timeout ({@code shutdown(30, TimeUnit.SECONDS)}).
    *
    * @return a future completed when shutdown has completed
    */
@@ -128,19 +128,20 @@ public interface HttpConnection {
   }
 
   /**
-   * Initiate a graceful connection shutdown, the connection is taken out of service and closed when all current requests
-   * are processed, otherwise after {@code delay} the connection will be closed. Client connection are immediately removed
+   * Initiate a graceful connection shutdown, the connection is taken out of service and closed when all the inflight requests
+   * are processed, otherwise after a {@code timeout} the connection will be closed. Client connection are immediately removed
    * from the pool.
    *
    * <ul>
-   *   <li>HTTP/2 connections will send a go away frame immediately to signal the other side the connection will close</li>
-   *   <li>HTTP/1.x client connection supports this feature</li>
-   *   <li>HTTP/1.x server connections do not support this feature</li>
+   *   <li>HTTP/2 connections will send a go away frame immediately to signal the other side the connection will close.</li>
+   *   <li>HTTP/1.x connection will be closed.</li>
    * </ul>
    *
+   * @param timeout the amount of time after which all resources are forcibly closed
+   * @param unit the of the timeout
    * @return a future completed when shutdown has completed
    */
-  Future<Void> shutdown(long delay, TimeUnit unit);
+  Future<Void> shutdown(long timeout, TimeUnit unit);
 
   /**
    * Set a close handler. The handler will get notified when the connection is closed.

--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -119,15 +119,7 @@ public interface HttpConnection {
   HttpConnection shutdownHandler(@Nullable  Handler<Void> handler);
 
   /**
-   * Initiate a graceful connection shutdown, the connection is taken out of service and closed when all current requests
-   * are processed, otherwise after 30 seconds the connection will be closed. Client connection are immediately removed
-   * from the pool.
-   *
-   * <ul>
-   *   <li>HTTP/2 connections will send a go away frame immediately to signal the other side the connection will close</li>
-   *   <li>HTTP/1.x client connection supports this feature</li>
-   *   <li>HTTP/1.x server connections do not support this feature</li>
-   * </ul>
+   * Shutdown with a delay of 30 seconds ({@code shutdown(30, TimeUnit.SECONDS)}).
    *
    * @return a future completed when shutdown has completed
    */
@@ -144,9 +136,19 @@ public interface HttpConnection {
   }
 
   /**
-   * Like {@link #shutdown()} but with a specific {@code timeout} in milliseconds.
+   * Initiate a graceful connection shutdown, the connection is taken out of service and closed when all current requests
+   * are processed, otherwise after {@code delay} the connection will be closed. Client connection are immediately removed
+   * from the pool.
+   *
+   * <ul>
+   *   <li>HTTP/2 connections will send a go away frame immediately to signal the other side the connection will close</li>
+   *   <li>HTTP/1.x client connection supports this feature</li>
+   *   <li>HTTP/1.x server connections do not support this feature</li>
+   * </ul>
+   *
+   * @return a future completed when shutdown has completed
    */
-  Future<Void> shutdown(long timeout, TimeUnit unit);
+  Future<Void> shutdown(long delay, TimeUnit unit);
 
   /**
    * Set a close handler. The handler will get notified when the connection is closed.
@@ -158,11 +160,9 @@ public interface HttpConnection {
   HttpConnection closeHandler(Handler<Void> handler);
 
   /**
-   * Close the connection and all the currently active streams.
-   * <p/>
-   * An HTTP/2 connection will send a {@literal GOAWAY} frame before.
+   * Close immediately ({@code shutdown(0, TimeUnit.SECONDS}).
    *
-   * @return a future completed when the connection is closed
+   * @return a future notified when the client is closed
    */
   Future<Void> close();
 

--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -12,7 +12,6 @@
 package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.*;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;

--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -128,14 +128,6 @@ public interface HttpConnection {
   }
 
   /**
-   * Like {@link #shutdown()} but with a specific {@code timeout} in milliseconds.
-   */
-  @Deprecated
-  default Future<Void> shutdown(long timeoutMs) {
-    return shutdown(timeoutMs, TimeUnit.MILLISECONDS);
-  }
-
-  /**
    * Initiate a graceful connection shutdown, the connection is taken out of service and closed when all current requests
    * are processed, otherwise after {@code delay} the connection will be closed. Client connection are immediately removed
    * from the pool.

--- a/src/main/java/io/vertx/core/http/RequestOptions.java
+++ b/src/main/java/io/vertx/core/http/RequestOptions.java
@@ -34,12 +34,7 @@ import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
  */
 @DataObject
 @JsonGen(publicConverter = false)
-public class RequestOptions {
-
-  /**
-   * The default value for proxy options = {@code null}
-   */
-  public static final ProxyOptions DEFAULT_PROXY_OPTIONS = null;
+public class RequestOptions extends HttpConnectOptions {
 
   /**
    * The default value for server method = {@code null}
@@ -91,18 +86,11 @@ public class RequestOptions {
    */
   public static final long DEFAULT_IDLE_TIMEOUT = -1L;
 
-  private ProxyOptions proxyOptions;
-  private Address server;
   private HttpMethod method;
-  private String host;
-  private Integer port;
-  private Boolean ssl;
-  private ClientSSLOptions sslOptions;;
   private String uri;
   private MultiMap headers;
   private boolean followRedirects;
   private long timeout;
-  private long connectTimeout;
   private long idleTimeout;
   private String traceOperation;
 
@@ -110,19 +98,7 @@ public class RequestOptions {
    * Default constructor
    */
   public RequestOptions() {
-    proxyOptions = DEFAULT_PROXY_OPTIONS;
-    server = DEFAULT_SERVER;
-    method = DEFAULT_HTTP_METHOD;
-    host = DEFAULT_HOST;
-    port = DEFAULT_PORT;
-    ssl = DEFAULT_SSL;
-    sslOptions = null;
-    uri = DEFAULT_URI;
-    followRedirects = DEFAULT_FOLLOW_REDIRECTS;
-    timeout = DEFAULT_TIMEOUT;
-    connectTimeout = DEFAULT_CONNECT_TIMEOUT;
-    idleTimeout = DEFAULT_IDLE_TIMEOUT;
-    traceOperation = null;
+    super();
   }
 
   /**
@@ -131,17 +107,11 @@ public class RequestOptions {
    * @param other  the options to copy
    */
   public RequestOptions(RequestOptions other) {
-    setProxyOptions(other.proxyOptions);
-    setServer(other.server);
+    super(other);
     setMethod(other.method);
-    setHost(other.host);
-    setPort(other.port);
-    setSsl(other.ssl);
-    sslOptions = other.sslOptions != null ? new ClientSSLOptions(other.sslOptions) : null;
     setURI(other.uri);
     setFollowRedirects(other.followRedirects);
     setIdleTimeout(other.idleTimeout);
-    setConnectTimeout(other.connectTimeout);
     setTimeout(other.timeout);
     if (other.headers != null) {
       setHeaders(MultiMap.caseInsensitiveMultiMap().setAll(other.headers));
@@ -155,15 +125,11 @@ public class RequestOptions {
    * @param json the JSON
    */
   public RequestOptions(JsonObject json) {
-    this();
+    super(json);
     RequestOptionsConverter.fromJson(json, this);
     String method = json.getString("method");
     if (method != null) {
       setMethod(HttpMethod.valueOf(method));
-    }
-    JsonObject server = json.getJsonObject("server");
-    if (server != null) {
-      this.server = SocketAddress.fromJson(server);
     }
     JsonObject headers = json.getJsonObject("headers");
     if (headers != null) {
@@ -182,48 +148,24 @@ public class RequestOptions {
     }
   }
 
-  /**
-   * Get the proxy options override for connections
-   *
-   * @return proxy options override
-   */
-  public ProxyOptions getProxyOptions() {
-    return proxyOptions;
+  @Override
+  protected void init() {
+    super.init();
+    method = DEFAULT_HTTP_METHOD;
+    uri = DEFAULT_URI;
+    followRedirects = DEFAULT_FOLLOW_REDIRECTS;
+    timeout = DEFAULT_TIMEOUT;
+    idleTimeout = DEFAULT_IDLE_TIMEOUT;
+    traceOperation = null;
   }
 
-  /**
-   * Override the {@link HttpClientOptions#setProxyOptions(ProxyOptions)} proxy options
-   * for connections.
-   *
-   * @param proxyOptions proxy options override object
-   * @return a reference to this, so the API can be used fluently
-   */
   public RequestOptions setProxyOptions(ProxyOptions proxyOptions) {
-    this.proxyOptions = proxyOptions;
+    super.setProxyOptions(proxyOptions);
     return this;
   }
 
-  /**
-   * Get the server address to be used by the client request.
-   *
-   * @return the server address
-   */
-  public Address getServer() {
-    return server;
-  }
-
-  /**
-   * Set the server address to be used by the client request.
-   *
-   * <p> When the server address is {@code null}, the address will be resolved after the {@code host}
-   * property by the Vert.x resolver.
-   *
-   * <p> Use this when you want to connect to a specific server address without name resolution.
-   *
-   * @return a reference to this, so the API can be used fluently
-   */
   public RequestOptions setServer(Address server) {
-    this.server = server;
+    super.setServer(server);
     return this;
   }
 
@@ -248,78 +190,23 @@ public class RequestOptions {
     return this;
   }
 
-  /**
-   * Get the host name to be used by the client request.
-   *
-   * @return  the host name
-   */
-  public String getHost() {
-    return host;
-  }
-
-  /**
-   * Set the host name to be used by the client request.
-   *
-   * @return a reference to this, so the API can be used fluently
-   */
   public RequestOptions setHost(String host) {
-    this.host = host;
+    super.setHost(host);
     return this;
   }
 
-  /**
-   * Get the port to be used by the client request.
-   *
-   * @return  the port
-   */
-  public Integer getPort() {
-    return port;
-  }
-
-  /**
-   * Set the port to be used by the client request.
-   *
-   * @return a reference to this, so the API can be used fluently
-   */
   public RequestOptions setPort(Integer port) {
-    this.port = port;
+    super.setPort(port);
     return this;
   }
 
-  /**
-   * @return is SSL/TLS enabled?
-   */
-  public Boolean isSsl() {
-    return ssl;
-  }
-
-  /**
-   * Set whether SSL/TLS is enabled.
-   *
-   * @param ssl  true if enabled
-   * @return a reference to this, so the API can be used fluently
-   */
   public RequestOptions setSsl(Boolean ssl) {
-    this.ssl = ssl;
+    super.setSsl(ssl);
     return this;
   }
 
-  /**
-   * @return the SSL options
-   */
-  public ClientSSLOptions getSslOptions() {
-    return sslOptions;
-  }
-
-  /**
-   * Set the SSL options to use.
-   * <p>
-   * When none is provided, the client SSL options will be used instead.
-   * @param sslOptions the SSL options to use
-   * @return a reference to this, so the API can be used fluently
-   */
   public RequestOptions setSslOptions(ClientSSLOptions sslOptions) {
-    this.sslOptions = sslOptions;
+    super.setSslOptions(sslOptions);
     return this;
   }
 
@@ -384,27 +271,8 @@ public class RequestOptions {
     return this;
   }
 
-  /**
-   * @return the amount of time after which, if the request is not obtained from the client within the timeout period,
-   *         the {@code Future<HttpClientRequest>} obtained from the client is failed with a {@link java.util.concurrent.TimeoutException}
-   */
-  public long getConnectTimeout() {
-    return connectTimeout;
-  }
-
-  /**
-   * Sets the amount of time after which, if the request is not obtained from the client within the timeout period,
-   * the {@code Future<HttpClientRequest>} obtained from the client is failed with a {@link java.util.concurrent.TimeoutException}.
-   *
-   * Note this is not related to the TCP {@link HttpClientOptions#setConnectTimeout(int)} option, when a request is made against
-   * a pooled HTTP client, the timeout applies to the duration to obtain a connection from the pool to serve the request, the timeout
-   * might fire because the server does not respond in time or the pool is too busy to serve a request.
-   *
-   * @param timeout the amount of time in milliseconds.
-   * @return a reference to this, so the API can be used fluently
-   */
   public RequestOptions setConnectTimeout(long timeout) {
-    this.connectTimeout = timeout;
+    super.setConnectTimeout(timeout);
     return this;
   }
 
@@ -483,10 +351,10 @@ public class RequestOptions {
       default:
         throw new IllegalArgumentException();
     }
-    this.uri = relativeUri;
-    this.port = port;
-    this.ssl = ssl;
-    this.host = url.getHost();
+    setURI(relativeUri);
+    setPort(port);
+    setSsl(ssl);
+    setHost(url.getHost());
     return this;
   }
 
@@ -633,15 +501,10 @@ public class RequestOptions {
   }
 
   public JsonObject toJson() {
-    JsonObject json = new JsonObject();
+    JsonObject json = super.toJson();
     RequestOptionsConverter.toJson(this, json);
     if (method != null) {
       json.put("method", method.name());
-    }
-    Address serverAddr = this.server;
-    if (serverAddr instanceof SocketAddress) {
-      SocketAddress socketAddr = (SocketAddress) serverAddr;
-      json.put("server", socketAddr.toJson());
     }
     if (this.headers != null) {
       JsonObject headers = new JsonObject();

--- a/src/main/java/io/vertx/core/http/WebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/WebSocketClient.java
@@ -77,12 +77,21 @@ public interface WebSocketClient extends Measured {
   Future<WebSocket> connect(WebSocketConnectOptions options);
 
   /**
-   * Close the client immediately ({@code close(0, TimeUnit.SECONDS}).
+   * Shutdown with a delay of 30 secons ({@code shutdown(30, TimeUnit.SECONDS)}).
+   *
+   * @return a future completed when shutdown has completed
+   */
+  default Future<Void> shutdown() {
+    return shutdown(30, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Close immediately ({@code shutdown(0, TimeUnit.SECONDS}).
    *
    * @return a future notified when the client is closed
    */
   default Future<Void> close() {
-    return close(0, TimeUnit.SECONDS);
+    return shutdown(0, TimeUnit.SECONDS);
   }
 
   /**
@@ -115,6 +124,6 @@ public interface WebSocketClient extends Measured {
    *
    * @return a future notified when the client is closed
    */
-  Future<Void> close(long timeout, TimeUnit timeUnit);
+  Future<Void> shutdown(long timeout, TimeUnit timeUnit);
 
 }

--- a/src/main/java/io/vertx/core/http/WebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/WebSocketClient.java
@@ -77,7 +77,7 @@ public interface WebSocketClient extends Measured {
   Future<WebSocket> connect(WebSocketConnectOptions options);
 
   /**
-   * Shutdown with a delay of 30 secons ({@code shutdown(30, TimeUnit.SECONDS)}).
+   * Shutdown with a 30 seconds timeout ({@code shutdown(30, TimeUnit.SECONDS)}).
    *
    * @return a future completed when shutdown has completed
    */
@@ -120,10 +120,12 @@ public interface WebSocketClient extends Measured {
   Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force);
 
   /**
-   * Initiate the client close sequence.
+   * Initiate the client shutdown sequence.
    *
    * @return a future notified when the client is closed
+   * @param timeout the amount of time after which all resources are forcibly closed
+   * @param unit the of the timeout
    */
-  Future<Void> shutdown(long timeout, TimeUnit timeUnit);
+  Future<Void> shutdown(long timeout, TimeUnit unit);
 
 }

--- a/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -116,7 +116,7 @@ public class CleanableHttpClient implements HttpClientInternal {
   }
 
   @Override
-  public Future<HttpClientConnection> connect(SocketAddress server, HostAndPort peer) {
-    return delegate.connect(server, peer);
+  public Future<HttpClientConnection> connect(HttpConnectOptions options) {
+    return delegate.connect(options);
   }
 }

--- a/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -67,15 +67,15 @@ public class CleanableHttpClient implements HttpClientInternal {
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
     if (timeout < 0L) {
       throw new IllegalArgumentException();
     }
-    if (timeUnit == null) {
+    if (unit == null) {
       throw new IllegalArgumentException();
     }
     action.timeout = timeout;
-    action.timeUnit = timeUnit;
+    action.timeUnit = unit;
     cleanable.clean();
     return action.closeFuture;
   }

--- a/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -67,7 +67,7 @@ public class CleanableHttpClient implements HttpClientInternal {
   }
 
   @Override
-  public Future<Void> close(long timeout, TimeUnit timeUnit) {
+  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
     if (timeout < 0L) {
       throw new IllegalArgumentException();
     }

--- a/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
@@ -69,15 +69,15 @@ public class CleanableWebSocketClient implements WebSocketClient, MetricsProvide
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
     if (timeout < 0L) {
       throw new IllegalArgumentException();
     }
-    if (timeUnit == null) {
+    if (unit == null) {
       throw new IllegalArgumentException();
     }
     action.timeout = timeout;
-    action.timeUnit = timeUnit;
+    action.timeUnit = unit;
     cleanable.clean();
     return action.closeFuture;
   }

--- a/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
+++ b/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
@@ -69,7 +69,7 @@ public class CleanableWebSocketClient implements WebSocketClient, MetricsProvide
   }
 
   @Override
-  public Future<Void> close(long timeout, TimeUnit timeUnit) {
+  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
     if (timeout < 0L) {
       throw new IllegalArgumentException();
     }

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -72,7 +72,7 @@ import static io.vertx.core.http.HttpHeaders.*;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> implements HttpClientConnection {
+public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> implements HttpClientConnectionInternal {
 
   private static final Logger log = LoggerFactory.getLogger(Http1xClientConnection.class);
 
@@ -139,7 +139,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   }
 
   @Override
-  public HttpClientConnection evictionHandler(Handler<Void> handler) {
+  public HttpClientConnectionInternal evictionHandler(Handler<Void> handler) {
     evictionHandler = handler;
     return this;
   }
@@ -155,7 +155,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   }
 
   @Override
-  public HttpClientConnection concurrencyChangeHandler(Handler<Long> handler) {
+  public HttpClientConnectionInternal concurrencyChangeHandler(Handler<Long> handler) {
     // Never changes
     return this;
   }
@@ -554,7 +554,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     }
 
     @Override
-    public HttpClientConnection connection() {
+    public HttpClientConnectionInternal connection() {
       return conn;
     }
 
@@ -1218,11 +1218,6 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     for (Stream stream : allStreams) {
       stream.handleException(e);
     }
-  }
-
-  @Override
-  public Future<HttpClientRequest> createRequest(ContextInternal context) {
-    return ((HttpClientImpl)client).createRequest(this, context);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -1278,9 +1278,9 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   }
 
   @Override
-  public Future<Void> shutdown(long delay, TimeUnit unit) {
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
     PromiseInternal<Void> promise = vertx.promise();
-    shutdown(delay, unit, promise);
+    shutdown(timeout, unit, promise);
     return promise.future();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -90,6 +90,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   private final HttpVersion version;
   private final long lowWaterMark;
   private final long highWaterMark;
+  private final boolean pooled;
 
   private Deque<Stream> requests = new ArrayDeque<>();
   private Deque<Stream> responses = new ArrayDeque<>();
@@ -117,7 +118,8 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
                          SocketAddress server,
                          HostAndPort authority,
                          ContextInternal context,
-                         ClientMetrics metrics) {
+                         ClientMetrics metrics,
+                         boolean pooled) {
     super(context, chctx);
     this.client = client;
     this.options = client.options();
@@ -131,6 +133,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     this.lowWaterMark = chctx.channel().config().getWriteBufferLowWaterMark();
     this.keepAliveTimeout = options.getKeepAliveTimeout();
     this.expirationTimestamp = expirationTimestampOf(keepAliveTimeout);
+    this.pooled = pooled;
   }
 
   @Override
@@ -168,6 +171,11 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   @Override
   public synchronized long activeStreams() {
     return requests.isEmpty() && responses.isEmpty() ? 0 : 1;
+  }
+
+  @Override
+  public boolean pooled() {
+    return pooled;
   }
 
   /**

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -1278,9 +1278,9 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+  public Future<Void> shutdown(long delay, TimeUnit unit) {
     PromiseInternal<Void> promise = vertx.promise();
-    shutdown(timeout, unit, promise);
+    shutdown(delay, unit, promise);
     return promise.future();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -151,7 +151,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   protected void handleEvent(Object evt) {
     if (evt instanceof ShutdownEvent) {
       ShutdownEvent shutdown = (ShutdownEvent) evt;
-      shutdown(shutdown.timeUnit().toMillis(shutdown.timeout()));
+      shutdown(shutdown.timeout(), shutdown.timeUnit());
     } else {
       super.handleEvent(evt);
     }

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -116,9 +116,9 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
   }
 
   @Override
-  public Future<Void> shutdown(long delay, TimeUnit unit) {
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
     Promise<Void> promise = vertx.promise();
-    context.execute(() -> shutdown(promise, delay, unit));
+    context.execute(() -> shutdown(promise, timeout, unit));
     return promise.future();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -116,9 +116,9 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+  public Future<Void> shutdown(long delay, TimeUnit unit) {
     Promise<Void> promise = vertx.promise();
-    context.execute(() -> shutdown(promise, timeout, unit));
+    context.execute(() -> shutdown(promise, delay, unit));
     return promise.future();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -38,7 +38,7 @@ import java.util.function.BiConsumer;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-class Http2ClientConnection extends Http2ConnectionBase implements HttpClientConnection {
+class Http2ClientConnection extends Http2ConnectionBase implements HttpClientConnectionInternal {
 
   private final HttpClientBase client;
   private final ClientMetrics metrics;
@@ -155,11 +155,6 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
         return context.failedFuture(e);
       }
     }
-  }
-
-  @Override
-  public Future<HttpClientRequest> createRequest(ContextInternal context) {
-    return ((HttpClientImpl)client).createRequest(this, context);
   }
 
   private StreamImpl createStream2(ContextInternal context) {
@@ -661,7 +656,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
     }
 
     @Override
-    public HttpClientConnection connection() {
+    public HttpClientConnectionInternal connection() {
       return conn;
     }
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
@@ -358,9 +358,9 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
   }
 
   @Override
-  public Future<Void> shutdown(long delay, TimeUnit unit) {
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
     PromiseInternal<Void> promise = vertx.promise();
-    shutdown(delay, unit, promise);
+    shutdown(timeout, unit, promise);
     return promise.future();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
@@ -358,9 +358,9 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+  public Future<Void> shutdown(long delay, TimeUnit unit) {
     PromiseInternal<Void> promise = vertx.promise();
-    shutdown(timeout, unit, promise);
+    shutdown(delay, unit, promise);
     return promise.future();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
@@ -389,7 +389,7 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
     ChannelPromise pr = chctx.newPromise();
     ChannelPromise channelPromise = pr.addListener(promise);
     handlerContext.writeAndFlush(Unpooled.EMPTY_BUFFER, pr);
-    channelPromise.addListener((ChannelFutureListener) future -> shutdown(0L));
+    channelPromise.addListener((ChannelFutureListener) future -> shutdown(0L, TimeUnit.SECONDS));
     return promise.future();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -892,8 +892,8 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
-    return current.shutdown(timeout, unit);
+  public Future<Void> shutdown(long delay, TimeUnit unit) {
+    return current.shutdown(delay, unit);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -46,14 +46,14 @@ import java.util.concurrent.TimeUnit;
  * A connection that attempts to perform a protocol upgrade to H2C. The connection might use HTTP/1 or H2C
  * depending on the initial server response.
  */
-public class Http2UpgradeClientConnection implements HttpClientConnection {
+public class Http2UpgradeClientConnection implements HttpClientConnectionInternal {
 
   private static final Object SEND_BUFFERED_MESSAGES = new Object();
 
   private static final Logger log = LoggerFactory.getLogger(Http2UpgradeClientConnection.class);
 
   private HttpClientBase client;
-  private HttpClientConnection current;
+  private HttpClientConnectionInternal current;
   private boolean upgradeProcessed;
 
   private Handler<Void> closeHandler;
@@ -70,7 +70,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
     this.current = connection;
   }
 
-  public HttpClientConnection unwrap() {
+  public HttpClientConnectionInternal unwrap() {
     return current;
   }
 
@@ -145,7 +145,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
     }
 
     @Override
-    public HttpClientConnection connection() {
+    public HttpClientConnectionInternal connection() {
       return connection;
     }
 
@@ -302,7 +302,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
     }
 
     @Override
-    public HttpClientConnection connection() {
+    public HttpClientConnectionInternal connection() {
       return upgradedConnection;
     }
 
@@ -796,11 +796,6 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
   }
 
   @Override
-  public Future<HttpClientRequest> createRequest(ContextInternal context) {
-    return ((HttpClientImpl)client).createRequest(this, context);
-  }
-
-  @Override
   public ContextInternal getContext() {
     return current.getContext();
   }
@@ -864,7 +859,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
   }
 
   @Override
-  public HttpClientConnection evictionHandler(Handler<Void> handler) {
+  public HttpClientConnectionInternal evictionHandler(Handler<Void> handler) {
     if (current instanceof Http1xClientConnection) {
       evictionHandler = handler;
     }
@@ -873,7 +868,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
   }
 
   @Override
-  public HttpClientConnection concurrencyChangeHandler(Handler<Long> handler) {
+  public HttpClientConnectionInternal concurrencyChangeHandler(Handler<Long> handler) {
     if (current instanceof Http1xClientConnection) {
       concurrencyChangeHandler = handler;
     }

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -887,8 +887,8 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
   }
 
   @Override
-  public Future<Void> shutdown(long delay, TimeUnit unit) {
-    return current.shutdown(delay, unit);
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return current.shutdown(timeout, unit);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -887,11 +887,6 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
   }
 
   @Override
-  public Future<Void> shutdown(long timeoutMs) {
-    return current.shutdown(timeoutMs);
-  }
-
-  @Override
   public Future<Void> shutdown(long delay, TimeUnit unit) {
     return current.shutdown(delay, unit);
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -85,6 +85,11 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
   }
 
   @Override
+  public boolean pooled() {
+    return current.pooled();
+  }
+
+  @Override
   public long activeStreams() {
     return current.concurrency();
   }
@@ -359,7 +364,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
         public void upgradeTo(ChannelHandlerContext ctx, FullHttpResponse upgradeResponse) throws Exception {
 
           // Now we need to upgrade this to an HTTP2
-          VertxHttp2ConnectionHandler<Http2ClientConnection> handler = Http2ClientConnection.createHttp2ConnectionHandler(upgradedConnection.client, upgradingConnection.metrics, upgradingConnection.getContext(), true, upgradedConnection.current.metric(), upgradedConnection.current.authority());
+          VertxHttp2ConnectionHandler<Http2ClientConnection> handler = Http2ClientConnection.createHttp2ConnectionHandler(upgradedConnection.client, upgradingConnection.metrics, upgradingConnection.getContext(), true, upgradedConnection.current.metric(), upgradedConnection.current.authority(), upgradingConnection.pooled());
           upgradingConnection.channel().pipeline().addLast(handler);
           handler.connectFuture().addListener(future -> {
             if (!future.isSuccess()) {

--- a/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
@@ -107,10 +107,10 @@ public class HttpChannelConnector {
     netClient.connectInternal(connectOptions, promise, context);
   }
 
-  public Future<HttpClientConnection> wrap(ContextInternal context, NetSocket so_) {
+  public Future<HttpClientConnectionInternal> wrap(ContextInternal context, NetSocket so_) {
     NetSocketImpl so = (NetSocketImpl) so_;
     Object metric = so.metric();
-    PromiseInternal<HttpClientConnection> promise = context.promise();
+    PromiseInternal<HttpClientConnectionInternal> promise = context.promise();
 
     // Remove all un-necessary handlers
     ChannelPipeline pipeline = so.channelHandlerContext().pipeline();
@@ -158,12 +158,12 @@ public class HttpChannelConnector {
     return promise.future();
   }
 
-  public Future<HttpClientConnection> httpConnect(ContextInternal context) {
+  public Future<HttpClientConnectionInternal> httpConnect(ContextInternal context) {
     Promise<NetSocket> promise = context.promise();
     Future<NetSocket> future = promise.future();
     // We perform the compose operation before calling connect to be sure that the composition happens
     // before the promise is completed by the connect operation
-    Future<HttpClientConnection> ret = future.compose(so -> wrap(context, so));
+    Future<HttpClientConnectionInternal> ret = future.compose(so -> wrap(context, so));
     connect(context, promise);
     return ret;
   }
@@ -205,7 +205,7 @@ public class HttpChannelConnector {
                                ContextInternal context,
                                Object socketMetric,
                                Channel ch,
-                               Promise<HttpClientConnection> future) {
+                               Promise<HttpClientConnectionInternal> future) {
     boolean upgrade = version == HttpVersion.HTTP_2 && options.isHttp2ClearTextUpgrade();
     VertxHandler<Http1xClientConnection> clientHandler = VertxHandler.create(chctx -> {
       HttpClientMetrics met = client.metrics();
@@ -229,7 +229,7 @@ public class HttpChannelConnector {
               HttpClientStream stream = ar.result();
               stream.headHandler(resp -> {
                 Http2UpgradeClientConnection connection = (Http2UpgradeClientConnection) stream.connection();
-                HttpClientConnection unwrap = connection.unwrap();
+                HttpClientConnectionInternal unwrap = connection.unwrap();
                 future.tryComplete(unwrap);
               });
               stream.exceptionHandler(future::tryFail);
@@ -253,7 +253,7 @@ public class HttpChannelConnector {
   private void http2Connected(ContextInternal context,
                               Object metric,
                               Channel ch,
-                              PromiseInternal<HttpClientConnection> promise) {
+                              PromiseInternal<HttpClientConnectionInternal> promise) {
     VertxHttp2ConnectionHandler<Http2ClientConnection> clientHandler;
     try {
       clientHandler = Http2ClientConnection.createHttp2ConnectionHandler(client, metrics, context, false, metric, authority);
@@ -266,7 +266,7 @@ public class HttpChannelConnector {
     clientHandler.connectFuture().addListener(promise);
   }
 
-  private void connectFailed(Channel ch, Throwable t, Promise<HttpClientConnection> future) {
+  private void connectFailed(Channel ch, Throwable t, Promise<HttpClientConnectionInternal> future) {
     if (ch != null) {
       try {
         ch.close();

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -157,9 +157,9 @@ public class HttpClientBase implements MetricsProvider, Closeable {
     netClient.close().onComplete(p);
   }
 
-  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
     this.closeTimeout = timeout;
-    this.closeTimeoutUnit = timeUnit;
+    this.closeTimeoutUnit = unit;
     return closeSequence.close();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -149,23 +149,6 @@ public class HttpClientBase implements MetricsProvider, Closeable {
     return metrics;
   }
 
-  /**
-   * Connect to a server.
-   */
-  public Future<HttpClientConnection> connect(SocketAddress server) {
-    return connect(server, null);
-  }
-
-  /**
-   * Connect to a server.
-   */
-  public Future<HttpClientConnection> connect(SocketAddress server, HostAndPort peer) {
-    ContextInternal context = vertx.getOrCreateContext();
-    HttpChannelConnector connector = new HttpChannelConnector(this, netClient, defaultSslOptions, null, null, options.getProtocolVersion(), options.isSsl(), options.isUseAlpn(), peer, server);
-    return connector.httpConnect(context);
-  }
-
-
   protected void doShutdown(Promise<Void> p) {
     netClient.shutdown(closeTimeout, closeTimeoutUnit).onComplete(p);
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -157,7 +157,7 @@ public class HttpClientBase implements MetricsProvider, Closeable {
     netClient.close().onComplete(p);
   }
 
-  public Future<Void> close(long timeout, TimeUnit timeUnit) {
+  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
     this.closeTimeout = timeout;
     this.closeTimeoutUnit = timeUnit;
     return closeSequence.close();

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -135,8 +135,8 @@ public class HttpClientBase implements MetricsProvider, Closeable {
     return proxyOptions;
   }
 
-  protected ClientSSLOptions sslOptions(RequestOptions requestOptions) {
-    ClientSSLOptions sslOptions = requestOptions.getSslOptions();
+  protected ClientSSLOptions sslOptions(HttpConnectOptions connectOptions) {
+    ClientSSLOptions sslOptions = connectOptions.getSslOptions();
     if (sslOptions != null) {
       sslOptions = new ClientSSLOptions(sslOptions);
     } else {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -96,11 +96,11 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
   }
 
   @Override
-  public HttpClient build() {
+  public HttpClientAgent build() {
     HttpClientOptions co = clientOptions != null ? clientOptions : new HttpClientOptions();
     PoolOptions po = poolOptions != null ? poolOptions : new PoolOptions();
     CloseFuture cf = resolveCloseFuture();
-    HttpClient client;
+    HttpClientAgent client;
     Closeable closeable;
     EndpointResolver<?> resolver = endpointResolver(co);
     if (co.isShared()) {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -116,7 +116,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
     } else {
       HttpClientImpl impl = new HttpClientImpl(vertx, resolver, co, po);
       closeable = impl;
-      client = new CleanableHttpClient(impl, vertx.cleaner(), impl::close);
+      client = new CleanableHttpClient(impl, vertx.cleaner(), impl::shutdown);
     }
     cf.add(closeable);
     if (redirectHandler != null) {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnectionInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnectionInternal.java
@@ -15,8 +15,9 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpClientConnection;
 import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
@@ -25,9 +26,9 @@ import io.vertx.core.net.HostAndPort;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public interface HttpClientConnection extends HttpConnection {
+public interface HttpClientConnectionInternal extends HttpClientConnection {
 
-  Logger log = LoggerFactory.getLogger(HttpClientConnection.class);
+  Logger log = LoggerFactory.getLogger(HttpClientConnectionInternal.class);
 
   Handler<Void> DEFAULT_EVICTION_HANDLER = v -> {
     log.warn("Connection evicted");
@@ -43,7 +44,7 @@ public interface HttpClientConnection extends HttpConnection {
    * @param handler the handler
    * @return a reference to this, so the API can be used fluently
    */
-  HttpClientConnection evictionHandler(Handler<Void> handler);
+  HttpClientConnectionInternal evictionHandler(Handler<Void> handler);
 
   /**
    * Set a {@code handler} called when the connection concurrency changes.
@@ -52,7 +53,7 @@ public interface HttpClientConnection extends HttpConnection {
    * @param handler the handler
    * @return a reference to this, so the API can be used fluently
    */
-  HttpClientConnection concurrencyChangeHandler(Handler<Long> handler);
+  HttpClientConnectionInternal concurrencyChangeHandler(Handler<Long> handler);
 
   /**
    * @return the connection concurrency
@@ -78,9 +79,29 @@ public interface HttpClientConnection extends HttpConnection {
    * Create an HTTP stream.
    *
    * @param context the stream context
-   * @return a future notified with the created stream
+   * @return a future notified with the created request
    */
-  Future<HttpClientRequest> createRequest(ContextInternal context);
+  default Future<HttpClientRequest> createRequest(ContextInternal context, RequestOptions options) {
+    return createStream(context).map(stream -> {
+      HttpClientRequestImpl request = new HttpClientRequestImpl(stream);
+      if (options != null) {
+        request.init(options);
+      }
+      return request;
+    });
+  }
+
+  @Override
+  default Future<HttpClientRequest> createRequest() {
+    ContextInternal ctx = getContext().owner().getOrCreateContext();
+    return createRequest(ctx, null);
+  }
+
+  @Override
+  default Future<HttpClientRequest> createRequest(RequestOptions options) {
+    ContextInternal ctx = getContext().owner().getOrCreateContext();
+    return createRequest(ctx, options);
+  }
 
   /**
    * Create an HTTP stream.

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnectionInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnectionInternal.java
@@ -90,12 +90,6 @@ public interface HttpClientConnectionInternal extends HttpClientConnection {
   }
 
   @Override
-  default Future<HttpClientRequest> request() {
-    ContextInternal ctx = getContext().owner().getOrCreateContext();
-    return request(ctx, null);
-  }
-
-  @Override
   default Future<HttpClientRequest> request(RequestOptions options) {
     ContextInternal ctx = getContext().owner().getOrCreateContext();
     return request(ctx, options);

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnectionInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnectionInternal.java
@@ -56,16 +56,6 @@ public interface HttpClientConnectionInternal extends HttpClientConnection {
   HttpClientConnectionInternal concurrencyChangeHandler(Handler<Long> handler);
 
   /**
-   * @return the connection concurrency
-   */
-  long concurrency();
-
-  /**
-   * @return the number of active streams
-   */
-  long activeStreams();
-
-  /**
    * @return whether the connection is pooled
    */
   boolean pooled();

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnectionInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnectionInternal.java
@@ -76,7 +76,7 @@ public interface HttpClientConnectionInternal extends HttpClientConnection {
    * @param context the stream context
    * @return a future notified with the created request
    */
-  default Future<HttpClientRequest> createRequest(ContextInternal context, RequestOptions options) {
+  default Future<HttpClientRequest> request(ContextInternal context, RequestOptions options) {
     if (pooled()) {
       return context.failedFuture("HTTP requests cannot be directly created from pool HTTP client request, use the pool instead");
     }
@@ -90,15 +90,15 @@ public interface HttpClientConnectionInternal extends HttpClientConnection {
   }
 
   @Override
-  default Future<HttpClientRequest> createRequest() {
+  default Future<HttpClientRequest> request() {
     ContextInternal ctx = getContext().owner().getOrCreateContext();
-    return createRequest(ctx, null);
+    return request(ctx, null);
   }
 
   @Override
-  default Future<HttpClientRequest> createRequest(RequestOptions options) {
+  default Future<HttpClientRequest> request(RequestOptions options) {
     ContextInternal ctx = getContext().owner().getOrCreateContext();
-    return createRequest(ctx, options);
+    return request(ctx, options);
   }
 
   /**

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnectionInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnectionInternal.java
@@ -66,6 +66,11 @@ public interface HttpClientConnectionInternal extends HttpClientConnection {
   long activeStreams();
 
   /**
+   * @return whether the connection is pooled
+   */
+  boolean pooled();
+
+  /**
    * @return the connection channel
    */
   Channel channel();
@@ -82,6 +87,9 @@ public interface HttpClientConnectionInternal extends HttpClientConnection {
    * @return a future notified with the created request
    */
   default Future<HttpClientRequest> createRequest(ContextInternal context, RequestOptions options) {
+    if (pooled()) {
+      return context.failedFuture("HTTP requests cannot be directly created from pool HTTP client request, use the pool instead");
+    }
     return createStream(context).map(stream -> {
       HttpClientRequestImpl request = new HttpClientRequestImpl(stream);
       if (options != null) {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -183,7 +183,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
         key = new EndpointKey(key.ssl, key.sslOptions, proxyOptions, server, key.authority);
         proxyOptions = null;
       }
-      HttpChannelConnector connector = new HttpChannelConnector(HttpClientImpl.this, netClient, key.sslOptions, proxyOptions, metrics, options.getProtocolVersion(), key.ssl, options.isUseAlpn(), key.authority, key.server);
+      HttpChannelConnector connector = new HttpChannelConnector(HttpClientImpl.this, netClient, key.sslOptions, proxyOptions, metrics, options.getProtocolVersion(), key.ssl, options.isUseAlpn(), key.authority, key.server, true);
       return new SharedClientHttpStreamEndpoint(
         HttpClientImpl.this,
         metrics,
@@ -287,7 +287,8 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
       useSSL,
       useAlpn,
       authority,
-      server);
+      server,
+      false);
     return (Future) connector.httpConnect(vertx.getOrCreateContext());
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -264,10 +264,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
       throw new IllegalArgumentException("Only socket address are currently supported");
     }
     HostAndPort authority = HostAndPort.create(host, port);
-    ClientSSLOptions sslOptions = connect.getSslOptions();
-    if (sslOptions == null) {
-      sslOptions = options.getSslOptions();
-    }
+    ClientSSLOptions sslOptions = sslOptions(connect);
     ProxyOptions proxyOptions = computeProxyOptions(connect.getProxyOptions(), server);
     ClientMetrics clientMetrics = metrics != null ? metrics.createEndpointMetrics(server, 1) : null;
     Boolean ssl = connect.isSsl();

--- a/src/main/java/io/vertx/core/http/impl/HttpClientInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientInternal.java
@@ -14,7 +14,6 @@ package io.vertx.core.http.impl;
 import io.vertx.core.Closeable;
 import io.vertx.core.Future;
 import io.vertx.core.http.*;
-import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
@@ -34,20 +33,4 @@ public interface HttpClientInternal extends HttpClient, MetricsProvider, Closeab
 
   Future<Void> closeFuture();
 
-  /**
-   * Connect to a server.
-   *
-   * @param server the server address
-   */
-  default Future<HttpClientConnection> connect(SocketAddress server) {
-    return connect(server, null);
-  }
-
-  /**
-   * Connect to a server.
-   *
-   * @param server the server address
-   * @param peer the peer
-   */
-  Future<HttpClientConnection> connect(SocketAddress server, HostAndPort peer);
 }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientInternal.java
@@ -15,12 +15,10 @@ import io.vertx.core.Closeable;
 import io.vertx.core.Future;
 import io.vertx.core.http.*;
 import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.net.HostAndPort;
-import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.NetClientInternal;
 import io.vertx.core.spi.metrics.MetricsProvider;
 
-public interface HttpClientInternal extends HttpClient, MetricsProvider, Closeable {
+public interface HttpClientInternal extends HttpClientAgent, MetricsProvider, Closeable {
 
   /**
    * @return the vertx, for use in package related classes only.

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -42,8 +42,10 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   private long currentTimeoutMs;
   private long lastDataReceived;
   private Throwable reset;
+  private HttpConnection connection;
 
-  HttpClientRequestBase(HttpClientStream stream, PromiseInternal<HttpClientResponse> responsePromise, HttpMethod method, String uri) {
+  HttpClientRequestBase(HttpConnection connection, HttpClientStream stream, PromiseInternal<HttpClientResponse> responsePromise, HttpMethod method, String uri) {
+    this.connection = connection;
     this.stream = stream;
     this.responsePromise = responsePromise;
     this.context = responsePromise.context();
@@ -100,6 +102,11 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
 
   public synchronized String getURI() {
     return uri;
+  }
+
+  @Override
+  public HttpConnection connection() {
+    return connection;
   }
 
   @Override
@@ -160,7 +167,7 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   }
 
   void handlePush(HttpClientPush push) {
-    HttpClientRequestPushPromise pushReq = new HttpClientRequestPushPromise(push.stream, push.method, push.uri, push.headers);
+    HttpClientRequestPushPromise pushReq = new HttpClientRequestPushPromise(connection, push.stream, push.method, push.uri, push.headers);
     if (pushHandler != null) {
       pushHandler.handle(pushReq);
     } else {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -67,8 +67,8 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   private boolean isConnect;
   private String traceOperation;
 
-  HttpClientRequestImpl(HttpClientStream stream) {
-    super(stream, stream.getContext().promise(), HttpMethod.GET, "/");
+  HttpClientRequestImpl(HttpConnection connection, HttpClientStream stream) {
+    super(connection, stream, stream.getContext().promise(), HttpMethod.GET, "/");
     this.chunked = false;
     this.endPromise = context.promise();
     this.endFuture = endPromise.future();
@@ -315,11 +315,6 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
 
   private void tryComplete() {
     endPromise.tryComplete();
-  }
-
-  @Override
-  public HttpClientConnection connection() {
-    return stream.connection();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -22,11 +22,16 @@ import io.vertx.core.impl.Arguments;
 import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.ProxyType;
 
+import java.util.Base64;
 import java.util.Objects;
 import java.util.function.Function;
 
 import static io.vertx.core.http.HttpHeaders.CONTENT_LENGTH;
+import static io.vertx.core.http.impl.HttpClientImpl.ABS_URI_START_PATTERN;
 
 /**
  * This class is optimised for performance when used on the same event loop that is passed to the handler with.
@@ -62,9 +67,8 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   private boolean isConnect;
   private String traceOperation;
 
-  HttpClientRequestImpl(HttpClientStream stream, PromiseInternal<HttpClientResponse> responsePromise, HttpMethod method,
-                        String requestURI) {
-    super(stream, responsePromise, method, requestURI);
+  HttpClientRequestImpl(HttpClientStream stream) {
+    super(stream, stream.getContext().promise(), HttpMethod.GET, "/");
     this.chunked = false;
     this.endPromise = context.promise();
     this.endFuture = endPromise.future();
@@ -76,6 +80,41 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
     stream.earlyHintsHandler(this::handleEarlyHints);
     stream.drainHandler(this::handleDrained);
     stream.exceptionHandler(this::handleException);
+  }
+
+  public void init(RequestOptions options) {
+    MultiMap headers = options.getHeaders();
+    if (headers != null) {
+      headers().setAll(headers);
+    }
+    HttpClientConnectionInternal conn = stream.connection();
+    boolean useSSL = conn.isSsl();
+    String requestURI = options.getURI();
+    HttpMethod method = options.getMethod();
+    String traceOperation = options.getTraceOperation();
+    Boolean followRedirects = options.getFollowRedirects();
+    long idleTimeout = options.getIdleTimeout();
+    ProxyOptions proxyOptions = options.getProxyOptions();
+    if (proxyOptions != null && !useSSL && proxyOptions.getType() == ProxyType.HTTP) {
+      HostAndPort authority = conn.authority();
+      if (!ABS_URI_START_PATTERN.matcher(requestURI).find()) {
+        int defaultPort = 80;
+        String addPort = (authority.port() != -1 && authority.port() != defaultPort) ? (":" + authority.port()) : "";
+        requestURI = "http://" + authority.host() + addPort + requestURI;
+      }
+      if (proxyOptions.getUsername() != null && proxyOptions.getPassword() != null) {
+        headers().add("Proxy-Authorization", "Basic " + Base64.getEncoder()
+          .encodeToString((proxyOptions.getUsername() + ":" + proxyOptions.getPassword()).getBytes()));
+      }
+    }
+    setURI(requestURI);
+    setMethod(method);
+    traceOperation(traceOperation);
+    setFollowRedirects(followRedirects == Boolean.TRUE);
+    if (idleTimeout > 0L) {
+      // Maybe later ?
+      idleTimeout(idleTimeout);
+    }
   }
 
   @Override
@@ -279,7 +318,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   }
 
   @Override
-  public synchronized HttpConnection connection() {
+  public HttpClientConnection connection() {
     return stream.connection();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -30,11 +30,12 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   private final MultiMap headers;
 
   public HttpClientRequestPushPromise(
+    HttpConnection connection,
     HttpClientStream stream,
     HttpMethod method,
     String uri,
     MultiMap headers) {
-    super(stream, stream.connection().getContext().promise(), method, uri);
+    super(connection, stream, stream.connection().getContext().promise(), method, uri);
     this.stream = stream;
     this.headers = headers;
   }
@@ -52,11 +53,6 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   @Override
   public HttpClientRequest exceptionHandler(Handler<Throwable> handler) {
     return this;
-  }
-
-  @Override
-  public HttpClientConnection connection() {
-    return stream.connection();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -55,7 +55,7 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
-  public HttpConnection connection() {
+  public HttpClientConnection connection() {
     return stream.connection();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -18,11 +18,16 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.buffer.impl.BufferInternal;
-import io.vertx.core.http.HttpFrame;
-import io.vertx.core.http.HttpVersion;
-import io.vertx.core.http.StreamPriority;
+import io.vertx.core.http.*;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.ProxyType;
 import io.vertx.core.streams.WriteStream;
+
+import java.util.Base64;
+
+import static io.vertx.core.http.impl.HttpClientImpl.ABS_URI_START_PATTERN;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -44,7 +49,7 @@ public interface HttpClientStream extends WriteStream<Buffer> {
    */
   HttpVersion version();
 
-  HttpClientConnection connection();
+  HttpClientConnectionInternal connection();
   ContextInternal getContext();
 
   Future<Void> writeHead(HttpRequestHead request, boolean chunked, ByteBuf buf, boolean end, StreamPriority priority, boolean connect);

--- a/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
@@ -60,7 +60,7 @@ class StatisticsGatheringHttpClientStream implements HttpClientStream {
   }
 
   @Override
-  public HttpClientConnection connection() {
+  public HttpClientConnectionInternal connection() {
     return delegate.connection();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
@@ -79,8 +79,8 @@ public class UnpooledHttpClientConnection implements HttpClientConnection {
   }
 
   @Override
-  public Future<Void> shutdown(long delay, TimeUnit timeUnit) {
-    return actual.shutdown(delay, timeUnit);
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return actual.shutdown(timeout, unit);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
@@ -74,8 +74,13 @@ public class UnpooledHttpClientConnection implements HttpClientConnection {
   }
 
   @Override
+  public Future<Void> shutdown() {
+    return actual.shutdown();
+  }
+
+  @Override
   public Future<Void> shutdown(long delay, TimeUnit timeUnit) {
-    return actual.shutdown(timeUnit.toMillis(delay));
+    return actual.shutdown(delay, timeUnit);
   }
 
   @Override
@@ -122,11 +127,6 @@ public class UnpooledHttpClientConnection implements HttpClientConnection {
   @Fluent
   public HttpConnection shutdownHandler(@Nullable Handler<Void> handler) {
     return actual.shutdownHandler(handler);
-  }
-
-  @Override
-  public Future<Void> shutdown(long timeoutMs) {
-    return actual.shutdown(timeoutMs);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
@@ -74,8 +74,8 @@ public class UnpooledHttpClientConnection implements HttpClientConnection {
   }
 
   @Override
-  public Future<Void> close(long timeout, TimeUnit timeUnit) {
-    return actual.shutdown(timeUnit.toMillis(timeout));
+  public Future<Void> shutdown(long delay, TimeUnit timeUnit) {
+    return actual.shutdown(timeUnit.toMillis(delay));
   }
 
   @Override
@@ -122,11 +122,6 @@ public class UnpooledHttpClientConnection implements HttpClientConnection {
   @Fluent
   public HttpConnection shutdownHandler(@Nullable Handler<Void> handler) {
     return actual.shutdownHandler(handler);
-  }
-
-  @Override
-  public Future<Void> shutdown() {
-    return actual.shutdown();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.vertx.codegen.annotations.CacheReturn;
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.future.PromiseInternal;
+import io.vertx.core.net.SocketAddress;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.cert.X509Certificate;
+import java.security.cert.Certificate;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An un-pooled HTTP client connection that maintains a queue for pending requests that cannot be served
+ * by the actual connection.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class UnpooledHttpClientConnection implements HttpClientConnection {
+
+  private final HttpClientConnectionInternal actual;
+  private final Deque<PromiseInternal<HttpClientStream>> pending;
+  private long concurrency;
+  private long inflight;
+
+  public UnpooledHttpClientConnection(HttpClientConnectionInternal actual) {
+    this.actual = actual;
+    this.concurrency = actual.concurrency();
+    this.pending = new ArrayDeque<>();
+  }
+
+  UnpooledHttpClientConnection init() {
+    actual.evictionHandler(v -> {
+      // Ignore
+    });
+    actual.concurrencyChangeHandler(val -> {
+      synchronized (UnpooledHttpClientConnection.this) {
+        concurrency = val;
+      }
+      checkPending(null);
+    });
+    return this;
+  }
+
+  @Override
+  public long activeStreams() {
+    return actual.activeStreams();
+  }
+
+  @Override
+  public synchronized long maxActiveStreams() {
+    return concurrency;
+  }
+
+  @Override
+  public Future<Void> close(long timeout, TimeUnit timeUnit) {
+    return actual.shutdown(timeUnit.toMillis(timeout));
+  }
+
+  @Override
+  public Future<Void> close() {
+    return actual.shutdown();
+  }
+
+  @Override
+  public int getWindowSize() {
+    return actual.getWindowSize();
+  }
+
+  @Override
+  @Fluent
+  public HttpConnection setWindowSize(int windowSize) {
+    return actual.setWindowSize(windowSize);
+  }
+
+  @Override
+  @Fluent
+  public HttpConnection goAway(long errorCode) {
+    return actual.goAway(errorCode);
+  }
+
+  @Override
+  @Fluent
+  public HttpConnection goAway(long errorCode, int lastStreamId) {
+    return actual.goAway(errorCode, lastStreamId);
+  }
+
+  @Override
+  @Fluent
+  public HttpConnection goAway(long errorCode, int lastStreamId, Buffer debugData) {
+    return actual.goAway(errorCode, lastStreamId, debugData);
+  }
+
+  @Override
+  @Fluent
+  public HttpConnection goAwayHandler(@Nullable Handler<GoAway> handler) {
+    return actual.goAwayHandler(handler);
+  }
+
+  @Override
+  @Fluent
+  public HttpConnection shutdownHandler(@Nullable Handler<Void> handler) {
+    return actual.shutdownHandler(handler);
+  }
+
+  @Override
+  public Future<Void> shutdown() {
+    return actual.shutdown();
+  }
+
+  @Override
+  public Future<Void> shutdown(long timeoutMs) {
+    return actual.shutdown(timeoutMs);
+  }
+
+  @Override
+  @Fluent
+  public HttpConnection closeHandler(Handler<Void> handler) {
+    return actual.closeHandler(handler);
+  }
+
+  @Override
+  public Http2Settings settings() {
+    return actual.settings();
+  }
+
+  @Override
+  public Future<Void> updateSettings(Http2Settings settings) {
+    return actual.updateSettings(settings);
+  }
+
+  @Override
+  public Http2Settings remoteSettings() {
+    return actual.remoteSettings();
+  }
+
+  @Override
+  @Fluent
+  public HttpConnection remoteSettingsHandler(Handler<Http2Settings> handler) {
+    return actual.remoteSettingsHandler(handler);
+  }
+
+  @Override
+  public Future<Buffer> ping(Buffer data) {
+    return actual.ping(data);
+  }
+
+  @Override
+  @Fluent
+  public HttpConnection pingHandler(@Nullable Handler<Buffer> handler) {
+    return actual.pingHandler(handler);
+  }
+
+  @Override
+  @Fluent
+  public HttpConnection exceptionHandler(Handler<Throwable> handler) {
+    return actual.exceptionHandler(handler);
+  }
+
+  @Override
+  @CacheReturn
+  public SocketAddress remoteAddress() {
+    return actual.remoteAddress();
+  }
+
+  @Override
+  public SocketAddress remoteAddress(boolean real) {
+    return actual.remoteAddress(real);
+  }
+
+  @Override
+  @CacheReturn
+  public SocketAddress localAddress() {
+    return actual.localAddress();
+  }
+
+  @Override
+  public SocketAddress localAddress(boolean real) {
+    return actual.localAddress(real);
+  }
+
+  @Override
+  public boolean isSsl() {
+    return actual.isSsl();
+  }
+
+  @Override
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  public SSLSession sslSession() {
+    return actual.sslSession();
+  }
+
+  @Override
+  @GenIgnore
+  @Deprecated
+  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+    return actual.peerCertificateChain();
+  }
+
+  @Override
+  @GenIgnore
+  public List<Certificate> peerCertificates() throws SSLPeerUnverifiedException {
+    return actual.peerCertificates();
+  }
+
+  @Override
+  public String indicatedServerName() {
+    return actual.indicatedServerName();
+  }
+
+  /**
+   * Create an HTTP stream.
+   *
+   * @param context the stream context
+   * @return a future notified with the created request
+   */
+  public Future<HttpClientRequest> request(ContextInternal context, RequestOptions options) {
+    Future<HttpClientStream> future;
+    synchronized (this) {
+      if (inflight >= concurrency) {
+        PromiseInternal<HttpClientStream> promise = context.promise();
+        pending.add(promise);
+        future = promise.future();
+      } else {
+        inflight++;
+        future = actual.createStream(context);
+      }
+    }
+    return future.map(stream -> {
+      HttpClientRequestImpl request = new HttpClientRequestImpl(this, stream);
+      stream.closeHandler(this::checkPending);
+      if (options != null) {
+        request.init(options);
+      }
+      return request;
+    });
+  }
+
+  private void checkPending(Void v) {
+    PromiseInternal<HttpClientStream> promise;
+    synchronized (this) {
+      if (--inflight >= concurrency || (promise = pending.poll()) == null) {
+        return;
+      }
+      inflight++;
+    }
+    actual.createStream(promise.context()).onComplete(promise);
+  }
+
+  @Override
+  public Future<HttpClientRequest> request(RequestOptions options) {
+    ContextInternal ctx = actual.getContext().owner().getOrCreateContext();
+    return request(ctx, options);
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
@@ -181,7 +181,7 @@ class VertxHttp2ConnectionHandler<C extends Http2ConnectionBase> extends Http2Co
         connection.handleIdle((IdleStateEvent) evt);
       } else if (evt instanceof ShutdownEvent) {
         ShutdownEvent shutdownEvt = (ShutdownEvent) evt;
-        connection.shutdown(shutdownEvt.timeUnit().toMillis(shutdownEvt.timeout()));
+        connection.shutdown(shutdownEvt.timeout(), shutdownEvt.timeUnit());
       }
     }
   }

--- a/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
@@ -72,7 +72,7 @@ public class WebSocketClientImpl extends HttpClientBase implements WebSocketClie
     EndpointProvider<EndpointKey, WebSocketEndpoint> provider = (key_, dispose) -> {
       int maxPoolSize = options.getMaxConnections();
       ClientMetrics metrics = WebSocketClientImpl.this.metrics != null ? WebSocketClientImpl.this.metrics.createEndpointMetrics(key_.server, maxPoolSize) : null;
-      HttpChannelConnector connector = new HttpChannelConnector(WebSocketClientImpl.this, netClient, sslOptions, key_.proxyOptions, metrics, HttpVersion.HTTP_1_1, key_.ssl, false, key_.authority, key_.server);
+      HttpChannelConnector connector = new HttpChannelConnector(WebSocketClientImpl.this, netClient, sslOptions, key_.proxyOptions, metrics, HttpVersion.HTTP_1_1, key_.ssl, false, key_.authority, key_.server, false);
       return new WebSocketEndpoint(null, maxPoolSize, connector, dispose);
     };
     webSocketCM

--- a/src/main/java/io/vertx/core/http/impl/WebSocketEndpoint.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketEndpoint.java
@@ -22,11 +22,11 @@ import java.util.Deque;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-class WebSocketEndpoint extends ClientHttpEndpointBase<HttpClientConnection> {
+class WebSocketEndpoint extends ClientHttpEndpointBase<HttpClientConnectionInternal> {
 
   private static class Waiter {
 
-    final Promise<HttpClientConnection> promise;
+    final Promise<HttpClientConnectionInternal> promise;
     final ContextInternal context;
 
     Waiter(ContextInternal context) {
@@ -59,14 +59,14 @@ class WebSocketEndpoint extends ClientHttpEndpointBase<HttpClientConnection> {
     tryConnect(h.context).onComplete(h.promise);
   }
 
-  private Future<HttpClientConnection> tryConnect(ContextInternal ctx) {
+  private Future<HttpClientConnectionInternal> tryConnect(ContextInternal ctx) {
     ContextInternal eventLoopContext;
     if (ctx.isEventLoopContext()) {
       eventLoopContext = ctx;
     } else {
       eventLoopContext = ctx.owner().createEventLoopContext(ctx.nettyEventLoop(), ctx.workerPool(), ctx.classLoader());
     }
-    Future<HttpClientConnection> fut = connector.httpConnect(eventLoopContext);
+    Future<HttpClientConnectionInternal> fut = connector.httpConnect(eventLoopContext);
     return fut.map(c -> {
       if (incRefCount()) {
         c.evictionHandler(v -> onEvict());
@@ -79,7 +79,7 @@ class WebSocketEndpoint extends ClientHttpEndpointBase<HttpClientConnection> {
   }
 
   @Override
-  protected Future<HttpClientConnection> requestConnection2(ContextInternal ctx, long timeout) {
+  protected Future<HttpClientConnectionInternal> requestConnection2(ContextInternal ctx, long timeout) {
     synchronized (this) {
       if (inflightConnections >= maxPoolSize) {
         Waiter waiter = new Waiter(ctx);

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -402,7 +402,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     } else {
       WebSocketClientImpl impl = new WebSocketClientImpl(this, o, options);
       closeable = impl;
-      client = new CleanableWebSocketClient(impl, cleaner, impl::close);
+      client = new CleanableWebSocketClient(impl, cleaner, impl::shutdown);
     }
     cf.add(closeable);
     return client;

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -409,16 +409,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   @Override
-  public HttpClient createHttpClient(HttpClientOptions options) {
-    return createHttpClient(options, new PoolOptions());
-  }
-
-  @Override
-  public HttpClient createHttpClient(PoolOptions poolOptions) {
-    return createHttpClient(new HttpClientOptions(), poolOptions);
-  }
-
-  @Override
   public HttpClientBuilder httpClientBuilder() {
     return new HttpClientBuilderInternal(this);
   }

--- a/src/main/java/io/vertx/core/net/NetClient.java
+++ b/src/main/java/io/vertx/core/net/NetClient.java
@@ -11,7 +11,6 @@
 
 package io.vertx.core.net;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
@@ -89,23 +88,34 @@ public interface NetClient extends Measured {
   Future<NetSocket> connect(ConnectOptions connectOptions);
 
   /**
-   * Close the client.
-   * <p>
-   * Any sockets which have not been closed manually will be closed here. The close is asynchronous and may not
-   * complete until some time after the method has returned.
+   * Close immediately ({@code shutdown(0, TimeUnit.SECONDS}).
+   *
    * @return a future notified when the client is closed
    */
   default Future<Void> close() {
-    return close(0L, TimeUnit.SECONDS);
+    return shutdown(0L, TimeUnit.SECONDS);
   }
 
   /**
-   * Initiate the client close sequence.
+   * Shutdown with a 30 seconds timeout ({@code shutdown(30, TimeUnit.SECONDS)}).
    *
-   * <p> Connections are taken out of service and notified the close sequence has started through {@link NetSocket#shutdownHandler(Handler)}.
-   * When all connections are closed the client is closed. When the timeout expires, all unclosed connections are immediately closed.
+   * @return a future completed when shutdown has completed
    */
-  Future<Void> close(long timeout, TimeUnit unit);
+  default Future<Void> shutdown() {
+    return shutdown(30, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Initiate the client shutdown sequence.
+   * <p>
+   * Connections are taken out of service and notified the close sequence has started through {@link NetSocket#shutdownHandler(Handler)}.
+   * When all connections are closed the client is closed. When the {@code timeout} expires, all unclosed connections are immediately closed.
+   *
+   * @return a future notified when the client is closed
+   * @param timeout the amount of time after which all resources are forcibly closed
+   * @param unit the of the timeout
+   */
+  Future<Void> shutdown(long timeout, TimeUnit unit);
 
   /**
    * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different

--- a/src/main/java/io/vertx/core/net/impl/CleanableNetClient.java
+++ b/src/main/java/io/vertx/core/net/impl/CleanableNetClient.java
@@ -37,7 +37,7 @@ public class CleanableNetClient implements NetClientInternal {
     }
     @Override
     public void run() {
-      client.close(timeout, timeUnit);
+      client.shutdown(timeout, timeUnit);
     }
   }
 
@@ -101,19 +101,14 @@ public class CleanableNetClient implements NetClientInternal {
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
-    return client.shutdown(timeout, timeUnit);
-  }
-
-  @Override
-  public Future<Void> close(long timeout, TimeUnit timeUnit) {
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
     if (timeout < 0L) {
       throw new IllegalArgumentException("Invalid timeout: " + timeout);
     }
     action.timeout = timeout;
-    action.timeUnit = Objects.requireNonNull(TimeUnit.SECONDS);
+    action.timeUnit = Objects.requireNonNull(unit);
     cleanable.clean();
-    return (client).closeFuture();
+    return client.closeFuture();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -209,12 +209,6 @@ class NetClientImpl implements NetClientInternal {
   @Override
   public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
     closeEvent = new ShutdownEvent(timeout, timeUnit);
-    return closeSequence.progressTo(1);
-  }
-
-  @Override
-  public Future<Void> close(long timeout, TimeUnit timeUnit) {
-    closeEvent = new ShutdownEvent(timeout, timeUnit);
     return closeSequence.close();
   }
 

--- a/src/main/java/io/vertx/core/net/impl/NetClientInternal.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientInternal.java
@@ -34,15 +34,4 @@ public interface NetClientInternal extends NetClient, MetricsProvider, Closeable
 
   Future<Void> closeFuture();
 
-  /**
-   * Shutdown the client, a {@link ShutdownEvent} is broadcast to all channels. The operation completes
-   * when all channels are closed or the timeout expires. This method does not close the remaining connections
-   * forcibly.
-   *
-   * @param timeout the shutdown timeout
-   * @param timeUnit the shutdown timeout unit
-   * @return a future completed when all channels are closed or the timeout expires.
-   */
-  Future<Void> shutdown(long timeout, TimeUnit timeUnit);
-
 }

--- a/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
@@ -41,7 +41,7 @@ public interface HttpClientMetrics<R, W, S, T> extends TCPMetrics<S> {
    * Provides metrics for a particular endpoint
    *
    * @param remoteAddress the endpoint remote address
-   * @param maxPoolSize the server max pool size
+   * @param maxPoolSize the client max pool size
    * @return the endpoint metric
    */
   default ClientMetrics<R, T, HttpRequest, HttpResponse> createEndpointMetrics(SocketAddress remoteAddress, int maxPoolSize) {

--- a/src/test/java/io/vertx/core/http/Http1xClientConnectionTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xClientConnectionTest.java
@@ -10,39 +10,30 @@
  */
 package io.vertx.core.http;
 
-import io.netty.buffer.Unpooled;
-import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
-import io.vertx.core.http.impl.HttpClientConnectionInternal;
-import io.vertx.core.http.impl.HttpRequestHead;
-import io.vertx.core.impl.ContextInternal;
 import org.junit.Test;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class Http1xClientConnectionTest extends HttpClientConnectionTest {
 
   @Test
   public void testResetStreamBeforeSend() throws Exception {
-    waitFor(1);
     server.requestHandler(req -> {
+      req.response().end("Hello World");
     });
     startServer(testAddress);
     client.connect(new HttpConnectOptions().setServer(testAddress)).onComplete(onSuccess(conn -> {
-      HttpClientConnectionInternal ci = (HttpClientConnectionInternal) conn;
-      AtomicInteger evictions = new AtomicInteger();
-      ci.evictionHandler(v -> {
-        evictions.incrementAndGet();
-      });
-      ci
-        .createStream((ContextInternal) vertx.getOrCreateContext())
-        .onComplete(onSuccess(stream -> {
-        Exception cause = new Exception();
-        stream.closeHandler(v -> {
-          assertEquals(0, evictions.get());
-          complete();
+      conn.request().onComplete(onSuccess(req -> {
+        req.reset();
+        vertx.runOnContext(v -> {
+          conn.request()
+            .compose(req2 -> req2
+              .send()
+              .compose(HttpClientResponse::body))
+            .onComplete(onSuccess(body -> {
+              assertEquals("Hello World", body.toString());
+              testComplete();
+            }));
         });
-        stream.reset(cause);
       }));
     }));
     await();
@@ -50,33 +41,23 @@ public class Http1xClientConnectionTest extends HttpClientConnectionTest {
 
   @Test
   public void testResetStreamRequestSent() throws Exception {
-    waitFor(1);
+    waitFor(2);
     Promise<Void> continuation = Promise.promise();
     server.requestHandler(req -> {
       continuation.complete();
     });
     startServer(testAddress);
-    client.connect(new HttpConnectOptions().setServer(testAddress)).onComplete(onSuccess(conn -> {
-      HttpClientConnectionInternal ci = (HttpClientConnectionInternal) conn;
-      AtomicInteger evictions = new AtomicInteger();
-      ci.evictionHandler(v -> {
-        evictions.incrementAndGet();
-      });
-      ci
-        .createStream((ContextInternal) vertx.getOrCreateContext())
-        .onComplete(onSuccess(stream -> {
-        Exception cause = new Exception();
-        stream.closeHandler(v -> {
-          assertEquals(1, evictions.get());
-          complete();
-        });
-        continuation
-          .future()
-          .onSuccess(v -> {
-            stream.reset(cause);
-          });
-        stream.writeHead(new HttpRequestHead(
-          HttpMethod.GET, "/", MultiMap.caseInsensitiveMultiMap(), DEFAULT_HTTP_HOST_AND_PORT, "", null), false, Unpooled.EMPTY_BUFFER, false, new StreamPriority(), false);
+    HttpConnectOptions connect = new HttpConnectOptions().setServer(testAddress);
+    client.connect(connect).onComplete(onSuccess(conn -> {
+      conn.closeHandler(v -> complete());
+      conn.request()
+        .onComplete(onSuccess(req -> {
+          req.send().onComplete(onFailure(err -> complete()));
+          continuation
+            .future()
+            .onSuccess(v -> {
+              req.reset();
+            });
       }));
     }));
     await();
@@ -84,25 +65,22 @@ public class Http1xClientConnectionTest extends HttpClientConnectionTest {
 
   @Test
   public void testServerConnectionClose() throws Exception {
-    waitFor(1);
+    waitFor(2);
     server.requestHandler(req -> {
-      req.response().putHeader("Connection", "close").end();
+      req.response().putHeader("Connection", "close").end("Hello World");
     });
     startServer(testAddress);
     client.connect(new HttpConnectOptions().setServer(testAddress)).onComplete(onSuccess(conn -> {
-      HttpClientConnectionInternal ci = (HttpClientConnectionInternal) conn;
-      AtomicInteger evictions = new AtomicInteger();
-      ci.evictionHandler(v -> {
-        assertEquals(1, evictions.incrementAndGet());
-      });
-      ci.createStream((ContextInternal) vertx.getOrCreateContext()).onComplete(onSuccess(stream -> {
-        stream.closeHandler(v -> {
-          assertEquals(1, evictions.get());
+      conn.closeHandler(v -> complete());
+      conn
+        .request()
+        .compose(req -> req
+          .send()
+          .compose(HttpClientResponse::body))
+        .onComplete(onSuccess(body -> {
+          assertEquals("Hello World", body.toString());
           complete();
-        });
-        stream.writeHead(new HttpRequestHead(
-          HttpMethod.GET, "/", MultiMap.caseInsensitiveMultiMap(), DEFAULT_HTTP_HOST_AND_PORT, "", null), false, Unpooled.EMPTY_BUFFER, true, new StreamPriority(), false);
-      }));
+        }));
     }));
     await();
   }

--- a/src/test/java/io/vertx/core/http/Http1xClientConnectionTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xClientConnectionTest.java
@@ -13,6 +13,7 @@ package io.vertx.core.http;
 import io.netty.buffer.Unpooled;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
+import io.vertx.core.http.impl.HttpClientConnectionInternal;
 import io.vertx.core.http.impl.HttpRequestHead;
 import io.vertx.core.impl.ContextInternal;
 import org.junit.Test;
@@ -27,12 +28,13 @@ public class Http1xClientConnectionTest extends HttpClientConnectionTest {
     server.requestHandler(req -> {
     });
     startServer(testAddress);
-    client.connect(testAddress).onComplete(onSuccess(conn -> {
+    client.connect(new HttpConnectOptions().setServer(testAddress)).onComplete(onSuccess(conn -> {
+      HttpClientConnectionInternal ci = (HttpClientConnectionInternal) conn;
       AtomicInteger evictions = new AtomicInteger();
-      conn.evictionHandler(v -> {
+      ci.evictionHandler(v -> {
         evictions.incrementAndGet();
       });
-      conn
+      ci
         .createStream((ContextInternal) vertx.getOrCreateContext())
         .onComplete(onSuccess(stream -> {
         Exception cause = new Exception();
@@ -54,12 +56,13 @@ public class Http1xClientConnectionTest extends HttpClientConnectionTest {
       continuation.complete();
     });
     startServer(testAddress);
-    client.connect(testAddress).onComplete(onSuccess(conn -> {
+    client.connect(new HttpConnectOptions().setServer(testAddress)).onComplete(onSuccess(conn -> {
+      HttpClientConnectionInternal ci = (HttpClientConnectionInternal) conn;
       AtomicInteger evictions = new AtomicInteger();
-      conn.evictionHandler(v -> {
+      ci.evictionHandler(v -> {
         evictions.incrementAndGet();
       });
-      conn
+      ci
         .createStream((ContextInternal) vertx.getOrCreateContext())
         .onComplete(onSuccess(stream -> {
         Exception cause = new Exception();
@@ -86,12 +89,13 @@ public class Http1xClientConnectionTest extends HttpClientConnectionTest {
       req.response().putHeader("Connection", "close").end();
     });
     startServer(testAddress);
-    client.connect(testAddress).onComplete(onSuccess(conn -> {
+    client.connect(new HttpConnectOptions().setServer(testAddress)).onComplete(onSuccess(conn -> {
+      HttpClientConnectionInternal ci = (HttpClientConnectionInternal) conn;
       AtomicInteger evictions = new AtomicInteger();
-      conn.evictionHandler(v -> {
+      ci.evictionHandler(v -> {
         assertEquals(1, evictions.incrementAndGet());
       });
-      conn.createStream((ContextInternal) vertx.getOrCreateContext()).onComplete(onSuccess(stream -> {
+      ci.createStream((ContextInternal) vertx.getOrCreateContext()).onComplete(onSuccess(stream -> {
         stream.closeHandler(v -> {
           assertEquals(1, evictions.get());
           complete();

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -5421,7 +5421,7 @@ public class Http1xTest extends HttpTest {
         assertWaitUntil(() -> ref.get() != null);
       }
     }
-    Future<Void> shutdown = client.close(10, TimeUnit.SECONDS);
+    Future<Void> shutdown = client.shutdown(10, TimeUnit.SECONDS);
     ref.get().response().end("hello");
     awaitFuture(shutdown);
     await();

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -5055,7 +5055,7 @@ public class Http1xTest extends HttpTest {
       if (clientConnection != null) {
         long now = System.currentTimeMillis();
         clientConnection
-          .shutdown(500L)
+          .shutdown(500, TimeUnit.MILLISECONDS)
           .onComplete(onSuccess(v -> {
             assertTrue(System.currentTimeMillis() - now >= 500L);
             complete();
@@ -5090,7 +5090,7 @@ public class Http1xTest extends HttpTest {
     waitFor(2);
     server.requestHandler(req -> {
       long now = System.currentTimeMillis();
-      clientConnectionRef.get().shutdown(0L)
+      clientConnectionRef.get().close()
         .onComplete(onSuccess(v -> {
           assertTrue(System.currentTimeMillis() - now <= 2000L);
           complete();
@@ -5119,7 +5119,7 @@ public class Http1xTest extends HttpTest {
         assertTrue(ended.get());
         complete();
       });
-      Future<Void> shutdown = conn.shutdown(10_000);
+      Future<Void> shutdown = conn.shutdown(10, TimeUnit.SECONDS);
       shutdown.onComplete(onSuccess(v -> {
         assertTrue(ended.get());
         complete();
@@ -5153,7 +5153,7 @@ public class Http1xTest extends HttpTest {
               assertEquals(2, status.get());
               complete();
             });
-            Future<Void> shutdown = conn.shutdown(10_000);
+            Future<Void> shutdown = conn.shutdown(10, TimeUnit.SECONDS);
             shutdown.onComplete(onSuccess(v -> {
               assertEquals(2, status.get());
               complete();
@@ -5190,7 +5190,7 @@ public class Http1xTest extends HttpTest {
     server.requestHandler(req -> {
       HttpConnection conn = req.connection();
       long now = System.currentTimeMillis();
-      conn.shutdown(1000);
+      conn.shutdown(1, TimeUnit.SECONDS);
       conn.closeHandler(v -> {
         assertTrue(System.currentTimeMillis() - now >= 1000);
         complete();

--- a/src/test/java/io/vertx/core/http/Http2ClientConnectionTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientConnectionTest.java
@@ -14,7 +14,8 @@ public class Http2ClientConnectionTest extends HttpClientConnectionTest {
 
   @Override
   protected HttpServerOptions createBaseServerOptions() {
-    return Http2TestBase.createHttp2ServerOptions(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST);
+    return Http2TestBase.createHttp2ServerOptions(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST)
+      .setInitialSettings(new Http2Settings().setMaxConcurrentStreams(10));
   }
 
   @Override

--- a/src/test/java/io/vertx/core/http/Http2ClientTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientTest.java
@@ -28,7 +28,7 @@ import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.buffer.impl.BufferInternal;
 import io.vertx.core.http.impl.Http2UpgradeClientConnection;
-import io.vertx.core.http.impl.HttpClientConnection;
+import io.vertx.core.http.impl.HttpClientConnectionInternal;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
@@ -1694,7 +1694,7 @@ public class Http2ClientTest extends Http2TestBase {
           assertEquals(HttpVersion.HTTP_2, resp1.version());
           client.request(requestOptions).onComplete(onSuccess(req2 -> {
             req2.send().onComplete(onSuccess(resp2 -> {
-              assertSame(((HttpClientConnection)conn).channel(), ((HttpClientConnection)resp2.request().connection()).channel());
+              assertSame(((HttpClientConnectionInternal)conn).channel(), ((HttpClientConnectionInternal)resp2.request().connection()).channel());
               testComplete();
             }));
           }));

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -1769,7 +1769,7 @@ public class Http2ServerTest extends Http2TestBase {
           assertEquals(1, status.getAndIncrement());
           complete();
         });
-        conn.shutdown(300);
+        conn.shutdown(300, TimeUnit.MILLISECONDS);
       }
     };
     testServerSendGoAway(requestHandler, 0);
@@ -1972,9 +1972,9 @@ public class Http2ServerTest extends Http2TestBase {
     Handler<HttpServerRequest> requestHandler = req -> {
       HttpConnection conn = req.connection();
       shutdown.set(System.currentTimeMillis());
-      conn.shutdown(10000);
+      conn.shutdown(10, TimeUnit.SECONDS);
       vertx.setTimer(300, v -> {
-        conn.shutdown(300);
+        conn.shutdown(300, TimeUnit.MILLISECONDS);
       });
     };
     server.requestHandler(requestHandler);

--- a/src/test/java/io/vertx/core/http/Http2Test.java
+++ b/src/test/java/io/vertx/core/http/Http2Test.java
@@ -232,7 +232,7 @@ public class Http2Test extends HttpTest {
     AtomicInteger count = new AtomicInteger();
     server.requestHandler(req -> {
       if (count.getAndIncrement() == 0) {
-        req.connection().shutdown(0L);
+        req.connection().close();
       } else {
         req.response().end();
       }

--- a/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
+++ b/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
@@ -66,11 +66,11 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
   }
 
   private Function<Vertx, HttpServer> serverFactory;
-  private Function<Vertx, HttpClient> clientFactory;
+  private Function<Vertx, HttpClientAgent> clientFactory;
   private Function<Vertx, HttpServer> nonTrafficShapedServerFactory;
 
   public HttpBandwidthLimitingTest(double protoVersion, Function<Vertx, HttpServer> serverFactory,
-                                   Function<Vertx, HttpClient> clientFactory,
+                                   Function<Vertx, HttpClientAgent> clientFactory,
                                    Function<Vertx, HttpServer> nonTrafficShapedServerFactory) {
     this.serverFactory = serverFactory;
     this.clientFactory = clientFactory;

--- a/src/test/java/io/vertx/core/http/HttpClientConnectionTest.java
+++ b/src/test/java/io/vertx/core/http/HttpClientConnectionTest.java
@@ -39,7 +39,7 @@ public abstract class HttpClientConnectionTest extends HttpTestBase {
     });
     startServer(testAddress);
     client.connect(new HttpConnectOptions().setServer(testAddress).setHost(requestOptions.getHost()).setPort(requestOptions.getPort()))
-      .compose(HttpClientConnection::createRequest)
+      .compose(HttpClientConnection::request)
       .compose(request -> request
         .send()
         .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
@@ -128,7 +128,7 @@ public abstract class HttpClientConnectionTest extends HttpTestBase {
   }
 
   private void createRequestRecursively(HttpClientConnection conn, long num, BiConsumer<Throwable, Long> callback) {
-    Future<HttpClientRequest> fut = conn.createRequest(new RequestOptions());
+    Future<HttpClientRequest> fut = conn.request(new RequestOptions());
     fut.onComplete(ar1 -> {
       if (ar1.succeeded()) {
         HttpClientRequest req = ar1.result();

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -39,7 +39,6 @@ import io.vertx.core.impl.VertxThread;
 import io.vertx.core.net.*;
 import io.vertx.core.net.impl.KeyStoreHelper;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -1729,7 +1728,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
     startServer(testAddress);
     Function<HttpClient, Future<Buffer>> request = client -> client.request(requestOptions).compose(req -> req.send().compose(HttpClientResponse::body));
     HttpClient client1 = vertx.createHttpClient(createBaseClientOptions().setVerifyHost(false).setTrustOptions(bluh.apply(0)));
-    HttpClient client2 = vertx.createHttpClient(createBaseClientOptions().setVerifyHost(false).setTrustOptions(bluh.apply(0)));
+    HttpClientAgent client2 = vertx.createHttpClient(createBaseClientOptions().setVerifyHost(false).setTrustOptions(bluh.apply(0)));
     request.apply(client1).onComplete(onSuccess(body1 -> {
       assertEquals("Hello World", body1.toString());
       server.updateSSLOptions(createBaseServerOptions().setKeyCertOptions(blah.apply(1)).getSslOptions(), force).onComplete(onSuccess(updateOccurred -> {

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -4174,7 +4174,7 @@ public abstract class HttpTest extends HttpTestBase {
       public HttpClientRequest pushHandler(Handler<HttpClientRequest> handler) { throw new UnsupportedOperationException(); }
       public boolean reset(long code) { return false; }
       public boolean reset(long code, Throwable cause) { return false; }
-      public HttpConnection connection() { throw new UnsupportedOperationException(); }
+      public HttpClientConnection connection() { throw new UnsupportedOperationException(); }
       public Future<Void> writeCustomFrame(int type, int flags, Buffer payload) { throw new UnsupportedOperationException(); }
       public boolean writeQueueFull() { throw new UnsupportedOperationException(); }
       public StreamPriority getStreamPriority() { return null; }

--- a/src/test/java/io/vertx/core/http/HttpTestBase.java
+++ b/src/test/java/io/vertx/core/http/HttpTestBase.java
@@ -42,7 +42,7 @@ public class HttpTestBase extends VertxTestBase {
   public static final String DEFAULT_TEST_URI = "some-uri";
 
   protected HttpServer server;
-  protected HttpClient client;
+  protected HttpClientAgent client;
   protected TestProxyBase proxy;
   protected SocketAddress testAddress;
   protected RequestOptions requestOptions;

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -57,7 +57,7 @@ public class MetricsTest extends VertxTestBase {
   private static final String ADDRESS1 = "some-address1";
 
   private HttpServer server;
-  private HttpClient client;
+  private HttpClientAgent client;
   private WebSocketClient wsClient;
   private VertxMetricsFactory metricsFactory;
 
@@ -640,12 +640,12 @@ public class MetricsTest extends VertxTestBase {
 
   @Test
   public void testHttpClientName() throws Exception {
-    HttpClient client1 = vertx.createHttpClient();
+    HttpClientAgent client1 = vertx.createHttpClient();
     try {
       FakeHttpClientMetrics metrics1 = FakeMetricsBase.getMetrics(client1);
       assertEquals("", metrics1.getName());
       String name = TestUtils.randomAlphaString(10);
-      HttpClient client2 = vertx.createHttpClient(new HttpClientOptions().setMetricsName(name));
+      HttpClientAgent client2 = vertx.createHttpClient(new HttpClientOptions().setMetricsName(name));
       try {
         FakeHttpClientMetrics metrics2 = FakeMetricsBase.getMetrics(client2);
         assertEquals(name, metrics2.getName());


### PR DESCRIPTION
Introduce an HTTP client connection API.

The client can create an un-pooled client connection (`HttpClientConnection`) to a server, such connection is fully managed by the user. This provides full control over client connections which can matters in some cases (e.g. writing load tests).

The `HttpClient` interface now only exposes an HTTP interaction API, other methods are moved to a new interface `HttpClientAgent` which takes responsibility for managing HTTP connection pools as well as queuing requests until connections are available.

Both `HttpClientAgent` and `HttpClientConnection` extends `HttpClient` interface. It allows clients based on HTTP client to wrap either a pooling client or a mere connection, e.g. `WebClient` or `GrpcClient`.
