### PR TITLE
5074 Fix the WebSocket exception handling strategy

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -1229,17 +1229,12 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   }
 
   @Override
-  protected void handleException(Throwable e) {
+  public void handleException(Throwable e) {
     super.handleException(e);
-    WebSocketImpl ws;
     LinkedHashSet<Stream> allStreams = new LinkedHashSet<>();
     synchronized (this) {
-      ws = webSocket;
       allStreams.addAll(requests);
       allStreams.addAll(responses);
-    }
-    if (ws != null) {
-      ws.handleException(e);
     }
     for (Stream stream : allStreams) {
       stream.handleException(e);

--- a/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
@@ -112,6 +112,11 @@ abstract class Http1xConnectionBase<S extends WebSocketImplBase<S>> extends Conn
   }
 
   @Override
+  public void handleException(Throwable t) {
+    super.handleException(t);
+  }
+
+  @Override
   public HttpConnection goAway(long errorCode, int lastStreamId, Buffer debugData) {
     throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
   }

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -521,13 +521,11 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
   }
 
   @Override
-  protected void handleException(Throwable t) {
+  public void handleException(Throwable t) {
     super.handleException(t);
     Http1xServerRequest responseInProgress;
     Http1xServerRequest requestInProgress;
-    ServerWebSocketImpl ws;
     synchronized (this) {
-      ws = this.webSocket;
       requestInProgress = this.requestInProgress;
       responseInProgress = this.responseInProgress;
       if (METRICS_ENABLED && metrics != null) {
@@ -539,9 +537,6 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
     }
     if (responseInProgress != null && responseInProgress != requestInProgress) {
       responseInProgress.handleException(t);
-    }
-    if (ws != null) {
-      ws.context.execute(v -> ws.handleException(t));
     }
   }
 


### PR DESCRIPTION
Linked to this issue : https://github.com/eclipse-vertx/vert.x/issues/5074

The ConnectionBase exception handler was not set when `webSocket.exceptionHandler(...)` is called. This was leading `ConnectionBase` to consider the exception as uncaught and to print it, ignoring the exception handler set at the WebSocketImplBase level.

Moreover, this WebSocket handler was also called after the call to `ConnectionBase#handleException(...)`.

So I decided to set the `ConnectionBase` exception handler with the WebSocketImplBase.

The replacement of `Http1xConnectionBase conn` with `Http1xConnectionBase<?> conn` was needed otherwise the compiler complains.
