### PR TITLE
Add helper method to determine if request can be upgraded to websocket.

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -983,4 +983,24 @@ public final class HttpUtils {
     int len = host.length();
     return HostAndPortImpl.parseHost(host, 0, len) == len;
   }
+
+  public static boolean canUpgradeToWebSocket(HttpServerRequest req) {
+    if (req.version() != io.vertx.core.http.HttpVersion.HTTP_1_1) {
+      return false;
+    }
+    if (req.method() != io.vertx.core.http.HttpMethod.GET) {
+      return false;
+    }
+    MultiMap headers = req.headers();
+    for (String connection : headers.getAll(io.vertx.core.http.HttpHeaders.CONNECTION)) {
+      if (connection.toLowerCase().contains(io.vertx.core.http.HttpHeaders.UPGRADE)) {
+        for (String upgrade : headers.getAll(io.vertx.core.http.HttpHeaders.UPGRADE)) {
+          if (upgrade.toLowerCase().contains(io.vertx.core.http.HttpHeaders.WEBSOCKET)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
 }

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -44,10 +44,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.LongConsumer;
+import java.util.function.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -5371,6 +5368,63 @@ public class Http1xTest extends HttpTest {
     NetClient nc = vertx.createNetClient();
     nc.connect(testAddress).onComplete(onSuccess(so -> {
       so.write("GET / HTTP/1.1\r\n\r\n");
+    }));
+    await();
+  }
+
+  @Test
+  public void testCanUpgradeToWebSocket() throws Exception {
+    UnaryOperator<RequestOptions> config = ro -> ro.setMethod(HttpMethod.GET)
+      .putHeader(HttpHeaders.CONNECTION, HttpHeaders.UPGRADE)
+      .putHeader(HttpHeaders.UPGRADE, HttpHeaders.WEBSOCKET);
+    doTestCanUpgradeToWebSocket(config, true);
+  }
+
+  @Test
+  public void testCanUpgradeToWebSocketFirefox() throws Exception {
+    UnaryOperator<RequestOptions> config = ro -> ro.setMethod(HttpMethod.GET)
+      .putHeader(HttpHeaders.CONNECTION, HttpHeaders.KEEP_ALIVE + ", " + HttpHeaders.UPGRADE)
+      .putHeader(HttpHeaders.UPGRADE, HttpHeaders.WEBSOCKET);
+    doTestCanUpgradeToWebSocket(config, true);
+  }
+
+  @Test
+  public void testCannotUpgradePostRequestToWebSocket() throws Exception {
+    UnaryOperator<RequestOptions> config = ro -> ro.setMethod(HttpMethod.POST)
+      .putHeader(HttpHeaders.CONNECTION, HttpHeaders.UPGRADE)
+      .putHeader(HttpHeaders.UPGRADE, HttpHeaders.WEBSOCKET);
+    doTestCanUpgradeToWebSocket(config, false);
+  }
+
+  @Test
+  public void testCannotUpgradeToWebSocketIfConnectionHeaderIsMissing() throws Exception {
+    UnaryOperator<RequestOptions> config = ro -> ro.setMethod(HttpMethod.GET)
+      .putHeader(HttpHeaders.UPGRADE, HttpHeaders.WEBSOCKET);
+    doTestCanUpgradeToWebSocket(config, false);
+  }
+
+  @Test
+  public void testCannotUpgradeToWebSocketIfUpgradeDoesNotContainWebsocket() throws Exception {
+    UnaryOperator<RequestOptions> config = ro -> ro.setMethod(HttpMethod.GET)
+      .putHeader(HttpHeaders.CONNECTION, HttpHeaders.UPGRADE)
+      .putHeader(HttpHeaders.UPGRADE, "foo");
+    doTestCanUpgradeToWebSocket(config, false);
+  }
+
+  private void doTestCanUpgradeToWebSocket(UnaryOperator<RequestOptions> config, boolean shouldSucceed) throws Exception {
+    server.requestHandler(req -> {
+      HttpServerResponse serverResponse = req.response();
+      int statusCode = HttpUtils.canUpgradeToWebSocket(req) ? 200 : 500;
+      serverResponse.setStatusCode(statusCode);
+      serverResponse.end();
+    });
+    startServer(testAddress);
+    client.request(config.apply(new RequestOptions(requestOptions))).onComplete(onSuccess(req -> {
+      req.response().onComplete(onSuccess(resp -> {
+        assertEquals(shouldSucceed ? 200 : 500, resp.statusCode());
+        testComplete();
+      }));
+      req.send();
     }));
     await();
   }


### PR DESCRIPTION
Vert.x Web And Vert.x HTTP Proxy have similar code. This method covers all cases and can be reused.