### PR TITLE
HTTP/2 configurable stream byte distributor

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -703,6 +703,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
     VertxHttp2ConnectionHandler<Http2ClientConnection> handler = new VertxHttp2ConnectionHandlerBuilder<Http2ClientConnection>()
       .server(false)
       .useDecompression(client.options().isDecompressionSupported())
+      .useUniformStreamByteDistributor(client.useH2UniformStreamByteDistributor)
       .gracefulShutdownTimeoutMillis(0) // So client close tests don't hang 30 seconds - make this configurable later but requires HTTP/1 impl
       .initialSettings(client.options().getInitialSettings())
       .connectionFactory(connHandler -> {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -50,6 +50,7 @@ public class HttpClientBase implements MetricsProvider, Closeable {
   protected final CloseFuture closeFuture;
   private Predicate<SocketAddress> proxyFilter;
   private final Function<ContextInternal, ContextInternal> contextProvider;
+  final boolean useH2UniformStreamByteDistributor;
 
   public HttpClientBase(VertxInternal vertx, HttpClientOptions options, CloseFuture closeFuture) {
     this.vertx = vertx;
@@ -67,6 +68,7 @@ public class HttpClientBase implements MetricsProvider, Closeable {
           break;
       }
     }
+    this.useH2UniformStreamByteDistributor = HttpUtils.useH2UniformStreamByteDistributor();
     this.keepAlive = options.isKeepAlive();
     this.pipelining = options.isPipelining();
     if (!keepAlive && pipelining) {

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -50,16 +50,17 @@ public class HttpServerImpl extends TCPServerBase implements HttpServer, Closeab
   static final boolean DISABLE_WEBSOCKETS = Boolean.getBoolean(DISABLE_WEBSOCKETS_PROP_NAME);
 
   final HttpServerOptions options;
+  final boolean useH2UniformStreamByteDistributor;
   private final HttpStreamHandler<ServerWebSocket> wsStream = new HttpStreamHandler<>();
   private final HttpStreamHandler<HttpServerRequest> requestStream = new HttpStreamHandler<>();
   private Handler<HttpServerRequest> invalidRequestHandler;
   private Handler<HttpConnection> connectionHandler;
-
   private Handler<Throwable> exceptionHandler;
 
   public HttpServerImpl(VertxInternal vertx, HttpServerOptions options) {
     super(vertx, options);
     this.options = new HttpServerOptions(options);
+    this.useH2UniformStreamByteDistributor = HttpUtils.useH2UniformStreamByteDistributor();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpServerWorker.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerWorker.java
@@ -259,6 +259,7 @@ public class HttpServerWorker implements BiConsumer<Channel, SslChannelProvider>
       .decoderEnforceMaxRstFramesPerWindow(maxRstFramesPerWindow, secondsPerWindow)
       .useDecompression(options.isDecompressionSupported())
       .initialSettings(options.getInitialSettings())
+      .useUniformStreamByteDistributor(server.useH2UniformStreamByteDistributor)
       .connectionFactory(connHandler -> {
         Http2ServerConnection conn = new Http2ServerConnection(ctx, streamContextSupplier, serverOrigin, connHandler, encodingDetector, options, metrics);
         if (metrics != null) {

--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -62,6 +62,13 @@ import static io.vertx.core.http.Http2Settings.*;
  */
 public final class HttpUtils {
 
+  static final String H2_STREAM_BYTE_DISTRIBUTOR = "vertx.h2StreamByteDistributor";
+  static final String UNIFORM_DISTRIBUTOR = "uniform";
+
+  static boolean useH2UniformStreamByteDistributor() {
+    return UNIFORM_DISTRIBUTOR.equals(System.getProperty(H2_STREAM_BYTE_DISTRIBUTOR));
+  }
+
   static final HttpClosedException CONNECTION_CLOSED_EXCEPTION = new HttpClosedException("Connection was closed");
   static final HttpClosedException STREAM_CLOSED_EXCEPTION = new HttpClosedException("Stream was closed");
   static final int SC_SWITCHING_PROTOCOLS = 101;

--- a/src/test/java/io/vertx/core/http/impl/Http2StreamByteDistributorTest.java
+++ b/src/test/java/io/vertx/core/http/impl/Http2StreamByteDistributorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.Http2TestBase;
+import io.vertx.core.http.HttpClientResponse;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class Http2StreamByteDistributorTest extends Http2TestBase {
+
+  @Test
+  public void smokeTest() throws Exception {
+    System.setProperty(HttpUtils.H2_STREAM_BYTE_DISTRIBUTOR, HttpUtils.UNIFORM_DISTRIBUTOR);
+    try {
+      server.requestHandler(req -> {
+        req.response().end("Hello World");
+      });
+      startServer(testAddress);
+      Future<Buffer> response = client
+        .request(requestOptions)
+        .compose(req -> req
+          .send()
+          .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+          .compose(HttpClientResponse::body));
+      response.onComplete(onSuccess(body -> {
+        assertEquals("Hello World", body.toString());
+        testComplete();
+      }));
+      await();
+    } finally {
+      System.clearProperty(HttpUtils.H2_STREAM_BYTE_DISTRIBUTOR);
+    }
+  }
+}


### PR DESCRIPTION
A replacement of the HTTP/2 priority handling with a uniform stream byte distributor.

The default stream byte distributor use stream priorities to determine the amount of bytes to be sent for each stream, this change allows to use a strategy that does not use stream priorities and yields better performance since it consumes less CPU.

The default implementation remains the WeightedFairQueueByteDistributor, it can be replaced by UniformStreamByteDistributor with the system property `vertx.h2StreamByteDistributor` set to `uniform`. Note that this system property is evaluated when an HTTP server or an HTTP client is created and is not cached statically.
