### PR TITLE
Validate content length early during HttpServerResponse#sendFile

### DIFF
--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -74,7 +74,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -2131,10 +2131,8 @@ public abstract class HttpTest extends HttpTestBase {
 
   @Test
   public void testSendZeroRangeFileFromClasspath() throws Exception {
-    server.requestHandler(res -> {
-      // hosts_config.txt is 23 bytes
-      res.response().sendFile("hosts_config.txt", 23, 0);
-    });
+    File f = setupFile("twenty_three_bytes.txt", TestUtils.randomAlphaString(23));
+    server.requestHandler(res -> res.response().sendFile(f.getAbsolutePath(), 23, 0));
     startServer(testAddress);
     client.request(requestOptions)
       .compose(req -> req
@@ -2151,10 +2149,10 @@ public abstract class HttpTest extends HttpTestBase {
 
   @Test
   public void testSendOffsetIsHigherThanFileLengthForFileFromClasspath() throws Exception {
+    File f = setupFile("twenty_three_bytes.txt", TestUtils.randomAlphaString(23));
     server.requestHandler(res -> {
       try {
-        // hosts_config.txt is 23 bytes
-        res.response().sendFile("hosts_config.txt", 33, 10)
+        res.response().sendFile(f.getAbsolutePath(), 33, 10)
           .onFailure(throwable -> {
             try {
               res.response().setStatusCode(500).end();
@@ -2189,10 +2187,10 @@ public abstract class HttpTest extends HttpTestBase {
 
   @Test
   public void testSendFileFromClasspathWithNegativeLength() throws Exception {
+    File f = setupFile("twenty_three_bytes.txt", TestUtils.randomAlphaString(23));
     server.requestHandler(res -> {
       try {
-        // hosts_config.txt is 23 bytes
-        res.response().sendFile("hosts_config.txt", 0, -100)
+        res.response().sendFile(f.getAbsolutePath(), 0, -100)
           .onFailure(throwable -> {
             // should not reach here, the response should not be sent if the offset is negative
             fail("Should not reach here");
@@ -2217,10 +2215,10 @@ public abstract class HttpTest extends HttpTestBase {
 
   @Test
   public void testSendFileFromClasspathWithNegativeOffset() throws Exception {
+    File f = setupFile("twenty_three_bytes.txt", TestUtils.randomAlphaString(23));
     server.requestHandler(res -> {
       try {
-        // hosts_config.txt is 23 bytes
-        res.response().sendFile("hosts_config.txt", -100, 23)
+        res.response().sendFile(f.getAbsolutePath(), -100, 23)
           .onFailure(throwable -> {
             // should not reach here, the response should not be sent if the offset is negative
             fail("Should not reach here");

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -2130,7 +2130,7 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
-  public void testSendZeroRangeFileFromClasspath() throws Exception {
+  public void testSendZeroRangeFile() throws Exception {
     File f = setupFile("twenty_three_bytes.txt", TestUtils.randomAlphaString(23));
     server.requestHandler(res -> res.response().sendFile(f.getAbsolutePath(), 23, 0));
     startServer(testAddress);
@@ -2148,7 +2148,7 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
-  public void testSendOffsetIsHigherThanFileLengthForFileFromClasspath() throws Exception {
+  public void testSendOffsetIsHigherThanFileLengthForFile() throws Exception {
     File f = setupFile("twenty_three_bytes.txt", TestUtils.randomAlphaString(23));
     server.requestHandler(res -> {
       try {
@@ -2186,7 +2186,7 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
-  public void testSendFileFromClasspathWithNegativeLength() throws Exception {
+  public void testSendFileWithNegativeLength() throws Exception {
     File f = setupFile("twenty_three_bytes.txt", TestUtils.randomAlphaString(23));
     server.requestHandler(res -> {
       try {
@@ -2214,7 +2214,7 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
-  public void testSendFileFromClasspathWithNegativeOffset() throws Exception {
+  public void testSendFileWithNegativeOffset() throws Exception {
     File f = setupFile("twenty_three_bytes.txt", TestUtils.randomAlphaString(23));
     server.requestHandler(res -> {
       try {


### PR DESCRIPTION
In `HttpServerResponse#sendFile`, when the offset is greater than the file length, the calculated content length is negative. Currently, the value is not validated until after the head (response status and other headers) is written. An application might have downstream processing that would act on the `IllegalArgumentException` thrown when validating the content length. However, it is too late for the downstream processor to write a different response status (for example a 400 BAD REQUEST), to signal the client that the request is not valid. The problem is exacerbated when the downstream processor tries to write a status code, because the `IllegalStateException` exception will be thrown because the `Response head is already sent`. This leaves the connection hanging on the server side, while the client is expecting content.

Additionally, the `offset` and `length` parameters are not validated, which can produce negative content length.

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
