### PR TITLE
HttpServerRequest#isExpectMultipart regression fix

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -92,6 +92,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   private HttpEventHandler eventHandler;
   private Handler<HttpServerFileUpload> uploadHandler;
   private MultiMap attributes;
+  private boolean expectMultipart;
   private HttpPostRequestDecoder decoder;
   private boolean ended;
   private long bytesRead;
@@ -483,6 +484,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   public HttpServerRequest setExpectMultipart(boolean expect) {
     synchronized (conn) {
       checkEnded();
+      expectMultipart = expect;
       if (expect) {
         if (decoder == null) {
           String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
@@ -510,10 +512,8 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   }
 
   @Override
-  public boolean isExpectMultipart() {
-    synchronized (conn) {
-      return decoder != null;
-    }
+  public synchronized boolean isExpectMultipart() {
+    return expectMultipart;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -63,6 +63,7 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
   private HttpEventHandler eventHandler;
   private boolean ended;
   private Handler<HttpServerFileUpload> uploadHandler;
+  private boolean expectMultipart;
   private HttpPostRequestDecoder postRequestDecoder;
   private Handler<HttpFrame> customFrameHandler;
   private Handler<StreamPriority> streamPriorityHandler;
@@ -401,6 +402,7 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
   public HttpServerRequest setExpectMultipart(boolean expect) {
     synchronized (stream.conn) {
       checkEnded();
+      expectMultipart = expect;
       if (expect) {
         if (postRequestDecoder == null) {
           String contentType = headersMap.get(HttpHeaderNames.CONTENT_TYPE);
@@ -435,7 +437,7 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
   @Override
   public boolean isExpectMultipart() {
     synchronized (stream.conn) {
-      return postRequestDecoder != null;
+      return expectMultipart;
     }
   }
 

--- a/src/test/java/io/vertx/core/http/HttpServerFileUploadTest.java
+++ b/src/test/java/io/vertx/core/http/HttpServerFileUploadTest.java
@@ -304,6 +304,7 @@ public abstract class HttpServerFileUploadTest extends HttpTestBase {
         req.endHandler(v -> {
           MultiMap attrs = req.formAttributes();
           attributeCount.set(attrs.size());
+          assertTrue(req.isExpectMultipart());
           req.response().end();
         });
       }


### PR DESCRIPTION
Fix a regression in `HttpServerRequest#isExpectMultipart` due to the cleanup of the form