### PR TITLE
CompositeFuture implementation must unregister against its component on completion

### DIFF
--- a/src/main/java/io/vertx/core/impl/future/FailedFuture.java
+++ b/src/main/java/io/vertx/core/impl/future/FailedFuture.java
@@ -99,6 +99,10 @@ public final class FailedFuture<T> extends FutureBase<T> {
   }
 
   @Override
+  public void removeListener(Listener<T> listener) {
+  }
+
+  @Override
   public T result() {
     return null;
   }

--- a/src/main/java/io/vertx/core/impl/future/FutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureImpl.java
@@ -232,6 +232,19 @@ public class FutureImpl<T> extends FutureBase<T> {
     }
   }
 
+  @Override
+  public void removeListener(Listener<T> l) {
+    synchronized (this) {
+      Object listener = this.listener;
+      if (listener == l) {
+        this.listener = null;
+      } else if (listener instanceof ListenerArray<?>) {
+        ListenerArray<?> listeners = (ListenerArray<?>) listener;
+        listeners.remove(l);
+      }
+    }
+  }
+
   public boolean tryComplete(T result) {
     Listener<T> l;
     synchronized (this) {

--- a/src/main/java/io/vertx/core/impl/future/FutureInternal.java
+++ b/src/main/java/io/vertx/core/impl/future/FutureInternal.java
@@ -32,4 +32,11 @@ public interface FutureInternal<T> extends Future<T> {
    */
   void addListener(Listener<T> listener);
 
+  /**
+   * Remove a listener to the future result.
+   *
+   * @param listener the listener
+   */
+  void removeListener(Listener<T> listener);
+
 }

--- a/src/main/java/io/vertx/core/impl/future/SucceededFuture.java
+++ b/src/main/java/io/vertx/core/impl/future/SucceededFuture.java
@@ -89,6 +89,10 @@ public final class SucceededFuture<T> extends FutureBase<T> {
   }
 
   @Override
+  public void removeListener(Listener<T> listener) {
+  }
+
+  @Override
   public T result() {
     return result;
   }

--- a/src/test/java/io/vertx/core/FutureInternalTest.java
+++ b/src/test/java/io/vertx/core/FutureInternalTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core;
+
+import io.vertx.core.impl.future.FutureImpl;
+import io.vertx.core.impl.future.Listener;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class FutureInternalTest extends FutureTestBase {
+
+  @Test
+  public void testAddListener() {
+    FutureImpl<Void> future = (FutureImpl<Void>) Promise.promise();
+    AtomicInteger successes = new AtomicInteger();
+    AtomicInteger failures = new AtomicInteger();
+    Listener<Void> listener = new Listener<Void>() {
+      @Override
+      public void onSuccess(Void value) {
+        successes.incrementAndGet();
+      }
+      @Override
+      public void onFailure(Throwable failure) {
+        failures.incrementAndGet();
+      }
+    };
+    future.addListener(listener);
+    future.tryComplete(null);
+    assertEquals(1, successes.get());
+    assertEquals(0, failures.get());
+  }
+
+  @Test
+  public void testRemoveListener1() {
+    testRemoveListener((FutureImpl<Void>) Promise.promise());
+  }
+
+  @Test
+  public void testRemoveListener2() {
+    FutureImpl<Void> fut = (FutureImpl<Void>) Promise.promise();
+    fut.onComplete(ar -> {});
+    testRemoveListener(fut);
+  }
+
+  private void testRemoveListener(FutureImpl<Void> future) {
+    AtomicInteger count = new AtomicInteger();
+    Listener<Void> listener = new Listener<Void>() {
+      @Override
+      public void onSuccess(Void value) {
+        count.incrementAndGet();
+      }
+      @Override
+      public void onFailure(Throwable failure) {
+        count.incrementAndGet();
+      }
+    };
+    future.addListener(listener);
+    future.removeListener(listener);
+    future.tryComplete(null);
+    assertEquals(0, count.get());
+  }
+}


### PR DESCRIPTION
A `CompositeFuture` should unregister itself against its components when the composite future completes since the composite future is not interested anymore by the completion of the uncompleted futures. Otherwise the composite future might remain forever in the list of a promise pending completion, which could lead in some situation to a memory leak.

The implementation of `CompositeFuture` now does unregister when it completes, the registration against the component new uses the internal listener interface instead of the API `onComplete` method in order to keep a reference to the listener that was registered in order to unregister the same listener. In addition a single listener is now used, reducing the number of listener required to implement the composition behavior to a single listener instead of a listener per component. The creation of implementation performs now a two phase initialisation instead of a single since a component might already be completed and this should not interfere with the listener registration process, e.g. a component might be completed and the remaining components to register a listener for should be unregistered or avoid to be registered; it seems cleaner to first register against all components and have the listener only update the state of the composite future and then perform an initialization phase that will finish the completion if the composite future was completed during the registration phase.

The implementation of `Future` has been modified to allow the unregistration of a listener as require by the composite future change.
