### PR TITLE
Add support for HTTP 1.x server connection shutdown

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -23,6 +23,7 @@ import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 import java.security.cert.Certificate;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Represents an HTTP connection.
@@ -132,13 +133,21 @@ public interface HttpConnection {
    * @return a future completed when shutdown has completed
    */
   default Future<Void> shutdown() {
-    return shutdown(30000L);
+    return shutdown(30, TimeUnit.SECONDS);
   }
 
   /**
    * Like {@link #shutdown()} but with a specific {@code timeout} in milliseconds.
    */
-  Future<Void> shutdown(long timeoutMs);
+  @Deprecated
+  default Future<Void> shutdown(long timeoutMs) {
+    return shutdown(timeoutMs, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Like {@link #shutdown()} but with a specific {@code timeout} in milliseconds.
+   */
+  Future<Void> shutdown(long timeout, TimeUnit unit);
 
   /**
    * Set a close handler. The handler will get notified when the connection is closed.

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -57,6 +57,7 @@ import io.vertx.core.streams.impl.InboundBuffer;
 
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 import static io.netty.handler.codec.http.websocketx.WebSocketVersion.*;
@@ -1263,9 +1264,9 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
   }
 
   @Override
-  public Future<Void> shutdown(long timeoutMs) {
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
     PromiseInternal<Void> promise = vertx.promise();
-    shutdown(timeoutMs, promise);
+    shutdown(timeout, unit, promise);
     return promise.future();
   }
 
@@ -1274,7 +1275,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     close();
   }
 
-  private void shutdown(long timeoutMs, PromiseInternal<Void> promise) {
+  private void shutdown(long timeout, TimeUnit unit, PromiseInternal<Void> promise) {
     synchronized (this) {
       if (shutdown) {
         promise.fail("Already shutdown");
@@ -1285,8 +1286,8 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     }
     synchronized (this) {
       if (!closed) {
-        if (timeoutMs > 0L) {
-          shutdownTimerID = context.setTimer(timeoutMs, id -> shutdownNow());
+        if (timeout > 0L) {
+          shutdownTimerID = context.setTimer(unit.toMillis(timeout), id -> shutdownNow());
         } else {
           close = true;
         }

--- a/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
@@ -137,11 +137,6 @@ abstract class Http1xConnectionBase<S extends WebSocketImplBase<S>> extends Conn
   }
 
   @Override
-  public Future<Void> shutdown(long timeoutMs) {
-    throw new UnsupportedOperationException("HTTP/1.x connections cannot be shutdown");
-  }
-
-  @Override
   public Http2Settings settings() {
     throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
   }

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -43,7 +43,6 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.impl.MessageWrite;
 import io.vertx.core.net.impl.NetSocketImpl;
 import io.vertx.core.net.impl.SSLHelper;
-import io.vertx.core.net.impl.SslChannelProvider;
 import io.vertx.core.net.impl.VertxHandler;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
@@ -81,7 +80,6 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
 
   private final String serverOrigin;
   private final Supplier<ContextInternal> streamContextSupplier;
-  private final SslChannelProvider sslChannelProvider;
   private final TracingPolicy tracingPolicy;
   private boolean requestFailed;
 
@@ -98,7 +96,6 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
   final SSLHelper sslHelper;
 
   public Http1xServerConnection(Supplier<ContextInternal> streamContextSupplier,
-                                SslChannelProvider sslChannelProvider,
                                 SSLHelper sslHelper,
                                 HttpServerOptions options,
                                 ChannelHandlerContext chctx,
@@ -110,7 +107,6 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
     this.streamContextSupplier = streamContextSupplier;
     this.options = options;
     this.sslHelper = sslHelper;
-    this.sslChannelProvider = sslChannelProvider;
     this.metrics = metrics;
     this.handle100ContinueAutomatically = options.isHandle100ContinueAutomatically();
     this.tracingPolicy = options.getTracingPolicy();

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -85,7 +85,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
 
   private Http1xServerRequest requestInProgress;
   private Http1xServerRequest responseInProgress;
-  private boolean keepAlive;
+  private boolean wantClose;
   private boolean channelPaused;
   private Handler<HttpServerRequest> requestHandler;
   private Handler<HttpServerRequest> invalidRequestHandler;
@@ -110,7 +110,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
     this.metrics = metrics;
     this.handle100ContinueAutomatically = options.isHandle100ContinueAutomatically();
     this.tracingPolicy = options.getTracingPolicy();
-    this.keepAlive = true;
+    this.wantClose = false;
   }
 
   TracingPolicy tracingPolicy() {
@@ -136,7 +136,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
 
   public void handleMessage(Object msg) {
     assert msg != null;
-    if (requestInProgress == null && !keepAlive && webSocket == null) {
+    if (requestInProgress == null && wantClose && webSocket == null) {
       // Discard message
       return;
     }
@@ -144,20 +144,21 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
     if (msg == LastHttpContent.EMPTY_LAST_CONTENT) {
       onEnd();
     } else if (msg instanceof DefaultHttpRequest) {
-        // fast path type check vs concrete class
-        DefaultHttpRequest request = (DefaultHttpRequest) msg;
-        ContextInternal requestCtx = streamContextSupplier.get();
-        Http1xServerRequest req = new Http1xServerRequest(this, request, requestCtx);
-        requestInProgress = req;
-        if (responseInProgress != null) {
-          enqueueRequest(req);
-          return;
-        }
-        responseInProgress = requestInProgress;
-        keepAlive = HttpUtils.isKeepAlive(request);
-        req.handleBegin(keepAlive);
-        Handler<HttpServerRequest> handler = request.decoderResult().isSuccess() ? requestHandler : invalidRequestHandler;
-        req.context.emit(req, handler);
+      // fast path type check vs concrete class
+      DefaultHttpRequest request = (DefaultHttpRequest) msg;
+      ContextInternal requestCtx = streamContextSupplier.get();
+      Http1xServerRequest req = new Http1xServerRequest(this, request, requestCtx);
+      requestInProgress = req;
+      if (responseInProgress != null) {
+        enqueueRequest(req);
+        return;
+      }
+      boolean keepAlive = HttpUtils.isKeepAlive(request);
+      responseInProgress = requestInProgress;
+      wantClose = !keepAlive;
+      req.handleBegin(keepAlive);
+      Handler<HttpServerRequest> handler = request.decoderResult().isSuccess() ? requestHandler : invalidRequestHandler;
+      req.context.emit(req, handler);
     } else {
       handleOther(msg);
     }
@@ -202,7 +203,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
     synchronized (this) {
       request = requestInProgress;
       requestInProgress = null;
-      close = !keepAlive && responseInProgress == null;
+      close = wantClose && responseInProgress == null;
     }
     request.context.execute(request, Http1xServerRequest::handleEnd);
     if (close) {
@@ -242,7 +243,7 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
       responseInProgress = null;
       DecoderResult result = request.decoderResult();
       if (result.isSuccess()) {
-        if (keepAlive) {
+        if (!wantClose) {
           Http1xServerRequest next = request.next();
           if (next != null) {
             // Handle pipelined request
@@ -266,8 +267,9 @@ public class Http1xServerConnection extends Http1xConnectionBase<ServerWebSocket
   }
 
   private void handleNext(Http1xServerRequest next) {
+    boolean keepAlive = HttpUtils.isKeepAlive(next.nettyRequest());
     responseInProgress = next;
-    keepAlive = HttpUtils.isKeepAlive(next.nettyRequest());
+    wantClose = !keepAlive;
     next.handleBegin(keepAlive);
     next.context.emit(next, next_ -> {
       next_.resume();

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -81,6 +81,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   Http1xServerRequest next;
   Object metric;
   Object trace;
+  boolean reportMetricsFailed;
 
   private Http1xServerResponse response;
 

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -40,6 +40,7 @@ import java.security.cert.Certificate;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A connection that attempts to perform a protocol upgrade to H2C. The connection might use HTTP/1 or H2C
@@ -888,6 +889,11 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
   @Override
   public Future<Void> shutdown(long timeoutMs) {
     return current.shutdown(timeoutMs);
+  }
+
+  @Override
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return current.shutdown(timeout, unit);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpServerWorker.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerWorker.java
@@ -310,18 +310,14 @@ public class HttpServerWorker implements TCPServerBase.Worker {
       return;
     }
     HttpServerMetrics metrics = (HttpServerMetrics) server.getMetrics();
-    VertxHandler<Http1xServerConnection> handler = VertxHandler.create(chctx -> {
-      Http1xServerConnection conn = new Http1xServerConnection(
-        streamContextSupplier,
-        sslChannelProvider,
-        sslHelper,
-        options,
-        chctx,
-        context,
-        serverOrigin,
-        metrics);
-      return conn;
-    });
+    VertxHandler<Http1xServerConnection> handler = VertxHandler.create(chctx -> new Http1xServerConnection(
+      streamContextSupplier,
+      sslHelper,
+      options,
+      chctx,
+      context,
+      serverOrigin,
+      metrics));
     pipeline.addLast("handler", handler);
     Http1xServerConnection conn = handler.getConnection();
     if (metrics != null) {

--- a/src/test/benchmarks/io/vertx/core/http/impl/HttpServerHandlerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/core/http/impl/HttpServerHandlerBenchmark.java
@@ -225,8 +225,7 @@ public class HttpServerHandlerBenchmark extends BenchmarkBase {
     VertxHandler<Http1xServerConnection> handler = VertxHandler.create(chctx -> {
       Http1xServerConnection conn = new Http1xServerConnection(
         () -> context,
-        null,
-        null,
+              null,
         new HttpServerOptions(),
         chctx,
         context,


### PR DESCRIPTION
HTTP/2 and HTTP/1.x client connection support the HTTP connection shutdown.

This implements HTTP/1.x server connection shutdown in order to fully support this method.

In addition the HTTP connection shutdown method is deprecated and replaced by a version that contains a time unit.