### PR TITLE
Explicit configuration of the TCP over TLS client hostname verification

### DIFF
--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -538,16 +538,22 @@ be sure who you are connecting to. Use this with caution. Default value is false
 If {@link io.vertx.core.net.ClientOptionsBase#setTrustAll trustAll} is not set then a client trust store must be
 configured and should contain the certificates of the servers that the client trusts.
 
-By default, host verification is disabled on the client.
-To enable host verification, set the algorithm to use on your client (only HTTPS and LDAPS is currently supported):
+By default, host verification is *not* configured on the client. This verifies the CN portion of the server certificate against the server hostname to avoid [Man-in-the-middle attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack).
 
+You must configure it explicitly on your client
+
+- `""` (empty string) disables host verification
+- `"HTTPS"` enables HTTP over TLS [verification](https://datatracker.ietf.org/doc/html/rfc2818#section-3.1)
+- `LDAPS` enables LDAP v3 extension for TLS [verification](https://datatracker.ietf.org/doc/html/rfc2830#section-3.6)
 
 [source,$lang]
 ----
 {@link examples.NetExamples#example46}
 ----
 
-Likewise server configuration, the client trust can be configured in several ways:
+NOTE: the Vert.x HTTP client uses the TCP client and configures with `"HTTPS"` the verification algorithm.
+
+Like server configuration, the client trust can be configured in several ways:
 
 The first method is by specifying the location of a Java trust-store which contains the certificate authority.
 

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -597,10 +597,10 @@ public class NetExamples {
       setSslEngineOptions(new OpenSSLEngineOptions());
   }
 
-  public void example46(Vertx vertx, JksOptions keyStoreOptions) {
+  public void example46(Vertx vertx, String verificationAlgorithm) {
     NetClientOptions options = new NetClientOptions().
       setSsl(true).
-      setHostnameVerificationAlgorithm("HTTPS");
+      setHostnameVerificationAlgorithm(verificationAlgorithm);
     NetClient client = vertx.createNetClient(options);
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -75,7 +75,9 @@ public class ClusteredEventBus extends EventBusImpl {
   public ClusteredEventBus(VertxInternal vertx, VertxOptions options, ClusterManager clusterManager, NodeSelector nodeSelector) {
     super(vertx);
 
-    NetClient client = createNetClient(vertx, new NetClientOptions(options.getEventBusOptions().toJson()));
+    NetClient client = createNetClient(vertx, new NetClientOptions(options.getEventBusOptions().toJson())
+      .setHostnameVerificationAlgorithm("")
+    );
 
     this.options = options.getEventBusOptions();
     this.clusterManager = clusterManager;

--- a/src/main/java/io/vertx/core/net/ClientSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/ClientSSLOptions.java
@@ -26,9 +26,9 @@ import java.util.concurrent.TimeUnit;
 public class ClientSSLOptions extends SSLOptions {
 
   /**
-   * Default value to determine hostname verification algorithm hostname verification (for SSL/TLS) = ""
+   * Default value to determine hostname verification algorithm hostname verification (for SSL/TLS) = null
    */
-  public static final String DEFAULT_HOSTNAME_VERIFICATION_ALGORITHM = "";
+  public static final String DEFAULT_HOSTNAME_VERIFICATION_ALGORITHM = null;
 
   /**
    * The default value of whether all servers (SSL/TLS) should be trusted = false

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -195,8 +195,15 @@ public class SSLHelper {
   }
 
   private Future<Config> buildConfig(SSLOptions sslOptions, boolean force, ContextInternal ctx) {
+    if (sslOptions instanceof ClientSSLOptions) {
+      ClientSSLOptions clientSSLOptions = (ClientSSLOptions) sslOptions;
+      if (clientSSLOptions.getHostnameVerificationAlgorithm() == null) {
+        return ctx.failedFuture("Missing hostname verification algorithm: you must set TCP client options host name" +
+          " verification algorithm");
+      }
+    }
     if (sslOptions.getTrustOptions() == null && sslOptions.getKeyCertOptions() == null) {
-      return Future.succeededFuture(NULL_CONFIG);
+      return ctx.succeededFuture(NULL_CONFIG);
     }
     Promise<Config> promise;
     ConfigKey k = new ConfigKey(sslOptions);

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -1197,6 +1197,7 @@ public class MetricsTest extends VertxTestBase {
       .setSslEngineOptions(new JdkSSLEngineOptions())
       .setUseAlpn(true)
       .setSsl(true)
+      .setHostnameVerificationAlgorithm("HTTPS")
       .setTrustOptions(Trust.SERVER_JKS.get())
       .setApplicationLayerProtocols(Collections.singletonList("h2")));
     CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
Vert.x TCP client does configure the TLS hostname verification algorithm to the empty string which means no checks of the server identity shall be performed beyond checking the validity of the certificate.

This set the default algorithm to null instead of the empty string, any usage of the TCP client must set the verification algorithm when used over TLS, valid values are empty string, HTTPS or LDAPS.

This is a breaking change when using NetClient over TLS.
