### PR TITLE
Explicit configuration of the TCP over TLS client hostname verification

### DIFF
--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -536,16 +536,21 @@ be sure who you are connecting to. Use this with caution. Default value is false
 If {@link io.vertx.core.net.ClientOptionsBase#setTrustAll trustAll} is not set then a client trust store must be
 configured and should contain the certificates of the servers that the client trusts.
 
-By default, host verification is disabled on the client.
-To enable host verification, set the algorithm to use on your client (only HTTPS and LDAPS is currently supported):
+By default, host verification is *not* configured on the client. This verifies the CN portion of the server certificate against the server hostname to avoid [Man-in-the-middle attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack).
 
+You must configure it explicitly on your client
 
+- `""` (empty string) disables host verification
+- `"HTTPS"` enables HTTP over TLS [verification](https://datatracker.ietf.org/doc/html/rfc2818#section-3.1)
+- `LDAPS` enables LDAP v3 extension for TLS [verification](https://datatracker.ietf.org/doc/html/rfc2830#section-3.6)
 [source,$lang]
 ----
 {@link examples.NetExamples#example46}
 ----
 
-Likewise server configuration, the client trust can be configured in several ways:
+NOTE: the Vert.x HTTP client uses the TCP client and configures with `"HTTPS"` the verification algorithm.
+
+Like server configuration, the client trust can be configured in several ways:
 
 The first method is by specifying the location of a Java trust-store which contains the certificate authority.
 

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -583,10 +583,10 @@ public class NetExamples {
       setOpenSslEngineOptions(new OpenSSLEngineOptions());
   }
 
-  public void example46(Vertx vertx, JksOptions keyStoreOptions) {
+  public void example46(Vertx vertx, String verificationAlgorithm) {
     NetClientOptions options = new NetClientOptions().
       setSsl(true).
-      setHostnameVerificationAlgorithm("HTTPS");
+      setHostnameVerificationAlgorithm(verificationAlgorithm);
     NetClient client = vertx.createNetClient(options);
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -83,7 +83,7 @@ public class ClusteredEventBus extends EventBusImpl {
     this.nodeSelector = nodeSelector;
     closeFuture = new CloseFuture(log);
     ebContext = vertx.createEventLoopContext(null, closeFuture, null, Thread.currentThread().getContextClassLoader());
-    this.client = createNetClient(vertx, new NetClientOptions(this.options.toJson()), closeFuture);
+    this.client = createNetClient(vertx, new NetClientOptions(this.options.toJson()).setHostnameVerificationAlgorithm(""), closeFuture);
   }
 
   private NetClient createNetClient(VertxInternal vertx, NetClientOptions clientOptions, CloseFuture closeFuture) {

--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -43,9 +43,9 @@ public class NetClientOptions extends ClientOptionsBase {
   public static final long DEFAULT_RECONNECT_INTERVAL = 1000;
 
   /**
-   * Default value to determine hostname verification algorithm hostname verification (for SSL/TLS) = ""
+   * Default value to determine hostname verification algorithm hostname verification (for SSL/TLS) = null
    */
-  public static final String DEFAULT_HOSTNAME_VERIFICATION_ALGORITHM = "";
+  public static final String DEFAULT_HOSTNAME_VERIFICATION_ALGORITHM = null;
 
   /**
    * Whether a write-handler should be registered by default = false.

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsTest.java
@@ -1200,6 +1200,7 @@ public class MetricsTest extends VertxTestBase {
       .setUseAlpn(true)
       .setSsl(true)
       .setTrustStoreOptions(Trust.SERVER_JKS.get())
+      .setHostnameVerificationAlgorithm("HTTPS")
       .setApplicationLayerProtocols(Collections.singletonList("h2")));
     CountDownLatch latch = new CountDownLatch(1);
     client.connect(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, onSuccess(so -> {


### PR DESCRIPTION
Vert.x TCP client does configure the TLS hostname verification algorithm to the empty string which means no checks of the server identity shall be performed beyond checking the validity of the certificate.

This set the default algorithm to null instead of the empty string, any usage of the TCP client must set the verification algorithm when used over TLS, valid values are empty string, HTTPS or LDAPS.

This is a breaking change when using NetClient over TLS.