### PR TITLE
Fix TCP TLS server SNI server name leak

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -126,6 +126,14 @@ public class SSLHelper {
     this.applicationProtocols = applicationProtocols;
   }
 
+  public synchronized int sniEntrySize() {
+    CachedProvider res = cachedProvider.result();
+    if (res != null) {
+      return res.sslChannelProvider.sniEntrySize();
+    }
+    return 0;
+  }
+
   private static class CachedProvider {
     final SSLOptions options;
     final long id;

--- a/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
@@ -17,6 +17,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AsyncMapping;
 import io.netty.util.concurrent.ImmediateExecutor;
+import io.vertx.core.VertxException;
 import io.vertx.core.net.SocketAddress;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -25,6 +26,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+
+import static io.vertx.core.net.impl.SslContextProvider.createTrustAllTrustManager;
 
 /**
  * Provider for {@link SslHandler} and {@link SniHandler}.
@@ -74,11 +77,31 @@ public class SslChannelProvider {
 
   public SslContext sslClientContext(String serverName, boolean useAlpn, boolean trustAll) {
     int idx = idx(useAlpn);
-    if (sslContexts[idx] == null) {
-      SslContext context = sslContextProvider.createClientContext(serverName, useAlpn, trustAll);
-      sslContexts[idx] = context;
+    if (serverName == null) {
+      if (sslContexts[idx] == null) {
+        SslContext context = sslContextProvider.createClientContext(useAlpn, trustAll);
+        sslContexts[idx] = context;
+      }
+      return sslContexts[idx];
+    } else {
+      KeyManagerFactory kmf;
+      try {
+        kmf = sslContextProvider.resolveKeyManagerFactory(serverName);
+      } catch (Exception e) {
+        throw new VertxException(e);
+      }
+      TrustManager[] trustManagers;
+      if (trustAll) {
+        trustManagers = new TrustManager[] { createTrustAllTrustManager() };
+      } else {
+        try {
+          trustManagers = sslContextProvider.resolveTrustManagers(serverName);
+        } catch (Exception e) {
+          throw new VertxException(e);
+        }
+      }
+      return sslContextMaps[idx].computeIfAbsent(serverName, s -> sslContextProvider.createClientContext(kmf, trustManagers, s, useAlpn));
     }
-    return sslContexts[idx];
   }
 
   public SslContext sslServerContext(boolean useAlpn) {

--- a/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
@@ -27,8 +27,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-import static io.vertx.core.net.impl.SslContextProvider.createTrustAllTrustManager;
-
 /**
  * Provider for {@link SslHandler} and {@link SniHandler}.
  * <br/>
@@ -76,40 +74,34 @@ public class SslChannelProvider {
   }
 
   public SslContext sslClientContext(String serverName, boolean useAlpn, boolean trustAll) {
+    try {
+      return sslContext(serverName, useAlpn, false, trustAll);
+    } catch (Exception e) {
+      throw new VertxException(e);
+    }
+  }
+
+  public SslContext sslContext(String serverName, boolean useAlpn, boolean server, boolean trustAll) throws Exception {
     int idx = idx(useAlpn);
     if (serverName == null) {
       if (sslContexts[idx] == null) {
-        SslContext context = sslContextProvider.createClientContext(useAlpn, trustAll);
+        SslContext context = sslContextProvider.createContext(server, null, null, null, useAlpn, trustAll);
         sslContexts[idx] = context;
       }
       return sslContexts[idx];
     } else {
-      KeyManagerFactory kmf;
-      try {
-        kmf = sslContextProvider.resolveKeyManagerFactory(serverName);
-      } catch (Exception e) {
-        throw new VertxException(e);
-      }
-      TrustManager[] trustManagers;
-      if (trustAll) {
-        trustManagers = new TrustManager[] { createTrustAllTrustManager() };
-      } else {
-        try {
-          trustManagers = sslContextProvider.resolveTrustManagers(serverName);
-        } catch (Exception e) {
-          throw new VertxException(e);
-        }
-      }
-      return sslContextMaps[idx].computeIfAbsent(serverName, s -> sslContextProvider.createClientContext(kmf, trustManagers, s, useAlpn));
+      KeyManagerFactory kmf = sslContextProvider.resolveKeyManagerFactory(serverName);
+      TrustManager[] trustManagers = trustAll ? null : sslContextProvider.resolveTrustManagers(serverName);
+      return sslContextMaps[idx].computeIfAbsent(serverName, s -> sslContextProvider.createContext(server, kmf, trustManagers, s, useAlpn, trustAll));
     }
   }
 
   public SslContext sslServerContext(boolean useAlpn) {
-    int idx = idx(useAlpn);
-    if (sslContexts[idx] == null) {
-      sslContexts[idx] = sslContextProvider.createServerContext(useAlpn);
+    try {
+      return sslContext(null, useAlpn, true, false);
+    } catch (Exception e) {
+      throw new VertxException(e);
     }
-    return sslContexts[idx];
   }
 
   /**
@@ -120,27 +112,14 @@ public class SslChannelProvider {
   public AsyncMapping<? super String, ? extends SslContext> serverNameMapping() {
     return (AsyncMapping<String, SslContext>) (serverName, promise) -> {
       workerPool.execute(() -> {
-        if (serverName == null) {
-          promise.setSuccess(sslServerContext(useAlpn));
-        } else {
-          KeyManagerFactory kmf;
-          try {
-            kmf = sslContextProvider.resolveKeyManagerFactory(serverName);
-          } catch (Exception e) {
-            promise.setFailure(e);
-            return;
-          }
-          TrustManager[] trustManagers;
-          try {
-            trustManagers = sslContextProvider.resolveTrustManagers(serverName);
-          } catch (Exception e) {
-            promise.setFailure(e);
-            return;
-          }
-          int idx = idx(useAlpn);
-          SslContext sslContext = sslContextMaps[idx].computeIfAbsent(serverName, s -> sslContextProvider.createServerContext(kmf, trustManagers, s, useAlpn));
-          promise.setSuccess(sslContext);
+        SslContext sslContext;
+        try {
+          sslContext = sslContext(serverName, useAlpn, true, false);
+        } catch (Exception e) {
+          promise.setFailure(e);
+          return;
         }
+        promise.setSuccess(sslContext);
       });
       return promise;
     };

--- a/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
@@ -154,13 +154,6 @@ public class SslContextProvider {
     }
   }
 
-  public KeyManagerFactory loadKeyManagerFactory(String serverName) throws Exception {
-    if (keyManagerFactoryMapper != null) {
-      return keyManagerFactoryMapper.apply(serverName);
-    }
-    return null;
-  }
-
   public TrustManager[] defaultTrustManagers() {
     return trustManagerFactory != null ? trustManagerFactory.getTrustManagers() : null;
   }
@@ -174,8 +167,7 @@ public class SslContextProvider {
   }
 
   /**
-   * Resolve the {@link KeyManagerFactory} for the {@code serverName}, when a factory cannot be resolved, the default
-   * factory is returned.
+   * Resolve the {@link KeyManagerFactory} for the {@code serverName}, when a factory cannot be resolved, {@code null} is returned.
    * <br/>
    * This can block and should be executed on the appropriate thread.
    *
@@ -184,23 +176,14 @@ public class SslContextProvider {
    * @throws Exception anything that would prevent loading the factory
    */
   public KeyManagerFactory resolveKeyManagerFactory(String serverName) throws Exception {
-    KeyManagerFactory kmf = loadKeyManagerFactory(serverName);
-    if (kmf == null) {
-      kmf = keyManagerFactory;
-    }
-    return kmf;
-  }
-
-  public TrustManager[] loadTrustManagers(String serverName) throws Exception {
-    if (trustManagerMapper != null) {
-      return trustManagerMapper.apply(serverName);
+    if (keyManagerFactoryMapper != null) {
+      return keyManagerFactoryMapper.apply(serverName);
     }
     return null;
   }
 
   /**
-   * Resolve the {@link TrustManager}[] for the {@code serverName}, when managers cannot be resolved, the default
-   * managers are returned.
+   * Resolve the {@link TrustManager}[] for the {@code serverName}, when managers cannot be resolved, {@code null} is returned.
    * <br/>
    * This can block and should be executed on the appropriate thread.
    *
@@ -209,11 +192,10 @@ public class SslContextProvider {
    * @throws Exception anything that would prevent loading the managers
    */
   public TrustManager[] resolveTrustManagers(String serverName) throws Exception {
-    TrustManager[] trustManagers = loadTrustManagers(serverName);
-    if (trustManagers == null && trustManagerFactory != null) {
-      trustManagers = trustManagerFactory.getTrustManagers();
+    if (trustManagerMapper != null) {
+      return trustManagerMapper.apply(serverName);
     }
-    return trustManagers;
+    return null;
   }
 
   private VertxTrustManagerFactory buildVertxTrustManagerFactory(TrustManager[] mgrs) {

--- a/src/main/java/io/vertx/core/net/impl/TCPServerBase.java
+++ b/src/main/java/io/vertx/core/net/impl/TCPServerBase.java
@@ -125,6 +125,10 @@ public abstract class TCPServerBase implements Closeable, MetricsProvider {
     return trafficShapingHandler;
   }
 
+  public int sniEntrySize() {
+    return sslHelper.sniEntrySize();
+  }
+
   public Future<Boolean> updateSSLOptions(SSLOptions options, boolean force) {
     TCPServerBase server = actualServer;
     if (server != null && server != this) {

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -95,12 +95,7 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -1530,6 +1525,28 @@ public class NetTest extends VertxTestBase {
     test.run(true);
     await();
     assertEquals("host2.com", cnOf(test.clientPeerCert()));
+  }
+
+  @Test
+  public void testClientSniMultipleServerName() throws Exception {
+    List<String> receivedServerNames = Collections.synchronizedList(new ArrayList<>());
+    server = vertx.createNetServer(new NetServerOptions()
+      .setSni(true)
+      .setSsl(true)
+      .setKeyCertOptions(Cert.SNI_JKS.get())
+    ).connectHandler(so -> {
+      receivedServerNames.add(so.indicatedServerName());
+    });
+    startServer();
+    List<String> serverNames = Arrays.asList("host1", "host2.com");
+    client = vertx.createNetClient(new NetClientOptions().setSsl(true).setTrustAll(true));
+    for (String serverName : serverNames) {
+      NetSocket so = client.connect(testAddress, serverName).toCompletionStage().toCompletableFuture().get();
+      String host = cnOf(so.peerCertificates().get(0));
+      assertEquals(serverName, host);
+    }
+    assertWaitUntil(() -> receivedServerNames.size() == 2);
+    assertEquals(receivedServerNames, serverNames);
   }
 
   @Test

--- a/src/test/java/io/vertx/core/net/SSLHelperTest.java
+++ b/src/test/java/io/vertx/core/net/SSLHelperTest.java
@@ -46,7 +46,7 @@ public class SSLHelperTest extends VertxTestBase {
     helper
       .buildContextProvider(new SSLOptions().setKeyCertOptions(Cert.CLIENT_JKS.get()).setTrustOptions(Trust.SERVER_JKS.get()), (ContextInternal) vertx.getOrCreateContext())
       .onComplete(onSuccess(provider -> {
-        SslContext ctx = provider.createClientContext(null, false, false);
+        SslContext ctx = provider.createClientContext(false, false);
         assertEquals(new HashSet<>(Arrays.asList(expected)), new HashSet<>(ctx.cipherSuites()));
         testComplete();
     }));
@@ -60,7 +60,7 @@ public class SSLHelperTest extends VertxTestBase {
         new HttpClientOptions().setOpenSslEngineOptions(new OpenSSLEngineOptions()).setPemKeyCertOptions(Cert.CLIENT_PEM.get()).setTrustOptions(Trust.SERVER_PEM.get()),
       null);
     helper.buildContextProvider(new SSLOptions().setKeyCertOptions(Cert.CLIENT_PEM.get()).setTrustOptions(Trust.SERVER_PEM.get()), (ContextInternal) vertx.getOrCreateContext()).onComplete(onSuccess(provider -> {
-      SslContext ctx = provider.createClientContext(null, false, false);
+      SslContext ctx = provider.createClientContext(false, false);
       assertEquals(expected, new HashSet<>(ctx.cipherSuites()));
       testComplete();
     }));
@@ -185,6 +185,6 @@ public class SSLHelperTest extends VertxTestBase {
   }
 
   public SSLEngine createEngine(SslContextProvider provider) {
-    return provider.createClientContext(null, false, false).newEngine(ByteBufAllocator.DEFAULT);
+    return provider.createClientContext(false, false).newEngine(ByteBufAllocator.DEFAULT);
   }
 }

--- a/src/test/java/io/vertx/core/net/SSLHelperTest.java
+++ b/src/test/java/io/vertx/core/net/SSLHelperTest.java
@@ -46,7 +46,7 @@ public class SSLHelperTest extends VertxTestBase {
     helper
       .buildContextProvider(new SSLOptions().setKeyCertOptions(Cert.CLIENT_JKS.get()).setTrustOptions(Trust.SERVER_JKS.get()), (ContextInternal) vertx.getOrCreateContext())
       .onComplete(onSuccess(provider -> {
-        SslContext ctx = provider.createClientContext(false, false);
+        SslContext ctx = provider.createContext(false, false);
         assertEquals(new HashSet<>(Arrays.asList(expected)), new HashSet<>(ctx.cipherSuites()));
         testComplete();
     }));
@@ -60,7 +60,7 @@ public class SSLHelperTest extends VertxTestBase {
         new HttpClientOptions().setOpenSslEngineOptions(new OpenSSLEngineOptions()).setPemKeyCertOptions(Cert.CLIENT_PEM.get()).setTrustOptions(Trust.SERVER_PEM.get()),
       null);
     helper.buildContextProvider(new SSLOptions().setKeyCertOptions(Cert.CLIENT_PEM.get()).setTrustOptions(Trust.SERVER_PEM.get()), (ContextInternal) vertx.getOrCreateContext()).onComplete(onSuccess(provider -> {
-      SslContext ctx = provider.createClientContext(false, false);
+      SslContext ctx = provider.createContext(false, false);
       assertEquals(expected, new HashSet<>(ctx.cipherSuites()));
       testComplete();
     }));
@@ -90,7 +90,7 @@ public class SSLHelperTest extends VertxTestBase {
     defaultHelper
       .buildContextProvider(httpServerOptions.getSslOptions(), (ContextInternal) vertx.getOrCreateContext())
       .onComplete(onSuccess(provider -> {
-        SslContext ctx = provider.createServerContext(false);
+        SslContext ctx = provider.createContext(true, false);
 
         SSLSessionContext sslSessionContext = ctx.sessionContext();
         assertTrue(sslSessionContext instanceof OpenSslServerSessionContext);
@@ -185,6 +185,6 @@ public class SSLHelperTest extends VertxTestBase {
   }
 
   public SSLEngine createEngine(SslContextProvider provider) {
-    return provider.createClientContext(false, false).newEngine(ByteBufAllocator.DEFAULT);
+    return provider.createContext(false, false).newEngine(ByteBufAllocator.DEFAULT);
   }
 }

--- a/src/test/java/io/vertx/it/SSLEngineTest.java
+++ b/src/test/java/io/vertx/it/SSLEngineTest.java
@@ -105,7 +105,7 @@ public class SSLEngineTest extends HttpTestBase {
       }
     }
     SslContextProvider provider = ((HttpServerImpl)server).sslContextProvider();
-    SslContext ctx = provider.createClientContext(null, false, false);
+    SslContext ctx = provider.createClientContext(false, false);
     switch (expectedSslContext != null ? expectedSslContext : "jdk") {
       case "jdk":
         assertTrue(ctx.sessionContext().getClass().getName().equals("sun.security.ssl.SSLSessionContextImpl"));

--- a/src/test/java/io/vertx/it/SSLEngineTest.java
+++ b/src/test/java/io/vertx/it/SSLEngineTest.java
@@ -105,7 +105,7 @@ public class SSLEngineTest extends HttpTestBase {
       }
     }
     SslContextProvider provider = ((HttpServerImpl)server).sslContextProvider();
-    SslContext ctx = provider.createClientContext(false, false);
+    SslContext ctx = provider.createContext(false, false);
     switch (expectedSslContext != null ? expectedSslContext : "jdk") {
       case "jdk":
         assertTrue(ctx.sessionContext().getClass().getName().equals("sun.security.ssl.SSLSessionContextImpl"));


### PR DESCRIPTION
The `SslChannelProvider` class maintains a map of server name to Netty `SslContext` that is filled when a client provides a server name. When a server name does not resolve to a `KeyManagerFactory` or `TrustManagerFactory`, the default factories are used and the entry is stored in the map. Instead no specific factory is resolved the default Netty `SslContext` is used, since this can lead to a a memory leak when a client specifies spurious SNI server names. This affects only a TCP server when SNI is set in the `HttpServerOptions`.

In addition fix: the TCP client will not send the correct server name to the client due to SSL client resumption performed by the SSL implementation although we are using a new engine implementation.