### PR TITLE
Fix TCP TLS server SNI server name leak

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -100,6 +100,17 @@ public class SSLHelper {
     this.useWorkerPool = sslEngineOptions.getUseWorkerThread();
   }
 
+  public synchronized int sniEntrySize() {
+    int size = 0;
+    for (Future<SslChannelProvider> fut : sslChannelProviderMap.values()) {
+      SslChannelProvider result = fut.result();
+      if (result != null) {
+        size += result.sniEntrySize();
+      }
+    }
+    return size;
+  }
+
   public SSLHelper(SSLEngineOptions sslEngineOptions) {
     this(sslEngineOptions, 256);
   }

--- a/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
@@ -53,6 +53,10 @@ public class SslChannelProvider {
     this.sslContextProvider = sslContextProvider;
   }
 
+  public int sniEntrySize() {
+    return sslContextMaps[0].size() + sslContextMaps[1].size();
+  }
+
   public SslContextProvider sslContextProvider() {
     return sslContextProvider;
   }
@@ -67,17 +71,18 @@ public class SslChannelProvider {
 
   public SslContext sslContext(String serverName, boolean useAlpn, boolean server, boolean trustAll) throws Exception {
     int idx = idx(useAlpn);
-    if (serverName == null) {
-      if (sslContexts[idx] == null) {
-        SslContext context = sslContextProvider.createContext(server, null, null, null, useAlpn, trustAll);
-        sslContexts[idx] = context;
-      }
-      return sslContexts[idx];
-    } else {
+    if (serverName != null) {
       KeyManagerFactory kmf = sslContextProvider.resolveKeyManagerFactory(serverName);
       TrustManager[] trustManagers = trustAll ? null : sslContextProvider.resolveTrustManagers(serverName);
-      return sslContextMaps[idx].computeIfAbsent(serverName, s -> sslContextProvider.createContext(server, kmf, trustManagers, s, useAlpn, trustAll));
+      if (kmf != null || trustManagers != null || !server) {
+        return sslContextMaps[idx].computeIfAbsent(serverName, s -> sslContextProvider.createContext(server, kmf, trustManagers, s, useAlpn, trustAll));
+      }
     }
+    if (sslContexts[idx] == null) {
+      SslContext context = sslContextProvider.createContext(server, null, null, serverName, useAlpn, trustAll);
+      sslContexts[idx] = context;
+    }
+    return sslContexts[idx];
   }
 
   public SslContext sslServerContext(boolean useAlpn) {

--- a/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
@@ -154,13 +154,6 @@ public class SslContextProvider {
     }
   }
 
-  public KeyManagerFactory loadKeyManagerFactory(String serverName) throws Exception {
-    if (keyManagerFactoryMapper != null) {
-      return keyManagerFactoryMapper.apply(serverName);
-    }
-    return null;
-  }
-
   public TrustManager[] defaultTrustManagers() {
     return trustManagerFactory != null ? trustManagerFactory.getTrustManagers() : null;
   }
@@ -174,8 +167,7 @@ public class SslContextProvider {
   }
 
   /**
-   * Resolve the {@link KeyManagerFactory} for the {@code serverName}, when a factory cannot be resolved, the default
-   * factory is returned.
+   * Resolve the {@link KeyManagerFactory} for the {@code serverName}, when a factory cannot be resolved, {@code null} is returned.
    * <br/>
    * This can block and should be executed on the appropriate thread.
    *
@@ -184,23 +176,14 @@ public class SslContextProvider {
    * @throws Exception anything that would prevent loading the factory
    */
   public KeyManagerFactory resolveKeyManagerFactory(String serverName) throws Exception {
-    KeyManagerFactory kmf = loadKeyManagerFactory(serverName);
-    if (kmf == null) {
-      kmf = keyManagerFactory;
-    }
-    return kmf;
-  }
-
-  public TrustManager[] loadTrustManagers(String serverName) throws Exception {
-    if (trustManagerMapper != null) {
-      return trustManagerMapper.apply(serverName);
+    if (keyManagerFactoryMapper != null) {
+      return keyManagerFactoryMapper.apply(serverName);
     }
     return null;
   }
 
   /**
-   * Resolve the {@link TrustManager}[] for the {@code serverName}, when managers cannot be resolved, the default
-   * managers are returned.
+   * Resolve the {@link TrustManager}[] for the {@code serverName}, when managers cannot be resolved, {@code null} is returned.
    * <br/>
    * This can block and should be executed on the appropriate thread.
    *
@@ -209,11 +192,10 @@ public class SslContextProvider {
    * @throws Exception anything that would prevent loading the managers
    */
   public TrustManager[] resolveTrustManagers(String serverName) throws Exception {
-    TrustManager[] trustManagers = loadTrustManagers(serverName);
-    if (trustManagers == null && trustManagerFactory != null) {
-      trustManagers = trustManagerFactory.getTrustManagers();
+    if (trustManagerMapper != null) {
+      return trustManagerMapper.apply(serverName);
     }
-    return trustManagers;
+    return null;
   }
 
   private VertxTrustManagerFactory buildVertxTrustManagerFactory(TrustManager[] mgrs) {

--- a/src/main/java/io/vertx/core/net/impl/TCPServerBase.java
+++ b/src/main/java/io/vertx/core/net/impl/TCPServerBase.java
@@ -122,6 +122,10 @@ public abstract class TCPServerBase implements Closeable, MetricsProvider {
   protected void configure(SSLOptions options) {
   }
 
+  public int sniEntrySize() {
+    return sslHelper.sniEntrySize();
+  }
+
   public Future<Boolean> updateSSLOptions(ServerSSLOptions options, boolean force) {
     TCPServerBase server = actualServer;
     if (server != null && server != this) {

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -1481,14 +1481,17 @@ public class NetTest extends VertxTestBase {
       receivedServerNames.add(so.indicatedServerName());
     });
     startServer();
-    List<String> serverNames = Arrays.asList("host1", "host2.com");
+    List<String> serverNames = Arrays.asList("host1", "host2.com", "fake");
+    List<String> cns = new ArrayList<>();
     client = vertx.createNetClient(new NetClientOptions().setSsl(true).setTrustAll(true));
     for (String serverName : serverNames) {
       NetSocket so = awaitFuture(client.connect(testAddress, serverName));
       String host = cnOf(so.peerCertificates().get(0));
-      assertEquals(serverName, host);
+      cns.add(host);
     }
-    assertWaitUntil(() -> receivedServerNames.size() == 2);
+    assertEquals(Arrays.asList("host1", "host2.com", "localhost"), cns);
+    assertEquals(2, ((TCPServerBase)server).sniEntrySize());
+    assertWaitUntil(() -> receivedServerNames.size() == 3);
     assertEquals(receivedServerNames, serverNames);
   }
 

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -71,12 +71,7 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -1473,6 +1468,28 @@ public class NetTest extends VertxTestBase {
     test.run(true);
     await();
     assertEquals("host2.com", cnOf(test.clientPeerCert()));
+  }
+
+  @Test
+  public void testClientSniMultipleServerName() throws Exception {
+    List<String> receivedServerNames = Collections.synchronizedList(new ArrayList<>());
+    server = vertx.createNetServer(new NetServerOptions()
+      .setSni(true)
+      .setSsl(true)
+      .setKeyCertOptions(Cert.SNI_JKS.get())
+    ).connectHandler(so -> {
+      receivedServerNames.add(so.indicatedServerName());
+    });
+    startServer();
+    List<String> serverNames = Arrays.asList("host1", "host2.com");
+    client = vertx.createNetClient(new NetClientOptions().setSsl(true).setTrustAll(true));
+    for (String serverName : serverNames) {
+      NetSocket so = awaitFuture(client.connect(testAddress, serverName));
+      String host = cnOf(so.peerCertificates().get(0));
+      assertEquals(serverName, host);
+    }
+    assertWaitUntil(() -> receivedServerNames.size() == 2);
+    assertEquals(receivedServerNames, serverNames);
   }
 
   @Test

--- a/src/test/java/io/vertx/core/net/impl/SSLHelperTest.java
+++ b/src/test/java/io/vertx/core/net/impl/SSLHelperTest.java
@@ -45,7 +45,7 @@ public class SSLHelperTest extends VertxTestBase {
     helper
       .buildContextProvider(new SSLOptions().setKeyCertOptions(Cert.CLIENT_JKS.get()).setTrustOptions(Trust.SERVER_JKS.get()), null, ClientAuth.NONE, null, false, (ContextInternal) vertx.getOrCreateContext())
       .onComplete(onSuccess(provider -> {
-        SslContext ctx = provider.createClientContext(null, false, false);
+        SslContext ctx = provider.createClientContext(false, false);
         assertEquals(new HashSet<>(Arrays.asList(expected)), new HashSet<>(ctx.cipherSuites()));
         testComplete();
     }));
@@ -57,7 +57,7 @@ public class SSLHelperTest extends VertxTestBase {
     Set<String> expected = OpenSsl.availableOpenSslCipherSuites();
     SSLHelper helper = new SSLHelper(new OpenSSLEngineOptions());
     helper.buildContextProvider(new SSLOptions().setKeyCertOptions(Cert.CLIENT_PEM.get()).setTrustOptions(Trust.SERVER_PEM.get()), null, ClientAuth.NONE, null, false, (ContextInternal) vertx.getOrCreateContext()).onComplete(onSuccess(provider -> {
-      SslContext ctx = provider.createClientContext(null, false, false);
+      SslContext ctx = provider.createClientContext(false, false);
       assertEquals(expected, new HashSet<>(ctx.cipherSuites()));
       testComplete();
     }));
@@ -201,6 +201,6 @@ public class SSLHelperTest extends VertxTestBase {
   }
 
   public SSLEngine createEngine(SslContextProvider provider) {
-    return provider.createClientContext(null, false, false).newEngine(ByteBufAllocator.DEFAULT);
+    return provider.createClientContext(false, false).newEngine(ByteBufAllocator.DEFAULT);
   }
 }

--- a/src/test/java/io/vertx/core/net/impl/SSLHelperTest.java
+++ b/src/test/java/io/vertx/core/net/impl/SSLHelperTest.java
@@ -45,7 +45,7 @@ public class SSLHelperTest extends VertxTestBase {
     helper
       .buildContextProvider(new SSLOptions().setKeyCertOptions(Cert.CLIENT_JKS.get()).setTrustOptions(Trust.SERVER_JKS.get()), null, ClientAuth.NONE, null, false, (ContextInternal) vertx.getOrCreateContext())
       .onComplete(onSuccess(provider -> {
-        SslContext ctx = provider.createClientContext(false, false);
+        SslContext ctx = provider.createContext(false, false);
         assertEquals(new HashSet<>(Arrays.asList(expected)), new HashSet<>(ctx.cipherSuites()));
         testComplete();
     }));
@@ -57,7 +57,7 @@ public class SSLHelperTest extends VertxTestBase {
     Set<String> expected = OpenSsl.availableOpenSslCipherSuites();
     SSLHelper helper = new SSLHelper(new OpenSSLEngineOptions());
     helper.buildContextProvider(new SSLOptions().setKeyCertOptions(Cert.CLIENT_PEM.get()).setTrustOptions(Trust.SERVER_PEM.get()), null, ClientAuth.NONE, null, false, (ContextInternal) vertx.getOrCreateContext()).onComplete(onSuccess(provider -> {
-      SslContext ctx = provider.createClientContext(false, false);
+      SslContext ctx = provider.createContext(false, false);
       assertEquals(expected, new HashSet<>(ctx.cipherSuites()));
       testComplete();
     }));
@@ -91,7 +91,7 @@ public class SSLHelperTest extends VertxTestBase {
     defaultHelper
       .buildContextProvider(sslOptions, null, ClientAuth.NONE, null, false, (ContextInternal) vertx.getOrCreateContext())
       .onComplete(onSuccess(provider -> {
-        SslContext ctx = provider.createServerContext(false);
+        SslContext ctx = provider.createContext(true, false);
 
         SSLSessionContext sslSessionContext = ctx.sessionContext();
         assertTrue(sslSessionContext instanceof OpenSslServerSessionContext);
@@ -201,6 +201,6 @@ public class SSLHelperTest extends VertxTestBase {
   }
 
   public SSLEngine createEngine(SslContextProvider provider) {
-    return provider.createClientContext(false, false).newEngine(ByteBufAllocator.DEFAULT);
+    return provider.createContext(false, false).newEngine(ByteBufAllocator.DEFAULT);
   }
 }

--- a/src/test/java/io/vertx/it/SSLEngineTest.java
+++ b/src/test/java/io/vertx/it/SSLEngineTest.java
@@ -99,7 +99,7 @@ public class SSLEngineTest extends HttpTestBase {
       }
     }
     SslContextProvider provider = ((HttpServerImpl)server).sslContextProvider();
-    SslContext ctx = provider.createClientContext(false, false);
+    SslContext ctx = provider.createContext(false, false);
     switch (expectedSslContext != null ? expectedSslContext : "jdk") {
       case "jdk":
         assertTrue(ctx.sessionContext().getClass().getName().equals("sun.security.ssl.SSLSessionContextImpl"));

--- a/src/test/java/io/vertx/it/SSLEngineTest.java
+++ b/src/test/java/io/vertx/it/SSLEngineTest.java
@@ -99,7 +99,7 @@ public class SSLEngineTest extends HttpTestBase {
       }
     }
     SslContextProvider provider = ((HttpServerImpl)server).sslContextProvider();
-    SslContext ctx = provider.createClientContext(null, false, false);
+    SslContext ctx = provider.createClientContext(false, false);
     switch (expectedSslContext != null ? expectedSslContext : "jdk") {
       case "jdk":
         assertTrue(ctx.sessionContext().getClass().getName().equals("sun.security.ssl.SSLSessionContextImpl"));


### PR DESCRIPTION
The `SslChannelProvider` class maintains a map of server name to Netty `SslContext` that is filled when a client provides a server name. When a server name does not resolve to a `KeyManagerFactory` or `TrustManagerFactory`, the default factories are used and the entry is stored in the map. Instead no specific factory is resolved the default Netty `SslContext` is used, since this can lead to a a memory leak when a client specifies spurious SNI server names. This affects only a TCP server when SNI is set in the `HttpServerOptions`.

In addition fix: the TCP client will not send the correct server name to the client due to SSL client resumption performed by the SSL implementation although we are using a new engine implementation.