### PR TITLE
Fixed non-idempotent test `DeploymentTest#testDeployClass`

### DIFF
--- a/src/test/java/io/vertx/core/DeploymentTest.java
+++ b/src/test/java/io/vertx/core/DeploymentTest.java
@@ -44,6 +44,7 @@ public class DeploymentTest extends VertxTestBase {
   public void setUp() throws Exception {
     super.setUp();
     TestVerticle.instanceCount.set(0);
+    ReferenceSavingMyVerticle.myVerticles.clear();
   }
 
   @Test


### PR DESCRIPTION
## Motivation:

The test `io.vertx.core.DeploymentTest.testDeployClass` is not idempotent and fails in the second run in the same JVM, because it pollutes state shared among tests. Specifically, it deploys a vertical but did not clean up `ReferenceSavingMyVerticle.myVerticles` after the deployment, hence the assertion `assertEquals(deploymentId, myVerticle.deploymentID);` can fail when `myVerticles` still contains verticals from the previous run. It shall be good to clean this state pollution so that other tests do not fail in the future due to the shared state polluted by this test.

##Stacktrace of failure in the second run:
```
org.junit.ComparisonFailure: expected:<3[7b3fe25-12dd-4a61-b70d-734f577c4b0a]> but was:<3[e168fd5-0d9b-40ff-8801-d20b74837de8]>
	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at io.vertx.test.core.AsyncTestBase.assertEquals(AsyncTestBase.java:360)
	at io.vertx.core.DeploymentTest.lambda$testDeployClass$126(DeploymentTest.java:1189)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at io.vertx.core.DeploymentTest.lambda$testDeployClass$127(DeploymentTest.java:1188)
```
## Proposed Fix
Clear `ReferenceSavingMyVerticle.myVerticles` before starting the individual tests.

## Conformance:
ECA Submitted
