### PR TITLE
Refactor HttpUtils#absoluteURI

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -12,8 +12,8 @@
 package io.vertx.core.http.impl;
 
 import io.netty.handler.codec.DecoderResult;
-import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http.multipart.Attribute;
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
@@ -23,9 +23,9 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.buffer.impl.BufferInternal;
-import io.vertx.core.http.*;
 import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.*;
 import io.vertx.core.http.impl.headers.HeadersAdaptor;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
@@ -43,7 +43,6 @@ import io.vertx.core.streams.impl.InboundBuffer;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.security.cert.X509Certificate;
-import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
@@ -382,11 +381,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   @Override
   public String absoluteURI() {
     if (absoluteURI == null) {
-      try {
-        absoluteURI = HttpUtils.absoluteURI(conn.getServerOrigin(), this);
-      } catch (URISyntaxException e) {
-        log.error("Failed to create abs uri", e);
-      }
+      absoluteURI = HttpUtils.absoluteURI(conn.getServerOrigin(), this);
     }
     return absoluteURI;
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -12,11 +12,7 @@
 package io.vertx.core.http.impl;
 
 import io.netty.handler.codec.DecoderResult;
-import io.netty.handler.codec.http.DefaultHttpContent;
-import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http.multipart.Attribute;
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
@@ -29,15 +25,9 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.buffer.impl.BufferInternal;
 import io.vertx.core.http.Cookie;
-import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerFileUpload;
-import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpVersion;
-import io.vertx.core.http.ServerWebSocket;
-import io.vertx.core.http.StreamPriority;
-import io.vertx.core.http.StreamResetException;
-import io.vertx.core.http.HttpFrame;
+import io.vertx.core.http.*;
 import io.vertx.core.http.impl.headers.Http2HeadersAdaptor;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.logging.Logger;
@@ -48,7 +38,6 @@ import io.vertx.core.net.SocketAddress;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.security.cert.X509Certificate;
-import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
@@ -388,11 +377,7 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
     }
     synchronized (stream.conn) {
       if (absoluteURI == null) {
-        try {
-          absoluteURI = HttpUtils.absoluteURI(serverOrigin, this);
-        } catch (URISyntaxException e) {
-          log.error("Failed to create abs uri", e);
-        }
+        absoluteURI = HttpUtils.absoluteURI(serverOrigin, this);
       }
       return absoluteURI;
     }

--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -514,26 +514,27 @@ public final class HttpUtils {
     }
   }
 
-  static String absoluteURI(String serverOrigin, HttpServerRequest req) throws URISyntaxException {
+  static String absoluteURI(String serverOrigin, HttpServerRequest req) {
+    String uri = req.uri();
+    if ("*".equals(uri)) {
+      return null;
+    }
+    if (uri.startsWith("https://") || uri.startsWith("http://")) {
+      return uri;
+    }
     String absoluteURI;
-    URI uri = new URI(req.uri());
-    String scheme = uri.getScheme();
-    if (scheme != null && (scheme.equals("http") || scheme.equals("https"))) {
-      absoluteURI = uri.toString();
-    } else {
-      boolean ssl = req.isSSL();
-      HostAndPort authority = req.authority();
-      if (authority != null) {
-        StringBuilder sb = new StringBuilder(req.scheme()).append("://").append(authority.host());
-        if (authority.port() > 0 && (ssl && authority.port() != 443) || (!ssl && authority.port() != 80)) {
-          sb.append(':').append(authority.port());
-        }
-        sb.append(uri);
-        absoluteURI = sb.toString();
-      } else {
-        // Fall back to the server origin
-        absoluteURI = serverOrigin + uri;
+    boolean ssl = req.isSSL();
+    HostAndPort authority = req.authority();
+    if (authority != null) {
+      StringBuilder sb = new StringBuilder(req.scheme()).append("://").append(authority.host());
+      if (authority.port() > 0 && (ssl && authority.port() != 443) || (!ssl && authority.port() != 80)) {
+        sb.append(':').append(authority.port());
       }
+      sb.append(uri);
+      absoluteURI = sb.toString();
+    } else {
+      // Fall back to the server origin
+      absoluteURI = serverOrigin + uri;
     }
     return absoluteURI;
   }


### PR DESCRIPTION
This is a fix for #2797 and https://github.com/eclipse-vertx/vertx-tracing/issues/74

A proposal was made originally by @aruis but it did not address all possible cases, as described in https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html

This PR covers all cases and adds tests for them.