### PR TITLE
fix: Dropped proxy on redirect

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -467,7 +467,10 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
       request.redirectHandler(resp -> {
         Future<RequestOptions> fut_ = rHandler.apply(resp);
         if (fut_ != null) {
-          return fut_.compose(this::request);
+          return fut_.compose(o -> {
+            o.setProxyOptions(options.getProxyOptions());
+            return this.request(o);
+          });
         } else {
           return null;
         }

--- a/src/test/java/io/vertx/test/proxy/HttpProxy.java
+++ b/src/test/java/io/vertx/test/proxy/HttpProxy.java
@@ -168,7 +168,7 @@ public class HttpProxy extends TestProxyBase<HttpProxy> {
             }
             resp.body().onComplete(ar2 -> {
               if (ar2.succeeded()) {
-                request.response().end(ar2.result());
+                request.response().setStatusCode(resp.statusCode()).end(ar2.result());
               } else {
                 request.response().setStatusCode(500).end(ar2.cause().toString() + " on client request");
               }


### PR DESCRIPTION
Motivation:

Fixes #5136

This can also be fixed by setting the original proxy on `HttpClientRequest` but this way it works with custom handlers.

`WebClient` can be fixed naturally via this commit OR can have its own fix, since it contains other ways to retrieve the proxy in request chain
