### PR TITLE
Allow dynamic update of read and write limits set for Servers

### DIFF
--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -365,6 +365,18 @@ through {@link io.vertx.core.net.NetServerOptions} and for HttpServer it can be 
 {@link examples.NetExamples#configureTrafficShapingForHttpServer}
 ----
 
+These traffic shaping options can also be dynamically updated after server start.
+
+[source,$lang]
+----
+{@link examples.NetExamples#dynamicallyUpdateTrafficShapingForNetServer}
+----
+
+[source,$lang]
+----
+{@link examples.NetExamples#dynamicallyUpdateTrafficShapingForHttpServer}
+----
+
 [[ssl]]
 === Configuring servers and clients to work with SSL/TLS
 

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -721,6 +721,23 @@ public class NetExamples {
     NetServer server = vertx.createNetServer(options);
   }
 
+  public void dynamicallyUpdateTrafficShapingForNetServer(Vertx vertx) {
+    NetServerOptions options = new NetServerOptions()
+                                 .setHost("localhost")
+                                 .setPort(1234)
+                                 .setTrafficShapingOptions(new TrafficShapingOptions()
+                                                             .setInboundGlobalBandwidth(64 * 1024)
+                                                             .setOutboundGlobalBandwidth(128 * 1024));
+    NetServer server = vertx.createNetServer(options);
+    TrafficShapingOptions update = new TrafficShapingOptions()
+                                     .setInboundGlobalBandwidth(2 * 64 * 1024) // twice
+                                     .setOutboundGlobalBandwidth(128 * 1024); // unchanged
+    server
+      .listen(1234, "localhost")
+      // wait until traffic shaping handler is created for updates
+      .onSuccess(v -> server.updateTrafficShapingOptions(update));
+  }
+
   public void configureTrafficShapingForHttpServer(Vertx vertx) {
     HttpServerOptions options = new HttpServerOptions()
       .setHost("localhost")
@@ -730,5 +747,23 @@ public class NetExamples {
         .setOutboundGlobalBandwidth(128 * 1024));
 
     HttpServer server = vertx.createHttpServer(options);
+  }
+
+
+  public void dynamicallyUpdateTrafficShapingForHttpServer(Vertx vertx) {
+    HttpServerOptions options = new HttpServerOptions()
+                                  .setHost("localhost")
+                                  .setPort(1234)
+                                  .setTrafficShapingOptions(new TrafficShapingOptions()
+                                                              .setInboundGlobalBandwidth(64 * 1024)
+                                                              .setOutboundGlobalBandwidth(128 * 1024));
+    HttpServer server = vertx.createHttpServer(options);
+    TrafficShapingOptions update = new TrafficShapingOptions()
+                                     .setInboundGlobalBandwidth(2 * 64 * 1024) // twice
+                                     .setOutboundGlobalBandwidth(128 * 1024); // unchanged
+    server
+      .listen(1234, "localhost")
+      // wait until traffic shaping handler is created for updates
+      .onSuccess(v -> server.updateTrafficShapingOptions(update));
   }
 }

--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -21,6 +21,7 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.metrics.Measured;
 import io.vertx.core.net.SSLOptions;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.TrafficShapingOptions;
 import io.vertx.core.net.impl.SocketAddressImpl;
 import io.vertx.core.streams.ReadStream;
 
@@ -181,6 +182,14 @@ public interface HttpServer extends Measured {
       fut.onComplete(handler);
     }
   }
+
+  /**
+   * Update traffic shaping options {@code options}, the update happens if valid values are passed for traffic
+   * shaping options. This update happens synchronously and at best effort for rate update to take effect immediately.
+   *
+   * @param options the new traffic shaping options
+   */
+  void updateTrafficShapingOptions(TrafficShapingOptions options);
 
   /**
    * Tell the server to start listening. The server will listen on the port and host specified in the

--- a/src/main/java/io/vertx/core/net/NetServer.java
+++ b/src/main/java/io/vertx/core/net/NetServer.java
@@ -256,4 +256,12 @@ public interface NetServer extends Measured {
       fut.onComplete(handler);
     }
   }
+
+  /**
+   * Update traffic shaping options {@code options}, the update happens if valid values are passed for traffic
+   * shaping options. This update happens synchronously and at best effort for rate update to take effect immediately.
+   *
+   * @param options the new traffic shaping options
+   */
+  void updateTrafficShapingOptions(TrafficShapingOptions options);
 }

