### PR TITLE
Decouple the trust all manager from SslContextHelper/SslChannelProvider

### DIFF
--- a/src/main/java/io/vertx/core/net/ClientSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/ClientSSLOptions.java
@@ -53,7 +53,7 @@ public class ClientSSLOptions extends SSLOptions {
     super(other);
 
     hostnameVerificationAlgorithm = other.getHostnameVerificationAlgorithm();
-    trustAll = other.isTrustAll();
+    trustAll = other.trustAll;
   }
 
   /**

--- a/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
@@ -30,7 +30,6 @@ import io.vertx.core.net.SocketAddress;
 import javax.net.ssl.SSLHandshakeException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.concurrent.TimeUnit;
 
 /**
  * The logic for connecting to an host, this implementations performs a connection
@@ -108,7 +107,7 @@ public final class ChannelProvider {
 
   private void initSSL(Handler<Channel> handler, SocketAddress peerAddress, String serverName, boolean ssl, ClientSSLOptions sslOptions, Channel ch, Promise<Channel> channelHandler) {
     if (ssl) {
-      SslHandler sslHandler = sslContextProvider.createClientSslHandler(peerAddress, serverName, sslOptions.isUseAlpn(), sslOptions.isTrustAll(), sslOptions.getSslHandshakeTimeout(), sslOptions.getSslHandshakeTimeoutUnit());
+      SslHandler sslHandler = sslContextProvider.createClientSslHandler(peerAddress, serverName, sslOptions.isUseAlpn(), sslOptions.getSslHandshakeTimeout(), sslOptions.getSslHandshakeTimeoutUnit());
       ChannelPipeline pipeline = ch.pipeline();
       pipeline.addLast("ssl", sslHandler);
       pipeline.addLast(new ChannelInboundHandlerAdapter() {

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -321,7 +321,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
             ChannelHandler sslHandler;
             if (sslOptions instanceof ClientSSLOptions) {
               ClientSSLOptions clientSSLOptions = (ClientSSLOptions) sslOptions;
-              sslHandler = sslChannelProvider.createClientSslHandler(remoteAddress, serverName, sslOptions.isUseAlpn(), clientSSLOptions.isTrustAll(), clientSSLOptions.getSslHandshakeTimeout(), clientSSLOptions.getSslHandshakeTimeoutUnit());
+              sslHandler = sslChannelProvider.createClientSslHandler(remoteAddress, serverName, sslOptions.isUseAlpn(), clientSSLOptions.getSslHandshakeTimeout(), clientSSLOptions.getSslHandshakeTimeoutUnit());
             } else {
               sslHandler = sslChannelProvider.createServerHandler(sslOptions.isUseAlpn(), sslOptions.getSslHandshakeTimeout(), sslOptions.getSslHandshakeTimeoutUnit());
             }

--- a/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
@@ -70,14 +70,11 @@ public class SslContextProvider {
                                        KeyManagerFactory keyManagerFactory,
                                        TrustManager[] trustManagers,
                                        String serverName,
-                                       boolean useAlpn,
-                                       boolean trustAll) {
+                                       boolean useAlpn) {
     if (keyManagerFactory == null) {
       keyManagerFactory = defaultKeyManagerFactory();
     }
-    if (trustAll) {
-      trustManagers = SslContextProvider.createTrustAllManager();
-    } else if (trustManagers == null) {
+    if (trustManagers == null) {
       trustManagers = defaultTrustManagers();
     }
     if (server) {
@@ -88,7 +85,7 @@ public class SslContextProvider {
   }
 
   public VertxSslContext createContext(boolean server, boolean useAlpn) {
-    return createContext(server, defaultKeyManagerFactory(), defaultTrustManagers(), null, useAlpn, false);
+    return createContext(server, defaultKeyManagerFactory(), defaultTrustManagers(), null, useAlpn);
   }
 
   public VertxSslContext createClientContext(
@@ -243,26 +240,6 @@ public class SslContextProvider {
       }
     }
     return trustMgrs;
-  }
-
-  private static final TrustManager TRUST_ALL_MANAGER = new X509TrustManager() {
-    @Override
-    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-    }
-
-    @Override
-    public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-    }
-
-    @Override
-    public X509Certificate[] getAcceptedIssuers() {
-      return new X509Certificate[0];
-    }
-  };
-
-  // Create a TrustManager which trusts everything
-  private static TrustManager[] createTrustAllManager() {
-    return new TrustManager[] { TRUST_ALL_MANAGER };
   }
 
   public void configureEngine(SSLEngine engine, Set<String> enabledProtocols, String serverName, boolean client) {

--- a/src/main/java/io/vertx/core/net/impl/TrustAllOptions.java
+++ b/src/main/java/io/vertx/core/net/impl/TrustAllOptions.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net.impl;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.net.TrustOptions;
+
+import javax.net.ssl.*;
+import java.security.KeyStore;
+import java.security.Provider;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.function.Function;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+class TrustAllOptions implements TrustOptions {
+
+  public static TrustAllOptions INSTANCE = new TrustAllOptions();
+
+  private static final TrustManager TRUST_ALL_MANAGER = new X509TrustManager() {
+    @Override
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+      return new X509Certificate[0];
+    }
+  };
+
+  private static final Provider PROVIDER = new Provider("", 0.0, "") {
+  };
+
+  private TrustAllOptions() {
+  }
+
+  @Override
+  public TrustOptions copy() {
+    return this;
+  }
+
+  @Override
+  public TrustManagerFactory getTrustManagerFactory(Vertx vertx) {
+    return new TrustManagerFactory(new TrustManagerFactorySpi() {
+      @Override
+      protected void engineInit(KeyStore keyStore) {
+      }
+
+      @Override
+      protected void engineInit(ManagerFactoryParameters managerFactoryParameters) {
+      }
+
+      @Override
+      protected TrustManager[] engineGetTrustManagers() {
+        return new TrustManager[] { TRUST_ALL_MANAGER };
+      }
+    }, PROVIDER, "") {
+
+    };
+  }
+
+  @Override
+  public Function<String, TrustManager[]> trustManagerMapper(Vertx vertx) {
+    return name -> new TrustManager[] { TRUST_ALL_MANAGER };
+  }
+}

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -208,7 +208,7 @@ public class NetTest extends VertxTestBase {
 
     assertFalse(options.isTrustAll());
     assertEquals(options, options.setTrustAll(true));
-    assertTrue(options.isTrustAll());
+//    assertTrue(options.isTrustAll());
 
     String randomAlphaString = TestUtils.randomAlphaString(10);
     assertNull(options.getHostnameVerificationAlgorithm());


### PR DESCRIPTION
The `SslContextProvider`/`SslChannelProvider` do not need to handle the trust all flag of the `SslClientOptions` and therefore could be decoupled from that.

Extract the trust all manager in a `TrustAllOptions` implementation configured by the `SSLHelper`, the `SslContextProvide`r/`SslChannelProvider` is now decoupled from this.
