### PR TITLE
Deprecate HTTP connection shutdown variants with a timeout value for a variant with a time unit

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -56,6 +56,7 @@ import io.vertx.core.streams.impl.InboundBuffer;
 
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 import static io.netty.handler.codec.http.websocketx.WebSocketVersion.*;
@@ -1284,21 +1285,16 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     return expirationTimestamp == 0 || System.currentTimeMillis() <= expirationTimestamp;
   }
 
-  @Override
-  public void shutdown(long timeout, Handler<AsyncResult<Void>> handler) {
-    shutdown(timeout, vertx.promise(handler));
-  }
-
-  @Override
-  public Future<Void> shutdown(long timeoutMs) {
-    PromiseInternal<Void> promise = vertx.promise();
-    shutdown(timeoutMs, promise);
-    return promise.future();
-  }
-
   private synchronized void shutdownNow() {
     shutdownTimerID = -1L;
     close();
+  }
+
+  @Override
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+    PromiseInternal<Void> promise = vertx.promise();
+    shutdown(unit.toMillis(timeout), promise);
+    return promise.future();
   }
 
   private void shutdown(long timeoutMs, PromiseInternal<Void> promise) {

--- a/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
@@ -41,6 +41,8 @@ import io.vertx.core.http.impl.ws.WebSocketFrameInternal;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.net.impl.ConnectionBase;
 
+import java.util.concurrent.TimeUnit;
+
 import static io.vertx.core.net.impl.VertxHandler.safeBuffer;
 
 /**
@@ -132,12 +134,7 @@ abstract class Http1xConnectionBase<S extends WebSocketImplBase<S>> extends Conn
   }
 
   @Override
-  public void shutdown(long timeout, Handler<AsyncResult<Void>> handler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections cannot be shutdown");
-  }
-
-  @Override
-  public Future<Void> shutdown(long timeoutMs) {
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
     throw new UnsupportedOperationException("HTTP/1.x connections cannot be shutdown");
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
@@ -47,6 +47,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -363,14 +364,9 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
   }
 
   @Override
-  public void shutdown(long timeout, Handler<AsyncResult<Void>> handler) {
-    shutdown(timeout, vertx.promise(handler));
-  }
-
-  @Override
-  public Future<Void> shutdown(long timeoutMs) {
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
     PromiseInternal<Void> promise = vertx.promise();
-    shutdown(timeoutMs, promise);
+    shutdown(unit.toMillis(timeout), promise);
     return promise.future();
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -38,6 +38,7 @@ import java.security.cert.Certificate;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A connection that attempts to perform a protocol upgrade to H2C. The connection might use HTTP/1 or H2C
@@ -885,13 +886,8 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
   }
 
   @Override
-  public void shutdown(long timeout, Handler<AsyncResult<Void>> handler) {
-    current.shutdown(timeout, handler);
-  }
-
-  @Override
-  public Future<Void> shutdown(long timeoutMs) {
-    return current.shutdown(timeoutMs);
+  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return current.shutdown(timeout, unit);
   }
 
   @Override


### PR DESCRIPTION
Add to HttpConnection shutdown variants with a time unit for the timeout, deprecate methods with only the timeout in milliseconds.