--- a/src/main/java/io/vertx/core/net/TrafficShapingOptions.java
+++ b/src/main/java/io/vertx/core/net/TrafficShapingOptions.java
@@ -139,14 +139,14 @@ public class TrafficShapingOptions {
   }
 
   /**
-   * Set the delay between two computations of performances for channels or 0 if no stats are to be computed
+   * Set the delay between two computations of performances for channels
    *
    * @param checkIntervalForStats delay between two computations of performances
    * @return a reference to this, so the API can be used fluently
    */
   public TrafficShapingOptions setCheckIntervalForStats(long checkIntervalForStats) {
     this.checkIntervalForStats = checkIntervalForStats;
-    ObjectUtil.checkPositive(this.checkIntervalForStats, "checkIntervalForStats");
+    ObjectUtil.checkPositiveOrZero(this.checkIntervalForStats, "checkIntervalForStats");
     return this;
   }
 

--- a/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
+++ b/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
@@ -55,22 +55,27 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
 
     Function<Vertx, HttpServer> http1ServerFactory = (v) -> Providers.http1Server(v, INBOUND_LIMIT, OUTBOUND_LIMIT);
     Function<Vertx, HttpServer> http2ServerFactory = (v) -> Providers.http2Server(v, INBOUND_LIMIT, OUTBOUND_LIMIT);
+    Function<Vertx, HttpServer> http1NonTrafficShapedServerFactory = (v) -> Providers.http1Server(v, 0, 0);
+    Function<Vertx, HttpServer> http2NonTrafficShapedServerFactory = (v) -> Providers.http1Server(v, 0, 0);
     Function<Vertx, HttpClient> http1ClientFactory = (v) -> v.createHttpClient();
     Function<Vertx, HttpClient> http2ClientFactory = (v) -> v.createHttpClient(createHttp2ClientOptions());
 
     return Arrays.asList(new Object[][] {
-      { 1.1, http1ServerFactory, http1ClientFactory },
-      { 2.0, http2ServerFactory, http2ClientFactory }
+      { 1.1, http1ServerFactory, http1ClientFactory, http1NonTrafficShapedServerFactory },
+      { 2.0, http2ServerFactory, http2ClientFactory, http2NonTrafficShapedServerFactory }
     });
   }
 
   private Function<Vertx, HttpServer> serverFactory;
   private Function<Vertx, HttpClient> clientFactory;
+  private Function<Vertx, HttpServer> nonTrafficShapedServerFactory;
 
   public HttpBandwidthLimitingTest(double protoVersion, Function<Vertx, HttpServer> serverFactory,
-                                   Function<Vertx, HttpClient> clientFactory) {
+                                   Function<Vertx, HttpClient> clientFactory,
+                                   Function<Vertx, HttpServer> nonTrafficShapedServerFactory) {
     this.serverFactory = serverFactory;
     this.clientFactory = clientFactory;
+    this.nonTrafficShapedServerFactory = nonTrafficShapedServerFactory;
   }
 
   @Before
@@ -199,6 +204,63 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
     Assert.assertTrue(elapsedMillis > expectedTimeMillis(totalReceivedLength.get(), OUTBOUND_LIMIT)); // because there are simultaneous 2 requests
   }
 
