### PR TITLE
Graceful handling of Jackson 2.15.x series

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -428,7 +428,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>3.2.5</version>
         <executions>
           <execution>
             <id>ssl-engine:default</id>
@@ -580,6 +580,29 @@
               </systemProperties>
               <classpathDependencyExcludes>
                 <classpathDependencyExclude>io.netty:netty-codec-haproxy</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>no-recycler-pool-jackson</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>io/vertx/it/NoRecyclerPoolJacksonTest.java</include>
+              </includes>
+              <additionalClasspathDependencies>
+                <additionalClasspathDependency>
+                  <groupId>com.fasterxml.jackson.core</groupId>
+                  <artifactId>jackson-core</artifactId>
+                  <version>2.15.1</version>
+                </additionalClasspathDependency>
+              </additionalClasspathDependencies>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-core</classpathDependencyExclude>
+                <classpathDependencyExclude>com.fasterxml.jackson.core:jackson-databind</classpathDependencyExclude>
               </classpathDependencyExcludes>
             </configuration>
           </execution>

--- a/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -11,11 +11,7 @@
 
 package io.vertx.core.json.jackson;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
@@ -34,6 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -53,11 +50,31 @@ import static java.time.format.DateTimeFormatter.ISO_INSTANT;
  */
 public class JacksonCodec implements JsonCodec {
 
-  private static final JsonFactory factory = JsonFactory.builder().recyclerPool(HybridJacksonPool.getInstance()).build();
+  private static JsonFactory buildFactory() {
+    TSFBuilder<?, ?> builder = JsonFactory.builder();
+    try {
+      // Use reflection to configure the recycler pool
+      Method[] methods = builder.getClass().getMethods();
+      for (Method method : methods) {
+        if (method.getName().equals("recyclerPool")) {
+          Class<?> poolClass = JacksonCodec.class.getClassLoader().loadClass("io.vertx.core.json.jackson.HybridJacksonPool");
+          Method getInstanceMethod = poolClass.getMethod("getInstance");
+          Object pool = getInstanceMethod.invoke(null);
+          method.invoke(builder, pool);
+          break;
+        }
+      }
+    } catch (Throwable e) {
+      // Ignore: most likely no Recycler Pool with Jackson < 2.16
+    }
+    return builder.build();
+  }
+
+  private static final JsonFactory factory = buildFactory();
 
   static {
     // Non-standard JSON but we allow C style comments in our JSON
-    factory.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+    JacksonCodec.factory.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
   }
 
   @Override

--- a/src/test/java/io/vertx/it/NoRecyclerPoolJacksonTest.java
+++ b/src/test/java/io/vertx/it/NoRecyclerPoolJacksonTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.it;
+
+import com.fasterxml.jackson.core.Version;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonObject;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class NoRecyclerPoolJacksonTest extends VertxTestBase {
+
+  @Test
+  public void testJsonObject() {
+
+    Version version = com.fasterxml.jackson.core.json.PackageVersion.VERSION;
+    assertEquals("2.15.1", version.toString());
+
+    JsonObject obj = new JsonObject("{\"foo\":\"bar\"}");
+    assertEquals("bar", obj.getString("foo"));
+    assertEquals("{\"foo\":\"bar\"}", obj.toString());
+    try {
+      obj.mapTo(Object.class);
+      fail();
+    } catch (DecodeException ignore) {
+      // Expected
+    }
+  }
+}


### PR DESCRIPTION
The upgrade to Jackson 2.16.x brought the new recycler pool feature. We should support Jackson versions that do not support this feature to avoid forcing users to move Jackson 2.16.x

Use reflection to configure the pool instead and gracefully fail when configuration cannot be achieved.
