### PR TITLE
Allow dynamic update of read and write limits set for Servers

### DIFF
--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -367,6 +367,18 @@ through {@link io.vertx.core.net.NetServerOptions} and for HttpServer it can be 
 {@link examples.NetExamples#configureTrafficShapingForHttpServer}
 ----
 
+These traffic shaping options can also be dynamically updated after server start.
+
+[source,$lang]
+----
+{@link examples.NetExamples#dynamicallyUpdateTrafficShapingForNetServer}
+----
+
+[source,$lang]
+----
+{@link examples.NetExamples#dynamicallyUpdateTrafficShapingForHttpServer}
+----
+
 [[ssl]]
 === Configuring servers and clients to work with SSL/TLS
 

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -748,12 +748,8 @@ public class NetExamples {
                                      .setOutboundGlobalBandwidth(128 * 1024); // unchanged
     server
       .listen(1234, "localhost")
-      .onComplete(res -> {
-        if (res.succeeded()) {
-          // wait until traffic shaping handler is created for updates
-          server.updateTrafficShapingOptions(update);
-        }
-      });
+      // wait until traffic shaping handler is created for updates
+      .onSuccess(v -> server.updateTrafficShapingOptions(update));
   }
 
   public void configureTrafficShapingForHttpServer(Vertx vertx) {
@@ -781,11 +777,7 @@ public class NetExamples {
                                      .setOutboundGlobalBandwidth(128 * 1024); // unchanged
     server
       .listen(1234, "localhost")
-      .onComplete(res -> {
-        if (res.succeeded()) {
-          // wait until traffic shaping handler is created for updates
-          server.updateTrafficShapingOptions(update);
-        }
-      });
+      // wait until traffic shaping handler is created for updates
+      .onSuccess(v -> server.updateTrafficShapingOptions(update));
   }
 }

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -735,6 +735,27 @@ public class NetExamples {
     NetServer server = vertx.createNetServer(options);
   }
 
+  public void dynamicallyUpdateTrafficShapingForNetServer(Vertx vertx) {
+    NetServerOptions options = new NetServerOptions()
+                                 .setHost("localhost")
+                                 .setPort(1234)
+                                 .setTrafficShapingOptions(new TrafficShapingOptions()
+                                                             .setInboundGlobalBandwidth(64 * 1024)
+                                                             .setOutboundGlobalBandwidth(128 * 1024));
+    NetServer server = vertx.createNetServer(options);
+    TrafficShapingOptions update = new TrafficShapingOptions()
+                                     .setInboundGlobalBandwidth(2 * 64 * 1024) // twice
+                                     .setOutboundGlobalBandwidth(128 * 1024); // unchanged
+    server
+      .listen(1234, "localhost")
+      .onComplete(res -> {
+        if (res.succeeded()) {
+          // wait until traffic shaping handler is created for updates
+          server.updateTrafficShapingOptions(update);
+        }
+      });
+  }
+
   public void configureTrafficShapingForHttpServer(Vertx vertx) {
     HttpServerOptions options = new HttpServerOptions()
       .setHost("localhost")
@@ -744,5 +765,27 @@ public class NetExamples {
         .setOutboundGlobalBandwidth(128 * 1024));
 
     HttpServer server = vertx.createHttpServer(options);
+  }
+
+
+  public void dynamicallyUpdateTrafficShapingForHttpServer(Vertx vertx) {
+    HttpServerOptions options = new HttpServerOptions()
+                                  .setHost("localhost")
+                                  .setPort(1234)
+                                  .setTrafficShapingOptions(new TrafficShapingOptions()
+                                                              .setInboundGlobalBandwidth(64 * 1024)
+                                                              .setOutboundGlobalBandwidth(128 * 1024));
+    HttpServer server = vertx.createHttpServer(options);
+    TrafficShapingOptions update = new TrafficShapingOptions()
+                                     .setInboundGlobalBandwidth(2 * 64 * 1024) // twice
+                                     .setOutboundGlobalBandwidth(128 * 1024); // unchanged
+    server
+      .listen(1234, "localhost")
+      .onComplete(res -> {
+        if (res.succeeded()) {
+          // wait until traffic shaping handler is created for updates
+          server.updateTrafficShapingOptions(update);
+        }
+      });
   }
 }

--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -12,15 +12,14 @@
 package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.metrics.Measured;
-import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.TrafficShapingOptions;
 import io.vertx.core.net.impl.SocketAddressImpl;
 
 /**
@@ -129,6 +128,14 @@ public interface HttpServer extends Measured {
    * @return a future signaling the update success
    */
   Future<Boolean> updateSSLOptions(ServerSSLOptions options, boolean force);
+
+  /**
+   * Update traffic shaping options {@code options}, the update happens if valid values are passed for traffic
+   * shaping options. This update happens synchronously and at best effort for rate update to take effect immediately.
+   *
+   * @param options the new traffic shaping options
+   */
+  void updateTrafficShapingOptions(TrafficShapingOptions options);
 
   /**
    * Tell the server to start listening. The server will listen on the port and host specified in the

--- a/src/main/java/io/vertx/core/net/NetServer.java
+++ b/src/main/java/io/vertx/core/net/NetServer.java
@@ -146,4 +146,12 @@ public interface NetServer extends Measured {
    * @return a future signaling the update success
    */
   Future<Boolean> updateSSLOptions(ServerSSLOptions options, boolean force);
+
+  /**
+   * Update traffic shaping options {@code options}, the update happens if valid values are passed for traffic
+   * shaping options. This update happens synchronously and at best effort for rate update to take effect immediately.
+   *
+   * @param options the new traffic shaping options
+   */
+  void updateTrafficShapingOptions(TrafficShapingOptions options);
 }

--- a/src/main/java/io/vertx/core/net/TrafficShapingOptions.java
+++ b/src/main/java/io/vertx/core/net/TrafficShapingOptions.java
@@ -139,14 +139,14 @@ public class TrafficShapingOptions {
   }
 
   /**
-   * Set the delay between two computations of performances for channels or 0 if no stats are to be computed
+   * Set the delay between two computations of performances for channels
    *
    * @param checkIntervalForStats delay between two computations of performances
    * @return a reference to this, so the API can be used fluently
    */
   public TrafficShapingOptions setCheckIntervalForStats(long checkIntervalForStats) {
     this.checkIntervalForStats = checkIntervalForStats;
-    ObjectUtil.checkPositive(this.checkIntervalForStats, "checkIntervalForStats");
+    ObjectUtil.checkPositiveOrZero(this.checkIntervalForStats, "checkIntervalForStats");
     return this;
   }
 

--- a/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
+++ b/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
@@ -249,7 +249,7 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
     Assert.assertTrue(elapsedMillis < expectedUpperBoundTimeMillis(TEST_CONTENT_SIZE, INBOUND_LIMIT));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = IllegalStateException.class)
   public void testRateUpdateWhenServerStartedWithoutTrafficShaping() {
     HttpServer testServer = nonTrafficShapedServerFactory.apply(vertx);
 

--- a/src/test/java/io/vertx/core/net/NetBandwidthLimitingTest.java
+++ b/src/test/java/io/vertx/core/net/NetBandwidthLimitingTest.java
@@ -327,7 +327,7 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
     await();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = IllegalStateException.class)
   public void testRateUpdateWhenServerStartedWithoutTrafficShaping() {
     NetServerOptions options = new NetServerOptions().setHost(DEFAULT_HOST).setPort(DEFAULT_PORT);
     NetServer testServer = vertx.createNetServer(options);

--- a/src/test/java/io/vertx/core/net/NetBandwidthLimitingTest.java
+++ b/src/test/java/io/vertx/core/net/NetBandwidthLimitingTest.java
@@ -249,6 +249,96 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
     assertTimeTakenFallsInRange(expectedTimeInMillis, elapsedMillis);
   }
 
