### PR TITLE
Use a static FastThreadLocal in CombinerExecutor instead of a instance field

### DIFF
--- a/src/test/java/io/vertx/core/net/impl/pool/ConnectionPoolTest.java
+++ b/src/test/java/io/vertx/core/net/impl/pool/ConnectionPoolTest.java
@@ -958,14 +958,14 @@ public class ConnectionPoolTest extends VertxTestBase {
     List<Integer> res = Collections.synchronizedList(new LinkedList<>());
     AtomicInteger seq = new AtomicInteger();
     CountDownLatch latch = new CountDownLatch(1 + numAcquires);
+    int[] count = new int[1];
     ConnectionPool<Connection> pool = ConnectionPool.pool(new PoolConnector<Connection>() {
-      int count = 0;
       int reentrancy = 0;
       @Override
       public Future<ConnectResult<Connection>> connect(ContextInternal context, Listener listener) {
         assertEquals(0, reentrancy++);
         try {
-          int val = count++;
+          int val = count[0]++;
           if (val == 0) {
             // Queue extra requests
             for (int i = 0;i < numAcquires;i++) {
@@ -975,6 +975,7 @@ public class ConnectionPoolTest extends VertxTestBase {
                 latch.countDown();
               }));
             }
+            assertEquals(1, count[0]);
           }
           return Future.failedFuture("failure");
         } finally {
@@ -995,8 +996,79 @@ public class ConnectionPoolTest extends VertxTestBase {
       }));
     });
     awaitLatch(latch);
+    assertEquals(1 + numAcquires, count[0]);
     List<Integer> expected = IntStream.concat(IntStream.range(1, numAcquires + 1), IntStream.of(0)).boxed().collect(Collectors.toList());
     assertEquals(expected, res);
