### PR TITLE
[4.x Backport] Add option for whether semicolon is treated as normal character or not

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -211,7 +211,13 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
    * @return the query parameters in the request
    */
   @CacheReturn
-  MultiMap params();
+  default MultiMap params() { return params(false); }
+
+  /**
+   * @param semicolonIsNormalChar whether semicolon is treated as a normal character or a query parameter separator
+   * @return the query parameters in the request
+   */
+  MultiMap params(boolean semicolonIsNormalChar);
 
   /**
    * Return the first param value with the specified name

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -86,6 +86,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   // Cache this for performance
   private Charset paramsCharset = StandardCharsets.UTF_8;
   private MultiMap params;
+  private boolean semicolonIsNormalCharInParams;
   private MultiMap headers;
   private String absoluteURI;
 
@@ -311,9 +312,10 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   }
 
   @Override
-  public MultiMap params() {
-    if (params == null) {
-      params = HttpUtils.params(uri(), paramsCharset);
+  public MultiMap params(boolean semicolonIsNormalChar) {
+    if (params == null || semicolonIsNormalChar != semicolonIsNormalCharInParams) {
+      params = HttpUtils.params(uri(), paramsCharset, semicolonIsNormalChar);
+      semicolonIsNormalCharInParams = semicolonIsNormalChar;
     }
     return params;
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -58,6 +58,7 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
   // Accessed on context thread
   private Charset paramsCharset = StandardCharsets.UTF_8;
   private MultiMap params;
+  private boolean semicolonIsNormalCharInParams;
   private String absoluteURI;
   private MultiMap attributes;
   private HttpEventHandler eventHandler;
@@ -361,10 +362,11 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
     return paramsCharset.name();
   }
   @Override
-  public MultiMap params() {
+  public MultiMap params(boolean semicolonIsNormalChar) {
     synchronized (stream.conn) {
-      if (params == null) {
-        params = HttpUtils.params(uri(), paramsCharset);
+      if (params == null || semicolonIsNormalChar != semicolonIsNormalCharInParams) {
+        params = HttpUtils.params(uri(), paramsCharset, semicolonIsNormalChar);
+        semicolonIsNormalCharInParams = semicolonIsNormalChar;
       }
       return params;
     }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
@@ -149,8 +149,8 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
-  public MultiMap params() {
-    return delegate.params();
+  public MultiMap params(boolean semicolonIsNormalChar) {
+    return delegate.params(semicolonIsNormalChar);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -547,8 +547,8 @@ public final class HttpUtils {
     return absoluteURI;
   }
 
-  static MultiMap params(String uri, Charset charset) {
-    QueryStringDecoder queryStringDecoder = new QueryStringDecoder(uri, charset);
+  static MultiMap params(String uri, Charset charset, boolean semicolonIsNormalChar) {
+    QueryStringDecoder queryStringDecoder = new QueryStringDecoder(uri, charset, true, 1024, semicolonIsNormalChar);
     Map<String, List<String>> prms = queryStringDecoder.parameters();
     MultiMap params = MultiMap.caseInsensitiveMultiMap();
     if (!prms.isEmpty()) {

--- a/src/test/java/io/vertx/core/http/headers/VertxHttpHeadersTest.java
+++ b/src/test/java/io/vertx/core/http/headers/VertxHttpHeadersTest.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static io.vertx.core.http.HttpUtilsTest.HEADER_NAME_ALLOWED_CHARS;
+import static io.vertx.core.http.impl.HttpUtilsTest.HEADER_NAME_ALLOWED_CHARS;
 import static org.junit.Assert.*;
 
 /**

--- a/src/test/java/io/vertx/core/http/impl/HttpUtilsTest.java
+++ b/src/test/java/io/vertx/core/http/impl/HttpUtilsTest.java
@@ -8,12 +8,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.core.http;
+package io.vertx.core.http.impl;
 
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.impl.HttpUtils;
 import org.junit.Test;
 
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -228,5 +230,15 @@ public class HttpUtilsTest {
   private void check(String base, String ref, String expected) throws Exception {
     URI uri = HttpUtils.resolveURIReference(base, ref);
     assertEquals(expected, uri.getPath());
+  }
+
+  @Test
+  public void testParams() {
+    String uri = "https://foo.com/?a=1;b=2&c=3";
+    MultiMap result = HttpUtils.params(uri, Charset.defaultCharset(), false);
+    assertEquals("1", result.get("a"));
+
+    result = HttpUtils.params(uri, Charset.defaultCharset(), true);
+    assertEquals("1;b=2", result.get("a"));
   }
 }


### PR DESCRIPTION
This PR backports #5150 to `4.x`.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
