### PR TITLE
An SPI for interacting with local context storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -720,6 +720,21 @@
               </additionalClasspathElements>
             </configuration>
           </execution>
+          <execution>
+            <id>custom-context-local</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>io/vertx/it/CustomContextLocalTest.java</include>
+              </includes>
+              <additionalClasspathElements>
+                <additionalClasspathElement>${project.basedir}/src/test/classpath/customcontextlocal</additionalClasspathElement>
+              </additionalClasspathElements>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 

--- a/src/main/java/io/vertx/core/impl/ContextBase.java
+++ b/src/main/java/io/vertx/core/impl/ContextBase.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl;
+
+import io.vertx.core.spi.context.storage.AccessMode;
+import io.vertx.core.spi.context.storage.ContextLocal;
+
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Supplier;
+
+/**
+ * Base class for context.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+class ContextBase extends AtomicReferenceArray<Object> {
+
+  private final int localsLength;
+
+  ContextBase(int localsLength) {
+    super(localsLength);
+    this.localsLength = localsLength;
+  }
+
+  ContextBase(ContextBase another) {
+    super(another.localsLength);
+    this.localsLength = another.localsLength;
+  }
+
+  public final <T> T getLocal(ContextLocal<T> key, AccessMode accessMode) {
+    ContextLocalImpl<T> internalKey = (ContextLocalImpl<T>) key;
+    int index = internalKey.index;
+    if (index >= localsLength) {
+      throw new IllegalArgumentException();
+    }
+    Object res = accessMode.get(this, index);
+    return (T) res;
+  }
+
+  public final <T> T getLocal(ContextLocal<T> key, AccessMode accessMode, Supplier<? extends T> initialValueSupplier) {
+    ContextLocalImpl<T> internalKey = (ContextLocalImpl<T>) key;
+    int index = internalKey.index;
+    if (index >= localsLength) {
+      throw new IllegalArgumentException("Invalid key index: " + index);
+    }
+    Object res = accessMode.getOrCreate(this, index, (Supplier<Object>) initialValueSupplier);
+    return (T) res;
+  }
+
+  public final <T> void putLocal(ContextLocal<T> key, AccessMode accessMode, T value) {
+    ContextLocalImpl<T> internalKey = (ContextLocalImpl<T>) key;
+    int index = internalKey.index;
+    if (index >= localsLength) {
+      throw new IllegalArgumentException();
+    }
+    accessMode.put(this, index, value);
+  }
+}

--- a/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -28,7 +28,7 @@ import java.util.concurrent.*;
  * @author <a href="http://tfox.org">Tim Fox</a>
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public final class ContextImpl implements ContextInternal {
+public final class ContextImpl extends ContextBase implements ContextInternal {
 
   static <T> void setResultHandler(ContextInternal ctx, Future<T> fut, Handler<AsyncResult<T>> resultHandler) {
     if (resultHandler != null) {
@@ -52,7 +52,6 @@ public final class ContextImpl implements ContextInternal {
   private final EventLoop eventLoop;
   private final EventExecutor executor;
   private ConcurrentMap<Object, Object> data;
-  private ConcurrentMap<Object, Object> localData;
   private volatile Handler<Throwable> exceptionHandler;
   final TaskQueue internalOrderedTasks;
   final WorkerPool internalWorkerPool;
@@ -60,6 +59,7 @@ public final class ContextImpl implements ContextInternal {
   final TaskQueue orderedTasks;
 
   public ContextImpl(VertxInternal vertx,
+                     int localsLength,
                      ThreadingModel threadingModel,
                      EventLoop eventLoop,
                      EventExecutor executor,
@@ -69,6 +69,7 @@ public final class ContextImpl implements ContextInternal {
                      Deployment deployment,
                      CloseFuture closeFuture,
                      ClassLoader tccl) {
+    super(localsLength);
     this.threadingModel = threadingModel;
     this.deployment = deployment;
     this.config = deployment != null ? deployment.config() : new JsonObject();
@@ -248,14 +249,6 @@ public final class ContextImpl implements ContextInternal {
       data = new ConcurrentHashMap<>();
     }
     return data;
-  }
-
-  @Override
-  public synchronized ConcurrentMap<Object, Object> localContextData() {
-    if (localData == null) {
-      localData = new ConcurrentHashMap<>();
-    }
-    return localData;
   }
 
   public void reportException(Throwable t) {

--- a/src/main/java/io/vertx/core/impl/ContextLocalImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextLocalImpl.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl;
+
+import io.vertx.core.spi.context.storage.ContextLocal;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class ContextLocalImpl<T> implements ContextLocal<T> {
+
+  final int index;
+
+  public ContextLocalImpl(int index) {
+    this.index = index;
+  }
+
+  public ContextLocalImpl() {
+    this.index = LocalSeq.next();
+  }
+}

--- a/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -31,12 +31,12 @@ import java.util.concurrent.Executor;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-class DuplicatedContext implements ContextInternal {
+final class DuplicatedContext extends ContextBase implements ContextInternal {
 
-  protected final ContextImpl delegate;
-  private ConcurrentMap<Object, Object> localData;
+  final ContextImpl delegate;
 
   DuplicatedContext(ContextImpl delegate) {
+    super(delegate);
     this.delegate = delegate;
   }
 
@@ -114,16 +114,6 @@ class DuplicatedContext implements ContextInternal {
   @Override
   public final ConcurrentMap<Object, Object> contextData() {
     return delegate.contextData();
-  }
-
-  @Override
-  public final ConcurrentMap<Object, Object> localContextData() {
-    synchronized (this) {
-      if (localData == null) {
-        localData = new ConcurrentHashMap<>();
-      }
-      return localData;
-    }
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/LocalSeq.java
+++ b/src/main/java/io/vertx/core/impl/LocalSeq.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+class LocalSeq {
+
+  // 0 : reserved slot for local context map
+  private static final AtomicInteger seq = new AtomicInteger(1);
+
+  /**
+   * Hook for testing purposes
+   */
+  static void reset() {
+    seq.set((1));
+  }
+
+  static int get() {
+    return seq.get();
+  }
+
+  static int next() {
+    return seq.getAndIncrement();
+  }
+}

