### PR TITLE
refactor: remove usage of `class.newInstance()` deprecated method

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -63,6 +63,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.Cleaner;
 import java.lang.ref.WeakReference;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -740,7 +741,13 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public Future<String> deployVerticle(Class<? extends Verticle> verticleClass, DeploymentOptions options) {
-    return deployVerticle((Callable<Verticle>) verticleClass::newInstance, options);
+
+    try {
+      final var verticle = verticleClass.getDeclaredConstructor().newInstance();
+      return deployVerticle(verticle, options);
+    } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override


### PR DESCRIPTION
```java

 * @deprecated This method propagates any exception thrown by the
     * nullary constructor, including a checked exception.  Use of
     * this method effectively bypasses the compile-time exception
     * checking that would otherwise be performed by the compiler.
     * The {@link
     * java.lang.reflect.Constructor#newInstance(java.lang.Object...)
     * Constructor.newInstance} method avoids this problem by wrapping
     * any exception thrown by the constructor in a (checked) {@link
     * java.lang.reflect.InvocationTargetException}.

```