### PR TITLE
Future control flow using predicates

### DIFF
--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -1252,15 +1252,15 @@ The client interface is very simple and follows this pattern:
 3. handle the beginning of the {@link io.vertx.core.http.HttpClientResponse}
 4. process the response events
 
-You can use Vert.x future composition methods to make your code simpler, however the API is event driven
-and you need to understand it otherwise you might experience possible data races (i.e loosing events
+You can use Vert.x future composition methods to make your code simpler, however the API is event driven,
+and you need to understand it otherwise you might experience possible data races (i.e. loosing events
 leading to corrupted data).
 
 NOTE: https://vertx.io/docs/vertx-web-client/java/[Vert.x Web Client] is a higher level API alternative (in fact it is built
 on top of this client) you might consider if this client is too low level for your use cases
 
 The client API intentionally does not return a `Future<HttpClientResponse>` because setting a completion
-handler on the future can be racy when this is set outside of the event-loop.
+handler on the future can be racy when this is set outside the event-loop.
 
 [source,$lang]
 ----
@@ -1284,11 +1284,18 @@ vertx.deployVerticle(() -> new AbstractVerticle() {
 ----
 
 When you are interacting with the client possibly outside a verticle then you can safely perform
-composition as long as you do not delay the response events, e.g processing  directly the response on the event-loop.
+composition as long as you do not delay the response events, e.g. processing  directly the response on the event-loop.
 
 [source,$lang]
 ----
 {@link examples.HTTPExamples#exampleClientComposition03}
+----
+
+You can also guard the response body with <<response-expectations,HTTP responses expectations>>.
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#exampleClientComposition03_}
 ----
 
 If you need to delay the response processing then you need to `pause` the response or use a `pipe`, this
@@ -1298,6 +1305,65 @@ might be necessary when another asynchronous operation is involved.
 ----
 {@link examples.HTTPExamples#exampleClientComposition04}
 ----
+
+[[response-expectations]]
+==== Response expectations
+
+As seen above, you must perform sanity checks manually after the response is received.
+
+You can trade flexibility for clarity and conciseness using _response expectations_.
+
+{@link io.vertx.core.http.HttpResponseExpectation Response expectations} can guard the control flow when the response does
+not match a criteria.
+
+The HTTP Client comes with a set of out of the box predicates ready to use:
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#usingPredefinedExpectations}
+----
+
+You can also create custom predicates when existing predicates don't fit your needs:
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#usingPredicates}
+----
+
+==== Predefined expectations
+
+As a convenience, the HTTP Client ships a few predicates for common uses cases .
+
+For status codes, e.g. {@link io.vertx.core.http.HttpResponseExpectation#SC_SUCCESS} to verify that the
+response has a `2xx` code, you can also create a custom one:
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#usingSpecificStatus(io.vertx.core.http.HttpClient,io.vertx.core.http.RequestOptions)}
+----
+
+For content types, e.g. {@link io.vertx.core.http.HttpResponseExpectation#JSON} to verify that the
+response body contains JSON data, you can also create a custom one:
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#usingSpecificContentType}
+----
+
+Please refer to the {@link io.vertx.core.http.HttpResponseExpectation} documentation for a full list of predefined expectations.
+
+==== Creating custom failures
+
+By default, expectations (including the predefined ones) conveys a simple error message. You can customize the exception class by changing the error converter:
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#expectationCustomError()}
+----
+
+WARNING: creating exception in Java can have a performance cost when it captures a stack trace, so you might want
+to create exceptions that do not capture the stack trace. By default exceptions are reported using an exception that
+does not capture the stack trace.
 
 ==== Reading cookies from the response
 

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -13,14 +13,7 @@ package examples;
 
 import io.netty.handler.codec.compression.GzipOptions;
 import io.netty.handler.codec.compression.StandardCompressionOptions;
-import io.vertx.core.AbstractVerticle;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.AsyncFile;
 import io.vertx.core.file.FileSystem;
@@ -768,6 +761,24 @@ public class HTTPExamples {
     });
   }
 
+  public void exampleClientComposition03_(HttpClient client) throws Exception {
+
+    Future<JsonObject> future = client
+      .request(HttpMethod.GET, "some-uri")
+      .compose(request -> request
+        .send()
+        .expecting(HttpResponseExpectation.SC_OK.and(HttpResponseExpectation.JSON))
+        .compose(response -> response
+          .body()
+          .map(buffer -> buffer.toJsonObject())));
+    // Listen to the composed final json result
+    future.onSuccess(json -> {
+      System.out.println("Received json result " + json);
+    }).onFailure(err -> {
+      System.out.println("Something went wrong " + err.getMessage());
+    });
+  }
+
   public void exampleClientComposition04(HttpClient client, FileSystem fileSystem) throws Exception {
 
     Future<Void> future = client
@@ -790,6 +801,80 @@ public class HTTPExamples {
             return Future.failedFuture("Incorrect HTTP response");
           }
         }));
+  }
+
+  public void usingPredefinedExpectations(HttpClient client, RequestOptions options) {
+    Future<Buffer> fut = client
+      .request(options)
+      .compose(request -> request
+        .send()
+        .expecting(HttpResponseExpectation.SC_SUCCESS)
+        .compose(response -> response.body()));
+  }
+
+  public void usingPredicates(HttpClient client) {
+
+    // Check CORS header allowing to do POST
+    HttpResponseExpectation methodsPredicate =
+      resp -> {
+        String methods = resp.getHeader("Access-Control-Allow-Methods");
+        return methods != null && methods.contains("POST");
+      };
+
+    // Send pre-flight CORS request
+    client
+      .request(new RequestOptions()
+        .setMethod(HttpMethod.OPTIONS)
+        .setPort(8080)
+        .setHost("myserver.mycompany.com")
+        .setURI("/some-uri")
+        .putHeader("Origin", "Server-b.com")
+        .putHeader("Access-Control-Request-Method", "POST"))
+      .compose(request -> request
+        .send()
+        .expecting(methodsPredicate))
+      .onSuccess(res -> {
+        // Process the POST request now
+      })
+      .onFailure(err ->
+        System.out.println("Something went wrong " + err.getMessage()));
+  }
+
+  public void usingSpecificStatus(HttpClient client, RequestOptions options) {
+    client
+      .request(options)
+      .compose(request -> request
+        .send()
+        .expecting(HttpResponseExpectation.status(200, 202)))
+      .onSuccess(res -> {
+        // ....
+      });
+  }
+
+  public void usingSpecificContentType(HttpClient client, RequestOptions options) {
+    client
+      .request(options)
+      .compose(request -> request
+        .send()
+        .expecting(HttpResponseExpectation.contentType("some/content-type")))
+      .onSuccess(res -> {
+        // ....
+      });
+  }
+
+  public void expectationCustomError() {
+    Expectation<HttpResponseHead> expectation = HttpResponseExpectation.SC_SUCCESS
+      .wrappingFailure((resp, err) -> new MyCustomException(resp.statusCode(), err.getMessage()));
+  }
+
+  private static class MyCustomException extends Exception {
+
+    private final int code;
+
+    public MyCustomException(int code, String message) {
+      super(message);
+      this.code = code;
+    }
   }
 
   public void exampleFollowRedirect01(HttpClient client) {

--- a/src/main/java/io/vertx/core/Expectation.java
+++ b/src/main/java/io/vertx/core/Expectation.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * An expectation, very much like a predicate with the ability to provide a meaningful description of the failure.
+ * <p/>
+ * Expectation can be used with {@link Future#expecting(Expectation)}.
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@FunctionalInterface
+public interface Expectation<V> {
+
+  /**
+   * Check the {@code value}, this should be side effect free, the expectation should either succeed returning {@code true} or fail
+   * returning {@code false}.
+   *
+   * @param value the checked value
+   */
+  boolean test(V value);
+
+  /**
+   * Returned an expectation succeeding when this expectation and the {@code other} expectation succeeds.
+   *
+   * @param other the other expectation
+   * @return an expectation that is a logical and of this and {@code other}
+   */
+  default Expectation<V> and(Expectation<? super V> other) {
+    Objects.requireNonNull(other);
+    return new Expectation<>() {
+      @Override
+      public boolean test(V value) {
+        return Expectation.this.test(value) && other.test(value);
+      }
+      @Override
+      public Throwable describe(V value) {
+        if (!Expectation.this.test(value)) {
+          return Expectation.this.describe(value);
+        } else if (!other.test(value)) {
+          return other.describe(value);
+        }
+        return null;
+      }
+    };
+  }
+
+  /**
+   * Returned an expectation succeeding when this expectation or the {@code other} expectation succeeds.
+   *
+   * @param other the other expectation
+   * @return an expectation that is a logical or of this and {@code other}
+   */
+  default Expectation<V> or(Expectation<? super V> other) {
+    Objects.requireNonNull(other);
+    return new Expectation<>() {
+      @Override
+      public boolean test(V value) {
+        return Expectation.this.test(value) || other.test(value);
+      }
+      @Override
+      public Throwable describe(V value) {
+        if (Expectation.this.test(value)) {
+          return null;
+        } else if (other.test(value)) {
+          return null;
+        } else {
+          return Expectation.this.describe(value);
+        }
+      }
+    };
+  }
+
+  /**
+   * Turn an invalid {@code value} into an exception describing the failure, the default implementation returns a generic exception.
+   *
+   * @param value the value to describe
+   * @return a meaningful exception
+   */
+  default Throwable describe(V value) {
+    return new VertxException("Unexpected result: " + value, true);
+  }
+
+  /**
+   * Returns a new expectation with the same predicate and a customized error {@code descriptor}.
+   *
+   * @param descriptor the function describing the error
+   * @return a new expectation describing the error with {@code descriptor}
+   */
+  default Expectation<V> wrappingFailure(BiFunction<V, Throwable, Throwable> descriptor) {
+    class CustomizedExpectation implements Expectation<V> {
+      private final BiFunction<V, Throwable, Throwable> descriptor;
+      private CustomizedExpectation(BiFunction<V, Throwable, Throwable> descriptor) {
+        this.descriptor = Objects.requireNonNull(descriptor);
+      }
+      @Override
+      public boolean test(V value) {
+        return Expectation.this.test(value);
+      }
+      @Override
+      public Throwable describe(V value) {
+        Throwable err = Expectation.this.describe(value);
+        return descriptor.apply(value, err);
+      }
+      @Override
+      public Expectation<V> wrappingFailure(BiFunction<V, Throwable, Throwable> descriptor) {
+        return new CustomizedExpectation(descriptor);
+      }
+    }
+    return new CustomizedExpectation(descriptor);
+  }
+}

--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -537,6 +537,26 @@ public interface Future<T> extends AsyncResult<T> {
   }
 
   /**
+   * Guard the control flow of this future with an expectation.
+   * <p/>
+   * When the future is completed with a success, the {@code expectation} is called with the result, when the expectation
+   * returns {@code false} the returned future is failed, otherwise the future is completed with the same result.
+   * <p/>
+   * Expectations are usually lambda expressions:
+   * <pre>
+   * return future.expecting(response -> response.statusCode() == 200);
+   * </pre>
+   * {@link Expectation} instances can also be used:
+   * <pre>
+   * future = future.expecting(HttpResponseExpectation.SC_OK);
+   * </pre>
+   *
+   * @param expectation the expectation
+   * @return a future succeeded with the result or failed when the expectation returns false
+   */
+  Future<T> expecting(Expectation<? super T> expectation);
+
+  /**
    * Returns a future succeeded or failed with the outcome of this future when it happens before the timeout fires. When
    * the timeout fires before, the future is failed with a {@link java.util.concurrent.TimeoutException}, guaranteeing
    * the returned future to complete within the specified {@code delay}.

--- a/src/main/java/io/vertx/core/http/HttpClientResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpClientResponse.java
@@ -33,7 +33,7 @@ import java.util.List;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
-public interface HttpClientResponse extends ReadStream<Buffer> {
+public interface HttpClientResponse extends ReadStream<Buffer>, HttpResponseHead {
 
   @Override
   HttpClientResponse fetch(long amount);
@@ -60,44 +60,6 @@ public interface HttpClientResponse extends ReadStream<Buffer> {
   NetSocket netSocket();
 
   /**
-   * @return the version of the response
-   */
-  HttpVersion version();
-
-  /**
-   * @return the status code of the response
-   */
-  int statusCode();
-
-  /**
-   * @return the status message of the response
-   */
-  String statusMessage();
-
-  /**
-   * @return the headers
-   */
-  @CacheReturn
-  MultiMap headers();
-
-  /**
-   * Return the first header value with the specified name
-   *
-   * @param headerName  the header name
-   * @return the header value
-   */
-  @Nullable String getHeader(String headerName);
-
-  /**
-   * Return the first header value with the specified name
-   *
-   * @param headerName  the header name
-   * @return the header value
-   */
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  String getHeader(CharSequence headerName);
-
-  /**
    * Return the first trailer value with the specified name
    *
    * @param trailerName  the trailer name
@@ -110,12 +72,6 @@ public interface HttpClientResponse extends ReadStream<Buffer> {
    */
   @CacheReturn
   MultiMap trailers();
-
-  /**
-   * @return the Set-Cookie headers (including trailers)
-   */
-  @CacheReturn
-  List<String> cookies();
 
   /**
    * Convenience method for receiving the entire request body in one piece.

--- a/src/main/java/io/vertx/core/http/HttpResponseExpectation.java
+++ b/src/main/java/io/vertx/core/http/HttpResponseExpectation.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.core.Expectation;
+import io.vertx.core.VertxException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Common expectations for HTTP responses.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface HttpResponseExpectation extends Expectation<HttpResponseHead> {
+
+  /**
+   * Any 1XX informational response
+   */
+  HttpResponseExpectation SC_INFORMATIONAL_RESPONSE = status(100, 200);
+
+  /**
+   * 100 Continue
+   */
+  HttpResponseExpectation SC_CONTINUE = status(100);
+
+  /**
+   * 101 Switching Protocols
+   */
+  HttpResponseExpectation SC_SWITCHING_PROTOCOLS = status(101);
+
+  /**
+   * 102 Processing (WebDAV, RFC2518)
+   */
+  HttpResponseExpectation SC_PROCESSING = status(102);
+
+  /**
+   * 103 Early Hints
+   */
+  HttpResponseExpectation SC_EARLY_HINTS = status(103);
+
+  /**
+   * Any 2XX success
+   */
+  HttpResponseExpectation SC_SUCCESS = status(200, 300);
+
+  /**
+   * 200 OK
+   */
+  HttpResponseExpectation SC_OK = status(200);
+
+  /**
+   * 201 Created
+   */
+  HttpResponseExpectation SC_CREATED = status(201);
+
+  /**
+   * 202 Accepted
+   */
+  HttpResponseExpectation SC_ACCEPTED = status(202);
+
+  /**
+   * 203 Non-Authoritative Information (since HTTP/1.1)
+   */
+  HttpResponseExpectation SC_NON_AUTHORITATIVE_INFORMATION = status(203);
+
+  /**
+   * 204 No Content
+   */
+  HttpResponseExpectation SC_NO_CONTENT = status(204);
+
+  /**
+   * 205 Reset Content
+   */
+  HttpResponseExpectation SC_RESET_CONTENT = status(205);
+
+  /**
+   * 206 Partial Content
+   */
+  HttpResponseExpectation SC_PARTIAL_CONTENT = status(206);
+
+  /**
+   * 207 Multi-Status (WebDAV, RFC2518)
+   */
+  HttpResponseExpectation SC_MULTI_STATUS = status(207);
+
+  /**
+   * Any 3XX redirection
+   */
+  HttpResponseExpectation SC_REDIRECTION = status(300, 400);
+
+  /**
+   * 300 Multiple Choices
+   */
+  HttpResponseExpectation SC_MULTIPLE_CHOICES = status(300);
+
+  /**
+   * 301 Moved Permanently
+   */
+  HttpResponseExpectation SC_MOVED_PERMANENTLY = status(301);
+
+  /**
+   * 302 Found
+   */
+  HttpResponseExpectation SC_FOUND = status(302);
+
+  /**
+   * 303 See Other (since HTTP/1.1)
+   */
+  HttpResponseExpectation SC_SEE_OTHER = status(303);
+
+  /**
+   * 304 Not Modified
+   */
+  HttpResponseExpectation SC_NOT_MODIFIED = status(304);
+
+  /**
+   * 305 Use Proxy (since HTTP/1.1)
+   */
+  HttpResponseExpectation SC_USE_PROXY = status(305);
+
+  /**
+   * 307 Temporary Redirect (since HTTP/1.1)
+   */
+  HttpResponseExpectation SC_TEMPORARY_REDIRECT = status(307);
+
+  /**
+   * 308 Permanent Redirect (RFC7538)
+   */
+  HttpResponseExpectation SC_PERMANENT_REDIRECT = status(308);
+
+  /**
+   * Any 4XX client error
+   */
+  HttpResponseExpectation SC_CLIENT_ERRORS = status(400, 500);
+
+  /**
+   * 400 Bad Request
+   */
+  HttpResponseExpectation SC_BAD_REQUEST = status(400);
+
+  /**
+   * 401 Unauthorized
+   */
+  HttpResponseExpectation SC_UNAUTHORIZED = status(401);
+
+  /**
+   * 402 Payment Required
+   */
+  HttpResponseExpectation SC_PAYMENT_REQUIRED = status(402);
+
+  /**
+   * 403 Forbidden
+   */
+  HttpResponseExpectation SC_FORBIDDEN = status(403);
+
+  /**
+   * 404 Not Found
+   */
+  HttpResponseExpectation SC_NOT_FOUND = status(404);
+
+  /**
+   * 405 Method Not Allowed
+   */
+  HttpResponseExpectation SC_METHOD_NOT_ALLOWED = status(405);
+
+  /**
+   * 406 Not Acceptable
+   */
+  HttpResponseExpectation SC_NOT_ACCEPTABLE = status(406);
+
+  /**
+   * 407 Proxy Authentication Required
+   */
+  HttpResponseExpectation SC_PROXY_AUTHENTICATION_REQUIRED = status(407);
+
+  /**
+   * 408 Request Timeout
+   */
+  HttpResponseExpectation SC_REQUEST_TIMEOUT = status(408);
+
+  /**
+   * 409 Conflict
+   */
+  HttpResponseExpectation SC_CONFLICT = status(409);
+
+  /**
+   * 410 Gone
+   */
+  HttpResponseExpectation SC_GONE = status(410);
+
+  /**
+   * 411 Length Required
+   */
+  HttpResponseExpectation SC_LENGTH_REQUIRED = status(411);
+
+  /**
+   * 412 Precondition Failed
+   */
+  HttpResponseExpectation SC_PRECONDITION_FAILED = status(412);
+
+  /**
+   * 413 Request Entity Too Large
+   */
+  HttpResponseExpectation SC_REQUEST_ENTITY_TOO_LARGE = status(413);
+
+  /**
+   * 414 Request-URI Too Long
+   */
+  HttpResponseExpectation SC_REQUEST_URI_TOO_LONG = status(414);
+
+  /**
+   * 415 Unsupported Media Type
+   */
+  HttpResponseExpectation SC_UNSUPPORTED_MEDIA_TYPE = status(415);
+
+  /**
+   * 416 Requested Range Not Satisfiable
+   */
+  HttpResponseExpectation SC_REQUESTED_RANGE_NOT_SATISFIABLE = status(416);
+
+  /**
+   * 417 Expectation Failed
+   */
+  HttpResponseExpectation SC_EXPECTATION_FAILED = status(417);
+
+  /**
+   * 421 Misdirected Request
+   */
+  HttpResponseExpectation SC_MISDIRECTED_REQUEST = status(421);
+
+  /**
+   * 422 Unprocessable Entity (WebDAV, RFC4918)
+   */
+  HttpResponseExpectation SC_UNPROCESSABLE_ENTITY = status(422);
+
+  /**
+   * 423 Locked (WebDAV, RFC4918)
+   */
+  HttpResponseExpectation SC_LOCKED = status(423);
+
+  /**
+   * 424 Failed Dependency (WebDAV, RFC4918)
+   */
+  HttpResponseExpectation SC_FAILED_DEPENDENCY = status(424);
+
+  /**
+   * 425 Unordered Collection (WebDAV, RFC3648)
+   */
+  HttpResponseExpectation SC_UNORDERED_COLLECTION = status(425);
+
+  /**
+   * 426 Upgrade Required (RFC2817)
+   */
+  HttpResponseExpectation SC_UPGRADE_REQUIRED = status(426);
+
+  /**
+   * 428 Precondition Required (RFC6585)
+   */
+  HttpResponseExpectation SC_PRECONDITION_REQUIRED = status(428);
+
+  /**
+   * 429 Too Many Requests (RFC6585)
+   */
+  HttpResponseExpectation SC_TOO_MANY_REQUESTS = status(429);
+
+  /**
+   * 431 Request Header Fields Too Large (RFC6585)
+   */
+  HttpResponseExpectation SC_REQUEST_HEADER_FIELDS_TOO_LARGE = status(431);
+
+  /**
+   * Any 5XX server error
+   */
+  HttpResponseExpectation SC_SERVER_ERRORS = status(500, 600);
+
+  /**
+   * 500 Internal Server Error
+   */
+  HttpResponseExpectation SC_INTERNAL_SERVER_ERROR = status(500);
+
+  /**
+   * 501 Not Implemented
+   */
+  HttpResponseExpectation SC_NOT_IMPLEMENTED = status(501);
+
+  /**
+   * 502 Bad Gateway
+   */
+  HttpResponseExpectation SC_BAD_GATEWAY = status(502);
+
+  /**
+   * 503 Service Unavailable
+   */
+  HttpResponseExpectation SC_SERVICE_UNAVAILABLE = status(503);
+
+  /**
+   * 504 Gateway Timeout
+   */
+  HttpResponseExpectation SC_GATEWAY_TIMEOUT = status(504);
+
+  /**
+   * 505 HTTP Version Not Supported
+   */
+  HttpResponseExpectation SC_HTTP_VERSION_NOT_SUPPORTED = status(505);
+
+  /**
+   * 506 Variant Also Negotiates (RFC2295)
+   */
+  HttpResponseExpectation SC_VARIANT_ALSO_NEGOTIATES = status(506);
+
+  /**
+   * 507 Insufficient Storage (WebDAV, RFC4918)
+   */
+  HttpResponseExpectation SC_INSUFFICIENT_STORAGE = status(507);
+
+  /**
+   * 510 Not Extended (RFC2774)
+   */
+  HttpResponseExpectation SC_NOT_EXTENDED = status(510);
+
+  /**
+   * 511 Network Authentication Required (RFC6585)
+   */
+  HttpResponseExpectation SC_NETWORK_AUTHENTICATION_REQUIRED = status(511);
+
+  /**
+   * Creates an expectation asserting that the status response code is equal to {@code statusCode}.
+   *
+   * @param statusCode the expected status code
+   */
+  static HttpResponseExpectation status(int statusCode) {
+    return status(statusCode, statusCode + 1);
+  }
+
+  static HttpResponseExpectation status(int min, int max) {
+    return new HttpResponseExpectation() {
+      @Override
+      public boolean test(HttpResponseHead value) {
+        int sc = value.statusCode();
+        return sc >= min && sc < max;
+      }
+
+      @Override
+      public Exception describe(HttpResponseHead value) {
+        int sc = value.statusCode();
+        if (max - min == 1) {
+          return new VertxException("Response status code " + sc + " is not equal to " + min, true);
+        }
+        return new VertxException("Response status code " + sc + " is not between " + min + " and " + max, true);
+      }
+    };
+  }
+
+  /**
+   * Creates an expectation validating the response {@code content-type} is {@code application/json}.
+   */
+  HttpResponseExpectation JSON = contentType("application/json");
+
+  /**
+   * Creates an expectation validating the response has a {@code content-type} header matching the {@code mimeType}.
+   *
+   * @param mimeType the mime type
+   */
+  static HttpResponseExpectation contentType(String mimeType) {
+    return contentType(Collections.singletonList(mimeType));
+  }
+
+  /**
+   * Creates an expectation validating the response has a {@code content-type} header matching one of the {@code mimeTypes}.
+   *
+   * @param mimeTypes the list of mime types
+   */
+  static HttpResponseExpectation contentType(String... mimeTypes) {
+    return contentType(Arrays.asList(mimeTypes));
+  }
+
+  /**
+   * Creates an expectation validating the response has a {@code content-type} header matching one of the {@code mimeTypes}.
+   *
+   * @param mimeTypes the list of mime types
+   */
+  static HttpResponseExpectation contentType(List<String> mimeTypes) {
+    return new HttpResponseExpectation() {
+      @Override
+      public boolean test(HttpResponseHead value) {
+        String contentType = value.headers().get(HttpHeaders.CONTENT_TYPE);
+        if (contentType == null) {
+          return false;
+        }
+        int paramIdx = contentType.indexOf(';');
+        String mediaType = paramIdx != -1 ? contentType.substring(0, paramIdx) : contentType;
+
+        for (String mimeType : mimeTypes) {
+          if (mediaType.equalsIgnoreCase(mimeType)) {
+            return true;
+          }
+        }
+        return false;
+      }
+
+      @Override
+      public Exception describe(HttpResponseHead value) {
+        String contentType = value.headers().get(HttpHeaders.CONTENT_TYPE);
+        if (contentType == null) {
+          return new VertxException("Missing response content type", true);
+        }
+        StringBuilder sb = new StringBuilder("Expect content type ").append(contentType).append(" to be one of ");
+        boolean first = true;
+        for (String mimeType : mimeTypes) {
+          if (!first) {
+            sb.append(", ");
+          }
+          first = false;
+          sb.append(mimeType);
+        }
+        return new VertxException(sb.toString(), true);
+      }
+    };
+  }
+}

--- a/src/main/java/io/vertx/core/http/HttpResponseHead.java
+++ b/src/main/java/io/vertx/core/http/HttpResponseHead.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.CacheReturn;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.MultiMap;
+
+import java.util.List;
+
+/**
+ * The state of the HTTP response head:
+ *
+ * <ul>
+ *   <li>Status code / Message</li>
+ *   <li>Headers</li>
+ * </ul>
+ */
+@VertxGen(concrete = false)
+public interface HttpResponseHead {
+
+  /**
+   * @return the version of the response
+   */
+  HttpVersion version();
+
+  /**
+   * @return the status code of the response
+   */
+  int statusCode();
+
+  /**
+   * @return the status message of the response
+   */
+  String statusMessage();
+
+  /**
+   * @return the headers
+   */
+  @CacheReturn
+  MultiMap headers();
+
+  /**
+   * Return the first header value with the specified name
+   *
+   * @param headerName  the header name
+   * @return the header value
+   */
+  @Nullable String getHeader(String headerName);
+
+  /**
+   * Return the first header value with the specified name
+   *
+   * @param headerName  the header name
+   * @return the header value
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  String getHeader(CharSequence headerName);
+
+  /**
+   * @return the Set-Cookie headers (including trailers)
+   */
+  @CacheReturn
+  List<String> cookies();
+
+}

--- a/src/main/java/io/vertx/core/impl/future/Expect.java
+++ b/src/main/java/io/vertx/core/impl/future/Expect.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl.future;
+
+import io.vertx.core.Expectation;
+import io.vertx.core.VertxException;
+import io.vertx.core.impl.ContextInternal;
+
+/**
+ * Implements expectation.
+ */
+public class Expect<T> extends Operation<T> implements Listener<T> {
+
+  private final Expectation<? super T> expectation;
+
+  public Expect(ContextInternal context, Expectation<? super T> expectation) {
+    super(context);
+    this.expectation = expectation;
+  }
+
+  @Override
+  public void onSuccess(T value) {
+    Throwable err = null;
+    try {
+      if (!expectation.test(value)) {
+        err = expectation.describe(value);
+        if (err == null) {
+          err = new VertxException("Unexpected result: " + value, true);
+        }
+      }
+    } catch (Throwable e) {
+      err = e;
+    }
+    if (err != null) {
+      tryFail(err);
+    } else {
+      tryComplete(value);
+    }
+  }
+
+  @Override
+  public void onFailure(Throwable failure) {
+    tryFail(failure);
+  }
+}

--- a/src/main/java/io/vertx/core/impl/future/FutureBase.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureBase.java
@@ -11,11 +11,11 @@
 
 package io.vertx.core.impl.future;
 
-import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.OrderedEventExecutor;
 import io.netty.util.concurrent.ScheduledFuture;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Expectation;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.impl.ContextInternal;
@@ -136,6 +136,13 @@ public abstract class FutureBase<T> implements FutureInternal<T> {
     FixedOtherwise<T> operation = new FixedOtherwise<>(context, value);
     addListener(operation);
     return operation;
+  }
+
+  @Override
+  public Future<T> expecting(Expectation<? super T> expectation) {
+    Expect<T> expect = new Expect<>(context, expectation);
+    addListener(expect);
+    return expect;
   }
 
   @Override

--- a/src/test/java/io/vertx/core/ExpectationTest.java
+++ b/src/test/java/io/vertx/core/ExpectationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ExpectationTest {
+
+  @Test
+  public void testAnd() {
+    Throwable f1 = new Throwable();
+    Expectation<String> isNotA = new Expectation<>() {
+      @Override
+      public boolean test(String value) {
+        return !"a".equals(value);
+      }
+      @Override
+      public Throwable describe(String value) {
+        return f1;
+      }
+    };
+    Throwable f2 = new Throwable();
+    Expectation<String> isNotB = new Expectation<>() {
+      @Override
+      public boolean test(String value) {
+        return !"b".equals(value);
+      }
+      @Override
+      public Throwable describe(String value) {
+        return f2;
+      }
+    };
+    Expectation<String> isNotANorIsB = isNotA.and(isNotB);
+    assertFalse(isNotA.test("a"));
+    assertTrue(isNotA.test("b"));
+    assertTrue(isNotA.test("c"));
+    assertTrue(isNotB.test("a"));
+    assertFalse(isNotB.test("b"));
+    assertTrue(isNotB.test("c"));
+    assertTrue(isNotANorIsB.test("c"));
+    assertNull(isNotANorIsB.describe("c"));
+    assertFalse(isNotANorIsB.test("a"));
+    assertSame(f1, isNotANorIsB.describe("a"));
+    assertFalse(isNotANorIsB.test("b"));
+    assertSame(f2, isNotANorIsB.describe("b"));
+  }
+
+  @Test
+  public void testOr() {
+    Throwable f1 = new Throwable();
+    Expectation<String> isA = new Expectation<>() {
+      @Override
+      public boolean test(String value) {
+        return "a".equals(value);
+      }
+      @Override
+      public Throwable describe(String value) {
+        return f1;
+      }
+    };
+    Throwable f2 = new Throwable();
+    Expectation<String> isB = new Expectation<>() {
+      @Override
+      public boolean test(String value) {
+        return "b".equals(value);
+      }
+      @Override
+      public Throwable describe(String value) {
+        return f2;
+      }
+    };
+    Expectation<String> isAorIsB = isA.or(isB);
+    assertTrue(isA.test("a"));
+    assertFalse(isA.test("b"));
+    assertFalse(isA.test("c"));
+    assertFalse(isB.test("a"));
+    assertTrue(isB.test("b"));
+    assertFalse(isB.test("c"));
+    assertFalse(isAorIsB.test("c"));
+    assertSame(f1, isAorIsB.describe("c"));
+    assertTrue(isAorIsB.test("a"));
+    assertNull(isAorIsB.describe("a"));
+    assertTrue(isAorIsB.test("b"));
+    assertNull(isAorIsB.describe("b"));
+  }
+}

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -621,6 +621,84 @@ public class FutureTest extends FutureTestBase {
   }
 
   @Test
+  public void testExpectingSuccessWithValidSuccess() {
+    AtomicBoolean called = new AtomicBoolean();
+    Promise<String> p = Promise.promise();
+    Future<String> f = p.future();
+    Future<String> r = f.expecting(t -> {
+      called.set(true);
+      return true;
+    });
+    Checker<String> checker = new Checker<>(r);
+    checker.assertNotCompleted();
+    p.complete("yeah");
+    assertTrue(r.succeeded());
+    checker.assertSucceeded("yeah");
+    assertTrue(called.get());
+  }
+
+  @Test
+  public void testExpectingFailureWithInvalidSuccess() {
+    AtomicBoolean called = new AtomicBoolean();
+    Promise<String> p = Promise.promise();
+    Future<String> f = p.future();
+    Throwable err = new Throwable();
+    Future<String> r = f.expecting(new Expectation<String>() {
+      @Override
+      public boolean test(String value) {
+        called.set(true);
+        return false;
+      }
+      @Override
+      public Throwable describe(String value) {
+        return err;
+      }
+    });
+    Checker<String> checker = new Checker<>(r);
+    checker.assertNotCompleted();
+    p.complete("yeah");
+    assertFalse(r.succeeded());
+    checker.assertFailed(err);
+    assertTrue(called.get());
+  }
+
+  @Test
+  public void testExpectingFailureWithFailure() {
+    AtomicBoolean called = new AtomicBoolean();
+    Promise<String> p = Promise.promise();
+    Future<String> f = p.future();
+    Future<String> r = f.expecting(t -> {
+      called.set(true);
+      return true;
+    });
+    Checker<String> checker = new Checker<>(r);
+    checker.assertNotCompleted();
+    Throwable err = new Throwable();
+    p.fail(err);
+    assertTrue(r.failed());
+    checker.assertFailed(err);
+    assertFalse(called.get());
+  }
+
+  @Test
+  public void testExpectingThrowingError() {
+    AtomicBoolean called = new AtomicBoolean();
+    Promise<String> p = Promise.promise();
+    Future<String> f = p.future();
+    RuntimeException err = new RuntimeException();
+    Future<String> r = f.expecting(t -> {
+      called.set(true);
+      throw err;
+    });
+    Checker<String> checker = new Checker<>(r);
+    checker.assertNotCompleted();
+    p.complete("yeah");
+    assertTrue(r.failed());
+    checker.assertFailed(err);
+    assertTrue(called.get());
+  }
+
+  @Test
   public void testOtherwiseSuccessWithSuccess() {
     AtomicBoolean called = new AtomicBoolean();
     Promise<String> p = Promise.promise();
@@ -820,6 +898,8 @@ public class FutureTest extends FutureTestBase {
         this.cause = cause;
         return true;
       }
+
+      public Future<T> expecting(Expectation<? super T> expectation) { throw new UnsupportedOperationException(); }
       public boolean tryFail(String failureMessage) { throw new UnsupportedOperationException(); }
       public T result() { throw new UnsupportedOperationException(); }
       public Throwable cause() { throw new UnsupportedOperationException(); }

--- a/src/test/java/io/vertx/core/http/HttpResponseExpectationTest.java
+++ b/src/test/java/io/vertx/core/http/HttpResponseExpectationTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Expectation;
+import io.vertx.test.core.TestUtils;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+
+public class HttpResponseExpectationTest extends HttpTestBase {
+
+  @Test
+  public void testExpectFail() throws Exception {
+    testExpectation(true,
+      resp -> false,
+      HttpServerResponse::end);
+  }
+
+  @Test
+  public void testExpectPass() throws Exception {
+    testExpectation(false,
+      resp -> true,
+      HttpServerResponse::end);
+  }
+
+  @Test
+  public void testExpectStatusFail() throws Exception {
+    testExpectation(true,
+      HttpResponseExpectation.status(200),
+      resp -> resp.setStatusCode(201).end());
+  }
+
+  @Test
+  public void testExpectStatusPass() throws Exception {
+    testExpectation(false,
+      HttpResponseExpectation.status(200),
+      resp -> resp.setStatusCode(200).end());
+  }
+
+  @Test
+  public void testExpectStatusRangeFail() throws Exception {
+    testExpectation(true,
+      HttpResponseExpectation.SC_SUCCESS,
+      resp -> resp.setStatusCode(500).end());
+  }
+
+  @Test
+  public void testExpectStatusRangePass1() throws Exception {
+    testExpectation(false,
+      HttpResponseExpectation.SC_SUCCESS,
+      resp -> resp.setStatusCode(200).end());
+  }
+
+  @Test
+  public void testExpectStatusRangePass2() throws Exception {
+    testExpectation(false,
+      HttpResponseExpectation.SC_SUCCESS,
+      resp -> resp.setStatusCode(299).end());
+  }
+
+  @Test
+  public void testExpectContentTypeFail() throws Exception {
+    testExpectation(true,
+      HttpResponseExpectation.JSON,
+      HttpServerResponse::end);
+  }
+
+  @Test
+  public void testExpectOneOfContentTypesFail() throws Exception {
+    testExpectation(true,
+      HttpResponseExpectation.contentType(Arrays.asList("text/plain", "text/csv")),
+      httpServerResponse -> httpServerResponse.putHeader(HttpHeaders.CONTENT_TYPE, HttpHeaders.TEXT_HTML).end());
+  }
+
+  @Test
+  public void testExpectContentTypePass() throws Exception {
+    testExpectation(false,
+      HttpResponseExpectation.JSON,
+      resp -> resp.putHeader("content-type", "application/JSON").end());
+  }
+
+  @Test
+  public void testExpectContentTypeWithEncodingPass() throws Exception {
+    testExpectation(false,
+      HttpResponseExpectation.JSON,
+      resp -> resp.putHeader("content-type", "application/JSON;charset=UTF-8").end());
+  }
+
+  @Test
+  public void testExpectOneOfContentTypesPass() throws Exception {
+    testExpectation(false,
+      HttpResponseExpectation.contentType(Arrays.asList("text/plain", "text/HTML")),
+      httpServerResponse -> httpServerResponse.putHeader(HttpHeaders.CONTENT_TYPE, HttpHeaders.TEXT_HTML).end());
+  }
+
+  @Test
+  public void testExpectCustomException() throws Exception {
+    Expectation<HttpResponseHead> predicate = ((Expectation<HttpResponseHead>) value -> false)
+      .wrappingFailure((r,e) -> new CustomException("boom"));
+
+    testExpectation(true, predicate, HttpServerResponse::end, ar -> {
+      Throwable cause = ar.cause();
+      assertThat(cause, instanceOf(CustomException.class));
+      CustomException customException = (CustomException) cause;
+      assertEquals("boom", customException.getMessage());
+    });
+  }
+
+/*
+  @Test
+  public void testExpectCustomExceptionWithResponseBody() throws Exception {
+    UUID uuid = UUID.randomUUID();
+
+    ResponsePredicate predicate = ResponsePredicate.create(ResponsePredicate.SC_SUCCESS, ErrorConverter.createFullBody(result -> {
+      JsonObject body = result.response().bodyAsJsonObject();
+      return new CustomException(UUID.fromString(body.getString("tag")), body.getString("message"));
+    }));
+
+    testExpectation(true, req -> req.expect(predicate), httpServerResponse -> {
+      httpServerResponse
+        .setStatusCode(400)
+        .end(new JsonObject().put("tag", uuid.toString()).put("message", "tilt").toBuffer());
+    }, ar -> {
+      Throwable cause = ar.cause();
+      assertThat(cause, instanceOf(CustomException.class));
+      CustomException customException = (CustomException) cause;
+      assertEquals("tilt", customException.getMessage());
+      assertEquals(uuid, customException.tag);
+    });
+  }
+*/
+
+  @Test
+  public void testExpectCustomExceptionWithStatusCode() throws Exception {
+    UUID uuid = UUID.randomUUID();
+    int statusCode = 400;
+
+    Expectation<HttpResponseHead> predicate = HttpResponseExpectation.SC_SUCCESS
+      .wrappingFailure((value, err) -> new CustomException(uuid, String.valueOf(value.statusCode())));
+
+    testExpectation(true, predicate, httpServerResponse -> {
+      httpServerResponse
+        .setStatusCode(statusCode)
+        .end(TestUtils.randomBuffer(2048));
+    }, ar -> {
+      Throwable cause = ar.cause();
+      assertThat(cause, instanceOf(CustomException.class));
+      CustomException customException = (CustomException) cause;
+      assertEquals(String.valueOf(statusCode), customException.getMessage());
+      assertEquals(uuid, customException.tag);
+    });
+  }
+
+  @Test
+  public void testExpectFunctionThrowsException() throws Exception {
+    Expectation<HttpResponseHead> predicate = ((Expectation<HttpResponseHead>) value -> false)
+      .wrappingFailure((v,e) -> {
+        throw new IndexOutOfBoundsException("boom");
+      });
+
+    testExpectation(true, predicate, HttpServerResponse::end, ar -> {
+      assertThat(ar.cause(), instanceOf(IndexOutOfBoundsException.class));
+    });
+  }
+
+  @Test
+  public void testErrorConverterReturnsNull() throws Exception {
+    Expectation<HttpResponseHead> predicate = ((Expectation<HttpResponseHead>) value -> false)
+      .wrappingFailure((v,e) -> null);
+
+    testExpectation(true, predicate, HttpServerResponse::end, ar -> {
+      assertThat(ar.cause(), not(instanceOf(NullPointerException.class)));
+    });
+  }
+
+  private static class CustomException extends Exception {
+
+    UUID tag;
+
+    CustomException(String message) {
+      super(message);
+    }
+
+    CustomException(UUID tag, String message) {
+      super(message);
+      this.tag = tag;
+    }
+  }
+
+  private void testExpectation(boolean shouldFail,
+                               Expectation<HttpResponseHead> expectation,
+                               Consumer<HttpServerResponse> server) throws Exception {
+    testExpectation(shouldFail, expectation, server, null);
+  }
+
+  private void testExpectation(boolean shouldFail,
+                               Expectation<HttpResponseHead> expectation,
+                               Consumer<HttpServerResponse> server,
+                               Consumer<AsyncResult<?>> resultTest) throws Exception {
+    this.server.requestHandler(request -> server.accept(request.response()));
+    startServer();
+    client
+      .request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/test")
+      .compose(request -> request
+        .send()
+        .expecting(expectation))
+      .onComplete(ar -> {
+        if (ar.succeeded()) {
+          assertFalse("Expected response success", shouldFail);
+        } else {
+          assertTrue("Expected response failure", shouldFail);
+        }
+        if (resultTest != null) resultTest.accept(ar);
+        testComplete();
+      });
+    await();
+  }
+}


### PR DESCRIPTION
`Future` control flow using predicates.

`Future` has already synchronous operations modifying the control flow
- `map` : transforms a mapper failure into a failed future (e.g. `future.map(val -> throw new VertxException())`)
- `otherwise` : transforms a failure into a success

This contribution aims to transform a success into a failure based on the result of a predicate.

Goals

- capture useful predicates that modify the control flow, e.g. a predicate that checks the HTTP client response  (status code, headers, etc...)
- provide inline guards using lambda expressions

Vert.x Web Client has something close to this with HTTP expectations:

```java
    client
      .get(8080, "myserver.mycompany.com", "/some-uri")
      .expect(ResponsePredicate.SC_SUCCESS)
      .expect(ResponsePredicate.JSON)
      .send()
      .onSuccess(res -> {
        // Safely decode the body as a json object
        JsonObject body = res.bodyAsJsonObject();
        System.out.println(
          "Received response with status code" +
            res.statusCode() +
            " with body " +
            body);
      })
      .onFailure(err ->
        System.out.println("Something went wrong " + err.getMessage()));
```

A predicate like interface `Expectation`: a synchronous predicate that checks a boolean value and has a method to create a meaningful exception.

```java
Future<Buffer> body = client.request(options)
  .compose(req -> req
    .send()
    .expecting(resp -> resp.statusCode() == 200)
    .compose(resp -> resp.body()); 
```

The HTTP response status code can be captured so it can be reused.

```java
Future<Buffer> body = client.request(options)
  .compose(req -> req
    .send()
    .expecting(HttpResponseExpectation.SC_OK)
    .compose(resp -> resp.body()); 
```