--- a/src/main/java/io/vertx/core/spi/context/storage/AccessMode.java
+++ b/src/main/java/io/vertx/core/spi/context/storage/AccessMode.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.spi.context.storage;
+
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Supplier;
+
+/**
+ * Defines the access mode of a context local storage.
+ */
+public interface AccessMode {
+
+  /**
+   * This access mode provides concurrent access to context local storage with thread safety and atomicity.
+   */
+  AccessMode CONCURRENT = new AccessMode() {
+
+    @Override
+    public Object get(AtomicReferenceArray<Object> locals, int idx) {
+      return locals.get(idx);
+    }
+
+    @Override
+    public void put(AtomicReferenceArray<Object> locals, int idx, Object value) {
+      locals.set(idx, value);
+    }
+
+    @Override
+    public Object getOrCreate(AtomicReferenceArray<Object> locals, int idx, Supplier<Object> initialValueSupplier) {
+      Object res;
+      while (true) {
+        res = locals.get(idx);
+        if (res != null) {
+          break;
+        }
+        Object initial = initialValueSupplier.get();
+        if (initial == null) {
+          throw new IllegalStateException();
+        }
+        if (locals.compareAndSet(idx, null, initial)) {
+          res = initial;
+          break;
+        }
+      }
+      return res;
+    }
+  };
+
+  /**
+   * Return the object at index {@code idx} in the {@code locals} array.
+   * @param locals the array
+   * @param idx the index
+   * @return the object at {@code index}
+   */
+  Object get(AtomicReferenceArray<Object> locals, int idx);
+
+  /**
+   * Put {@code value} in the {@code locals} array at index {@code idx}
+   * @param locals the array
+   * @param idx the index
+   * @param value the value
+   */
+  void put(AtomicReferenceArray<Object> locals, int idx, Object value);
+
+  /**
+   * Get or create the object at index {@code index} in the {@code locals} array. When the object
+   * does not exist, {@code initialValueSupplier} must be called to obtain this value.
+   *
+   * @param locals the array
+   * @param idx the index
+   * @param initialValueSupplier the supplier of the initial value
+   */
+  Object getOrCreate(AtomicReferenceArray<Object> locals, int idx, Supplier<Object> initialValueSupplier);
+
+}