+  @Test
+  public void testDynamicOutboundRateUpdate() throws Exception {
+    Buffer expectedBuffer = TestUtils.randomBuffer(TEST_CONTENT_SIZE);
+
+    HttpServer testServer = serverFactory.apply(vertx);
+    testServer.requestHandler(HANDLERS.bufferRead(expectedBuffer));
+    startServer(testServer);
+
+    // update outbound rate to twice the limit
+    TrafficShapingOptions trafficOptions = new TrafficShapingOptions()
+                                             .setInboundGlobalBandwidth(INBOUND_LIMIT) // unchanged
+                                             .setOutboundGlobalBandwidth(2 * OUTBOUND_LIMIT);
+    testServer.updateTrafficShapingOptions(trafficOptions);
+
+    long startTime = System.nanoTime();
+    HttpClient testClient = clientFactory.apply(vertx);
+    read(expectedBuffer, testServer, testClient);
+    await();
+    long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+
+    Assert.assertTrue(elapsedMillis < expectedUpperBoundTimeMillis(TEST_CONTENT_SIZE, OUTBOUND_LIMIT));
+  }
+
+  @Test
+  public void testDynamicInboundRateUpdate() throws Exception {
+    Buffer expectedBuffer = TestUtils.randomBuffer((TEST_CONTENT_SIZE));
+
+    HttpServer testServer = serverFactory.apply(vertx);
+    testServer.requestHandler(HANDLERS.bufferWrite(expectedBuffer));
+    startServer(testServer);
+
+    // update inbound rate to twice the limit
+    TrafficShapingOptions trafficOptions = new TrafficShapingOptions()
+                                             .setOutboundGlobalBandwidth(OUTBOUND_LIMIT) // unchanged
+                                             .setInboundGlobalBandwidth(2 * INBOUND_LIMIT);
+    testServer.updateTrafficShapingOptions(trafficOptions);
+
+    long startTime = System.nanoTime();
+    HttpClient testClient = clientFactory.apply(vertx);
+    write(expectedBuffer, testServer, testClient);
+    await();
+    long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+
+    Assert.assertTrue(elapsedMillis < expectedUpperBoundTimeMillis(TEST_CONTENT_SIZE, INBOUND_LIMIT));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testRateUpdateWhenServerStartedWithoutTrafficShaping() {
+    HttpServer testServer = nonTrafficShapedServerFactory.apply(vertx);
+
+    // update inbound rate to twice the limit
+    TrafficShapingOptions trafficOptions = new TrafficShapingOptions()
+                                             .setOutboundGlobalBandwidth(OUTBOUND_LIMIT)
+                                             .setInboundGlobalBandwidth(2 * INBOUND_LIMIT);
+    testServer.updateTrafficShapingOptions(trafficOptions);
+  }
+
   /**
    * The throttling takes a while to kick in so the expected time cannot be strict especially
    * for small data sizes in these tests.
@@ -209,6 +271,10 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
    */
   private long expectedTimeMillis(long size, int rate) {
     return (long) (TimeUnit.MILLISECONDS.convert(( size / rate), TimeUnit.SECONDS) * 0.5); // multiplied by 0.5 to be more tolerant of time pauses during CI runs
+  }
+
+  private long expectedUpperBoundTimeMillis(long size, int rate) {
+    return TimeUnit.MILLISECONDS.convert(( size / rate), TimeUnit.SECONDS); // Since existing rate will be upperbound, runs should complete by this time
   }
 
   private void read(Buffer expected, HttpServer server, HttpClient client) {
@@ -280,19 +346,25 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
     private static HttpServer http1Server(Vertx vertx, int inboundLimit, int outboundLimit) {
       HttpServerOptions options = new HttpServerOptions()
                                     .setHost(DEFAULT_HTTP_HOST)
-                                    .setPort(DEFAULT_HTTP_PORT)
-                                    .setTrafficShapingOptions(new TrafficShapingOptions()
-                                                                .setInboundGlobalBandwidth(inboundLimit)
-                                                                .setOutboundGlobalBandwidth(outboundLimit));
+                                    .setPort(DEFAULT_HTTP_PORT);
+
+      if (inboundLimit != 0 || outboundLimit != 0) {
+        options.setTrafficShapingOptions(new TrafficShapingOptions()
+                                           .setInboundGlobalBandwidth(inboundLimit)
+                                           .setOutboundGlobalBandwidth(outboundLimit));
+      }
 
       return vertx.createHttpServer(options);
     }
 
     private static HttpServer http2Server(Vertx vertx, int inboundLimit, int outboundLimit) {
-      HttpServerOptions options = createHttp2ServerOptions(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST)
-                                    .setTrafficShapingOptions(new TrafficShapingOptions()
-                                                                .setInboundGlobalBandwidth(inboundLimit)
-                                                                .setOutboundGlobalBandwidth(outboundLimit));
+      HttpServerOptions options = createHttp2ServerOptions(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST);
+
+      if (inboundLimit != 0 || outboundLimit != 0) {
+        options.setTrafficShapingOptions(new TrafficShapingOptions()
+                                           .setInboundGlobalBandwidth(inboundLimit)
+                                           .setOutboundGlobalBandwidth(outboundLimit));
+      }
 
       return vertx.createHttpServer(options);
     }


### PR DESCRIPTION
Motivation:

Allowing dynamic updates of read and write limits set for HttpServer and NetServers created through Vert.x would be helpful during rate limit threshold setting tests. Currently dynamic updates are not possible, hence servers created have to be bounced and recreated. This could cause downtime. With this patch server thresholds can be updated dynamically.