### PR TITLE
Use a long password on generated in-memory KeyStore (4.4 branch)

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
@@ -65,7 +65,7 @@ import io.vertx.core.net.impl.pkcs1.PrivateKeyParser;
 public class KeyStoreHelper {
 
   // Dummy password for encrypting pem based stores in memory
-  public static final String DUMMY_PASSWORD = "dummy";
+  public static final String DUMMY_PASSWORD = "dummdummydummydummydummydummydummy";  // at least 32 characters for compat with FIPS mode
   private static final String DUMMY_CERT_ALIAS = "cert-";
 
   private static final Pattern BEGIN_PATTERN = Pattern.compile("-----BEGIN ([A-Z ]+)-----");
@@ -163,10 +163,10 @@ public class KeyStoreHelper {
     String keyStoreType = KeyStore.getDefaultType();
     KeyStore ks = KeyStore.getInstance(keyStoreType);
     ks.load(null, null);
-    ks.setKeyEntry("key", mgr.getPrivateKey(null), new char[0], mgr.getCertificateChain(null));
+    ks.setKeyEntry("key", mgr.getPrivateKey(null), DUMMY_PASSWORD.toCharArray(), mgr.getCertificateChain(null));
     String keyAlgorithm = KeyManagerFactory.getDefaultAlgorithm();
     KeyManagerFactory kmf = KeyManagerFactory.getInstance(keyAlgorithm);
-    kmf.init(ks, new char[0]);
+    kmf.init(ks, DUMMY_PASSWORD.toCharArray());
     return kmf;
   }
 

--- a/src/test/java/io/vertx/core/net/KeyStoreHelperTest.java
+++ b/src/test/java/io/vertx/core/net/KeyStoreHelperTest.java
@@ -89,9 +89,9 @@ public class KeyStoreHelperTest extends VertxTestBase {
     assertTrue(store.size() > 0);
     for (Enumeration<String> e = store.aliases(); e.hasMoreElements(); ) {
       String alias = e.nextElement();
-      // "dummy" is the password set by KeyStoreHelper when importing the
+      // "dummdummydummydummydummydummydummy" is the password set by KeyStoreHelper when importing the
       // keys into the internal key store
-      assertThat(store.getKey(alias, "dummy".toCharArray()), instanceOf(expectedKeyType));
+      assertThat(store.getKey(alias, "dummdummydummydummydummydummydummy".toCharArray()), instanceOf(expectedKeyType));
       assertThat(store.getCertificate(alias), instanceOf(X509Certificate.class));
     }
   }


### PR DESCRIPTION
Motivation:

Fix for https://github.com/eclipse-vertx/vert.x/issues/4906 on 4.4 branch
(backport of PR #4910 already merged in 4.x).

The Quarkus 3.2.x LTS release stream still uses the 4.4 releases of Vert.x.
Including this PR in the 4.4 branch propagate it in Quarkus 3.2 LTS next releases.