### PR TITLE
WebSocket connection

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -194,7 +194,9 @@ public interface HttpServer extends Measured {
    *
    * @return a future completed with the result
    */
-  Future<Void> close();
+  default Future<Void> close() {
+    return shutdown(0, TimeUnit.SECONDS);
+  }
 
   /**
    * Shutdown with a 30 seconds timeout ({@code shutdown(30, TimeUnit.SECONDS)}).

--- a/src/main/java/io/vertx/core/http/ServerWebSocket.java
+++ b/src/main/java/io/vertx/core/http/ServerWebSocket.java
@@ -114,7 +114,10 @@ public interface ServerWebSocket extends WebSocket {
    *
    * @throws IllegalStateException when the WebSocket handshake is already set
    */
-  void reject();
+  default void reject() {
+    // SC_BAD_GATEWAY
+    reject(502);
+  }
 
   /**
    * Like {@link #reject()} but with a {@code status}.

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequestHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequestHandler.java
@@ -45,9 +45,9 @@ public class Http1xServerRequestHandler implements Handler<HttpServerRequest> {
         // handle((Http1xServerRequest) req, wsHandler);
         ((Http1xServerRequest)req).webSocket().onComplete(ar -> {
           if (ar.succeeded()) {
-            ServerWebSocketImpl ws = (ServerWebSocketImpl) ar.result();
+            ServerWebSocketHandshaker ws = (ServerWebSocketHandshaker) ar.result();
             wsHandler.handle(ws);
-            ws.tryHandshake(101);
+            ws.tryAccept();
           } else {
             // ????
           }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -246,10 +246,13 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
       closeTimeoutUnit = unit;
       closeSequence = null;
     }
+    ContextInternal ctx = vertx.getOrCreateContext();
     if (seq == null) {
-      return vertx.getOrCreateContext().succeededFuture();
+      return ctx.succeededFuture();
     } else {
-      return seq.close();
+      Promise<Void> p = ctx.promise();
+      seq.close().onComplete(p);
+      return p.future();
     }
   }
 

--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketHandshaker.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketHandshaker.java
@@ -1,0 +1,530 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
+import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.*;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.impl.VertxHandler;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.cert.X509Certificate;
+import java.security.cert.Certificate;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
+
+/**
+ * Implementation that models a proxies a lazy {@link ServerWebSocket} since the API allows to reject a WebSocket
+ * handshake.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class ServerWebSocketHandshaker implements ServerWebSocket {
+
+  private static final int ST_PENDING = 0, ST_ACCEPTED = 1, ST_REJECTED = 2;
+
+  private Http1xServerRequest request;
+  private HttpServerOptions options;
+  private WebSocketServerHandshaker handshaker;
+  private int status;
+  private ServerWebSocket webSocket;
+  private Future<Integer> futureHandshake;
+  private Handler<Throwable> exceptionHandler;
+  private Handler<Buffer> dataHandler;
+  private Handler<Void> endHandler;
+  private Handler<Void> closeHandler;
+  private Handler<Void> drainHandler;
+  private Handler<WebSocketFrame> frameHandler;
+  private Handler<String> textMessageHandler;
+  private Handler<Buffer> binaryMessageHandler;
+  private Handler<Buffer> pongHandler;
+
+  public ServerWebSocketHandshaker(Http1xServerRequest request, WebSocketServerHandshaker handshaker, HttpServerOptions options) {
+    this.request = request;
+    this.handshaker = handshaker;
+    this.options = options;
+    this.status = ST_PENDING;
+  }
+
+  @Override
+  public @Nullable String scheme() {
+    Http1xServerRequest r = request;
+    if (r != null) {
+      return r.scheme();
+    } else {
+      return webSocket.scheme();
+    }
+  }
+
+  @Override
+  public @Nullable HostAndPort authority() {
+    Http1xServerRequest r = request;
+    if (r != null) {
+      return r.authority();
+    } else {
+      return webSocket.authority();
+    }
+  }
+
+  @Override
+  public String uri() {
+    Http1xServerRequest r = request;
+    if (r != null) {
+      return r.uri();
+    } else {
+      return webSocket.uri();
+    }
+  }
+
+  @Override
+  public String path() {
+    Http1xServerRequest r = request;
+    if (r != null) {
+      return r.path();
+    } else {
+      return webSocket.path();
+    }
+  }
+
+  @Override
+  public @Nullable String query() {
+    Http1xServerRequest r = request;
+    if (r != null) {
+      return r.query();
+    } else {
+      return webSocket.query();
+    }
+  }
+
+  @Override
+  public void accept() {
+    webSocketOrDie();
+  }
+
+  void tryAccept() {
+    resolveWebSocket();
+  }
+
+  @Override
+  public void reject(int sc) {
+    // Check SC is valid
+    synchronized (this) {
+        if (status == ST_PENDING) {
+            status = ST_REJECTED;
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+    rejectHandshake(sc);
+  }
+
+  @Override
+  public Future<Integer> setHandshake(Future<Integer> future) {
+    Future<Integer> ret;
+    synchronized (this) {
+      if (status != ST_PENDING || futureHandshake != null) {
+        throw new IllegalStateException();
+      }
+      ret = future.andThen(ar -> {
+        if (ar.succeeded()) {
+          int sc = ar.result();
+          if (sc == 101) {
+            synchronized (this) {
+              futureHandshake = null;
+              accept();
+            }
+          } else {
+            synchronized (this) {
+              status = ST_REJECTED;
+            }
+            reject(sc);
+          }
+        }
+      });
+      futureHandshake = ret;
+    }
+    return ret;
+  }
+
+  @Override
+  public ServerWebSocket exceptionHandler(Handler<Throwable> handler) {
+    exceptionHandler = handler;
+    WebSocket ws = webSocket;
+    if (ws != null) {
+      ws.exceptionHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public ServerWebSocket handler(Handler<Buffer> handler) {
+    dataHandler = handler;
+    WebSocket ws = webSocket;
+    if (ws != null) {
+      ws.handler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public ServerWebSocket pause() {
+    webSocketOrDie().pause();
+    return this;
+  }
+
+  @Override
+  public ServerWebSocket fetch(long amount) {
+    webSocketOrDie().fetch(amount);
+    return this;
+  }
+
+  @Override
+  public ServerWebSocket endHandler(Handler<Void> handler) {
+    endHandler = handler;
+    WebSocket ws = webSocket;
+    if (ws != null) {
+      ws.endHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public ServerWebSocket setWriteQueueMaxSize(int maxSize) {
+    webSocketOrDie().setWriteQueueMaxSize(maxSize);
+    return this;
+  }
+
+  @Override
+  public ServerWebSocket drainHandler(Handler<Void> handler) {
+    drainHandler = handler;
+    WebSocket ws = webSocket;
+    if (ws != null) {
+      ws.drainHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public ServerWebSocket closeHandler(Handler<Void> handler) {
+    closeHandler = handler;
+    WebSocket ws = webSocket;
+    if (ws != null) {
+      ws.closeHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public ServerWebSocket frameHandler(Handler<WebSocketFrame> handler) {
+    frameHandler = handler;
+    WebSocket ws = webSocket;
+    if (ws != null) {
+      ws.frameHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public String binaryHandlerID() {
+    return webSocketOrDie().binaryHandlerID();
+  }
+
+  @Override
+  public String textHandlerID() {
+    return webSocketOrDie().textHandlerID();
+  }
+
+  @Override
+  public String subProtocol() {
+    ServerWebSocket ws = webSocket;
+    if (ws == null) {
+      return null;
+    } else {
+      return ws.subProtocol();
+    }
+  }
+
+  @Override
+  public Short closeStatusCode() {
+    return webSocketOrDie().closeStatusCode();
+  }
+
+  @Override
+  public String closeReason() {
+    return webSocketOrDie().closeReason();
+  }
+
+  @Override
+  public MultiMap headers() {
+    return webSocketOrDie().headers();
+  }
+
+  @Override
+  public Future<Void> writeFrame(WebSocketFrame frame) {
+    return webSocketOrDie().writeFrame(frame);
+  }
+
+  @Override
+  public Future<Void> writeFinalTextFrame(String text) {
+    return webSocketOrDie().writeFinalTextFrame(text);
+  }
+
+  @Override
+  public Future<Void> writeFinalBinaryFrame(Buffer data) {
+    return webSocketOrDie().writeFinalBinaryFrame(data);
+  }
+
+  @Override
+  public Future<Void> writeBinaryMessage(Buffer data) {
+    return webSocketOrDie().writeBinaryMessage(data);
+  }
+
+  @Override
+  public Future<Void> writeTextMessage(String text) {
+    return webSocketOrDie().writeTextMessage(text);
+  }
+
+  @Override
+  public Future<Void> writePing(Buffer data) {
+    return webSocketOrDie().writePing(data);
+  }
+
+  @Override
+  public Future<Void> writePong(Buffer data) {
+    return webSocketOrDie().writePong(data);
+  }
+
+  @Override
+  public ServerWebSocket textMessageHandler(@Nullable Handler<String> handler) {
+    textMessageHandler = handler;
+    WebSocket ws = webSocket;
+    if (ws != null) {
+      ws.textMessageHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public ServerWebSocket binaryMessageHandler(@Nullable Handler<Buffer> handler) {
+    binaryMessageHandler = handler;
+    WebSocket ws = webSocket;
+    if (ws != null) {
+      ws.binaryMessageHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public ServerWebSocket pongHandler(@Nullable Handler<Buffer> handler) {
+    pongHandler = handler;
+    WebSocket ws = webSocket;
+    if (ws != null) {
+      ws.pongHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public Future<Void> end() {
+    return webSocketOrDie().end();
+  }
+
+  @Override
+  public Future<Void> close() {
+    WebSocket delegate = webSocketOrDie();
+    return delegate.close();
+  }
+
+  @Override
+  public Future<Void> close(short statusCode) {
+    return webSocketOrDie().close(statusCode);
+  }
+
+  @Override
+  public Future<Void> close(short statusCode, @Nullable String reason) {
+    return webSocketOrDie().close(statusCode, reason);
+  }
+
+  @Override
+  public SocketAddress remoteAddress() {
+    return webSocketOrDie().remoteAddress();
+  }
+
+  @Override
+  public SocketAddress localAddress() {
+    return webSocketOrDie().localAddress();
+  }
+
+  @Override
+  public boolean isSsl() {
+    return webSocketOrDie().isSsl();
+  }
+
+  @Override
+  public boolean isClosed() {
+    return webSocketOrDie().isClosed();
+  }
+
+  @Override
+  public SSLSession sslSession() {
+    return webSocketOrDie().sslSession();
+  }
+
+  @Override
+  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+    return webSocketOrDie().peerCertificateChain();
+  }
+
+  @Override
+  public List<Certificate> peerCertificates() throws SSLPeerUnverifiedException {
+    return webSocketOrDie().peerCertificates();
+  }
+
+  @Override
+  public Future<Void> write(Buffer data) {
+    return webSocketOrDie().write(data);
+  }
+
+  @Override
+  public boolean writeQueueFull() {
+    return webSocketOrDie().writeQueueFull();
+  }
+
+  private WebSocket webSocketOrDie() {
+    WebSocket ws = resolveWebSocket();
+    if (ws == null) {
+      throw new IllegalStateException("WebSocket handshake failed");
+    }
+    return ws;
+  }
+
+  private WebSocket resolveWebSocket() {
+    boolean reject = false;
+    try {
+      if (futureHandshake != null) {
+        throw new IllegalStateException();
+      }
+      synchronized (this) {
+        switch (status) {
+          case ST_PENDING:
+            ServerWebSocket ws;
+            try {
+              ws = acceptHandshake();
+            } catch (Exception e) {
+              status = ST_REJECTED;
+              reject = true;
+              throw e;
+            }
+            ws.handler(dataHandler);
+            ws.binaryMessageHandler(binaryMessageHandler);
+            ws.textMessageHandler(textMessageHandler);
+            ws.endHandler(endHandler);
+            ws.closeHandler(closeHandler);
+            ws.exceptionHandler(exceptionHandler);
+            ws.drainHandler(drainHandler);
+            ws.frameHandler(frameHandler);
+            ws.pongHandler(pongHandler);
+            status = ST_ACCEPTED;
+            webSocket = ws;
+            return ws;
+          case ST_REJECTED:
+            return null;
+          case ST_ACCEPTED:
+            return webSocket;
+          default:
+            throw new UnsupportedOperationException();
+        }
+      }
+    } finally {
+      if (reject) {
+        rejectHandshake(BAD_REQUEST.code());
+      }
+    }
+  }
+
+  private void rejectHandshake(int sc) {
+    HttpResponseStatus status = HttpResponseStatus.valueOf(sc);
+    Http1xServerResponse response = request.response();
+    response.setStatusCode(sc).end(status.reasonPhrase());
+  }
+
+  private ServerWebSocket acceptHandshake() {
+    Http1xServerConnection httpConn = (Http1xServerConnection) request.connection();
+    ChannelHandlerContext chctx = httpConn.channelHandlerContext();
+    Channel channel = chctx.channel();
+    Http1xServerResponse response = request.response();
+    Object requestMetric = request.metric;
+    try {
+      handshaker.handshake(channel, request.nettyRequest());
+    } catch (Exception e) {
+      rejectHandshake(BAD_REQUEST.code());
+      throw e;
+    }
+    response.completeHandshake();
+    // remove compressor as it's not needed anymore once connection was upgraded to websockets
+    ChannelPipeline pipeline = channel.pipeline();
+    ChannelHandler compressor = pipeline.get(HttpChunkContentCompressor.class);
+    if (compressor != null) {
+      pipeline.remove(compressor);
+    }
+    VertxHandler<WebSocketConnection> handler = VertxHandler.create(ctx -> {
+      WebSocketConnection webSocketConn = new WebSocketConnection(request.context, ctx, httpConn.metrics);
+      ServerWebSocketImpl webSocket = new ServerWebSocketImpl(
+        (ContextInternal) request.context(),
+        webSocketConn,
+        handshaker.version() != WebSocketVersion.V00,
+        options.getWebSocketClosingTimeout(),
+        request,
+        options.getMaxWebSocketFrameSize(),
+        options.getMaxWebSocketMessageSize(),
+        options.isRegisterWebSocketWriteHandlers());
+      String subprotocol = handshaker.selectedSubprotocol();
+      webSocket.subProtocol(subprotocol);
+      webSocketConn.webSocket(webSocket);
+      webSocketConn.metric(webSocketConn.metric());
+      return webSocketConn;
+    });
+    CompletableFuture<Void> latch = new CompletableFuture<>();
+    httpConn.getContext().execute(() -> {
+      // Must be done on event-loop
+      pipeline.replace(VertxHandler.class, "handler", handler);
+      latch.complete(null);
+    });
+    // This should actually only block the thread on a worker thread
+    try {
+      latch.get(10, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    ServerWebSocketImpl webSocket = (ServerWebSocketImpl) handler.getConnection().webSocket();
+    if (METRICS_ENABLED && httpConn.metrics != null) {
+      webSocket.setMetric(httpConn.metrics.connected(httpConn.metric(), requestMetric, this));
+    }
+    webSocket.registerHandler(httpConn.getContext().owner().eventBus());
+    return webSocket;
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -11,22 +11,11 @@
 
 package io.vertx.core.http.impl;
 
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
-import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.*;
 import io.vertx.core.http.ServerWebSocket;
-import io.vertx.core.http.WebSocketFrame;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.net.HostAndPort;
-import io.vertx.core.spi.metrics.HttpServerMetrics;
-
-import static io.netty.handler.codec.http.HttpResponseStatus.*;
-import static io.vertx.core.http.impl.HttpUtils.*;
-import static io.vertx.core.spi.metrics.Metrics.*;
+import io.vertx.core.net.impl.ConnectionBase;
 
 /**
  * This class is optimised for performance when used on the same event loop. However it can be used safely from other threads.
@@ -39,37 +28,28 @@ import static io.vertx.core.spi.metrics.Metrics.*;
  */
 public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocketImpl> implements ServerWebSocket {
 
-  private final Http1xServerConnection conn;
   private final long closingTimeoutMS;
   private final String scheme;
   private final HostAndPort authority;
   private final String uri;
   private final String path;
   private final String query;
-  private final WebSocketServerHandshaker handshaker;
-  private Http1xServerRequest request;
-  private Integer status;
-  private Promise<Integer> handshakePromise;
 
   ServerWebSocketImpl(ContextInternal context,
-                      Http1xServerConnection conn,
+                      ConnectionBase conn,
                       boolean supportsContinuation,
                       long closingTimeout,
                       Http1xServerRequest request,
-                      WebSocketServerHandshaker handshaker,
                       int maxWebSocketFrameSize,
                       int maxWebSocketMessageSize,
                       boolean registerWebSocketWriteHandlers) {
-    super(context, conn, request.headers(), supportsContinuation, maxWebSocketFrameSize, maxWebSocketMessageSize, registerWebSocketWriteHandlers);
-    this.conn = conn;
+    super(context, conn, conn.channelHandlerContext(), request.headers(), supportsContinuation, maxWebSocketFrameSize, maxWebSocketMessageSize, registerWebSocketWriteHandlers);
     this.closingTimeoutMS = closingTimeout >= 0 ? closingTimeout * 1000L : -1L;
     this.scheme = request.scheme();
     this.authority = request.authority();
     this.uri = request.uri();
     this.path = request.path();
     this.query = request.query();
-    this.request = request;
-    this.handshaker = handshaker;
   }
 
   @Override
@@ -98,38 +78,22 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocketImpl> 
   }
 
   @Override
-  public void accept() {
-    if (tryHandshake(SC_SWITCHING_PROTOCOLS) != Boolean.TRUE) {
-      throw new IllegalStateException("WebSocket already rejected");
-    }
+  public Future<Integer> setHandshake(Future<Integer> future) {
+    throw new IllegalStateException("WebSocket already sent");
   }
 
   @Override
-  public void reject() {
-    reject(SC_BAD_GATEWAY);
+  public void accept() {
+    throw new IllegalStateException("WebSocket already sent");
   }
 
   @Override
   public void reject(int sc) {
-    if (sc == SC_SWITCHING_PROTOCOLS) {
-      throw new IllegalArgumentException("Invalid WebSocket rejection status code: 101");
-    }
-    if (tryHandshake(sc) != Boolean.TRUE) {
-      throw new IllegalStateException("Cannot reject WebSocket, it has already been written to");
-    }
+    throw new IllegalStateException("WebSocket already sent");
   }
 
   @Override
   public Future<Void> close(short statusCode, String reason) {
-    synchronized (conn) {
-      if (status == null) {
-        if (handshakePromise == null) {
-          tryHandshake(101);
-        } else {
-          handshakePromise.tryComplete(101);
-        }
-      }
-    }
     Future<Void> fut = super.close(statusCode, reason);
     fut.onComplete(v -> {
       if (closingTimeoutMS == 0L) {
@@ -142,106 +106,8 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocketImpl> 
   }
 
   @Override
-  public Future<Void> writeFrame(WebSocketFrame frame) {
-    synchronized (conn) {
-      Boolean check = checkAccept();
-      if (check == null) {
-        throw new IllegalStateException("Cannot write to WebSocket, it is pending accept or reject");
-      }
-      if (!check) {
-        throw new IllegalStateException("Cannot write to WebSocket, it has been rejected");
-      }
-      return super.writeFrame(frame);
-    }
-  }
-
-  private Boolean checkAccept() {
-    return tryHandshake(SC_SWITCHING_PROTOCOLS);
-  }
-
-  private void handleHandshake(int sc) {
-    synchronized (conn) {
-      if (status == null) {
-        if (sc == SC_SWITCHING_PROTOCOLS) {
-          doHandshake();
-        } else {
-          status = sc;
-          HttpUtils.sendError(conn.channel(), HttpResponseStatus.valueOf(sc));
-        }
-      }
-    }
-  }
-
-  private void doHandshake() {
-    Channel channel = conn.channel();
-    Http1xServerResponse response = request.response();
-    try {
-      handshaker.handshake(channel, request.nettyRequest());
-    } catch (Exception e) {
-      response.setStatusCode(BAD_REQUEST.code()).end();
-      throw e;
-    } finally {
-      request = null;
-    }
-    response.completeHandshake();
-    status = SWITCHING_PROTOCOLS.code();
-    subProtocol(handshaker.selectedSubprotocol());
-    // remove compressor as its not needed anymore once connection was upgraded to websockets
-    ChannelPipeline pipeline = channel.pipeline();
-    ChannelHandler handler = pipeline.get(HttpChunkContentCompressor.class);
-    if (handler != null) {
-      pipeline.remove(handler);
-    }
-    registerHandler(conn.getContext().owner().eventBus());
-  }
-
-  Boolean tryHandshake(int sc) {
-    synchronized (conn) {
-      if (status == null && handshakePromise == null) {
-        setHandshake(Future.succeededFuture(sc));
-      }
-      return status == null ? null : status == sc;
-    }
-  }
-
-  @Override
-  public Future<Integer> setHandshake(Future<Integer> future) {
-    if (future == null) {
-      throw new NullPointerException();
-    }
-    // Change p1,p2 when we handle multiple listeners per future
-    Promise<Integer> p1 = Promise.promise();
-    Promise<Integer> p2 = Promise.promise();
-    synchronized (conn) {
-      if (handshakePromise != null) {
-        throw new IllegalStateException();
-      }
-      handshakePromise = p1;
-    }
-    future.onComplete(p1);
-    p1.future().onComplete(ar -> {
-      if (ar.succeeded()) {
-        handleHandshake(ar.result());
-      } else {
-        handleHandshake(500);
-      }
-      p2.handle(ar);
-    });
-    return p2.future();
-  }
-
-  @Override
   protected void handleCloseConnection() {
     closeConnection();
   }
 
-  @Override
-  protected void handleClose(boolean graceful) {
-    HttpServerMetrics metrics = conn.metrics;
-    if (METRICS_ENABLED && metrics != null) {
-      metrics.disconnected(getMetric());
-      setMetric(null);
-    }
-    super.handleClose(graceful);
-  }
 }

--- a/src/main/java/io/vertx/core/http/impl/WebSocketConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketConnection.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.websocketx.*;
+import io.vertx.core.Future;
+import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketFrameType;
+import io.vertx.core.http.impl.ws.WebSocketFrameImpl;
+import io.vertx.core.http.impl.ws.WebSocketFrameInternal;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.net.impl.ConnectionBase;
+import io.vertx.core.net.impl.ShutdownEvent;
+import io.vertx.core.spi.metrics.HttpClientMetrics;
+import io.vertx.core.spi.metrics.HttpServerMetrics;
+import io.vertx.core.spi.metrics.NetworkMetrics;
+import io.vertx.core.spi.metrics.TCPMetrics;
+
+import java.util.function.Function;
+
+import static io.vertx.core.net.impl.VertxHandler.safeBuffer;
+import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
+
+/**
+ * WebSocket connection.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+final class WebSocketConnection extends ConnectionBase {
+
+  private WebSocketImplBase<?> webSocket;
+  final TCPMetrics metrics;
+
+  WebSocketConnection(ContextInternal context, ChannelHandlerContext chctx, TCPMetrics metrics) {
+    super(context, chctx);
+    this.metrics = metrics;
+  }
+
+  WebSocketImplBase<?> webSocket() {
+    return webSocket;
+  }
+
+  WebSocketConnection webSocket(WebSocketImplBase<?> webSocket) {
+    this.webSocket = webSocket;
+    return this;
+  }
+
+  @Override
+  protected long sizeof(Object obj) {
+    if (obj instanceof WebSocketFrame) {
+      return ((WebSocketFrame) obj).content().readableBytes();
+    }
+    return super.sizeof(obj);
+  }
+
+  @Override
+  public NetworkMetrics metrics() {
+    return metrics;
+  }
+
+  @Override
+  public Future<Void> close() {
+    webSocket.close();
+    return closeFuture();
+  }
+
+  @Override
+  public void handleException(Throwable t) {
+    WebSocketImplBase<?> ws = webSocket;
+    if (ws != null) {
+      ws.context().execute(t, ws::handleException);
+    }
+  }
+
+  @Override
+  protected void handleWriteQueueDrained() {
+    WebSocketImplBase<?> ws = webSocket;
+    if (ws != null) {
+      ws.context().execute(ws::handleWriteQueueDrained);
+    }
+  }
+
+  @Override
+  protected void handleClosed() {
+    Object metric = null;
+    WebSocketImplBase<?> ws = webSocket;
+    if (ws != null) {
+      ws.context().execute(v -> ws.handleConnectionClosed());
+      metric = ws.getMetric();
+      ws.setMetric(null);
+    }
+    // Improve this with a common super interface to both
+    if (this.metrics instanceof HttpServerMetrics) {
+      HttpServerMetrics metrics = (HttpServerMetrics) this.metrics;
+      if (METRICS_ENABLED && metrics != null) {
+        metrics.disconnected(metric);
+      }
+    } else if (this.metrics instanceof HttpClientMetrics) {
+      HttpClientMetrics metrics = (HttpClientMetrics) this.metrics;
+      if (METRICS_ENABLED && metrics != null) {
+        metrics.disconnected(metric);
+      }
+    }
+    super.handleClosed();
+  }
+
+  protected void handleEvent(Object evt) {
+    if (evt instanceof ShutdownEvent) {
+      ShutdownEvent shutdown = (ShutdownEvent) evt;
+      webSocket.close();
+    } else {
+      super.handleEvent(evt);
+    }
+  }
+
+  @Override
+  protected void handleMessage(Object msg) {
+    if (msg instanceof WebSocketFrame) {
+      WebSocketFrame frame = (WebSocketFrame) msg;
+      handleWsFrame(frame);
+    }
+  }
+
+  void handleWsFrame(WebSocketFrame msg) {
+    WebSocketFrameInternal frame = decodeFrame(msg);
+    WebSocketImplBase<?> w;
+    synchronized (this) {
+      w = webSocket;
+    }
+    if (w != null) {
+      w.context().execute(frame, w::handleFrame);
+    }
+  }
+
+  private WebSocketFrameInternal decodeFrame(io.netty.handler.codec.http.websocketx.WebSocketFrame msg) {
+    ByteBuf payload = safeBuffer(msg.content());
+    boolean isFinal = msg.isFinalFragment();
+    WebSocketFrameType frameType;
+    if (msg instanceof BinaryWebSocketFrame) {
+      frameType = WebSocketFrameType.BINARY;
+    } else if (msg instanceof CloseWebSocketFrame) {
+      frameType = WebSocketFrameType.CLOSE;
+    } else if (msg instanceof PingWebSocketFrame) {
+      frameType = WebSocketFrameType.PING;
+    } else if (msg instanceof PongWebSocketFrame) {
+      frameType = WebSocketFrameType.PONG;
+    } else if (msg instanceof TextWebSocketFrame) {
+      frameType = WebSocketFrameType.TEXT;
+    } else if (msg instanceof ContinuationWebSocketFrame) {
+      frameType = WebSocketFrameType.CONTINUATION;
+    } else {
+      throw new IllegalStateException("Unsupported WebSocket msg " + msg);
+    }
+    return new WebSocketFrameImpl(frameType, payload, isFinal);
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/WebSocketInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketInternal.java
@@ -19,6 +19,4 @@ public interface WebSocketInternal extends WebSocket {
 
   ChannelHandlerContext channelHandlerContext();
 
-  HttpConnection connection();
-
 }

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -54,6 +54,7 @@ import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
  * we benefit from biased locking which makes the overhead of synchronized near zero.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public abstract class ConnectionBase {
 

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -45,6 +45,7 @@ import java.util.function.Predicate;
  * This class is thread-safe
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 class NetClientImpl implements NetClientInternal {
 

--- a/src/test/java/io/vertx/core/http/WebSocketTest.java
+++ b/src/test/java/io/vertx/core/http/WebSocketTest.java
@@ -1394,6 +1394,12 @@ public class WebSocketTest extends VertxTestBase {
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).webSocketHandler(ws -> {
       Promise<Integer> promise = Promise.promise();
       Future<Integer> result = ws.setHandshake(promise.future());
+      try {
+        ws.close();
+        fail();
+      } catch (IllegalStateException expected) {
+      }
+      promise.complete(101);
       ws.close();
 //      assertTrue(result.isComplete());
 //      assertEquals(101, (int)result.result());

--- a/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
+++ b/src/test/java/io/vertx/core/spi/metrics/MetricsContextTest.java
@@ -312,7 +312,7 @@ public class MetricsContextTest extends VertxTestBase {
           }
           @Override
           public Void connected(Void socketMetric, Void requestMetric, ServerWebSocket serverWebSocket) {
-            assertEquals(2, httpLifecycle.get());
+            assertEquals(4, httpLifecycle.get());
             webSocketConnected.set(true);
             return null;
           }

--- a/src/test/java/io/vertx/test/fakemetrics/FakeHttpServerMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeHttpServerMetrics.java
@@ -85,9 +85,6 @@ public class FakeHttpServerMetrics extends FakeTCPMetrics implements HttpServerM
 
   @Override
   public WebSocketMetric connected(SocketMetric socketMetric, HttpServerMetric requestMetric, ServerWebSocket serverWebSocket) {
-    if (!requests.remove(requestMetric)) {
-      throw new IllegalStateException();
-    }
     WebSocketMetric metric = new WebSocketMetric(serverWebSocket);
     if (webSockets.put(serverWebSocket, metric) != null) {
       throw new AssertionError();


### PR DESCRIPTION
Internal refactor of the WebSocket connection implementation
    
- Move WebSocket related code from `Http1xConnectionBase` to its own `ConnectionBase` subclass in order to simplify `Http1xConnectionBase` and ease its maintenance. The WebSocket connection has now its own Netty handler instead of relying on the HTTP/1.x handler. The HTTP/1.x handler now does not need to take in account WebSocket frames and WebSocket state. 
- Simplify server WebSocket code by moving the code related to WebSocket accept/reject API to a WebSocket implementation that proxies an accepted `WebSocket` using the same approach than `ClientWebSocket`