--- a/src/main/java/io/vertx/core/spi/context/storage/ContextLocal.java
+++ b/src/main/java/io/vertx/core/spi/context/storage/ContextLocal.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.spi.context.storage;
+
+import io.vertx.core.Context;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.ContextLocalImpl;
+
+import java.util.function.Supplier;
+
+/**
+ * A local storage for arbitrary data attached to a duplicated {@link Context}.
+ *
+ * <p>Local storage should be registered before creating a {@link io.vertx.core.Vertx} instance, once registered a
+ * local storage cannot be unregistered.
+ *
+ * <p>It is recommended to initialize local storage as static fields of a {@link io.vertx.core.spi.VertxServiceProvider},
+ * since providers are discovered before the capture of known local storages.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface ContextLocal<T> {
+
+  /**
+   * Registers a context local storage.
+   *
+   * @return the context local storage
+   */
+  static <T> ContextLocal<T> registerLocal(Class<T> type) {
+    return new ContextLocalImpl<>();
+  }
+
+  /**
+   * Get the local data from the {@code context}.
+   *
+   * @return the local data
+   */
+  default T get(Context context) {
+    return get(context, AccessMode.CONCURRENT);
+  }
+
+  /**
+   * Get the local data from the {@code context}, when it does not exist then call {@code initialValueSupplier} to obtain
+   * the initial value. The supplier can be called multiple times when several threads call this method concurrently.
+   *
+   * @param initialValueSupplier the supplier of the initial value
+   * @return the local data
+   */
+  default T get(Context context, Supplier<? extends T> initialValueSupplier) {
+    return get(context, AccessMode.CONCURRENT, initialValueSupplier);
+  }
+
+  /**
+   * Put local data in the {@code context}.
+   *
+   * @param data  the data
+   */
+  default void put(Context context, T data) {
+    put(context, AccessMode.CONCURRENT, data);
+  }
+
+  /**
+   * Remove the local data from the context.
+   */
+  default void remove(Context context) {
+    put(context, AccessMode.CONCURRENT, null);
+  }
+
+  /**
+   * Like {@link #get(Context)} but with an {@code accessMode}.
+   */
+  default T get(Context context, AccessMode accessMode) {
+    return ((ContextInternal)context).getLocal(this, accessMode);
+  }
+
+  /**
+   * Like {@link #get(Context, Supplier)} but with an {@code accessMode}.
+   */
+  default T get(Context context, AccessMode accessMode, Supplier<? extends T> initialValueSupplier) {
+    return ((ContextInternal)context).getLocal(this, accessMode, initialValueSupplier);
+  }
+
+  /**
+   * Like {@link #put(Context, T)} but with an {@code accessMode}.
+   */
+  default void put(Context context, AccessMode accessMode, T value) {
+    ((ContextInternal)context).putLocal(this, accessMode, value);
+  }
+
+  /**
+   * Like {@link #remove(Context)} but with an {@code accessMode}.
+   */
+  default void remove(Context context, AccessMode accessMode) {
+    put(context, accessMode, null);
+  }
+
+}

