### PR TITLE
support zstd compression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,12 @@
       <version>1.16.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+      <version>1.5.6-1</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- JMH -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>
-      <version>1.5.6-1</version>
+      <version>1.5.6-3</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -414,6 +414,18 @@ public interface HttpHeaders {
   CharSequence DEFLATE_GZIP_BR = createOptimized("deflate, gzip, br");
 
   /**
+   * deflate,gzip,zstd,br header value
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence DEFLATE_GZIP_ZSTD_BR = createOptimized("deflate, gzip, zstd, br");
+
+  /**
+   * deflate,gzip,zstd header value
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence DEFLATE_GZIP_ZSTD = createOptimized("deflate, gzip, zstd");
+
+  /**
    * text/html header value
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)

--- a/src/test/java/io/vertx/core/http/Http1xZstdCompressionTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xZstdCompressionTest.java
@@ -1,0 +1,43 @@
+package io.vertx.core.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.handler.codec.compression.StandardCompressionOptions;
+import io.netty.handler.codec.compression.Zstd;
+import io.netty.handler.codec.compression.ZstdEncoder;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+
+public class Http1xZstdCompressionTest extends HttpCompressionTestBase {
+
+  @BeforeClass
+  public static void zstdLibraryIsAvailable() {
+    Assert.assertTrue(Zstd.isAvailable());
+  }
+
+  @Override
+  protected HttpServerOptions createBaseServerOptions() {
+    return new HttpServerOptions().setPort(DEFAULT_HTTP_PORT).setHost(DEFAULT_HTTP_HOST);
+  }
+
+  @Override
+  protected HttpClientOptions createBaseClientOptions() {
+    return new HttpClientOptions().setDefaultPort(DEFAULT_HTTP_PORT).setDefaultHost(DEFAULT_HTTP_HOST);
+  }
+
+  @Override
+  protected MessageToByteEncoder<ByteBuf> encoder() {
+    return new ZstdEncoder();
+  }
+
+  @Override
+  protected String encoding() {
+    return "zstd";
+  }
+
+  @Override
+  protected void configureServerCompression(HttpServerOptions options) {
+    options.setCompressionSupported(true).addCompressor(StandardCompressionOptions.zstd());
+  }
+}

--- a/src/test/java/io/vertx/core/http/Http2ClientTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientTest.java
@@ -1401,7 +1401,7 @@ public class Http2ClientTest extends Http2TestBase {
     in.close();
     byte[] compressed = baos.toByteArray();
     server.requestHandler(req -> {
-      assertEquals(enabled ? "deflate, gzip, br" : null, req.getHeader(HttpHeaderNames.ACCEPT_ENCODING));
+      assertEquals(enabled ? "deflate, gzip, zstd, br" : null, req.getHeader(HttpHeaderNames.ACCEPT_ENCODING));
       req.response().putHeader(HttpHeaderNames.CONTENT_ENCODING.toLowerCase(), "gzip").end(Buffer.buffer(compressed));
     });
     startServer();


### PR DESCRIPTION
# Motivation

Netty supports zstd compression.

Google Chrome recently added support for zstd
https://www.phoronix.com/news/Zstd-1.5.6-Zstandard

# Conformance

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