+  @Test
+  public void testDynamicInboundRateUpdate() {
+    long startTime = System.nanoTime();
+
+    Buffer expected = TestUtils.randomBuffer(64 * 1024 * 4);
+    Buffer received = Buffer.buffer();
+    NetServer server = netServer(vertx);
+
+    server.connectHandler(sock -> {
+      sock.handler(buff -> {
+        received.appendBuffer(buff);
+        if (received.length() == expected.length()) {
+          assertEquals(expected, received);
+          long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+          assertTrue(elapsedMillis < expectedUpperBoundTimeMillis(received.length(), INBOUND_LIMIT));
+          testComplete();
+        }
+      });
+      // Send some data to the client to trigger the buffer write
+      sock.write("foo");
+    });
+    Future<NetServer> result = server.listen(testAddress);
+
+    // update rate
+    TrafficShapingOptions trafficOptions = new TrafficShapingOptions()
+                                             .setOutboundGlobalBandwidth(OUTBOUND_LIMIT) // unchanged
+                                             .setInboundGlobalBandwidth(2 * INBOUND_LIMIT);
+    server.updateTrafficShapingOptions(trafficOptions);
+
+    result.onComplete(onSuccess(resp -> {
+      Future<NetSocket> clientConnect = client.connect(testAddress);
+      clientConnect.onComplete(onSuccess(sock -> {
+        sock.handler(buf -> {
+          sock.write(expected);
+        });
+      }));
+    }));
+    await();
+  }
+
+  @Test
+  public void testDynamicOutboundRateUpdate() {
+    long startTime = System.nanoTime();
+
+    Buffer expected = TestUtils.randomBuffer(64 * 1024 * 4);
+    Buffer received = Buffer.buffer();
+    NetServer server = netServer(vertx);
+    server.connectHandler(sock -> {
+      sock.handler(buf -> {
+        sock.write(expected);
+      });
+    });
+    Future<NetServer> result = server.listen(testAddress);
+
+    // update rate
+    TrafficShapingOptions trafficOptions = new TrafficShapingOptions()
+                                             .setInboundGlobalBandwidth(INBOUND_LIMIT) // unchanged
+                                             .setOutboundGlobalBandwidth(2 * OUTBOUND_LIMIT);
+    server.updateTrafficShapingOptions(trafficOptions);
+
+    result.onComplete(onSuccess(resp -> {
+      Future<NetSocket> clientConnect = client.connect(testAddress);
+      clientConnect.onComplete(onSuccess(sock -> {
+        sock.handler(buff -> {
+          received.appendBuffer(buff);
+          if (received.length() == expected.length()) {
+            assertEquals(expected, received);
+            long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+            assertTrue(elapsedMillis < expectedUpperBoundTimeMillis(received.length(), OUTBOUND_LIMIT));
+            testComplete();
+          }
+        });
+        sock.write("foo");
+      }));
+    }));
+    await();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRateUpdateWhenServerStartedWithoutTrafficShaping() {
+    NetServerOptions options = new NetServerOptions().setHost(DEFAULT_HOST).setPort(DEFAULT_PORT);
+    NetServer testServer = vertx.createNetServer(options);
+
+    // update inbound rate to twice the limit
+    TrafficShapingOptions trafficOptions = new TrafficShapingOptions()
+                                             .setOutboundGlobalBandwidth(OUTBOUND_LIMIT)
+                                             .setInboundGlobalBandwidth(2 * INBOUND_LIMIT);
+    testServer.updateTrafficShapingOptions(trafficOptions);
+  }
+
   /**
    * Calculate time taken for transfer given bandwidth limit set.
    *
@@ -257,6 +347,13 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
    * @return expected time to be taken by server to send/receive data
    */
   private long expectedTimeMillis(int size, int rate) {
+    return TimeUnit.MILLISECONDS.convert((size / rate), TimeUnit.SECONDS);
+  }
+
+  /**
+   * Upperbound time taken is calculated with old rate limit before update. Hence time taken should be less than this value.
+   */
+  private long expectedUpperBoundTimeMillis(int size, int rate) {
     return TimeUnit.MILLISECONDS.convert((size / rate), TimeUnit.SECONDS);
   }
 


### PR DESCRIPTION
Motivation:

Allowing dynamic updates of read and write limits set for HttpServer and NetServers created through Vert.x would be helpful during rate limit threshold setting tests. Currently dynamic updates are not possible, hence servers created have to be bounced and recreated. This could cause downtime. With this patch server thresholds can be updated dynamically. 


