### PR TITLE
Vertx should build its virtual thread factory at runtime with correct reflection calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,11 +290,21 @@
             <execution>
               <id>default-jar</id>
               <configuration>
-                <archive>
-                  <manifestEntries>
-                    <Multi-Release>true</Multi-Release>
-                  </manifestEntries>
-                </archive>
+                <excludes>
+                  <exclude>/docoverride/**</exclude>
+                  <exclude>/examples/**</exclude>
+                  <exclude>META-INF/native-image/**</exclude>
+                </excludes>
+              </configuration>
+            </execution>
+            <execution>
+              <id>native-image-jar</id>
+              <configuration>
+                <excludes>
+                  <exclude>/docoverride/**</exclude>
+                  <exclude>/examples/**</exclude>
+                </excludes>
+                <classifier>native-image</classifier>
               </configuration>
             </execution>
           </executions>
@@ -738,6 +748,19 @@
                 <additionalClasspathElement>${project.basedir}/src/test/classpath/customcontextlocal</additionalClasspathElement>
               </additionalClasspathElements>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>native-image-jar</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -162,7 +162,7 @@ public class DeploymentManager {
         workerPool = vertx.createSharedWorkerPool(options.getWorkerPoolName(), options.getWorkerPoolSize(), options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit());
       }
     } else {
-      if (!VertxInternal.isVirtualThreadAvailable()) {
+      if (!vertx.isVirtualThreadAvailable()) {
         return callingContext.failedFuture("This Java runtime does not support virtual threads");
       }
     }

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -100,19 +100,8 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   private static final String NETTY_IO_RATIO_PROPERTY_NAME = "vertx.nettyIORatio";
   private static final int NETTY_IO_RATIO = Integer.getInteger(NETTY_IO_RATIO_PROPERTY_NAME, 50);
 
-  public static final ThreadFactory VIRTUAL_THREAD_FACTORY;
-  private static final Throwable VIRTUAL_THREAD_FACTORY_UNAVAILABILITY_CAUSE;
-
-  static {
-    // Disable Netty's resource leak detection to reduce the performance overhead if not set by user
-    // Supports both the default netty leak detection system property and the deprecated one
-    if (System.getProperty("io.netty.leakDetection.level") == null &&
-        System.getProperty("io.netty.leakDetectionLevel") == null) {
-      ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
-    }
-
-    ThreadFactory factory = null;
-    Throwable unavailabilityCause = null;
+  // Not cached for graalvm
+  private static ThreadFactory virtualThreadFactory() {
     try {
       Class<?> builderClass = ClassLoader.getSystemClassLoader().loadClass("java.lang.Thread$Builder");
       Class<?> ofVirtualClass = ClassLoader.getSystemClassLoader().loadClass("java.lang.Thread$Builder$OfVirtual");
@@ -121,12 +110,19 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       Method nameMethod = ofVirtualClass.getDeclaredMethod("name", String.class, long.class);
       Method factoryMethod = builderClass.getDeclaredMethod("factory");
       builder = nameMethod.invoke(builder, "vert.x-virtual-thread-", 0L);
-      factory = (ThreadFactory) factoryMethod.invoke(builder);
+      return (ThreadFactory) factoryMethod.invoke(builder);
     } catch (Exception e) {
-      unavailabilityCause = e;
+      return null;
     }
-    VIRTUAL_THREAD_FACTORY = factory;
-    VIRTUAL_THREAD_FACTORY_UNAVAILABILITY_CAUSE = unavailabilityCause;
+  }
+
+  static {
+    // Disable Netty's resource leak detection to reduce the performance overhead if not set by user
+    // Supports both the default netty leak detection system property and the deprecated one
+    if (System.getProperty("io.netty.leakDetection.level") == null &&
+        System.getProperty("io.netty.leakDetectionLevel") == null) {
+      ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
+    }
   }
 
   private final FileSystem fileSystem = getFileSystem();
@@ -195,6 +191,8 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     ExecutorService internalWorkerExec = executorServiceFactory.createExecutor(internalWorkerThreadFactory, internalBlockingPoolSize, internalBlockingPoolSize);
     PoolMetrics internalBlockingPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-internal-blocking", internalBlockingPoolSize) : null;
 
+    ThreadFactory virtualThreadFactory = virtualThreadFactory();
+
     contextLocals = LocalSeq.get();
     closeFuture = new CloseFuture(log);
     maxEventLoopExecTime = maxEventLoopExecuteTime;
@@ -204,8 +202,8 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     // The acceptor event loop thread needs to be from a different pool otherwise can get lags in accepted connections
     // under a lot of load
     acceptorEventLoopGroup = transport.eventLoopGroup(Transport.ACCEPTOR_EVENT_LOOP_GROUP, 1, acceptorEventLoopThreadFactory, 100);
-    virtualThreadExecutor = VIRTUAL_THREAD_FACTORY != null ? new ThreadPerTaskExecutorService(VIRTUAL_THREAD_FACTORY) : null;
-    virtualThreaWorkerPool = new WorkerPool(virtualThreadExecutor, null);
+    virtualThreadExecutor = virtualThreadFactory != null ? new ThreadPerTaskExecutorService(virtualThreadFactory) : null;
+    virtualThreaWorkerPool = virtualThreadFactory != null ? new WorkerPool(virtualThreadExecutor, null) : null;
     internalWorkerPool = new WorkerPool(internalWorkerExec, internalBlockingPoolMetrics);
     workerPool = new WorkerPool(workerExec, workerPoolMetrics);
     defaultWorkerPoolSize = options.getWorkerPoolSize();
@@ -582,7 +580,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   private ContextImpl createVirtualThreadContext(EventLoop eventLoop, CloseFuture closeFuture, Deployment deployment, ClassLoader tccl) {
-    if (!VertxInternal.isVirtualThreadAvailable()) {
+    if (!isVirtualThreadAvailable()) {
       throw new IllegalStateException("This Java runtime does not support virtual threads");
     }
     TaskQueue orderedTasks = new TaskQueue();
@@ -1129,6 +1127,11 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   @Override
   public void removeCloseHook(Closeable hook) {
     closeFuture.remove(hook);
+  }
+
+  @Override
+  public boolean isVirtualThreadAvailable() {
+    return virtualThreadExecutor != null;
   }
 
   private CloseFuture resolveCloseFuture() {

--- a/src/main/java/io/vertx/core/impl/VertxInternal.java
+++ b/src/main/java/io/vertx/core/impl/VertxInternal.java
@@ -239,7 +239,5 @@ public interface VertxInternal extends Vertx {
   /**
    * @return whether virtual threads are available
    */
