### PR TITLE
Provide a better event-loop to context message transfer queue

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -424,7 +424,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
           conn.doPause();
         }
         @Override
-        protected void handle(Object item) {
+        protected void handleMessage(Object item) {
           if (!reset) {
             if (item instanceof MultiMap) {
               Handler<MultiMap> handler = endHandler;

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -414,7 +414,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
       super(context, promise, id);
 
       this.conn = conn;
-      this.queue = new InboundMessageQueue<>(context) {
+      this.queue = new InboundMessageQueue<>(conn.context.nettyEventLoop(), context) {
         @Override
         protected void handleResume() {
           conn.doResume();

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -152,7 +152,7 @@ public class Http1xServerConnection extends Http1xConnection implements HttpServ
       DefaultHttpRequest request = (DefaultHttpRequest) msg;
       ContextInternal requestCtx = streamContextSupplier.get();
       boolean parked = responseInProgress != null;
-      Http1xServerRequest req = new Http1xServerRequest(this, request, requestCtx, parked);
+      Http1xServerRequest req = new Http1xServerRequest(this, request, requestCtx);
       requestInProgress = req;
       if (parked) {
         pipelinedRequest = req;
@@ -256,7 +256,6 @@ public class Http1xServerConnection extends Http1xConnection implements HttpServ
     responseInProgress = next;
     wantClose |= !keepAlive;
     next.handleBegin(keepAlive);
-    next.parked = false;
     next.context.emit(next, next_ -> {
       Handler<HttpServerRequest> handler = next_.nettyRequest().decoderResult().isSuccess() ? requestHandler : invalidRequestHandler;
       handler.handle(next_);

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -151,10 +151,10 @@ public class Http1xServerConnection extends Http1xConnection implements HttpServ
       // fast path type check vs concrete class
       DefaultHttpRequest request = (DefaultHttpRequest) msg;
       ContextInternal requestCtx = streamContextSupplier.get();
-      boolean parked = responseInProgress != null;
       Http1xServerRequest req = new Http1xServerRequest(this, request, requestCtx);
       requestInProgress = req;
-      if (parked) {
+      if (responseInProgress != null) {
+        assert pipelinedRequest == null;
         pipelinedRequest = req;
         doPause();
         return;

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -81,7 +81,6 @@ public class Http1xServerConnection extends Http1xConnection implements HttpServ
   private Http1xServerRequest requestInProgress;
   private Http1xServerRequest responseInProgress;
   private boolean wantClose;
-  private boolean channelPaused;
   private Handler<HttpServerRequest> requestHandler;
   private Handler<HttpServerRequest> invalidRequestHandler;
 
@@ -264,22 +263,6 @@ public class Http1xServerConnection extends Http1xConnection implements HttpServ
       handler.handle(next_);
       next_.unpark();
     });
-  }
-
-  @Override
-  public void doPause() {
-    if (!channelPaused) {
-      channelPaused = true;
-      super.doPause();
-    }
-  }
-
-  @Override
-  public void doResume() {
-    if (channelPaused) {
-      channelPaused = false;
-      super.doResume();
-    }
   }
 
   private void reportResponseComplete() {

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -151,9 +151,10 @@ public class Http1xServerConnection extends Http1xConnection implements HttpServ
       // fast path type check vs concrete class
       DefaultHttpRequest request = (DefaultHttpRequest) msg;
       ContextInternal requestCtx = streamContextSupplier.get();
-      Http1xServerRequest req = new Http1xServerRequest(this, request, requestCtx);
+      boolean parked = responseInProgress != null;
+      Http1xServerRequest req = new Http1xServerRequest(this, request, requestCtx, parked);
       requestInProgress = req;
-      if (responseInProgress != null) {
+      if (parked) {
         enqueueRequest(req);
         return;
       }
@@ -171,7 +172,6 @@ public class Http1xServerConnection extends Http1xConnection implements HttpServ
   private void enqueueRequest(Http1xServerRequest req) {
     // Deferred until the current response completion
     responseInProgress.enqueue(req);
-    req.pause();
   }
 
   private void handleOther(Object msg) {
@@ -261,16 +261,8 @@ public class Http1xServerConnection extends Http1xConnection implements HttpServ
     next.handleBegin(keepAlive);
     next.context.emit(next, next_ -> {
       Handler<HttpServerRequest> handler = next_.nettyRequest().decoderResult().isSuccess() ? requestHandler : invalidRequestHandler;
-      synchronized (Http1xServerConnection.this) {
-        next_.demand = Long.MAX_VALUE;
-      }
       handler.handle(next_);
-      synchronized (Http1xServerConnection.this) {
-        if (next.demand == 0L) {
-          return;
-        }
-      }
-      next_.drain();
+      next_.unpark();
     });
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -113,7 +113,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
     this.parked = parked;
     this.queue = new InboundMessageQueue<>(context.nettyEventLoop(), context) {
       @Override
-      protected void handle(Object elt) {
+      protected void handleMessage(Object elt) {
         if (elt == InboundBuffer.END_SENTINEL) {
           onEnd();
         } else {

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -81,7 +81,6 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   private String query;
 
   // Accessed on event loop
-  Http1xServerRequest next;
   Object metric;
   Object trace;
   boolean reportMetricsFailed;
@@ -103,9 +102,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   private boolean ended;
   private long bytesRead;
   private final InboundMessageQueue<Object> queue;
-  private long demand = Long.MAX_VALUE;
-  private boolean parked;
-  private boolean parkedDrain;
+  boolean parked;
 
   Http1xServerRequest(Http1xServerConnection conn, HttpRequest request, ContextInternal context, boolean parked) {
     this.conn = conn;
@@ -158,8 +155,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   void handleContent(Buffer buffer) {
     boolean drain = queue.add(buffer);
     if (parked) {
-      parkedDrain |= drain;
-      return;
+      throw new IllegalStateException();
     }
     if (drain) {
       queue.drain();
@@ -169,44 +165,11 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   void handleEnd() {
     boolean drain = queue.add(InboundBuffer.END_SENTINEL);
     if (parked) {
-      parkedDrain |= drain;
-      return;
+      throw new IllegalStateException();
     }
     if (drain) {
       queue.drain();
     }
-  }
-
-  void unpark() {
-    long demand;
-    synchronized (conn) {
-      parked = false;
-      demand = this.demand;
-    }
-    queue.demand(demand);
-    if (parkedDrain) {
-      queue.drain();
-    }
-  }
-
-  /**
-   * Enqueue a pipelined request.
-   *
-   * @param request the enqueued request
-   */
-  void enqueue(Http1xServerRequest request) {
-    Http1xServerRequest current = this;
-    while (current.next != null) {
-      current = current.next;
-    }
-    current.next = request;
-  }
-
-  /**
-   * @return the next request following this one
-   */
-  Http1xServerRequest next() {
-    return next;
   }
 
   private void check100() {
@@ -370,10 +333,6 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
       if (ended) {
         return this;
       }
-      if (parked) {
-        demand = 0L;
-        return this;
-      }
     }
     queue.pause();
     return this;
@@ -387,13 +346,6 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
     if (amount > 0L) {
       synchronized (conn) {
         if (ended) {
-          return this;
-        }
-        if (parked) {
-          demand += amount;
-          if (demand < 0L) {
-            demand = Long.MAX_VALUE;
-          }
           return this;
         }
       }

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -111,7 +111,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
     this.context = context;
     this.request = request;
     this.parked = parked;
-    this.queue = new InboundMessageQueue<>(context) {
+    this.queue = new InboundMessageQueue<>(context.nettyEventLoop(), context) {
       @Override
       protected void handle(Object elt) {
         if (elt == InboundBuffer.END_SENTINEL) {

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -95,6 +95,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   private MultiMap attributes;
   private boolean expectMultipart;
   private HttpPostRequestDecoder decoder;
+  private boolean ending;
   private boolean ended;
   private long bytesRead;
   private InboundBuffer<Object> pending;
@@ -510,7 +511,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   @Override
   public boolean isEnded() {
     synchronized (conn) {
-      return ended && (pending == null || (!pending.isPaused() && pending.isEmpty()));
+      return ended;
     }
   }
 
@@ -561,7 +562,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   void handleEnd() {
     InboundBuffer<Object> queue;
     synchronized (conn) {
-      ended = true;
+      ending = true;
       queue = pending;
     }
     if (queue != null) {
@@ -580,6 +581,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
       if (decoder != null) {
         endDecode();
       }
+      ended = true;
       handler = eventHandler;
     }
     // If there have been uploads then we let the last one call the end handler once any fileuploads are complete

--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketHandshaker.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketHandshaker.java
@@ -427,7 +427,7 @@ public class ServerWebSocketHandshaker implements ServerWebSocket {
     boolean reject = false;
     try {
       if (futureHandshake != null) {
-        throw new IllegalStateException();
+        return null;
       }
       synchronized (this) {
         switch (status) {

--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -42,7 +42,7 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocketImpl> 
                       int maxWebSocketFrameSize,
                       int maxWebSocketMessageSize,
                       boolean registerWebSocketWriteHandlers) {
-    super(context, conn, conn.channelHandlerContext(), request.headers(), supportsContinuation, maxWebSocketFrameSize, maxWebSocketMessageSize, registerWebSocketWriteHandlers);
+    super(context, conn, request.headers(), supportsContinuation, maxWebSocketFrameSize, maxWebSocketMessageSize, registerWebSocketWriteHandlers);
     this.scheme = request.scheme();
     this.authority = request.authority();
     this.uri = request.uri();

--- a/src/main/java/io/vertx/core/http/impl/WebSocketConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketConnection.java
@@ -198,7 +198,7 @@ final class WebSocketConnection extends VertxConnection {
       }
     }
     if (w != null) {
-      w.context().execute(frame, w::handleFrame);
+      w.handleFrame(frame);
     }
   }
 

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
@@ -14,6 +14,7 @@ package io.vertx.core.http.impl;
 import io.vertx.core.Handler;
 import io.vertx.core.http.WebSocket;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.net.impl.VertxConnection;
 
 /**
  * This class is optimised for performance when used on the same event loop. However it can be used safely from other threads.
@@ -29,12 +30,12 @@ public class WebSocketImpl extends WebSocketImplBase<WebSocketImpl> implements W
   private Handler<Void> evictionHandler;
 
   public WebSocketImpl(ContextInternal context,
-                       WebSocketConnection conn,
+                       VertxConnection conn,
                        boolean supportsContinuation,
                        int maxWebSocketFrameSize,
                        int maxWebSocketMessageSize,
                        boolean registerWebSocketWriteHandlers) {
-    super(context, conn, conn.channelHandlerContext(), null, supportsContinuation, maxWebSocketFrameSize, maxWebSocketMessageSize, registerWebSocketWriteHandlers);
+    super(context, conn, null, supportsContinuation, maxWebSocketFrameSize, maxWebSocketMessageSize, registerWebSocketWriteHandlers);
   }
 
   public void evictionHandler(Handler<Void> evictionHandler) {

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -113,7 +113,7 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
         conn.doPause();
       }
       @Override
-      protected void handle(WebSocketFrameInternal msg) {
+      protected void handleMessage(WebSocketFrameInternal msg) {
         receiveFrame(msg);
       }
     };

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -363,7 +363,7 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
       case PONG:
         Handler<Buffer> pongHandler = pongHandler();
         if (pongHandler != null) {
-          context.dispatch(frame.binaryData(), pongHandler);
+          context.emit(frame.binaryData(), pongHandler);
         }
         break;
       case CLOSE:
@@ -404,10 +404,10 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
       textConsumer.unregister();
     }
     if (exceptionHandler != null && !graceful) {
-      context.dispatch(HttpUtils.CONNECTION_CLOSED_EXCEPTION, exceptionHandler);
+      context.emit(HttpUtils.CONNECTION_CLOSED_EXCEPTION, exceptionHandler);
     }
     if (closeHandler != null) {
-      context.dispatch(null, closeHandler);
+      context.emit(null, closeHandler);
     }
   }
 

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -103,7 +103,7 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
     this.context = context;
     this.maxWebSocketFrameSize = maxWebSocketFrameSize;
     this.maxWebSocketMessageSize = maxWebSocketMessageSize;
-    this.pending = new InboundMessageQueue<>(context) {
+    this.pending = new InboundMessageQueue<>(context.nettyEventLoop(), context) {
       @Override
       protected void handleResume() {
         conn.doResume();

--- a/src/main/java/io/vertx/core/net/impl/InboundMessageQueue.java
+++ b/src/main/java/io/vertx/core/net/impl/InboundMessageQueue.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.core.net.impl;
 
 import io.vertx.core.impl.ContextInternal;

--- a/src/main/java/io/vertx/core/net/impl/InboundMessageQueue.java
+++ b/src/main/java/io/vertx/core/net/impl/InboundMessageQueue.java
@@ -48,7 +48,7 @@ public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
         break;
       }
     }
-    handle(msg);
+    handleMessage(msg);
     return true;
   }
 
@@ -69,7 +69,7 @@ public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
    *
    * @param msg the message
    */
-  protected void handle(M msg) {
+  protected void handleMessage(M msg) {
   }
 
   public boolean add(M msg) {

--- a/src/main/java/io/vertx/core/net/impl/InboundMessageQueue.java
+++ b/src/main/java/io/vertx/core/net/impl/InboundMessageQueue.java
@@ -1,0 +1,125 @@
+package io.vertx.core.net.impl;
+
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.streams.impl.InboundReadQueue;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+
+public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
+
+  private final ContextInternal context;
+  private final InboundReadQueue<M> readQueue;
+  private final AtomicLong demand = new AtomicLong(Long.MAX_VALUE);
+  private boolean draining;
+
+  public InboundMessageQueue(ContextInternal context) {
+    this.readQueue = new InboundReadQueue<>(this);
+    this.context = context;
+  }
+
+  @Override
+  public boolean test(M msg) {
+    while (true) {
+      long d = demand.get();
+      if (d == 0L) {
+        return false;
+      } else if (d == Long.MAX_VALUE || demand.compareAndSet(d, d - 1)) {
+        break;
+      }
+    }
+    handle(msg);
+    return true;
+  }
+
+  /**
+   * Handle resume, executed on the context thread.
+   */
+  protected void handleResume() {
+  }
+
+  /**
+   * Handler pause, executed on the event-loop thread
+   */
+  protected void handlePause() {
+  }
+
+  /**
+   * Handle a message.
+   *
+   * @param msg the message
+   */
+  protected void handle(M msg) {
+  }
+
+  public boolean add(M msg) {
+    int res = readQueue.add(msg);
+    if ((res & InboundReadQueue.QUEUE_UNWRITABLE_MASK) != 0) {
+      handlePause();
+    }
+    return (res & InboundReadQueue.DRAIN_REQUIRED_MASK) != 0;
+  }
+
+  public void write(M msg) {
+    if (add(msg)) {
+      drain();
+    }
+  }
+
+  @Override
+  public void run() {
+    if (draining) {
+      return;
+    }
+    draining = true;
+    try {
+      if ((readQueue.drain() & InboundReadQueue.QUEUE_WRITABLE_MASK) != 0) {
+        handleResume();
+      }
+    } finally {
+      draining = false;
+    }
+  }
+
+  public void drain() {
+    if (context.inThread()) {
+      run();
+    } else {
+      context.execute(this);
+    }
+  }
+
+  public void pause() {
+    demand.set(0L);
+  }
+
+  public void demand(long value) {
+    if (value < 0L) {
+      throw new IllegalArgumentException();
+    }
+    demand.set(value);
+    if (value > 0L) {
+      drain();
+    }
+  }
+
+  public void fetch(long amount) {
+    if (amount < 0L) {
+      throw new IllegalArgumentException();
+    }
+    if (amount == 0L) {
+      return;
+    }
+    while (true) {
+      long prev = demand.get();
+      long next = prev + amount;
+      if (next < 0L) {
+        next = Long.MAX_VALUE;
+      }
+      if (prev == next || demand.compareAndSet(prev, next)) {
+        break;
+      }
+    }
+    drain();
+  }
+}

--- a/src/main/java/io/vertx/core/net/impl/InboundMessageQueue.java
+++ b/src/main/java/io/vertx/core/net/impl/InboundMessageQueue.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.net.impl;
 
+import io.vertx.core.ThreadingModel;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.streams.impl.InboundReadQueue;
 
@@ -24,7 +25,13 @@ public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
   private boolean draining;
 
   public InboundMessageQueue(ContextInternal context) {
-    this.readQueue = new InboundReadQueue<>(this);
+    InboundReadQueue.Factory readQueueFactory;
+    if (context.threadingModel() == ThreadingModel.EVENT_LOOP) {
+      readQueueFactory = InboundReadQueue.SINGLE_THREADED;
+    } else {
+      readQueueFactory = InboundReadQueue.SPSC;
+    }
+    this.readQueue = readQueueFactory.create(this);
     this.context = context;
   }
 

--- a/src/main/java/io/vertx/core/net/impl/InboundMessageQueue.java
+++ b/src/main/java/io/vertx/core/net/impl/InboundMessageQueue.java
@@ -59,7 +59,7 @@ public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
   }
 
   @Override
-  public boolean test(M msg) {
+  public final boolean test(M msg) {
     while (true) {
       long d = demand.get();
       if (d == 0L) {
@@ -136,7 +136,7 @@ public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
   /**
    * Schedule a drain operation on the context thread.
    */
-  public void drain() {
+  public final void drain() {
     assert eventLoop.inEventLoop();
     if (context.inThread()) {
       drainInternal();
@@ -172,7 +172,7 @@ public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
   /**
    * Stop demand.
    */
-  public void pause() {
+  public final void pause() {
     demand.set(0L);
   }
 
@@ -181,7 +181,7 @@ public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
    *
    * @param amount the number of message to consume
    */
-  public void fetch(long amount) {
+  public final void fetch(long amount) {
     if (amount < 0L) {
       throw new IllegalArgumentException();
     }

--- a/src/main/java/io/vertx/core/net/impl/InboundMessageQueue.java
+++ b/src/main/java/io/vertx/core/net/impl/InboundMessageQueue.java
@@ -177,18 +177,6 @@ public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
   }
 
   /**
-   * Set an absolute demand.
-   *
-   * @param value the new demand
-   */
-  public void demand(long value) {
-    if (value < 0L) {
-      throw new IllegalArgumentException();
-    }
-    demand.set(value);
-  }
-
-  /**
    * Add {@code amount} to the current demand.
    *
    * @param amount the number of message to consume

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -100,7 +100,7 @@ public class NetSocketImpl extends VertxConnection implements NetSocketInternal 
         NetSocketImpl.this.doPause();
       }
       @Override
-      protected void handle(Object msg) {
+      protected void handleMessage(Object msg) {
         if (msg == InboundBuffer.END_SENTINEL) {
           Handler<Void> handler = endHandler();
           if (handler != null) {

--- a/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -29,6 +29,8 @@ import io.vertx.core.impl.logging.LoggerFactory;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -63,6 +65,9 @@ public class VertxConnection extends ConnectionBase {
   private boolean needsFlush;
   private boolean draining;
   private boolean channelWritable;
+  private boolean paused;
+  private Deque<Object> pending;
+  private boolean autoRead;
   private ScheduledFuture<?> shutdownTimeout;
 
   public VertxConnection(ContextInternal context, ChannelHandlerContext chctx) {
@@ -230,6 +235,19 @@ public class VertxConnection extends ConnectionBase {
     read = true;
     if (METRICS_ENABLED) {
       reportBytesRead(msg);
+    }
+    // SHOULD BE IN VERT HANDLER ????
+    // SHOULD COOP WITH READ COMPLETE ?
+    if (paused) {
+      if (pending == null) {
+        pending = new ArrayDeque<>();
+      }
+      pending.add(msg);
+      if (pending.size() >= 8) {
+        autoRead = false;
+        chctx.channel().config().setAutoRead(false);
+      }
+      return;
     }
     handleMessage(msg);
   }
@@ -430,12 +448,33 @@ public class VertxConnection extends ConnectionBase {
     }
   }
 
-  public void doPause() {
-    chctx.channel().config().setAutoRead(false);
+  public final void doPause() {
+    assert chctx.executor().inEventLoop();
+    paused = true;
   }
 
-  public void doResume() {
-    chctx.channel().config().setAutoRead(true);
+  public final void doResume() {
+    assert chctx.executor().inEventLoop();
+    if (!paused) {
+      return;
+    }
+    paused = false;
+    if (pending != null) {
+      assert !read;
+      read = true;
+      try {
+        Object msg;
+        while (!paused && (msg = pending.poll()) != null) {
+          handleMessage(msg);
+        }
+      } finally {
+        endReadAndFlush();
+        if (pending.isEmpty() && !autoRead) {
+          autoRead = true;
+          chctx.channel().config().setAutoRead(true);
+        }
+      }
+    }
   }
 
   public void doSetWriteQueueMaxSize(int size) {

--- a/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -237,17 +237,21 @@ public class VertxConnection extends ConnectionBase {
       reportBytesRead(msg);
     }
     if (paused) {
-      if (pending == null) {
-        pending = new ArrayDeque<>();
-      }
-      pending.add(msg);
-      if (pending.size() >= 8) {
-        autoRead = false;
-        chctx.channel().config().setAutoRead(false);
-      }
+      addPending(msg);
       return;
     }
     handleMessage(msg);
+  }
+
+  private void addPending(Object msg) {
+    if (pending == null) {
+      pending = new ArrayDeque<>();
+    }
+    pending.add(msg);
+    if (pending.size() >= 8) {
+      autoRead = false;
+      chctx.channel().config().setAutoRead(false);
+    }
   }
 
   /**

--- a/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -236,8 +236,6 @@ public class VertxConnection extends ConnectionBase {
     if (METRICS_ENABLED) {
       reportBytesRead(msg);
     }
-    // SHOULD BE IN VERT HANDLER ????
-    // SHOULD COOP WITH READ COMPLETE ?
     if (paused) {
       if (pending == null) {
         pending = new ArrayDeque<>();

--- a/src/main/java/io/vertx/core/streams/impl/InboundReadQueue.java
+++ b/src/main/java/io/vertx/core/streams/impl/InboundReadQueue.java
@@ -175,7 +175,7 @@ public class InboundReadQueue<E> {
       }
       overflow = null;
       if (consume(1) == 0L) {
-        return QUEUE_WRITABLE_MASK;
+        return 0;
       }
       if (maxIter != Long.MAX_VALUE) {
         maxIter--;

--- a/src/main/java/io/vertx/core/streams/impl/InboundReadQueue.java
+++ b/src/main/java/io/vertx/core/streams/impl/InboundReadQueue.java
@@ -1,0 +1,180 @@
+package io.vertx.core.streams.impl;
+
+import io.netty.util.internal.PlatformDependent;
+import io.vertx.core.impl.Arguments;
+
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+
+public class InboundReadQueue<E> {
+
+  /**
+   * Returns the number of times {@link #QUEUE_UNWRITABLE_MASK} signals encoded in {@code value}
+   *
+   * @param value the value
+   * @return then number of unwritable signals
+   */
+  public static int numberOfPendingElements(int value) {
+    return (value & ~0X1) >> 1;
+  }
+
+  public static int drainResult(int num, boolean writable) {
+    return (writable ? QUEUE_WRITABLE_MASK : 0) | (num << 1);
+  }
+
+  /**
+   * The default high-water mark value: {@code 16}
+   */
+  public static final int DEFAULT_HIGH_WATER_MARK = 16;
+
+  /**
+   * The default low-water mark value: {@code 8}
+   */
+  public static final int DEFAULT_LOW_WATER_MARK = 8;
+
+  /**
+   * When the masked bit is set, the caller has acquired the ownership of the queue and must drain it
+   * to attempt to release the ownership.
+   */
+  public static final int DRAIN_REQUIRED_MASK = 0x01;
+
+  /**
+   * When the masked bit is set, the queue became unwritable, this triggers only when the queue transitions
+   * from the <i>writable</i>> state to the <i>unwritable</i>> state.
+   */
+  public static final int QUEUE_UNWRITABLE_MASK = 0x02;
+
+  /**
+   * When the masked bit is set, the queue became writable, this triggers only when the queue transitions
+   * from the <i>unwritable</i>> state to the <i>writable</i> state.
+   */
+  public static final int QUEUE_WRITABLE_MASK = 0x01;
+
+  // NOW
+  // el -> handle content -> dispatch and maybe pause
+  // THEN
+  // el -> dispatch and maybe pause -> handle content with test
+
+  private final long highWaterMark;
+  private final long lowWaterMark;
+  private final AtomicLong wip = new AtomicLong(0L);
+  private final Queue<E> queue = PlatformDependent.newSpscQueue(); // BUT COULD BE REGULAR QUEUE IF SAME CONTEXT THREAD ???
+  private final Predicate<E> consumer;
+
+  // Consumer/Producer thread -> rely on happens-before of task execution
+  private E overflow;
+
+  // Consumer thread
+  private int writeQueueFull;
+
+  public InboundReadQueue(Predicate<E> consumer) {
+    this(consumer, DEFAULT_LOW_WATER_MARK, DEFAULT_HIGH_WATER_MARK);
+  }
+
+  public InboundReadQueue(Predicate<E> consumer, int lowWaterMark, int highWaterMark) {
+    Arguments.require(lowWaterMark >= 0, "The low-water mark must be >= 0");
+    Arguments.require(lowWaterMark <= highWaterMark, "The high-water mark must greater or equals to the low-water mark");
+    this.lowWaterMark = lowWaterMark;
+    this.highWaterMark = highWaterMark;
+    this.consumer = Objects.requireNonNull(consumer);
+  }
+
+  /**
+   * @return the queue high-water mark
+   */
+  public long highWaterMark() {
+    return highWaterMark;
+  }
+
+  /**
+   * @return the queue low-water mark
+   */
+  public long lowWaterMark() {
+    return lowWaterMark;
+  }
+
+  // Producer thread
+  public int add(E element) {
+    if (element == null) {
+      throw new NullPointerException();
+    }
+    if (wip.compareAndSet(0L, 1L)) {
+      overflow = element; // Do we need barrier ? should we always use the queue instead ???
+      return DRAIN_REQUIRED_MASK;
+    } else {
+      queue.offer(element);
+      long val = wip.incrementAndGet();
+      if (val != 1) {
+        return val == highWaterMark ? QUEUE_UNWRITABLE_MASK : 0; // Check branch-less
+      }
+      return DRAIN_REQUIRED_MASK;
+    }
+  }
+
+  // Consumer thread
+
+  /**
+   * Drain the queue
+   *
+   */
+  public int drain() {
+    return drain(Long.MAX_VALUE);
+  }
+
+  /**
+   * Drain the queue
+   *
+   */
+  public int drain(long maxIter) {
+    if (maxIter < 0L) {
+      throw new IllegalArgumentException();
+    }
+    if (maxIter == 0L) {
+      return 0;
+    }
+    E elt = overflow;
+    if (elt != null) {
+      if (!consumer.test(elt)) {
+        return 0;
+      }
+      overflow = null;
+      if (consume(1) == 0L) {
+        return QUEUE_WRITABLE_MASK;
+      }
+      if (maxIter != Long.MAX_VALUE) {
+        maxIter--;
+      }
+    }
+    long pending = wip.get();
+    do {
+      int consumed;
+      for (consumed = 0;consumed < pending && maxIter > 0L;consumed++) {
+        elt = queue.poll();
+        if (maxIter != Long.MAX_VALUE) {
+          maxIter--;
+        }
+        if (!consumer.test(elt)) {
+          overflow = elt;
+          break;
+        }
+      }
+      pending = consume(consumed);
+    } while (pending != 0 && overflow == null && maxIter > 0L);
+    boolean writabilityChanged = pending < lowWaterMark && writeQueueFull > 0;
+    if (writabilityChanged) {
+      writeQueueFull = 0;
+    }
+    return drainResult((int)pending, writabilityChanged);
+  }
+
+  private long consume(int amount) {
+    long pending = wip.addAndGet(-amount);
+    long size = pending + amount;
+    if (size >= highWaterMark && (size - amount) < highWaterMark) {
+      writeQueueFull++;
+    }
+    return pending;
+  }
+}

--- a/src/main/java/io/vertx/core/streams/impl/InboundReadQueue.java
+++ b/src/main/java/io/vertx/core/streams/impl/InboundReadQueue.java
@@ -248,11 +248,11 @@ public abstract class InboundReadQueue<E> {
     E elt = overflow;
     if (elt != null) {
       if (!consumer.test(elt)) {
-        return 0;
+        return drainResult((int)wipGet(), false); // TEST THIS
       }
       overflow = null;
       if (consume(1) == 0L) {
-        return 0;
+        return drainResult(0, false); // WRITABLE => false
       }
       if (maxIter != Long.MAX_VALUE) {
         maxIter--;

--- a/src/main/java/io/vertx/core/streams/impl/InboundReadQueue.java
+++ b/src/main/java/io/vertx/core/streams/impl/InboundReadQueue.java
@@ -273,7 +273,7 @@ public abstract class InboundReadQueue<E> {
       }
       pending = consume(consumed);
     } while (pending != 0 && overflow == null && maxIter > 0L);
-    boolean writabilityChanged = pending < lowWaterMark && writeQueueFull > 0;
+    boolean writabilityChanged = pending < lowWaterMark && writeQueueFull > 0; // SEEMS INCORRECT
     if (writabilityChanged) {
       writeQueueFull = 0;
     }

--- a/src/test/benchmarks/io/vertx/core/http/impl/HttpServerHandlerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/core/http/impl/HttpServerHandlerBenchmark.java
@@ -74,7 +74,7 @@ public class HttpServerHandlerBenchmark extends BenchmarkBase {
 
   static class Alloc implements ByteBufAllocator {
 
-    private final ByteBuf buf = Unpooled.buffer();
+    private final ByteBuf buf = Unpooled.buffer(512);
     private final int capacity = buf.capacity();
 
     @Override
@@ -88,7 +88,7 @@ public class HttpServerHandlerBenchmark extends BenchmarkBase {
       if (initialCapacity <= capacity) {
         return buffer();
       } else {
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("Invalid capacity " + initialCapacity + " > " + capacity);
       }
     }
 

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -3411,7 +3411,7 @@ public abstract class HttpTest extends HttpTestBase {
   @Repeat(times = 16)
   @Test
   public void testServerReadStreamInWorker() throws Exception {
-    int numReq = 16;
+    int numReq = 1;
     waitFor(numReq);
     Buffer body = Buffer.buffer(randomAlphaString(512 * 1024));
     vertx.deployVerticle(new AbstractVerticle() {
@@ -3423,7 +3423,9 @@ public abstract class HttpTest extends HttpTestBase {
             req.response().end();
           }));
           req.pause();
+          System.out.println("pause " + this);
           vertx.setTimer(10, id -> {
+            System.out.println("resume " + this);
             req.resume();
           });
         }).listen(testAddress)

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -3408,6 +3408,7 @@ public abstract class HttpTest extends HttpTestBase {
     await();
   }
 
+  @Repeat(times = 16)
   @Test
   public void testServerReadStreamInWorker() throws Exception {
     int numReq = 16;
@@ -3422,7 +3423,7 @@ public abstract class HttpTest extends HttpTestBase {
             req.response().end();
           }));
           req.pause();
-          vertx.setTimer(250, id -> {
+          vertx.setTimer(10, id -> {
             req.resume();
           });
         }).listen(testAddress)

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -2029,6 +2029,7 @@ public class WebSocketTest extends VertxTestBase {
     testRaceConditionWithWebSocketClient(vertx.getOrCreateContext());
   }
 
+  @Ignore
   @Test
   public void testRaceConditionWithWebSocketClientWorker() throws Exception {
     CompletableFuture<Context> fut = new CompletableFuture<>();
@@ -2140,6 +2141,7 @@ public class WebSocketTest extends VertxTestBase {
     await();
   }
 
+  @Ignore
   @Test
   public void testRaceConditionWithWebSocketClientWorker2() throws Exception {
     int size = getOptions().getWorkerPoolSize() - 4;

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -2164,6 +2164,7 @@ public class WebSocketTest extends VertxTestBase {
     await();
   }
 
+  @Ignore
   @Test
   public void testWorker() {
     waitFor(2);

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -2029,7 +2029,6 @@ public class WebSocketTest extends VertxTestBase {
     testRaceConditionWithWebSocketClient(vertx.getOrCreateContext());
   }
 
-  @Ignore
   @Test
   public void testRaceConditionWithWebSocketClientWorker() throws Exception {
     CompletableFuture<Context> fut = new CompletableFuture<>();
@@ -2141,7 +2140,6 @@ public class WebSocketTest extends VertxTestBase {
     await();
   }
 
-  @Ignore
   @Test
   public void testRaceConditionWithWebSocketClientWorker2() throws Exception {
     int size = getOptions().getWorkerPoolSize() - 4;
@@ -2164,7 +2162,6 @@ public class WebSocketTest extends VertxTestBase {
     await();
   }
 
-  @Ignore
   @Test
   public void testWorker() {
     waitFor(2);

--- a/src/test/java/io/vertx/core/http/impl/Http1xServerConnectionTest.java
+++ b/src/test/java/io/vertx/core/http/impl/Http1xServerConnectionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.impl.VertxHandler;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+public class Http1xServerConnectionTest extends VertxTestBase {
+
+  private static final String HELLO_WORLD = "Hello, world!";
+  private static final Buffer HELLO_WORLD_BUFFER = Buffer.buffer(HELLO_WORLD);
+
+  @Test
+  public void testSimple() {
+
+    Handler<HttpServerRequest> app = request -> {
+      HttpServerResponse response = request.response();
+      response.end(HELLO_WORLD_BUFFER);
+    };
+
+    VertxInternal vertx = (VertxInternal) this.vertx;
+
+    HttpServerOptions options = new HttpServerOptions();
+    EmbeddedChannel vertxChannel = new EmbeddedChannel(
+      new VertxHttpRequestDecoder(options),
+      new VertxHttpResponseEncoder());
+    vertxChannel.config().setAllocator(new HttpServerHandlerBenchmark.Alloc());
+
+    ContextInternal context = vertx.createEventLoopContext(vertxChannel.eventLoop(), null, Thread.currentThread().getContextClassLoader());
+
+
+    VertxHandler<Http1xServerConnection> handler = VertxHandler.create(chctx -> {
+      Http1xServerConnection conn = new Http1xServerConnection(
+        () -> context,
+        null,
+        new HttpServerOptions(),
+        chctx,
+        context,
+        "localhost",
+        null);
+      conn.handler(app);
+      return conn;
+    });
+    vertxChannel.pipeline().addLast("handler", handler);
+
+    ByteBuf GET = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer((
+      "GET / HTTP/1.1\r\n" +
+        "\r\n").getBytes()));
+    vertxChannel.writeInbound(GET);
+    vertxChannel.outboundMessages().poll();
+
+  }
+
+}

--- a/src/test/java/io/vertx/core/net/impl/ConnectionBaseTest.java
+++ b/src/test/java/io/vertx/core/net/impl/ConnectionBaseTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -512,5 +513,116 @@ public class ConnectionBaseTest extends VertxTestBase {
       ContextInternal ctx = ((VertxInternal)vertx).createEventLoopContext(chctx.channel().eventLoop(), null, null);
       return connectionFactory.apply(ctx, chctx);
     }));
+  }
+
+  private class TestConnection extends VertxConnection {
+    Handler<Message> handler;
+    public TestConnection(ChannelHandlerContext chctx) {
+      super(((VertxInternal)ConnectionBaseTest.this.vertx)
+        .createEventLoopContext((EventLoop) chctx.executor(), null, null), chctx);
+    }
+    @Override
+    protected void handleMessage(Object msg) {
+      Handler<Message> h = handler;
+      if (h != null) {
+        h.handle((Message) msg);
+      }
+    }
+
+    public void pause() {
+      doPause();
+    }
+
+    public void resume() {
+      chctx.executor().execute(this::doResume);
+    }
+  }
+
+  static class Message {
+    final String id;
+    Message(String id) {
+      this.id = id;
+    }
+  }
+
+  static class MessageFactory {
+    int seq = 0;
+    Message next() {
+      return new Message("msg-" + seq++);
+    }
+    Message[] next(int num) {
+      Message[] messages = new Message[num];
+      for (int i = 0;i < num;i++) {
+        messages[i] = next();
+      }
+      return messages;
+    }
+  }
+
+  @Test
+  public void testDisableAutoReadWhenPaused() {
+    List<Object> receivedMessages = new ArrayList<>();
+    MessageFactory factory = new MessageFactory();
+    EmbeddedChannel ch = new EmbeddedChannel();
+    ChannelPipeline pipeline = ch.pipeline();
+    pipeline.addLast(VertxHandler.create(chctx -> new TestConnection(chctx)));
+    TestConnection connection = (TestConnection) pipeline.get(VertxHandler.class).getConnection();
+    connection.handler = receivedMessages::add;
+    connection.pause();
+    ch.writeInbound((Object[])factory.next(8));
+    assertEquals(Collections.emptyList(), receivedMessages);
+    assertFalse(ch.config().isAutoRead());
+  }
+
+  @Test
+  public void testConsolidatesFlushesWhenResuming() {
+    MessageFactory factory = new MessageFactory();
+    EmbeddedChannel ch = new EmbeddedChannel() {
+    };
+    ChannelPipeline pipeline = ch.pipeline();
+    pipeline.addLast(VertxHandler.create(chctx -> new TestConnection(chctx)));
+    TestConnection connection = (TestConnection) pipeline.get(VertxHandler.class).getConnection();
+    connection.pause();
+    ch.writeInbound((Object[])factory.next(8));
+    assertFalse(ch.config().isAutoRead());
+    connection.resume();
+    assertTrue(ch.hasPendingTasks());
+    connection.handler = msg -> {
+      connection.writeToChannel(msg);
+      // Try to consume the messages (if it was flushed)
+      while (ch.readOutbound() != null) {
+
+      }
+    };
+    ch.runPendingTasks();
+    List<Object> flushed = new ArrayList<>();
+    Object outbound;
+    while ((outbound = ch.readOutbound()) != null) {
+      flushed.add(outbound);
+    }
+    assertEquals(8, flushed.size());
+    assertTrue(ch.config().isAutoRead());
+  }
+
+  @Test
+  public void testPauseWhenResuming() {
+    MessageFactory factory = new MessageFactory();
+    EmbeddedChannel ch = new EmbeddedChannel() {
+    };
+    ChannelPipeline pipeline = ch.pipeline();
+    pipeline.addLast(VertxHandler.create(chctx -> new TestConnection(chctx)));
+    TestConnection connection = (TestConnection) pipeline.get(VertxHandler.class).getConnection();
+    connection.pause();
+    ch.writeInbound((Object[])factory.next(4));
+    connection.resume();
+    assertTrue(ch.hasPendingTasks());
+    AtomicInteger count = new AtomicInteger();
+    connection.handler = event -> {
+      if (count.incrementAndGet() == 2) {
+        connection.pause();
+      }
+    };
+    ch.runPendingTasks();
+    assertEquals(2, count.get());
   }
 }

--- a/src/test/java/io/vertx/core/streams/InboundMessageQueueTest.java
+++ b/src/test/java/io/vertx/core/streams/InboundMessageQueueTest.java
@@ -1,0 +1,779 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.streams;
+
+import io.netty.channel.EventLoop;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.net.impl.InboundMessageQueue;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntConsumer;
+
+public class InboundMessageQueueTest extends VertxTestBase {
+
+  private volatile Runnable contextChecker;
+  private Context context;
+  private Bilto buffer;
+  private AtomicInteger sequence;
+
+  class Bilto extends InboundMessageQueue<Integer> {
+
+    final IntConsumer consumer;
+    private Handler<Void> drainHandler;
+    private boolean writable;
+    private int size;
+
+    public Bilto(IntConsumer consumer) {
+      super(((ContextInternal) context).nettyEventLoop(), (ContextInternal) context);
+      this.consumer = consumer;
+      this.writable = true;
+    }
+
+    public Bilto(IntConsumer consumer, int lwm, int hwm) {
+      super(((ContextInternal) context).nettyEventLoop(), (ContextInternal) context, lwm, hwm);
+      this.consumer = consumer;
+      this.writable = true;
+    }
+
+    int size() {
+      return size;
+    }
+
+    @Override
+    protected void handleMessage(Integer msg) {
+      size--;
+      consumer.accept(msg);
+    }
+
+    @Override
+    protected void handleResume() {
+      writable = true;
+      Handler<Void> handler = drainHandler;
+      if (handler != null) {
+        handler.handle(null);
+      }
+    }
+
+    @Override
+    protected void handlePause() {
+      writable = false;
+    }
+
+    final void resume() {
+      fetch(Long.MAX_VALUE);
+    }
+
+    final int fill() {
+      int count = 0;
+      boolean drain = false;
+      while (writable) {
+        drain |= add(sequence.getAndIncrement());
+        count++;
+      }
+      size += count;
+      if (drain) {
+        drain();
+      }
+      return count;
+    }
+
+    final boolean emit() {
+      size++;
+      write(sequence.getAndIncrement());
+      return writable;
+    }
+
+    final boolean emit(int count) {
+      size += count;
+      boolean drain = false;
+      for (int i = 0; i < count; i++) {
+        drain |= add(sequence.getAndIncrement());
+      }
+      if (drain) {
+        drain();
+      }
+      return writable;
+    }
+
+    Bilto drainHandler(Handler<Void> handler) {
+      this.drainHandler = handler;
+      return this;
+    }
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    context = vertx.getOrCreateContext();
+    sequence = new AtomicInteger();
+    context.runOnContext(v -> {
+      Thread contextThread = Thread.currentThread();
+      contextChecker = () -> {
+        assertSame(contextThread, Thread.currentThread());
+      };
+    });
+    waitUntil(() -> contextChecker != null);
+  }
+
+  public void tearDown() throws Exception {
+    super.tearDown();
+  }
+
+  private void checkContext() {
+    contextChecker.run();
+  }
+
+  @Test
+  public void testFlowing() {
+    context.runOnContext(v -> {
+      AtomicInteger events = new AtomicInteger();
+      buffer = buffer(elt -> {
+        checkContext();
+        assertEquals(0, elt);
+        assertEquals(0, events.getAndIncrement());
+        testComplete();
+      });
+      assertTrue(buffer.emit());
+    });
+    await();
+  }
+
+  private Bilto buffer(IntConsumer consumer) {
+    return new Bilto(consumer);
+  }
+
+  private Bilto buffer(IntConsumer consumer, int lwm, int hwm) {
+    return new Bilto(consumer, lwm, hwm);
+  }
+
+  @Test
+  public void testTake() {
+    context.runOnContext(v -> {
+      AtomicInteger events = new AtomicInteger();
+      buffer = buffer(elt -> {
+        checkContext();
+        assertEquals(0, elt);
+        assertEquals(0, events.getAndIncrement());
+        testComplete();
+      });
+      buffer.pause();
+      buffer.fetch(1);
+      assertTrue(buffer.emit());
+    });
+    await();
+  }
+
+  @Test
+  public void testFlowingAdd() {
+    context.runOnContext(v -> {
+      AtomicInteger events = new AtomicInteger();
+      buffer = buffer(elt -> {
+        checkContext();
+        events.getAndIncrement();
+      });
+      assertTrue(buffer.emit());
+      assertEquals(1, events.get());
+      assertTrue(buffer.emit());
+      assertEquals(2, events.get());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testFlowingRefill() {
+    context.runOnContext(v1 -> {
+      AtomicInteger events = new AtomicInteger();
+      buffer = buffer(elt -> {
+        checkContext();
+        events.getAndIncrement();
+      }, 5, 5).drainHandler(v -> {
+        checkContext();
+        assertEquals(8, events.get());
+        testComplete();
+      });
+      buffer.pause();
+      for (int i = 0; i < 8; i++) {
+        assertEquals("Expected " + i + " to be bilto", i < 4, buffer.emit());
+      }
+      buffer.resume();
+    });
+    await();
+  }
+
+  @Test
+  public void testPauseWhenFull() {
+    context.runOnContext(v1 -> {
+      AtomicInteger events = new AtomicInteger();
+      AtomicInteger reads = new AtomicInteger();
+      buffer = buffer(elt -> {
+        checkContext();
+        assertEquals(0, reads.get());
+        assertEquals(0, events.getAndIncrement());
+        testComplete();
+      }, 5, 5).drainHandler(v2 -> {
+        checkContext();
+        assertEquals(0, reads.getAndIncrement());
+      });
+      buffer.pause();
+      for (int i = 0; i < 5; i++) {
+        assertEquals(i < 4, buffer.emit());
+      }
+      buffer.fetch(1);
+    });
+    await();
+  }
+
+  @Test
+  public void testPausedResume() {
+    context.runOnContext(v1 -> {
+      AtomicInteger reads = new AtomicInteger();
+      AtomicInteger events = new AtomicInteger();
+      buffer = buffer(elt -> {
+        checkContext();
+        events.getAndIncrement();
+      }, 5, 5).drainHandler(v2 -> {
+        checkContext();
+        assertEquals(0, reads.getAndIncrement());
+        assertEquals(5, events.get());
+        testComplete();
+      });
+      buffer.pause();
+      buffer.fill();
+      buffer.resume();
+    });
+    await();
+  }
+
+  @Test
+  public void testPausedDrain() {
+    waitFor(2);
+    context.runOnContext(v1 -> {
+      AtomicInteger drained = new AtomicInteger();
+      AtomicInteger emitted = new AtomicInteger();
+      buffer = buffer(elt -> {
+        checkContext();
+        assertEquals(0, drained.get());
+        emitted.getAndIncrement();
+      }, 5, 5);
+      buffer.drainHandler(v2 -> {
+        checkContext();
+        assertEquals(0, drained.getAndIncrement());
+        assertEquals(5, emitted.get());
+        complete();
+      });
+      buffer.pause();
+      buffer.fill();
+      assertEquals(0, drained.get());
+      assertEquals(0, emitted.get());
+      buffer.resume();
+      complete();
+    });
+    await();
+  }
+
+  @Test
+  public void testPausedRequestLimited() {
+    context.runOnContext(v1 -> {
+      AtomicInteger events = new AtomicInteger();
+      AtomicInteger reads = new AtomicInteger();
+      buffer = buffer(elt -> {
+        checkContext();
+        events.getAndIncrement();
+      }, 3, 3)
+        .drainHandler(v2 -> {
+          checkContext();
+          assertEquals(0, reads.getAndIncrement());
+        });
+      buffer.pause();
+      buffer.fetch(1);
+      assertEquals(0, reads.get());
+      assertEquals(0, events.get());
+      assertTrue(buffer.emit());
+      assertEquals(0, reads.get());
+      waitUntilEquals(1, events::get);
+      assertTrue(buffer.emit());
+      assertEquals(0, reads.get());
+      assertEquals(1, events.get());
+      assertTrue(buffer.emit());
+      assertEquals(0, reads.get());
+      assertEquals(1, events.get());
+      assertFalse(buffer.emit());
+      assertEquals(0, reads.get());
+      assertEquals(1, events.get());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testPushReturnsTrueUntilHighWatermark() {
+    context.runOnContext(v1 -> {
+      buffer = buffer(elt -> {
+
+      }, 2, 2);
+      buffer.pause();
+      buffer.fetch(1);
+      assertTrue(buffer.emit());
+      assertTrue(buffer.emit());
+      assertFalse(buffer.emit());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testHighWaterMark() {
+    context.runOnContext(v -> {
+      buffer = buffer(elt -> {
+      }, 5, 5);
+      buffer.pause();
+      buffer.fill();
+      assertEquals(5, sequence.get());
+      testComplete();
+    });
+    await();
+  }
+
+  /*
+
+    @Test
+    public void testEmptyHandler() {
+      context.runOnContext(v1 -> {
+        buffer = new InboundBuffer<>(context, 4L);
+        AtomicInteger emptyCount = new AtomicInteger();
+        AtomicInteger itemCount = new AtomicInteger();
+        buffer.handler(item -> itemCount.incrementAndGet());
+        buffer.emptyHandler(v2 -> {
+          assertEquals(0, emptyCount.getAndIncrement());
+          testComplete();
+        });
+        assertTrue(emit());
+        assertEquals(1, itemCount.get());
+        buffer.pause();
+        assertTrue(emit());
+        assertTrue(emit());
+        assertTrue(emit());
+        assertEquals(1, itemCount.get());
+        assertFalse(buffer.isEmpty());
+        for (int i = 0;i < 3;i++) {
+          assertEquals(0, emptyCount.get());
+          buffer.fetch(1);
+        }
+      });
+      await();
+    }
+  */
+  @Test
+  public void testEmitWhenHandlingLastItem() {
+    context.runOnContext(v1 -> {
+      int next = sequence.get();
+      AtomicInteger received = new AtomicInteger(next);
+      AtomicInteger writable = new AtomicInteger();
+      buffer = buffer(elt -> {
+        if (received.decrementAndGet() == 0) {
+          buffer.write(next);
+        }
+      }, 4, 4)
+        .drainHandler(v2 -> {
+          writable.incrementAndGet();
+        });
+      buffer.pause();
+      buffer.fill();
+      buffer.fetch(sequence.get());
+      assertEquals(0, writable.get());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testEmitInElementHandler() {
+    context.runOnContext(v1 -> {
+      AtomicInteger events = new AtomicInteger();
+      AtomicBoolean receiving = new AtomicBoolean();
+      buffer = buffer(elt -> {
+        checkContext();
+        assertFalse(receiving.getAndSet(true));
+        events.incrementAndGet();
+        if (elt == 0) {
+          buffer.fill();
+        }
+        receiving.set(false);
+      }, 5, 5);
+      buffer.pause();
+      buffer.fetch(1);
+      assertFalse(buffer.emit());
+      assertEquals(5 - 1, buffer.size());
+      assertEquals(1, events.get());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testEmitInElementHandler1() {
+    testEmitInElementHandler(n -> {
+      assertFalse(buffer.emit(n));
+    });
+  }
+
+/*
+  @Test
+  public void testEmitInElementHandler2() {
+    testEmitInElementHandler(n -> {
+      for (int i = 0;i < n - 1;i++) {
+        assertTrue(buffer.emit());
+      }
+      assertFalse(buffer.emit());
+    });
+  }
+*/
+
+  private void testEmitInElementHandler(IntConsumer emit) {
+    context.runOnContext(v1 -> {
+      AtomicInteger events = new AtomicInteger();
+      AtomicInteger drained = new AtomicInteger();
+      AtomicBoolean draining = new AtomicBoolean();
+      buffer = buffer(elt -> {
+        checkContext();
+        switch (elt) {
+          case 5:
+            // Emitted in drain handler
+            emit.accept(9);
+            break;
+          case 9:
+            vertx.runOnContext(v2 -> {
+              assertEquals(1, drained.get());
+              assertEquals(10, events.get());
+              assertEquals(5, buffer.size());
+              testComplete();
+            });
+            break;
+        }
+        events.incrementAndGet();
+      }, 5, 5);
+      buffer.drainHandler(v3 -> {
+        // Check reentrancy
+        assertFalse(draining.get());
+        draining.set(true);
+        assertEquals(0, drained.getAndIncrement());
+        assertFalse(buffer.emit());
+        draining.set(false);
+      });
+      buffer.pause();
+      buffer.fill();
+      buffer.fetch(10);
+    });
+    await();
+  }
+
+  @Test
+  public void testEmitInDrainHandler1() {
+    context.runOnContext(v1 -> {
+      AtomicInteger drained = new AtomicInteger();
+      AtomicInteger expectedDrained = new AtomicInteger();
+      buffer = buffer(elt -> {
+        if (elt == 0) {
+          // This will set writable to false
+          buffer.fill();
+        }
+        assertEquals(expectedDrained.get(), drained.get());
+      }, 4, 4)
+        .drainHandler(v2 -> {
+          switch (drained.getAndIncrement()) {
+            case 0:
+              // Check that emitting again will not drain again
+              expectedDrained.set(1);
+              buffer.fill();
+              assertEquals(1, drained.get());
+              testComplete();
+              break;
+          }
+        });
+      buffer.pause();
+      buffer.fetch(1);
+      buffer.emit();
+      buffer.fetch(4L);
+    });
+    await();
+  }
+
+  @Test
+  public void testEmitInDrainHandler2() {
+    waitFor(2);
+    context.runOnContext(v1 -> {
+      AtomicInteger drained = new AtomicInteger();
+      AtomicBoolean draining = new AtomicBoolean();
+      AtomicInteger emitted = new AtomicInteger();
+      buffer = buffer(elt -> {
+        emitted.incrementAndGet();
+        if (elt == 0) {
+          assertEquals(0, drained.get());
+        } else if (elt == 6) {
+          assertEquals(1, drained.get());
+        }
+      }, 5, 5)
+        .drainHandler(v2 -> {
+          assertFalse(draining.get());
+          draining.set(true);
+          switch (drained.getAndIncrement()) {
+            case 0:
+              // This will trigger a new asynchronous drain
+              buffer.fill();
+              buffer.fetch(5);
+              break;
+            case 1:
+              assertEquals(10, emitted.get());
+              complete();
+              break;
+          }
+          draining.set(false);
+        });
+      buffer.pause();
+      buffer.fill();
+      buffer.fetch(5);
+      complete();
+    });
+    await();
+  }
+
+  @Test
+  public void testDrainAfter() {
+    context.runOnContext(v1 -> {
+      AtomicInteger events = new AtomicInteger();
+      AtomicBoolean receiving = new AtomicBoolean();
+      buffer = buffer(elt -> {
+        checkContext();
+        assertFalse(receiving.getAndSet(true));
+        events.incrementAndGet();
+        if (elt == 0) {
+          buffer.emit(5);
+        }
+        receiving.set(false);
+      }, 5, 5);
+      assertFalse(buffer.emit());
+      assertEquals(6, sequence.get());
+      assertEquals(6, events.get());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testPauseInElementHandler() {
+    context.runOnContext(v1 -> {
+      AtomicInteger events = new AtomicInteger();
+      buffer = buffer(elt -> {
+        events.incrementAndGet();
+        if (elt == 0) {
+          buffer.pause();
+          buffer.fill();
+        }
+      }, 5, 5);
+      assertFalse(buffer.emit());
+      assertEquals(1, events.get());
+      assertEquals(5 - 1, buffer.size());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testAddAllEmitInHandler() {
+    context.runOnContext(v1 -> {
+      List<Integer> emitted = new ArrayList<>();
+      buffer = buffer(elt -> {
+        switch (elt) {
+          case 0:
+            buffer.emit();
+        }
+        emitted.add(elt);
+      }, 4, 4);
+      assertFalse(buffer.emit(3));
+      assertEquals(Arrays.asList(0, 1, 2, 3), emitted);
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testAddAllWhenPaused() {
+    waitFor(2);
+    context.runOnContext(v1 -> {
+      AtomicInteger emitted = new AtomicInteger();
+      AtomicInteger emptied = new AtomicInteger();
+      AtomicInteger drained = new AtomicInteger();
+      buffer = buffer(elt -> {
+        emitted.incrementAndGet();
+        assertEquals(0, drained.get());
+        assertEquals(0, emptied.get());
+        buffer.fetch(1);
+      }, 4, 4)
+        .drainHandler(v2 -> {
+          assertEquals(5, emitted.get());
+          drained.incrementAndGet();
+          complete();
+        });
+      buffer.pause();
+      assertFalse(buffer.emit(5));
+      buffer.fetch(1);
+      complete();
+    });
+    await();
+  }
+
+  @Test
+  public void testAddAllWhenFlowing() {
+    context.runOnContext(v1 -> {
+      AtomicInteger emitted = new AtomicInteger();
+      AtomicInteger drained = new AtomicInteger();
+      buffer = buffer(elt -> {
+        emitted.incrementAndGet();
+      }, 4, 4)
+        .drainHandler(v2 -> drained.incrementAndGet());
+      assertFalse(buffer.emit(4));
+      context.runOnContext(v -> {
+        waitUntilEquals(1, drained::get);
+        waitUntilEquals(4, emitted::get);
+        testComplete();
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testAddAllWhenDelivering() {
+    context.runOnContext(v1 -> {
+      List<Integer> emitted = new ArrayList<>();
+      buffer = buffer(elt -> {
+        emitted.add(elt);
+        if (elt == 2) {
+          buffer.write(Arrays.asList(4, 5));
+          // Check that we haven't re-entered the handler
+          assertEquals(Arrays.asList(0, 1, 2), emitted);
+        }
+      }, 4, 4);
+      buffer.emit(4);
+      assertEquals(Arrays.asList(0, 1, 2, 3, 4, 5), emitted);
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testCheckThatPauseAfterResumeWontDoAnyEmission() {
+    context.runOnContext(v1 -> {
+      AtomicInteger emitted = new AtomicInteger();
+      buffer = buffer(elt -> emitted.incrementAndGet(), 4, 4);
+      buffer.pause();
+      buffer.fill();
+      // Resume will execute an asynchronous drain operation
+      buffer.resume();
+      // Pause just after to ensure that no elements will be delivered to he handler
+      buffer.pause();
+      // Give enough time to have elements delivered
+      vertx.setTimer(20, id -> {
+        // Check we haven't received anything
+        assertEquals(0, emitted.get());
+        testComplete();
+      });
+    });
+    await();
+  }
+/*
+
+
+  @Test
+  public void testBufferSignalingFullImmediately() {
+    context.runOnContext(v1 -> {
+      buffer = new InboundBuffer<>(context, 0L);
+      List<Integer> emitted = new ArrayList<>();
+      buffer.drainHandler(v -> {
+        assertEquals(Arrays.asList(0, 1), emitted);
+        testComplete();
+      });
+      buffer.handler(emitted::add);
+      assertTrue(emit());
+      assertEquals(Collections.singletonList(0), emitted);
+      buffer.pause();
+      assertFalse(emit());
+      buffer.resume();
+    });
+    await();
+  }
+
+  @Test
+  public void testPauseInHandlerSignalsFullImmediately() {
+    context.runOnContext(v -> {
+      buffer = new InboundBuffer<>(context, 0);
+      buffer.handler(elt -> {
+        checkContext();
+        buffer.pause();
+      });
+      assertFalse(emit());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testFetchWhenNotEmittingWithNoPendingElements() {
+    context.runOnContext(v1 -> {
+      buffer = new InboundBuffer<>(context, 0);
+      AtomicInteger drained = new AtomicInteger();
+      buffer.drainHandler(v2 -> {
+        context.runOnContext(v -> {
+          assertEquals(0, drained.getAndIncrement());
+          testComplete();
+        });
+      });
+      buffer.emptyHandler(v -> {
+        fail();
+      });
+      buffer.handler(elt -> {
+        checkContext();
+        switch (elt) {
+          case 0:
+            buffer.pause();
+            break;
+        }
+      });
+      assertFalse(emit());
+      buffer.fetch(1);
+    });
+    await();
+  }
+
+  @Test
+  public void testRejectWrongThread() {
+    buffer = new InboundBuffer<>(context);
+    try {
+      buffer.write(0);
+      fail();
+    } catch (IllegalStateException ignore) {
+    }
+    try {
+      buffer.write(Arrays.asList(0, 1, 2));
+      fail();
+    } catch (IllegalStateException ignore) {
+    }
+  }
+*/
+}

--- a/src/test/java/io/vertx/core/streams/InboundReadQueueTest.java
+++ b/src/test/java/io/vertx/core/streams/InboundReadQueueTest.java
@@ -22,6 +22,13 @@ public class InboundReadQueueTest extends AsyncTestBase {
   }
 
   @Test
+  public void testDrainSingle() {
+    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> true);
+    assertEquals(InboundReadQueue.DRAIN_REQUIRED_MASK, queue.add(0));
+    assertEquals(InboundReadQueue.drainResult(0, false), queue.drain(17));
+  }
+
+  @Test
   public void testFoo() {
     InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> false);
     assertEquals(InboundReadQueue.DRAIN_REQUIRED_MASK, queue.add(0));

--- a/src/test/java/io/vertx/core/streams/InboundReadQueueTest.java
+++ b/src/test/java/io/vertx/core/streams/InboundReadQueueTest.java
@@ -1,0 +1,126 @@
+package io.vertx.core.streams;
+
+import io.vertx.core.streams.impl.InboundReadQueue;
+import io.vertx.test.core.AsyncTestBase;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.vertx.core.streams.impl.InboundReadQueue.drainResult;
+
+public class InboundReadQueueTest extends AsyncTestBase {
+
+  @Test
+  public void testAdd() {
+    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> false);
+    assertEquals(InboundReadQueue.DRAIN_REQUIRED_MASK, queue.add(0));
+    for (int i = 1;i < 15;i++) {
+      assertEquals(0L, queue.add(i));
+    }
+    assertEquals(InboundReadQueue.QUEUE_UNWRITABLE_MASK, queue.add(17));
+  }
+
+  @Test
+  public void testFoo() {
+    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> false);
+    assertEquals(InboundReadQueue.DRAIN_REQUIRED_MASK, queue.add(0));
+    assertEquals(drainResult(0, false), queue.drain());
+  }
+
+  @Test
+  public void testDrainFully() {
+    LinkedList<Integer> consumed = new LinkedList<>();
+    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> {
+      consumed.add(elt);
+      return true;
+    });
+    assertEquals(InboundReadQueue.DRAIN_REQUIRED_MASK, queue.add(0));
+    int idx = 1;
+    while ((queue.add(idx++) & InboundReadQueue.QUEUE_UNWRITABLE_MASK) == 0) {
+      //
+    }
+    assertEquals(16, idx);
+    assertEquals(drainResult(0, true), queue.drain());
+    for (int i = 0;i < 16;i++) {
+      assertEquals(i, (int)consumed.poll());
+    }
+    assertTrue(consumed.isEmpty());
+  }
+
+  @Test
+  public void testConsumeDrain() {
+    AtomicInteger demand = new AtomicInteger(0);
+    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> {
+      if (demand.get() > 0) {
+        demand.decrementAndGet();
+        return true;
+      }
+      return false;
+    });
+    assertEquals(InboundReadQueue.DRAIN_REQUIRED_MASK, queue.add(0));
+    int idx = 1;
+    while ((queue.add(idx++) & InboundReadQueue.QUEUE_UNWRITABLE_MASK) == 0) {
+      //
+    }
+    assertEquals(16, idx);
+    for (int i = 0;i < 8;i++) {
+      demand.set(1);
+      assertEquals(drainResult((15 - i), false), queue.drain());
+    }
+    demand.set(1);
+    assertEquals(drainResult(7, true), queue.drain());
+  }
+
+  @Test
+  public void testPartialDrain() {
+    AtomicInteger demand = new AtomicInteger(0);
+    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> true);
+    int idx = 0;
+    while ((queue.add(idx++) & InboundReadQueue.QUEUE_UNWRITABLE_MASK) == 0) {
+      //
+    }
+    assertEquals(16, idx);
+    assertEquals(drainResult(12, false), queue.drain(4));
+    assertEquals(drainResult(7, true), queue.drain(5));
+    assertEquals(drainResult(0, false), queue.drain());
+  }
+
+  @Test
+  public void testUnwritableCount() {
+    AtomicInteger demand = new AtomicInteger();
+    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt-> {
+      if (demand.get() > 0) {
+        demand.decrementAndGet();
+        return true;
+      } else {
+        return false;
+      }
+    });
+    int count = 0;
+    while (true) {
+      if ((queue.add(count++) & InboundReadQueue.QUEUE_UNWRITABLE_MASK) != 0) {
+        break;
+      }
+    }
+    demand.set(1);
+    assertEquals(drainResult(15, false), queue.drain());
+    assertFlagsSet(queue.add(count++), InboundReadQueue.QUEUE_UNWRITABLE_MASK);
+    demand.set(count - 1);
+    int flags = queue.drain();
+    assertFlagsSet(flags, InboundReadQueue.QUEUE_WRITABLE_MASK);
+    assertEquals(0, InboundReadQueue.numberOfPendingElements(flags));
+  }
+
+  private void assertFlagsSet(int flags, int... masks) {
+    for (int mask : masks) {
+      assertTrue("Expecting flag " + Integer.toBinaryString(mask) + " to be set", (flags & mask) != 0);
+    }
+  }
+
+  private void assertFlagsClear(int flags, int... masks) {
+    for (int mask : masks) {
+      assertTrue("Expecting flag " + Integer.toBinaryString(mask) + " to be clear", (flags & mask) == 0);
+    }
+  }
+}

--- a/src/test/java/io/vertx/core/streams/InboundReadQueueTest.java
+++ b/src/test/java/io/vertx/core/streams/InboundReadQueueTest.java
@@ -11,9 +11,11 @@ import static io.vertx.core.streams.impl.InboundReadQueue.drainResult;
 
 public class InboundReadQueueTest extends AsyncTestBase {
 
+  final InboundReadQueue.Factory factory = InboundReadQueue.SPSC;
+
   @Test
   public void testAdd() {
-    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> false);
+    InboundReadQueue<Integer> queue = factory.create(elt -> false);
     assertEquals(InboundReadQueue.DRAIN_REQUIRED_MASK, queue.add(0));
     for (int i = 1;i < 15;i++) {
       assertEquals(0L, queue.add(i));
@@ -23,14 +25,14 @@ public class InboundReadQueueTest extends AsyncTestBase {
 
   @Test
   public void testDrainSingle() {
-    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> true);
+    InboundReadQueue<Integer> queue = factory.create(elt -> true);
     assertEquals(InboundReadQueue.DRAIN_REQUIRED_MASK, queue.add(0));
     assertEquals(InboundReadQueue.drainResult(0, false), queue.drain(17));
   }
 
   @Test
   public void testFoo() {
-    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> false);
+    InboundReadQueue<Integer> queue = factory.create(elt -> false);
     assertEquals(InboundReadQueue.DRAIN_REQUIRED_MASK, queue.add(0));
     assertEquals(drainResult(0, false), queue.drain());
   }
@@ -38,7 +40,7 @@ public class InboundReadQueueTest extends AsyncTestBase {
   @Test
   public void testDrainFully() {
     LinkedList<Integer> consumed = new LinkedList<>();
-    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> {
+    InboundReadQueue<Integer> queue = factory.create(elt -> {
       consumed.add(elt);
       return true;
     });
@@ -58,7 +60,7 @@ public class InboundReadQueueTest extends AsyncTestBase {
   @Test
   public void testConsumeDrain() {
     AtomicInteger demand = new AtomicInteger(0);
-    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> {
+    InboundReadQueue<Integer> queue = factory.create(elt -> {
       if (demand.get() > 0) {
         demand.decrementAndGet();
         return true;
@@ -82,7 +84,7 @@ public class InboundReadQueueTest extends AsyncTestBase {
   @Test
   public void testPartialDrain() {
     AtomicInteger demand = new AtomicInteger(0);
-    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt -> true);
+    InboundReadQueue<Integer> queue = factory.create(elt -> true);
     int idx = 0;
     while ((queue.add(idx++) & InboundReadQueue.QUEUE_UNWRITABLE_MASK) == 0) {
       //
@@ -96,7 +98,7 @@ public class InboundReadQueueTest extends AsyncTestBase {
   @Test
   public void testUnwritableCount() {
     AtomicInteger demand = new AtomicInteger();
-    InboundReadQueue<Integer> queue = new InboundReadQueue<>(elt-> {
+    InboundReadQueue<Integer> queue = factory.create(elt-> {
       if (demand.get() > 0) {
         demand.decrementAndGet();
         return true;

--- a/src/test/java/io/vertx/core/streams/InboundReadQueueTest.java
+++ b/src/test/java/io/vertx/core/streams/InboundReadQueueTest.java
@@ -34,7 +34,7 @@ public class InboundReadQueueTest extends AsyncTestBase {
   public void testFoo() {
     InboundReadQueue<Integer> queue = factory.create(elt -> false);
     assertEquals(InboundReadQueue.DRAIN_REQUIRED_MASK, queue.add(0));
-    assertEquals(drainResult(0, false), queue.drain());
+    assertEquals(drainResult(1, false), queue.drain());
   }
 
   @Test
@@ -55,6 +55,13 @@ public class InboundReadQueueTest extends AsyncTestBase {
       assertEquals(i, (int)consumed.poll());
     }
     assertTrue(consumed.isEmpty());
+  }
+
+  @Test
+  public void testDrainRefuseSingleElement() {
+    InboundReadQueue<Integer> queue = factory.create(elt -> false);
+    assertEquals(InboundReadQueue.DRAIN_REQUIRED_MASK, queue.add(0));
+    assertEquals(drainResult(1, false), queue.drain());
   }
 
   @Test

--- a/src/test/java/io/vertx/test/core/TestUtils.java
+++ b/src/test/java/io/vertx/test/core/TestUtils.java
@@ -37,6 +37,7 @@ import javax.security.cert.X509Certificate;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.util.NetUtil;
+import io.netty.util.internal.ThreadLocalRandom;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
@@ -118,13 +119,17 @@ public class TestUtils {
    */
   public static byte[] randomByteArray(int length, boolean avoid, byte avoidByte) {
     byte[] line = new byte[length];
-    for (int i = 0; i < length; i++) {
-      byte rand;
-      do {
-        rand = randomByte();
-      } while (avoid && rand == avoidByte);
+    if (avoid) {
+      for (int i = 0; i < length; i++) {
+        byte rand;
+        do {
+          rand = randomByte();
+        } while (rand == avoidByte);
 
-      line[i] = rand;
+        line[i] = rand;
+      }
+    } else {
+      ThreadLocalRandom.current().nextBytes(line);
     }
     return line;
   }


### PR DESCRIPTION

The Vert.x event-loop thread to context thread message transfer relies on the `InboundBuffer` implementation.

`InboundBuffer` performs the add/dispatch in the same method call assuming that the same thread actually handles the dispatch of the message, forcing the dispatch to then schedule the message delivery on the context thread.

## Inbound read queue

The `InboundReadQueue` design actually split this operation in two separate operations providing control to the caller of the message dispatch.

- the `add` operation queues a message and let the producer knows whether messages should be drained from the queue (e.g. if a drain operation is already in progress, then there is no need to schedule another drain).
- the `drain` operation let consumer consume messages from the queue until needed

The event-loop to context message dispatch then becomes:

1. add the message to the queue
2. ping the context thread to drain the queue

### Event-loop thread dispatch

In this use case, the `InboundReadQueue` assumes the same thread is producing/consuming messages and therefore no memory visibility is actually required. In practice the event-loop add to the queue and then drain delivers the message to the connection.

### Generic context thread dispatch

In this use case, the queue will be drained by the context thread and an SPSC + volatile WIP is used. This behaviour also can optimise the message delivery since we don't need anymore a message received ⇒ scheduling a task, the event-loop thread and the context thread can work in an SPSC consumer design.

This use case holds for:

- another event-loop thread (pooled HTTP client connection)
- worker thread
- virtual thread

## Back pressure

The context thread message deals controls the back-pressure and cannot control the inbound channel back-pressure without races. Like Like the `OutboundWriteQueue`, the `InboundReadQueue` relies on an internal buffer and the queue acts as an intermediary for back-pressure.

- the producer `add` operation signals when the queue becomes un-writable (e.g. it turns off Netty auto-read)
- the consumer consumes messages, when messages are consumed it is responsible to signal the queue is writable again

## Inbound message queue

The `InboundMessageQueue` is a construct integrating the `InboundReadQueue` with the Vert.x context and a demand counter (`ReadStream`). The consumer deals with `pause`/`resume`/`fetch` to control demand, the producer implements the message flow pause/resume. This queue is the `InboundBuffer` replacement.

## ConnectionBase message flow changes

`doPause`/`doResume` of `ConnectionBase` has been rewritten to be strict concerning the delivery of messages. Previously these operations were turning on/off channel auto read, however this was not controlling the reads in progress. This changes these operations to control a `paused` flag and buffer any messages to be handled by the connection base when paused.

This change has been made to let the `Http1xServerConnection` control precisely the message flow when processing an HTTP pipelined request content. Previously the content was poured in the pending queue of the pipelined request which is complicated to deliver when the pipelined request is processed and requires some hacks with respect to the request demand. After this change, `Http1xServerConnection` can immediately pause the connection after receiving a pipelined request and have the guarantee that no message will be processed until it is resumed. When the pipelined request is processed, the connection is resumed and will deliver the messages with the regular `handleMessage` flow.

 ## Performance

### Plaintext

<img width="1349" alt="Screenshot 2024-04-16 at 17 11 17" src="https://github.com/eclipse-vertx/vert.x/assets/225674/7b04a747-c295-4349-8146-e85207de87c4">

- master : 4.5.7 baseline
- 5.0.0 : 5.0.0 baseline
- 5.0.0-irq : this PR branch
- 5.0.0-irq-nv : this PR branch using non volatile but synchronised inbound buffer demand (relying on biased locking)

### Microbenchmark

```
> mvn clean package -DskipTests -Pbenchmarks
> java -jar target/vertx-core-5.0.0-SNAPSHOT-benchmarks.jar HttpServerHandlerBenchmark
```

#### InboundMessageQueue (synchronised long)

```
Benchmark                                      Mode  Cnt     Score    Error   Units
HttpServerHandlerBenchmark.netty              thrpt   10  2398.380 ± 19.954  ops/ms
HttpServerHandlerBenchmark.vertx              thrpt   10  1769.388 ±  6.817  ops/ms
HttpServerHandlerBenchmark.vertxOpt           thrpt   10  2241.688 ±  4.130  ops/ms
HttpServerHandlerBenchmark.vertxOptMetricsOn  thrpt   10  1906.300 ± 28.674  ops/ms
```

#### InboundMessageQueue (volatile long)

```
Benchmark                                      Mode  Cnt     Score    Error   Units
HttpServerHandlerBenchmark.netty              thrpt   10  2445.317 ± 17.642  ops/ms
HttpServerHandlerBenchmark.vertx              thrpt   10  1976.744 ±  7.916  ops/ms
HttpServerHandlerBenchmark.vertxOpt           thrpt   10  1951.065 ±  4.861  ops/ms
HttpServerHandlerBenchmark.vertxOptMetricsOn  thrpt   10  2192.769 ± 26.459  ops/ms
```

#### InboundBuffer (master)

```
Benchmark                                      Mode  Cnt     Score    Error   Units
HttpServerHandlerBenchmark.netty              thrpt   10  2423.540 ± 35.876  ops/ms
HttpServerHandlerBenchmark.vertx              thrpt   10  1860.064 ± 16.155  ops/ms
HttpServerHandlerBenchmark.vertxOpt           thrpt   10  2209.176 ± 11.710  ops/ms
HttpServerHandlerBenchmark.vertxOptMetricsOn  thrpt   10  1896.875 ± 14.296  ops/ms
```

### InboundBuffer (4.x)

```
Benchmark                                      Mode  Cnt     Score    Error   Units
HttpServerHandlerBenchmark.netty              thrpt   10  2368.750 ± 30.001  ops/ms
HttpServerHandlerBenchmark.vertx              thrpt   10  1892.064 ± 21.788  ops/ms
HttpServerHandlerBenchmark.vertxOpt           thrpt   10  2097.548 ±  9.652  ops/ms
HttpServerHandlerBenchmark.vertxOptMetricsOn  thrpt   10  2187.718 ± 10.779  ops/ms
```

## Integration with Vert.x Core

This integrates with

- HTTP/1.1 client/server chunk
- NetSocket
- WebSocket

Past attempts to solve this:
- https://github.com/eclipse-vertx/vert.x/pull/5177
- https://github.com/eclipse-vertx/vert.x/pull/5164