--- a/src/test/benchmarks/io/vertx/core/impl/BenchmarkContext.java
+++ b/src/test/benchmarks/io/vertx/core/impl/BenchmarkContext.java
@@ -34,6 +34,7 @@ public class BenchmarkContext {
     VertxImpl impl = (VertxImpl) vertx;
     return new ContextImpl(
       impl,
+      0,
       ThreadingModel.WORKER,
       impl.getEventLoopGroup().next(),
       EXECUTOR,

--- a/src/test/classpath/customcontextlocal/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/src/test/classpath/customcontextlocal/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,1 @@
+io.vertx.it.CustomContextLocal

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -14,6 +14,8 @@ package io.vertx.core;
 import io.netty.channel.EventLoop;
 import io.vertx.core.impl.*;
 import io.vertx.core.impl.future.PromiseInternal;
+import io.vertx.core.spi.context.storage.AccessMode;
+import io.vertx.core.spi.context.storage.ContextLocal;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Assume;
 import org.junit.Test;
@@ -38,6 +40,7 @@ import java.util.stream.Stream;
  */
 public class ContextTest extends VertxTestBase {
 
+  private ContextLocal<Object> contextLocal;
   private ExecutorService workerExecutor;
 
   private ContextInternal createWorkerContext() {
@@ -46,12 +49,14 @@ public class ContextTest extends VertxTestBase {
 
   @Override
   public void setUp() throws Exception {
+    contextLocal = ContextLocal.registerLocal(Object.class);
     workerExecutor = Executors.newFixedThreadPool(2, r -> new VertxThread(r, "vert.x-worker-thread", true, 10, TimeUnit.SECONDS));
     super.setUp();
   }
 
   @Override
   protected void tearDown() throws Exception {
+    ContextLocalHelper.reset();
     workerExecutor.shutdown();
     super.tearDown();
   }
@@ -478,9 +483,9 @@ public class ContextTest extends VertxTestBase {
     Object shared = new Object();
     Object local = new Object();
     ctx.put("key", shared);
-    ctx.putLocal("key", local);
+    contextLocal.put(ctx, local);
     assertSame(shared, duplicated.get("key"));
-    assertNull(duplicated.getLocal("key"));
+    assertNull(duplicated.getLocal(contextLocal));
     assertTrue(duplicated.remove("key"));
     assertNull(ctx.get("key"));
 
@@ -1083,4 +1088,37 @@ public class ContextTest extends VertxTestBase {
     }, new DeploymentOptions().setThreadingModel(ThreadingModel.VIRTUAL_THREAD));
     await();
   }
+
+  @Test
+  public void testConcurrentLocalAccess() throws Exception {
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    int numThreads = 10;
+    Thread[] threads = new Thread[numThreads];
+    int[] values = new int[numThreads];
+    CyclicBarrier barrier = new CyclicBarrier(numThreads);
+    for (int i = 0;i < numThreads;i++) {
+      values[i] = -1;
+      int val = i;
+      Supplier<Object> supplier = () -> val;
+      threads[i] = new Thread(() -> {
+        try {
+          barrier.await();
+        } catch (Exception e) {
+          return;
+        }
+        values[val] = (int)ctx.getLocal(contextLocal, AccessMode.CONCURRENT, supplier);
+      });
+    }
+    for (int i = 0;i < numThreads;i++) {
+      threads[i].start();
+    }
+    for (int i = 0;i < numThreads;i++) {
+      threads[i].join();
+    }
+    assertTrue(values[0] >= 0);
+    for (int i = 0;i < numThreads;i++) {
+      assertEquals(values[i], values[0]);
+    }
+  }
+
 }

--- a/src/test/java/io/vertx/core/FakeContext.java
+++ b/src/test/java/io/vertx/core/FakeContext.java
@@ -10,11 +10,14 @@ import io.vertx.core.impl.VertxImpl;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.WorkerPool;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.context.storage.AccessMode;
+import io.vertx.core.spi.context.storage.ContextLocal;
 import io.vertx.core.spi.tracing.VertxTracer;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 class FakeContext implements ContextInternal {
 
@@ -135,31 +138,22 @@ class FakeContext implements ContextInternal {
 
   @Override
   public <T> void emit(T argument, Handler<T> task) {
-
   }
 
   @Override
   public void execute(Runnable task) {
-
   }
 
   @Override
   public <T> void execute(T argument, Handler<T> task) {
-
   }
 
   @Override
   public void reportException(Throwable t) {
-
   }
 
   @Override
   public ConcurrentMap<Object, Object> contextData() {
-    return null;
-  }
-
-  @Override
-  public ConcurrentMap<Object, Object> localContextData() {
     return null;
   }
 
@@ -191,5 +185,20 @@ class FakeContext implements ContextInternal {
   @Override
   public CloseFuture closeFuture() {
     return null;
+  }
+
+  @Override
+  public <T> T getLocal(ContextLocal<T> key, AccessMode accessMode) {
+    return null;
+  }
+
+  @Override
+  public <T> T getLocal(ContextLocal<T> key, AccessMode accessMode, Supplier<? extends T> initialValueSupplier) {
+    return null;
+  }
+
+  @Override
+  public <T> void putLocal(ContextLocal<T> key, AccessMode accessMode, T value) {
+
   }
 }

--- a/src/test/java/io/vertx/core/impl/ContextLocalHelper.java
+++ b/src/test/java/io/vertx/core/impl/ContextLocalHelper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class ContextLocalHelper {
+
+  /**
+   * Reset the context locals, only available for testing purpose.
+   */
+  public static void reset() {
+    LocalSeq.reset();
+  }
+
+}

--- a/src/test/java/io/vertx/core/spi/tracing/HttpTracerTestBase.java
+++ b/src/test/java/io/vertx/core/spi/tracing/HttpTracerTestBase.java
@@ -17,14 +17,14 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpTestBase;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.ContextLocalHelper;
+import io.vertx.core.spi.context.storage.ContextLocal;
 import io.vertx.core.spi.observability.HttpRequest;
 import io.vertx.core.spi.observability.HttpResponse;
 import io.vertx.core.tracing.TracingPolicy;
-import io.vertx.test.core.TestUtils;
 import org.junit.Test;
 
 import java.util.UUID;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -32,6 +32,19 @@ import java.util.function.BiConsumer;
 public abstract class HttpTracerTestBase extends HttpTestBase {
 
   private VertxTracer tracer;
+  private ContextLocal<Object> key;
+
+  @Override
+  public void setUp() throws Exception {
+    key = ContextLocal.registerLocal(Object.class);
+    super.setUp();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    ContextLocalHelper.reset();
+    super.tearDown();
+  }
 
   @Override
   protected VertxTracer getTracer() {
@@ -40,14 +53,13 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
 
   @Test
   public void testHttpServer() throws Exception {
-    String key = TestUtils.randomAlphaString(10);
     Object val = new Object();
     AtomicInteger seq = new AtomicInteger();
     setTracer(new VertxTracer() {
       @Override
       public Object receiveRequest(Context context, SpanKind kind, TracingPolicy policy, Object request, String operation, Iterable headers, TagExtractor tagExtractor) {
-        assertNull(context.getLocal(key));
-        context.putLocal(key, val);
+        assertNull(key.get(context));
+        key.put(context, val);
         assertTrue(seq.compareAndSet(0, 1));
         return request;
       }
@@ -57,17 +69,17 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
         assertNotNull(response);
         assertTrue(response instanceof HttpServerResponse);
         assertNull(failure);
-        assertSame(val, context.getLocal(key));
-        assertTrue(context.removeLocal(key));
+        assertSame(val, key.get(context));
+        key.remove(context);
       }
     });
     CountDownLatch latch = new CountDownLatch(1);
     server.requestHandler(req -> {
       assertEquals(1, seq.get());
       ContextInternal ctx = (ContextInternal) Vertx.currentContext();
-      assertSame(val, ctx.localContextData().get(key));
+      assertSame(val, key.get(ctx));
       req.response().closeHandler(v -> {
-        assertNull(ctx.localContextData().get(key));
+        assertNull(key.get(ctx));
         assertEquals(2, seq.get());
       });
       req.response().end();
@@ -86,14 +98,13 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
   @Test
   public void testHttpServerError() throws Exception {
     waitFor(3);
-    String key = TestUtils.randomAlphaString(10);
     Object val = new Object();
     AtomicInteger seq = new AtomicInteger();
     setTracer(new VertxTracer() {
       @Override
       public Object receiveRequest(Context context, SpanKind kind, TracingPolicy policy, Object request, String operation, Iterable headers, TagExtractor tagExtractor) {
-        assertNull(context.getLocal(key));
-        context.putLocal(key, val);
+        assertNull(key.get(context));
+        key.put(context, val);
         assertTrue(seq.compareAndSet(0, 1));
         return request;
       }
@@ -102,7 +113,6 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
         assertTrue(seq.compareAndSet(1, 2));
         assertNull(response);
         assertNotNull(failure);
-        assertTrue(context.removeLocal(key));
         complete();
       }
     });
@@ -110,7 +120,7 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
     server.requestHandler(req -> {
       assertEquals(1, seq.get());
       ContextInternal ctx = (ContextInternal) Vertx.currentContext();
-      assertSame(val, ctx.localContextData().get(key));
+      assertSame(val, key.get(ctx));
       req.exceptionHandler(v -> {
 //        assertNull(ctx.localContextData().get(key));
 //        assertEquals(2, seq.get());
@@ -147,14 +157,13 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
   }
 
   private void testHttpClientRequest(RequestOptions request, String expectedOperation) throws Exception {
-    String key = TestUtils.randomAlphaString(10);
     Object val = new Object();
     AtomicInteger seq = new AtomicInteger();
     String traceId = UUID.randomUUID().toString();
     setTracer(new VertxTracer() {
       @Override
       public Object sendRequest(Context context, SpanKind kind, TracingPolicy policy, Object request, String operation, BiConsumer headers, TagExtractor tagExtractor) {
-        assertSame(val, context.getLocal(key));
+        assertSame(val, key.get(context));
         assertTrue(seq.compareAndSet(0, 1));
         headers.accept("X-B3-TraceId", traceId);
         assertNotNull(request);
@@ -164,8 +173,8 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
       }
       @Override
       public void receiveResponse(Context context, Object response, Object payload, Throwable failure, TagExtractor tagExtractor) {
-        assertSame(val, context.getLocal(key));
-        assertTrue(context.removeLocal(key));
+        assertSame(val, key.get(context));
+        key.remove(context);
         assertNotNull(response);
         assertTrue(response instanceof HttpResponse);
         assertNull(failure);
@@ -182,15 +191,14 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
     awaitLatch(latch);
     Context ctx = vertx.getOrCreateContext();
     ctx.runOnContext(v1 -> {
-      ConcurrentMap<Object, Object> tracerMap = ((ContextInternal) ctx).localContextData();
-      tracerMap.put(key, val);
+      key.put(ctx, val);
       client.request(request, onSuccess(req -> {
-        req.send(onSuccess(resp -> {
+        req.send().onComplete(onSuccess(resp -> {
           resp.endHandler(v2 -> {
             // Updates are done on the HTTP client context, so we need to run task on this context
             // to avoid data race
             ctx.runOnContext(v -> {
-              assertNull(tracerMap.get(key));
+              assertNull(key.get(ctx));
               testComplete();
             });
           });
@@ -203,22 +211,21 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
   @Test
   public void testHttpClientError() throws Exception {
     waitFor(2);
-    String key = TestUtils.randomAlphaString(10);
     Object val = new Object();
     AtomicInteger seq = new AtomicInteger();
     String traceId = UUID.randomUUID().toString();
     setTracer(new VertxTracer() {
       @Override
       public Object sendRequest(Context context, SpanKind kind, TracingPolicy policy, Object request, String operation, BiConsumer headers, TagExtractor tagExtractor) {
-        assertSame(val, context.getLocal(key));
+        assertSame(val, key.get(context));
         assertTrue(seq.compareAndSet(0, 1));
         headers.accept("X-B3-TraceId", traceId);
         return request;
       }
       @Override
       public void receiveResponse(Context context, Object response, Object payload, Throwable failure, TagExtractor tagExtractor) {
-        assertSame(val, context.getLocal(key));
-        assertTrue(context.removeLocal(key));
+        assertSame(val, key.get(context));
+        key.remove(context);
         assertNull(response);
         assertNotNull(failure);
         assertTrue(seq.compareAndSet(1, 2));
@@ -235,8 +242,7 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
     awaitLatch(latch);
     Context ctx = vertx.getOrCreateContext();
     ctx.runOnContext(v1 -> {
-      ConcurrentMap<Object, Object> tracerMap = ((ContextInternal) ctx).localContextData();
-      tracerMap.put(key, val);
+      key.put(ctx, val);
       client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, "localhost", "/").onComplete(onSuccess(req -> {
         req.send().onComplete(onFailure(err -> {
           // assertNull(tracerMap.get(key));

--- a/src/test/java/io/vertx/core/spi/tracing/LocalEventBusTracerTest.java
+++ b/src/test/java/io/vertx/core/spi/tracing/LocalEventBusTracerTest.java
@@ -32,15 +32,15 @@ public class LocalEventBusTracerTest extends EventBusTracerTestBase {
     tracer = new VertxTracer() {};
     vertx2.eventBus().addInboundInterceptor(deliveryCtx -> {
       ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-      ctx.localContextData().put("key", "val");
+//      ctx.putLocal(FakeTracer.ACTIVE_SCOPE_KEY, "val");
       deliveryCtx.next();
     });
     Context receiveCtx = vertx2.getOrCreateContext();
     CountDownLatch latch = new CountDownLatch(1);
     receiveCtx.runOnContext(v -> {
       vertx2.eventBus().consumer("the_address", msg -> {
-        Object val = ((ContextInternal) vertx.getOrCreateContext()).localContextData().get("key");
-        assertEquals("val", val);
+//        Object val = vertx.getOrCreateContext().getLocal(FakeTracer.ACTIVE_SCOPE_KEY);
+//        assertEquals("val", val);
         testComplete();
       });
       latch.countDown();

--- a/src/test/java/io/vertx/it/CustomContextLocal.java
+++ b/src/test/java/io/vertx/it/CustomContextLocal.java
@@ -1,0 +1,16 @@
+package io.vertx.it;
+
+import io.vertx.core.impl.VertxBuilder;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
+
+public class CustomContextLocal implements VertxServiceProvider  {
+
+  public static ContextLocal<Object> CUSTOM_LOCAL = ContextLocal.registerLocal(Object.class);
+  public static volatile boolean initialized;
+
+  @Override
+  public void init(VertxBuilder builder) {
+    initialized = true;
+  }
+}

--- a/src/test/java/io/vertx/it/CustomContextLocalTest.java
+++ b/src/test/java/io/vertx/it/CustomContextLocalTest.java
@@ -1,0 +1,17 @@
+package io.vertx.it;
+
+import io.vertx.core.Context;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+public class CustomContextLocalTest extends VertxTestBase {
+
+  @Test
+  public void testResolver() {
+    assertTrue(CustomContextLocal.initialized);
+    Context context = vertx.getOrCreateContext();
+    Object o = new Object();
+    CustomContextLocal.CUSTOM_LOCAL.put(context, o);
+    assertSame(o, CustomContextLocal.CUSTOM_LOCAL.get(context));
+  }
+}

--- a/src/test/java/io/vertx/test/faketracer/FakeTracer.java
+++ b/src/test/java/io/vertx/test/faketracer/FakeTracer.java
@@ -13,6 +13,8 @@ package io.vertx.test.faketracer;
 
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextLocalHelper;
+import io.vertx.core.spi.context.storage.ContextLocal;
 import io.vertx.core.spi.tracing.SpanKind;
 import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
@@ -30,8 +32,7 @@ import java.util.function.BiConsumer;
  */
 public class FakeTracer implements VertxTracer<Span, Span> {
 
-  private static final String ACTIVE_SCOPE_KEY = "active.scope";
-
+  private final ContextLocal<Scope> scopeKey = ContextLocal.registerLocal(Scope.class);
   private AtomicInteger idGenerator = new AtomicInteger(0);
   List<Span> finishedSpans = new CopyOnWriteArrayList<>();
   private AtomicInteger closeCount = new AtomicInteger();
@@ -53,7 +54,7 @@ public class FakeTracer implements VertxTracer<Span, Span> {
   }
 
   public Span activeSpan(Context data) {
-    Scope scope = data.getLocal(ACTIVE_SCOPE_KEY);
+    Scope scope = scopeKey.get(data);
     return scope != null ? scope.wrapped : null;
   }
 
@@ -62,9 +63,9 @@ public class FakeTracer implements VertxTracer<Span, Span> {
   }
 
   public Scope activate(Context context, Span span) {
-    Scope toRestore = context.getLocal(ACTIVE_SCOPE_KEY);
+    Scope toRestore = scopeKey.get(context);
     Scope active = new Scope(this, span, toRestore);
-    context.putLocal(ACTIVE_SCOPE_KEY, active);
+    scopeKey.put(context, active);
     return active;
   }
 
@@ -174,6 +175,7 @@ public class FakeTracer implements VertxTracer<Span, Span> {
   @Override
   public void close() {
     closeCount.incrementAndGet();
+    ContextLocalHelper.reset();
   }
 
   public int closeCount() {


### PR DESCRIPTION
The existing implementation uses on a concurrent hash map guarded by the context instance.

This new implementation relies on prior knowledge of the set of context locals, so the context allocates upfront the required space to hold the local storage, reducing synchronisation and simplifying lookup that uses allocated index instead of hashed string lookups.

The existing local context data is retrofit as a context local.