-  static boolean isVirtualThreadAvailable() {
-    return VertxImpl.VIRTUAL_THREAD_FACTORY != null;
-  }
+  boolean isVirtualThreadAvailable();
 }

--- a/src/main/java/io/vertx/core/impl/VertxWrapper.java
+++ b/src/main/java/io/vertx/core/impl/VertxWrapper.java
@@ -483,6 +483,11 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
+  public boolean isVirtualThreadAvailable() {
+    return delegate.isVirtualThreadAvailable();
+  }
+
+  @Override
   public boolean isMetricsEnabled() {
     return delegate.isMetricsEnabled();
   }

--- a/src/main/resources/META-INF/native-image/io.vertx/vertx-core/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/io.vertx/vertx-core/reflect-config.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "java.lang.Thread$Builder",
+    "condition": {
+      "typeReachable": "io.vertx.core.impl.VertxImpl"
+    },
+    "methods": [
+      {
+        "name": "factory",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "java.lang.Thread$Builder$OfVirtual",
+    "condition": {
+      "typeReachable": "io.vertx.core.impl.VertxImpl"
+    },
+    "methods": [
+      {
+        "name": "name",
+        "parameterTypes": ["java.lang.String", "long"]
+      }
+    ]
+  },
+  {
+    "name": "java.lang.Thread",
+    "condition": {
+      "typeReachable": "io.vertx.core.impl.VertxImpl"
+    },
+    "methods": [
+      {
+        "name": "ofVirtual",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -1007,7 +1007,7 @@ public class ContextTest extends VertxTestBase {
 
   @Test
   public void testAwaitFromVirtualThreadThread() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     testAwaitFromContextThread(ThreadingModel.VIRTUAL_THREAD, false);
   }
 
@@ -1031,7 +1031,7 @@ public class ContextTest extends VertxTestBase {
 
   @Test
   public void testInterruptThreadOnAwait() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     vertx.deployVerticle(() -> new AbstractVerticle() {
       @Override
       public void start() {

--- a/src/test/java/io/vertx/core/VirtualThreadContextTest.java
+++ b/src/test/java/io/vertx/core/VirtualThreadContextTest.java
@@ -36,7 +36,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   @Test
   public void testContext() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     vertx.createVirtualThreadContext().runOnContext(v -> {
       Thread thread = Thread.currentThread();
       assertTrue(VirtualThreadDeploymentTest.isVirtual(thread));
@@ -54,7 +54,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   @Test
   public void testAwaitFutureSuccess() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     Object result = new Object();
     vertx.createVirtualThreadContext().runOnContext(v -> {
       ContextInternal context = vertx.getOrCreateContext();
@@ -74,7 +74,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   @Test
   public void testAwaitFutureFailure() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     Exception failure = new Exception();
     vertx.createVirtualThreadContext().runOnContext(v -> {
       ContextInternal context = vertx.getOrCreateContext();
@@ -100,7 +100,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   @Test
   public void testAwaitCompoundFuture() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     Object result = new Object();
     vertx.createVirtualThreadContext().runOnContext(v -> {
       ContextInternal context = vertx.getOrCreateContext();
@@ -120,7 +120,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   @Test
   public void testDuplicateUseSameThread() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     int num = 1000;
     waitFor(num);
     vertx.createVirtualThreadContext().runOnContext(v -> {
@@ -139,7 +139,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   @Test
   public void testDuplicateConcurrentAwait() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     int num = 1000;
     waitFor(num);
     vertx.createVirtualThreadContext().runOnContext(v -> {
@@ -173,7 +173,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   @Test
   public void testTimer() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     vertx.createVirtualThreadContext().runOnContext(v -> {
       ContextInternal context = vertx.getOrCreateContext();
       PromiseInternal<String> promise = context.promise();
@@ -189,7 +189,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   @Test
   public void testInThread() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     vertx.createVirtualThreadContext().runOnContext(v1 -> {
       ContextInternal context = vertx.getOrCreateContext();
       assertTrue(context.inThread());
@@ -218,7 +218,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   @Test
   public void testSerializeBlocking() throws Exception {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     AtomicInteger inflight = new AtomicInteger();
     vertx.createVirtualThreadContext().runOnContext(v1 -> {
       Context ctx = vertx.getOrCreateContext();
@@ -232,7 +232,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   @Test
   public void testVirtualThreadsNotAvailable() {
-    Assume.assumeFalse(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeFalse(isVirtualThreadAvailable());
     try {
       vertx.createVirtualThreadContext();
       fail();

--- a/src/test/java/io/vertx/core/VirtualThreadDeploymentTest.java
+++ b/src/test/java/io/vertx/core/VirtualThreadDeploymentTest.java
@@ -52,7 +52,7 @@ public class VirtualThreadDeploymentTest extends VertxTestBase {
 
   @Test
   public void testDeploy() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     vertx.deployVerticle(new AbstractVerticle() {
       @Override
       public void start() {
@@ -67,7 +67,7 @@ public class VirtualThreadDeploymentTest extends VertxTestBase {
 
   @Test
   public void testExecuteBlocking() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     vertx.deployVerticle(new AbstractVerticle() {
       @Override
       public void start() {
@@ -85,7 +85,7 @@ public class VirtualThreadDeploymentTest extends VertxTestBase {
 
   @Test
   public void testDeployHTTPServer() throws Exception {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     AtomicInteger inflight = new AtomicInteger();
     AtomicBoolean processing = new AtomicBoolean();
     AtomicInteger max = new AtomicInteger();
@@ -126,7 +126,7 @@ public class VirtualThreadDeploymentTest extends VertxTestBase {
 
   @Test
   public void testVirtualThreadsNotAvailable() {
-    Assume.assumeFalse(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeFalse(isVirtualThreadAvailable());
     vertx.deployVerticle(new AbstractVerticle() {
       @Override
       public void start() {

--- a/src/test/java/io/vertx/core/eventbus/VirtualThreadEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/VirtualThreadEventBusTest.java
@@ -29,7 +29,7 @@ public class VirtualThreadEventBusTest extends VertxTestBase {
 
   @Test
   public void testEventBus() {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     EventBus eb = vertx.eventBus();
     eb.consumer("test-addr", msg -> {
       msg.reply(msg.body());

--- a/src/test/java/io/vertx/core/http/VirtualThreadHttpTest.java
+++ b/src/test/java/io/vertx/core/http/VirtualThreadHttpTest.java
@@ -35,7 +35,7 @@ public class VirtualThreadHttpTest extends VertxTestBase {
 
   @Test
   public void testHttpClient1() throws Exception {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     HttpServer server = vertx.createHttpServer();
     server.requestHandler(req -> {
       req.response().end("Hello World");
@@ -57,7 +57,7 @@ public class VirtualThreadHttpTest extends VertxTestBase {
 
   @Test
   public void testHttpClient2() throws Exception {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     waitFor(100);
     HttpServer server = vertx.createHttpServer();
     server.requestHandler(req -> {
@@ -90,7 +90,7 @@ public class VirtualThreadHttpTest extends VertxTestBase {
 
   @Test
   public void testHttpClientTimeout() throws Exception {
-    Assume.assumeTrue(VertxInternal.isVirtualThreadAvailable());
+    Assume.assumeTrue(isVirtualThreadAvailable());
     HttpServer server = vertx.createHttpServer();
     server.requestHandler(req -> {
     });

--- a/src/test/java/io/vertx/test/core/VertxTestBase.java
+++ b/src/test/java/io/vertx/test/core/VertxTestBase.java
@@ -12,6 +12,7 @@
 package io.vertx.test.core;
 
 import io.vertx.core.*;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.metrics.MetricsOptions;
@@ -115,6 +116,10 @@ public class VertxTestBase extends AsyncTestBase {
       });
     }
     Assert.assertTrue(latch.await(180, TimeUnit.SECONDS));
+  }
+
+  protected final boolean isVirtualThreadAvailable() {
+    return ((VertxInternal)vertx).isVirtualThreadAvailable();
   }
 
   /**


### PR DESCRIPTION
A Vertx uses cached reflection to build the virtual thread factory in order to remain compatible with Java 8. When running in a native image Vert.x will assume that the runtime might not have virtual thread incorrectly.

Defer the virtual thread factory availability when a Vertx instance is created, in addition declares that virtual thread factory API should not be cached so the Vertx instance is able to build the virtual thread factory correctly.

Native image metadata are held in the _native-image_ classifier jar since this is experimental and might collide with existing solution for managing native image where framework is embedded.