+  }
+
+  @Test
+  public void testConcurrentPostTasksTrampoline() throws Exception {
+    AtomicReference<ConnectionPool<Connection>> ref1 = new AtomicReference<>();
+    AtomicReference<ConnectionPool<Connection>> ref2 = new AtomicReference<>();
+    ContextInternal ctx = vertx.createEventLoopContext();
+    List<Integer> res = Collections.synchronizedList(new LinkedList<>());
+    CountDownLatch latch = new CountDownLatch(4);
+    ConnectionPool<Connection> pool1 = ConnectionPool.pool(new PoolConnector<>() {
+      int count = 0;
+      int reentrancy = 0;
+      @Override
+      public Future<ConnectResult<Connection>> connect(ContextInternal context, Listener listener) {
+        assertEquals(0, reentrancy++);
+        try {
+          int val = count++;
+          if (val == 0) {
+            ref1.get().acquire(ctx, 0, onFailure(err -> {
+              res.add(1);
+              latch.countDown();
+            }));
+            ref2.get().acquire(ctx, 0, onFailure(err -> {
+              res.add(2);
+              latch.countDown();
+            }));
+          }
+          return Future.failedFuture("failure");
+        } finally {
+          reentrancy--;
+        }
+      }
+      @Override
+      public boolean isValid(Connection connection) {
+        return true;
+      }
+    }, new int[]{1}, 2);
+    ConnectionPool<Connection> pool2 = ConnectionPool.pool(new PoolConnector<>() {
+      int count = 0;
+      int reentrancy = 0;
+      @Override
+      public Future<ConnectResult<Connection>> connect(ContextInternal context, Listener listener) {
+        assertEquals(0, reentrancy++);
+        try {
+          int val = count++;
+          if (val == 0) {
+            ref2.get().acquire(ctx, 0, onFailure(err -> {
+              res.add(3);
+              latch.countDown();
+            }));
+            ref1.get().acquire(ctx, 0, onFailure(err -> {
+              res.add(4);
+              latch.countDown();
+            }));
+          }
+          return Future.failedFuture("failure");
+        } finally {
+          reentrancy--;
+        }
+      }
+      @Override
+      public boolean isValid(Connection connection) {
+        return true;
+      }
+    }, new int[]{1}, 2);
+    ref1.set(pool1);
+    ref2.set(pool2);
+    pool1.acquire(ctx, 0, onFailure(err -> res.add(0)));
+    awaitLatch(latch);
+//    assertEquals(Arrays.asList(0, 2, 1, 3, 4), res);
   }
 
   static class Connection {

--- a/src/test/java/io/vertx/core/net/impl/pool/SynchronizationTest.java
+++ b/src/test/java/io/vertx/core/net/impl/pool/SynchronizationTest.java
@@ -10,12 +10,16 @@
  */
 package io.vertx.core.net.impl.pool;
 
+import io.netty.util.concurrent.FastThreadLocal;
 import io.vertx.test.core.AsyncTestBase;
 import org.junit.Assume;
 import org.junit.Test;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -72,12 +76,56 @@ public class SynchronizationTest extends AsyncTestBase {
   }
 
   @Test
+  public void testActionReentrancy2() throws Exception {
+    List<Integer> log = new LinkedList<>();
+    Executor<Object> combiner1 = new CombinerExecutor<>(new Object());
+    Executor<Object> combiner2 = new CombinerExecutor<>(new Object());
+    int[] reentrancy = new int[2];
+    combiner1.submit(state1 -> taskOf(() -> {
+      assertEquals(0, reentrancy[0]++);
+      combiner1.submit(state2 -> taskOf(() -> {
+        assertEquals(0, reentrancy[0]++);
+        log.add(0);
+        reentrancy[0]--;
+      }));
+      combiner2.submit(state2 -> taskOf(() -> {
+        assertEquals(0, reentrancy[1]++);
+        log.add(1);
+        combiner1.submit(state3 -> taskOf(() -> {
+          assertEquals(0, reentrancy[0]++);
+          log.add(2);
+          reentrancy[0]--;
+        }));
+        combiner2.submit(state3 -> taskOf(() -> {
+          assertEquals(0, reentrancy[1]++);
+          log.add(3);
+          reentrancy[1]--;
+        }));
+        reentrancy[1]--;
+      }));
+      reentrancy[0]--;
+    }));
+    assertEquals(0, reentrancy[0]);
+    assertEquals(0, reentrancy[1]);
+    assertEquals(Arrays.asList(1, 3, 0, 2), log);
+  }
+
+  static Task taskOf(Runnable runnable) {
+    return new Task() {
+      @Override
+      public void run() {
+        runnable.run();
+      }
+    };
+  }
+
+  @Test
   public void testFoo() throws Exception {
     Assume.assumeFalse(io.vertx.core.impl.Utils.isWindows());
     int numThreads = 8;
     int numIter = 1_000 * 100;
     Executor<Object> sync = new CombinerExecutor<>(new Object());
-    Executor.Action action = s -> {
+    Executor.Action<Object> action = s -> {
       burnCPU(10);
       return null;
     };
@@ -165,5 +213,23 @@ public class SynchronizationTest extends AsyncTestBase {
       };
     });
     assertEquals(3, order.get());
+  }
+
+  @Test
+  public void testFastThreadLocalStability() {
+    CombinerExecutor<Void> executor = new CombinerExecutor<>(null);
+    int expected = io.netty.util.internal.InternalThreadLocalMap.lastVariableIndex();
+    AtomicInteger counter = new AtomicInteger();
+    for (int i = 0;i < 1000;i++) {
+      executor = new CombinerExecutor<>(null);
+      executor.submit(state -> new Task() {
+        @Override
+        public void run() {
+          counter.incrementAndGet();
+        }
+      });
+      assertEquals(i + 1, counter.get());
+    }
+    assertEquals(expected, io.netty.util.internal.InternalThreadLocalMap.lastVariableIndex());
   }
 }


### PR DESCRIPTION
The CombinerExecutor class creates an instance of FastThreadLocal for each combiner executor leading to an increase of the InternalThreadLocalMap index. Consequently each thread local map of FastThreadLocalThread will get a new map sized accordingly, leading to an eventual memory leak.
    
Use a static FastThreadLocal in CombinerExecutor instead of a instance field, the data structure stored in this thread local map keeps track of the CombinerExecutor running in order to allow interleaved execution of CombinerExecutor post tasks without interfering each other. The structure is optimized for the most frequent case.

Fixes https://access.redhat.com/security/cve/CVE-2024-1023