### PR TITLE
refactor: migrate usages of the Provider class

### DIFF
--- a/src/main/java/io/vertx/core/net/TrustManagerFactoryWrapper.java
+++ b/src/main/java/io/vertx/core/net/TrustManagerFactoryWrapper.java
@@ -33,7 +33,7 @@ class TrustManagerFactoryWrapper extends TrustManagerFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TrustManagerFactoryWrapper.class);
   private static final String KEY_MANAGER_FACTORY_ALGORITHM = "no-algorithm";
-  private static final Provider PROVIDER = new Provider("", 1.0, "") {
+  private static final Provider PROVIDER = new Provider("", "1.0", "") {
   };
 
   TrustManagerFactoryWrapper(TrustManager trustManager) {


### PR DESCRIPTION
The constructor we are using was deprecated in Java 9

```java

 /**
     * Constructs a provider with the specified name, version number,
     * and information. Calling this constructor is equivalent to call the
     * {@link #Provider(String, String, String)} with {@code name}
     * name, {@code Double.toString(version)}, and {@code info}.
     *
     * @param name the provider name.
     *
     * @param version the provider version number.
     *
     * @param info a description of the provider and its services.
     *
     * @deprecated use {@link #Provider(String, String, String)} instead.
     */

```