### PR TITLE
ObjectMapper configuration should apply when pretty printing

### DIFF
--- a/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
+++ b/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -35,10 +34,11 @@ import java.util.concurrent.atomic.AtomicReference;
 public class DatabindCodec extends JacksonCodec {
 
   private static final ObjectMapper mapper = new ObjectMapper();
-  private static final AtomicReference<ObjectMapper> prettyMapper = new AtomicReference<>();
+  private static final ObjectMapper prettyMapper = new ObjectMapper();
 
   static {
     initialize(mapper, false);
+    initialize(prettyMapper, true);
   }
 
   private static void initialize(ObjectMapper om, boolean prettyPrint) {
@@ -64,13 +64,7 @@ public class DatabindCodec extends JacksonCodec {
    */
   @Deprecated
   public static ObjectMapper prettyMapper() {
-    ObjectMapper pm = prettyMapper.get();
-    if (pm != null) {
-      return pm;
-    }
-    pm = new ObjectMapper();
-    initialize(pm, true);
-    return prettyMapper.compareAndSet(null, pm) ? pm : prettyMapper.get();
+    return prettyMapper;
   }
 
   @Override

--- a/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
@@ -120,7 +120,9 @@ public class JacksonDatabindTest extends VertxTestBase {
     try {
       om.setConfig(sc.with(SerializationFeature.WRITE_ENUMS_USING_INDEX));
       ThreadingModel vt = ThreadingModel.VIRTUAL_THREAD;
-      assertEquals(Json.encode(vt), Json.encodePrettily(vt));
+      String expected = String.valueOf(vt.ordinal());
+      assertEquals(expected, Json.encodePrettily(vt));
+      assertEquals(expected, Json.encode(vt));
     } finally {
       om.setConfig(sc);
     }

--- a/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonDatabindTest.java
@@ -14,6 +14,9 @@ package io.vertx.core.json;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.vertx.core.ThreadingModel;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.core.json.jackson.JacksonCodec;
@@ -107,5 +110,19 @@ public class JacksonDatabindTest extends VertxTestBase {
     Instant instant;
     @JsonProperty
     byte[] bytes;
+  }
+
+  @Test
+  public void testObjectMapperConfigAppliesToPrettyPrinting() {
+    ObjectMapper om = DatabindCodec.mapper();
+    SerializationConfig sc = om.getSerializationConfig();
+    assertNotNull(sc);
+    try {
+      om.setConfig(sc.with(SerializationFeature.WRITE_ENUMS_USING_INDEX));
+      ThreadingModel vt = ThreadingModel.VIRTUAL_THREAD;
+      assertEquals(Json.encode(vt), Json.encodePrettily(vt));
+    } finally {
+      om.setConfig(sc);
+    }
   }
 }


### PR DESCRIPTION
Follows-up on https://github.com/eclipse-vertx/vert.x/pull/5060

Since the pretty mapper is deprecated, any customization of the object mapper should be used when pretty printing with `Json.encodePrettily`.