### PR TITLE
HTTP/1.1 client connection does not fail pending stream allocation requests when closed

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -719,6 +719,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     void handleClosed(Throwable err) {
       if (err != null) {
         handleException(err);
+        promise.tryFail(err);
       }
       if (!closed) {
         closed = true;

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -5438,4 +5438,39 @@ public class Http1xTest extends HttpTest {
     }
     await();
   }
+
+  @Test
+  public void testFailPendingRequestAllocationWhenConnectionIsClosed() throws Exception {
+    waitFor(2);
+    server.requestHandler(request -> {
+      HttpServerResponse resp = request.response();
+      resp.end().onComplete(onSuccess(v -> {
+        request.connection().close();
+      }));
+    });
+    startServer(testAddress);
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions().setPipelining(true), new PoolOptions().setHttp1MaxSize(1));
+    for (int i = 0;i < 2;i++) {
+      int val = i;
+      Future<HttpClientRequest> fut = client.request(requestOptions);
+      fut.onComplete(ar -> {
+        switch (val) {
+          case 0:
+            assertTrue(ar.succeeded());
+            HttpClientRequest req = ar.result();
+            req.sendHead();
+            req.response().onComplete(onSuccess(resp -> {
+              complete();
+            }));
+            break;
+          case 1:
+            assertTrue(ar.failed());
+            complete();
+            break;
+        }
+      });
+    }
+    await();
+  }
 }


### PR DESCRIPTION
The `Http1xClientConnection` will not fail the pending stream allocation requests when the connection is closed. The stream handle closed method does ignore the stream allocation request promise assuming that it is always succeeded. When a stream it closed with a failure the stream allocation request promise should be attempted to be failed.

Update the `Http1xClientConnection` stream implementation to fail the promise when the stream is closed with an exception.
