### PR TITLE
Remove context execution in Http1xServerRequest#handleContent that is not necessary

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -150,7 +150,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
         conn.doPause();
       }
     } else {
-      context.execute(buffer, this::onData);
+      onData(buffer);
     }
   }
 


### PR DESCRIPTION
HTTP/1 server request does execute twice the delivery of the content to the handler.

Remove the context execution in `Http1xServerRequest#handleContent` since this method is already executed on the context by `Http1xServerConnection`.
