### PR TITLE
Improve tests by replacing onSuccess (which fails the test) by expecting which fails the future and the flow

### DIFF
--- a/src/test/java/io/vertx/core/file/FileResolverTestBase.java
+++ b/src/test/java/io/vertx/core/file/FileResolverTestBase.java
@@ -286,7 +286,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
         .request(HttpMethod.GET, HttpTestBase.DEFAULT_HTTP_PORT, "localhost", "/")
         .compose(req -> req
           .send()
-          .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+          .expecting(HttpResponseExpectation.SC_OK)
           .compose(HttpClientResponse::body))
         .onComplete(onSuccess(body -> {
           assertTrue(body.toString().startsWith("<html><body>blah</body></html>"));

--- a/src/test/java/io/vertx/core/file/FileSystemTest.java
+++ b/src/test/java/io/vertx/core/file/FileSystemTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
+import static io.vertx.test.core.AssertExpectations.that;
 import static io.vertx.test.core.TestUtils.*;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
@@ -1980,7 +1981,7 @@ public class FileSystemTest extends VertxTestBase {
       .props(from)
       .compose(expected -> fs
         .props(from)
-        .andThen(onSuccess(actual -> {
+        .expecting(that(actual -> {
           assertEquals(expected.creationTime(), actual.creationTime());
           assertEquals(expected.lastModifiedTime(), actual.lastModifiedTime());
         }))
@@ -2015,12 +2016,12 @@ public class FileSystemTest extends VertxTestBase {
     fs.copy(from, to, options)
       .compose(v -> fs
         .lprops(to)
-        .andThen(onSuccess(props -> assertTrue(props.isSymbolicLink())))
+        .expecting(that(props -> assertTrue(props.isSymbolicLink())))
         .compose(v2 -> fs
           .readFile(from)
           .compose(expected -> fs
             .readFile(to)
-            .andThen(onSuccess(actual -> assertEquals(expected, actual)))))).onComplete(onSuccess(v -> complete()));
+            .expecting(that(actual -> assertEquals(expected, actual)))))).onComplete(onSuccess(v -> complete()));
     await();
   }
 
@@ -2169,7 +2170,7 @@ public class FileSystemTest extends VertxTestBase {
     createFileWithJunk(fileName, expected);
     AsyncFile file = vertx.fileSystem().openBlocking(testDir + pathSep + fileName, new OpenOptions());
     file.size()
-      .andThen(onSuccess(size -> assertEquals(expected, size.longValue())))
+      .expecting(that(size -> assertEquals(expected, size.longValue())))
       .compose(v -> file.close())
       .onComplete(onSuccess(v -> testComplete()));
     await();

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -29,6 +29,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.streams.WriteStream;
+import io.vertx.test.core.AssertExpectations;
 import io.vertx.test.core.CheckingSender;
 import io.vertx.test.core.Repeat;
 import io.vertx.test.core.TestUtils;
@@ -50,6 +51,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static io.vertx.core.http.HttpMethod.PUT;
+import static io.vertx.test.core.AssertExpectations.that;
 import static io.vertx.test.core.TestUtils.*;
 
 /**
@@ -1038,10 +1040,10 @@ public class Http1xTest extends HttpTest {
               .putHeader("count", String.valueOf(theCount)))
           .compose(req -> req
             .send(Buffer.buffer("This is content " + theCount))
-            .andThen(onSuccess(resp -> assertEquals(theCount, Integer.parseInt(resp.headers().get("count")))))
+            .expecting(that(resp -> assertEquals(theCount, Integer.parseInt(resp.headers().get("count")))))
             .compose(resp -> resp
               .body()
-              .andThen(onSuccess(buff -> assertEquals("This is content " + theCount, buff.toString())))))
+              .expecting(that(buff -> assertEquals("This is content " + theCount, buff.toString())))))
           .onComplete(onSuccess(v -> complete()));
       }
     });
@@ -1500,7 +1502,7 @@ public class Http1xTest extends HttpTest {
       client.request(new RequestOptions(requestOptions).setURI(path))
         .compose(req -> req.putHeader("count", String.valueOf(theCount))
           .send()
-          .andThen(onSuccess(resp -> {
+          .expecting(that(resp -> {
             resp.exceptionHandler(this::fail);
             assertEquals(200, resp.statusCode());
             assertEquals(theCount, Integer.parseInt(resp.headers().get("count")));
@@ -1861,7 +1863,7 @@ public class Http1xTest extends HttpTest {
       for (int i = 0;i < 3;i++) {
         client.request(requestOptions).compose(req -> req
             .send()
-            .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+          .expecting(that(resp -> assertEquals(200, resp.statusCode())))
             .compose(HttpClientResponse::end))
           .onComplete(onSuccess(v -> complete()));
       }
@@ -2255,7 +2257,7 @@ public class Http1xTest extends HttpTest {
       client.request(new RequestOptions(requestOptions).setMethod(PUT))
         .compose(req -> req
           .send(Buffer.buffer("1"))
-          .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+          .expecting(that(resp -> assertEquals(200, resp.statusCode())))
           .compose(HttpClientResponse::end))
         .onComplete(onSuccess(v -> complete()));
     }
@@ -2813,7 +2815,7 @@ public class Http1xTest extends HttpTest {
           .request(new RequestOptions(requestOptions).setURI(uri))
           .compose(req -> req
             .send()
-            .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+            .expecting(that(resp -> assertEquals(200, resp.statusCode())))
             .compose(HttpClientResponse::end))
           .onComplete(onSuccess(v -> respLatch.countDown()));
       }
@@ -3211,7 +3213,7 @@ public class Http1xTest extends HttpTest {
               client.request(new RequestOptions(requestOptions).setURI("/somepath"))
                 .compose(req -> req
                   .send()
-                  .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+                  .expecting(that(resp -> assertEquals(200, resp.statusCode())))
                   .compose(HttpClientResponse::body))
                 .onComplete(onSuccess(body -> {
                   assertEquals("Hello world", body.toString());
@@ -3228,7 +3230,7 @@ public class Http1xTest extends HttpTest {
             client.request(new RequestOptions(requestOptions).setURI("/somepath"))
               .compose(req -> req
                 .send()
-                .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+                .expecting(that(resp -> assertEquals(200, resp.statusCode())))
                 .compose(HttpClientResponse::body))
               .onComplete(onSuccess(body -> {
                 assertEquals("Hello world", body.toString());
@@ -4236,7 +4238,7 @@ public class Http1xTest extends HttpTest {
     client.request(new RequestOptions(requestOptions).setMethod(PUT))
       .compose(req -> req
         .send(expected)
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(that(resp -> assertEquals(200, resp.statusCode())))
         .compose(HttpClientResponse::body))
       .onComplete(onSuccess(body -> {
         assertEquals(expected, body);
@@ -4276,7 +4278,7 @@ public class Http1xTest extends HttpTest {
         client.request(new RequestOptions(requestOptions).setMethod(PUT))
           .compose(req -> req
             .send(TestUtils.randomAlphaString(1024))
-            .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+            .expecting(that(resp -> assertEquals(200, resp.statusCode())))
             .compose(HttpClientResponse::body))
           .onComplete(onSuccess(body -> {
             assertEquals(expected, body.toString());
@@ -4311,7 +4313,7 @@ public class Http1xTest extends HttpTest {
         client.request(new RequestOptions(requestOptions).setMethod(PUT))
           .compose(req -> req
             .send(TestUtils.randomAlphaString(1024))
-            .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+            .expecting(that(resp -> assertEquals(200, resp.statusCode())))
             .compose(HttpClientResponse::body))
           .onComplete(onSuccess(body -> {
             assertEquals(expected, body.toString());
@@ -5134,7 +5136,7 @@ public class Http1xTest extends HttpTest {
     startServer(testAddress);
     client.request(requestOptions).compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(that(resp -> assertEquals(200, resp.statusCode())))
         .compose(HttpClientResponse::body)
       )
       .onComplete(onSuccess(body -> complete()));
@@ -5178,7 +5180,7 @@ public class Http1xTest extends HttpTest {
     for (int i = 0;i < 2;i++) {
       client.request(requestOptions).compose(req -> req
           .send()
-          .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+          .expecting(that(resp -> assertEquals(200, resp.statusCode())))
           .compose(HttpClientResponse::body)
         )
         .onComplete(onSuccess(body -> complete()));

--- a/src/test/java/io/vertx/core/http/Http2ClientTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientTest.java
@@ -54,6 +54,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.zip.GZIPOutputStream;
 
+import static io.vertx.test.core.AssertExpectations.that;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -1070,10 +1072,8 @@ public class Http2ClientTest extends Http2TestBase {
         vertx.runOnContext(v -> {
           client.request(new RequestOptions(requestOptions).setTimeout(5000))
             .compose(HttpClientRequest::send)
-            .onComplete(onSuccess(resp2 -> {
-              assertEquals(2, connections.size());
-              testComplete();
-            }));
+            .expecting(that(v2 -> assertEquals(2, connections.size())))
+            .onComplete(onSuccess(resp2 -> testComplete()));
         });
       });
       req.send().onComplete(onFailure(resp -> {

--- a/src/test/java/io/vertx/core/http/Http2Test.java
+++ b/src/test/java/io/vertx/core/http/Http2Test.java
@@ -39,6 +39,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.vertx.test.core.AssertExpectations.that;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -72,7 +74,7 @@ public class Http2Test extends HttpTest {
     startServer(testAddress);
     client.request(requestOptions).compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+      .expecting(that(resp -> assertEquals(200, resp.statusCode())))
       .compose(HttpClientResponse::body)).
       onComplete(onSuccess(body -> {
         assertEquals(Buffer.buffer("hello world"), body);
@@ -91,7 +93,7 @@ public class Http2Test extends HttpTest {
     startServer(testAddress);
     client.request(requestOptions).compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::end))
       .onComplete(onSuccess(v -> testComplete()));
     await();
@@ -107,8 +109,8 @@ public class Http2Test extends HttpTest {
     startServer(testAddress);
     client.request(requestOptions).compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
-        .compose(resp -> resp.end().andThen(onSuccess(v -> {
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(resp -> resp.end().expecting(that(v -> {
           assertEquals(1, resp.trailers().size());
           assertEquals("trailer", resp.trailers().get("some"));
         }))))

--- a/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
+++ b/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
@@ -121,8 +121,8 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
     long expectedLength = Files.size(Path.of(sampleF.getAbsolutePath()));
     testClient.request(HttpMethod.GET, testServer.actualPort(), DEFAULT_HTTP_HOST,"/get-file")
               .compose(req -> req.send()
-                                 .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
-                                 .compose(HttpClientResponse::body))
+                .expecting(HttpResponseExpectation.SC_OK)
+                .compose(HttpClientResponse::body))
               .onComplete(onSuccess(body -> {
                 receivedLength.set(body.getBytes().length);
                 Assert.assertEquals(expectedLength, receivedLength.get());
@@ -188,8 +188,8 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
       for (int i=0; i<2; i++) {
         testClient.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST,"/get-file")
                   .compose(req -> req.send()
-                                     .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
-                                     .compose(HttpClientResponse::body))
+                    .expecting(HttpResponseExpectation.SC_OK)
+                    .compose(HttpClientResponse::body))
                   .onComplete(onSuccess(body -> {
                       long receivedBytes = body.getBytes().length;
                       totalReceivedLength.addAndGet(receivedBytes);
@@ -278,8 +278,10 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
 
   private void read(Buffer expected, HttpServer server, HttpClient client) {
     client.request(HttpMethod.GET, server.actualPort(), DEFAULT_HTTP_HOST,"/buffer-read")
-          .compose(req -> req.send()
-                             .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode()))).compose(HttpClientResponse::body))
+          .compose(req -> req
+            .send()
+            .expecting(HttpResponseExpectation.SC_OK)
+            .compose(HttpClientResponse::body))
           .onComplete(onSuccess(body -> {
               assertEquals(expected.getBytes().length, body.getBytes().length);
               testComplete();

--- a/src/test/java/io/vertx/core/http/HttpClientTimeoutTest.java
+++ b/src/test/java/io/vertx/core/http/HttpClientTimeoutTest.java
@@ -128,7 +128,7 @@ public abstract class HttpClientTimeoutTest extends HttpTestBase {
         client.request(requestOptions)
           .compose(req -> req
             .send()
-            .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+            .expecting(HttpResponseExpectation.SC_OK)
             .compose(HttpClientResponse::body))
           .onComplete(onSuccess(buff -> {
             assertEquals("OK", buff.toString());
@@ -335,7 +335,7 @@ public abstract class HttpClientTimeoutTest extends HttpTestBase {
     client.request(new RequestOptions(requestOptions).setIdleTimeout(timeout))
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::end))
       .onComplete(onSuccess(v -> testComplete()));
 

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -30,6 +30,7 @@ import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.*;
 import io.vertx.core.net.impl.HAProxyMessageCompletionHandler;
 import io.vertx.core.streams.ReadStream;
+import io.vertx.test.core.AssertExpectations;
 import io.vertx.test.core.DetectFileDescriptorLeaks;
 import io.vertx.test.core.Repeat;
 import io.vertx.test.core.TestUtils;
@@ -41,7 +42,6 @@ import org.apache.directory.server.dns.messages.RecordClass;
 import org.apache.directory.server.dns.messages.RecordType;
 import org.apache.directory.server.dns.store.DnsAttribute;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -62,6 +62,7 @@ import java.util.function.*;
 import java.util.stream.IntStream;
 
 import static io.vertx.core.http.HttpMethod.*;
+import static io.vertx.test.core.AssertExpectations.that;
 import static io.vertx.test.core.TestUtils.*;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
@@ -1864,7 +1865,7 @@ public abstract class HttpTest extends HttpTestBase {
     startServer(testAddress);
     client.request(requestOptions)
       .compose(req -> req.send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::end)
       ).onComplete(onSuccess(v -> testComplete()));
     await();
@@ -1881,9 +1882,9 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(requestOptions)
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
-        .andThen(onSuccess(buff -> assertEquals(body, buff))))
+        .expecting(that(buff -> assertEquals(body, buff))))
       .onComplete(onSuccess(v -> testComplete()));
 
     await();
@@ -1927,9 +1928,9 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(requestOptions)
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
-        .andThen(onSuccess(buff -> assertEquals(body, buff))))
+        .expecting(that(buff -> assertEquals(body, buff))))
       .onComplete(onSuccess(v -> testComplete()));
 
     await();
@@ -1993,9 +1994,9 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(requestOptions)
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
-        .andThen(onSuccess(buff -> assertEquals(body, encoding == null ? buff.toString() : buff.toString(encoding)))))
+        .expecting(that(buff -> assertEquals(body, encoding == null ? buff.toString() : buff.toString(encoding)))))
       .onComplete(onSuccess(v -> testComplete()));
 
     await();
@@ -2015,9 +2016,9 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(requestOptions)
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
-        .andThen(onSuccess(buff -> assertEquals(body, buff))))
+        .expecting(that(buff -> assertEquals(body, buff))))
       .onComplete(onSuccess(v -> testComplete()));
 
     await();
@@ -2052,7 +2053,7 @@ public abstract class HttpTest extends HttpTestBase {
     startServer(testAddress);
     requestFact.get().compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> {
+        .expecting(that(resp -> {
           assertEquals(200, resp.statusCode());
           assertEquals("text/html", resp.headers().get("Content-Type"));
           assertEquals(fileToSend.length(), Long.parseLong(resp.headers().get("content-length")));
@@ -2082,9 +2083,9 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(requestOptions)
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
-        .andThen(onSuccess(buff -> assertEquals("failed", buff.toString()))))
+        .expecting(that(buff -> assertEquals("failed", buff.toString()))))
       .onComplete(onSuccess(v -> testComplete()));
 
     await();
@@ -2104,13 +2105,13 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(requestOptions)
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> {
+        .expecting(that(resp -> {
           assertEquals(200, resp.statusCode());
           assertEquals(file.length(), Long.parseLong(resp.headers().get("content-length")));
           assertEquals("wibble", resp.headers().get("content-type"));
         }))
         .compose(HttpClientResponse::body)
-        .andThen(onSuccess(buff -> assertEquals(content, buff.toString()))))
+        .expecting(that(buff -> assertEquals(content, buff.toString()))))
       .onComplete(onSuccess(v -> testComplete()));
 
     await();
@@ -2173,7 +2174,7 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(requestOptions).onComplete(onSuccess(req -> {
       client.request(requestOptions)
         .compose(HttpClientRequest::send)
-        .andThen(onSuccess(resp -> assertEquals(String.valueOf(10), resp.headers().get("Content-Length"))))
+        .expecting(that(resp -> assertEquals(String.valueOf(10), resp.headers().get("Content-Length"))))
         .compose(HttpClientResponse::body)
         .onComplete(onSuccess(body -> {
           assertTrue(body.toString().startsWith("server.net"));
@@ -2193,7 +2194,7 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(requestOptions)
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(String.valueOf(10), resp.headers().get("Content-Length"))))
+        .expecting(that(resp -> assertEquals(String.valueOf(10), resp.headers().get("Content-Length"))))
         .compose(HttpClientResponse::body))
       .onComplete(onSuccess(body -> {
         assertEquals("server.net", body.toString());
@@ -2211,7 +2212,7 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(requestOptions)
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(String.valueOf(0), resp.headers().get("Content-Length"))))
+        .expecting(that(resp -> assertEquals(String.valueOf(0), resp.headers().get("Content-Length"))))
         .compose(HttpClientResponse::body))
       .onComplete(onSuccess(body -> {
         assertEquals("", body.toString());
@@ -2558,7 +2559,7 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(new RequestOptions(requestOptions).setMethod(HttpMethod.HEAD))
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(resp -> resp.end().map(resp.headers().get("Content-Length"))))
       .onComplete(onSuccess(contentLength -> {
         assertEquals("41", contentLength);
@@ -2693,7 +2694,7 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(new RequestOptions(requestOptions).setMethod(HttpMethod.HEAD))
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertNull(resp.headers().get(HttpHeaders.CONTENT_LENGTH))))
+        .expecting(that(resp -> assertNull(resp.headers().get(HttpHeaders.CONTENT_LENGTH))))
         .compose(HttpClientResponse::end))
       .onComplete(onSuccess(v -> testComplete()));
 
@@ -2713,7 +2714,7 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(new RequestOptions(requestOptions).setMethod(HttpMethod.HEAD))
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals("41", resp.headers().get(HttpHeaders.CONTENT_LENGTH))))
+        .expecting(that(resp -> assertEquals("41", resp.headers().get(HttpHeaders.CONTENT_LENGTH))))
         .compose(HttpClientResponse::end))
       .onComplete(onSuccess(v -> testComplete()));
 
@@ -2735,7 +2736,7 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(requestOptions)
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body))
       .onComplete(onSuccess(req -> {
         testComplete();
@@ -3179,7 +3180,7 @@ public abstract class HttpTest extends HttpTestBase {
     startServer(testAddress);
     client.request(requestOptions).compose(req -> req
       .send()
-      .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+      .expecting(HttpResponseExpectation.SC_OK)
       .compose(HttpClientResponse::body))
       .onComplete(onSuccess(buff -> {
         assertEquals(bodyBuff, buff);
@@ -6775,7 +6776,7 @@ public abstract class HttpTest extends HttpTestBase {
     client.request(requestOptions)
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::end))
       .onComplete(onSuccess(nothing -> complete()));
     await();
@@ -6803,7 +6804,7 @@ public abstract class HttpTest extends HttpTestBase {
     startServer(testAddress);
     client.request(requestOptions)
       .compose(req -> req.send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::end))
       .onComplete(onSuccess(nothing -> complete()));
     await();

--- a/src/test/java/io/vertx/core/http/ResolvingHttpClientTest.java
+++ b/src/test/java/io/vertx/core/http/ResolvingHttpClientTest.java
@@ -87,7 +87,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
     for (int i = 0;i < numServers * 2;i++) {
       client.request(new RequestOptions().setServer(new FakeAddress("example.com"))).compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
       ).onComplete(onSuccess(v -> {
         responses.add(v.toString());
@@ -118,7 +118,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
     for (int i = 0;i < numServers;i++) {
       client.request(new RequestOptions().setServer(new FakeAddress("example.com"))).compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
       ).onComplete(onSuccess(v -> {
         latch.countDown();
@@ -147,13 +147,13 @@ public class ResolvingHttpClientTest extends VertxTestBase {
       .build();
     Future<Buffer> result = client.request(new RequestOptions().setServer(new FakeAddress("server1.com"))).compose(req -> req
       .send()
-      .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+      .expecting(HttpResponseExpectation.SC_OK)
       .compose(HttpClientResponse::body)
     ).compose(body -> client
       .request(new RequestOptions().setServer(new FakeAddress("server2.com")))
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
       ));
     awaitFuture(result);
@@ -183,7 +183,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
     for (RequestOptions request : requests) {
       Future<Buffer> result = client.request(request).compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
       );
       Buffer response = awaitFuture(result);
@@ -231,7 +231,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
       for (int i = 0;i < numServers * 2;i++) {
         client.request(new RequestOptions().setServer(new FakeAddress("example.com"))).compose(req -> req
           .send()
-          .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+          .expecting(HttpResponseExpectation.SC_OK)
           .compose(HttpClientResponse::body)
         ).onComplete(onSuccess(v -> {
           responses.add(v.toString());
@@ -259,7 +259,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
       .build();
     client.request(new RequestOptions().setServer(new FakeAddress("foo.com"))).compose(req -> req
       .send()
-      .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+      .expecting(HttpResponseExpectation.SC_OK)
       .compose(HttpClientResponse::body)
     ).onComplete(onFailure(err -> {
       assertSame(cause, err);
@@ -277,7 +277,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
     client.request(new RequestOptions().setServer(new Address() {
     })).compose(req -> req
       .send()
-      .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+      .expecting(HttpResponseExpectation.SC_OK)
       .compose(HttpClientResponse::body)
     ).onComplete(onFailure(err -> {
       assertTrue(err.getMessage().contains("Cannot resolve address"));
@@ -304,7 +304,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
       .build();
     client.request(new RequestOptions().setServer(new FakeAddress("example.com"))).compose(req -> req
       .send()
-      .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+      .expecting(HttpResponseExpectation.SC_OK)
       .compose(HttpClientResponse::body)
     ).onComplete(onSuccess(v -> {
     }));
@@ -329,7 +329,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
       .build();
     awaitFuture(client.request(new RequestOptions().setServer(new FakeAddress("example.com"))).compose(req -> req
       .send()
-      .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+      .expecting(HttpResponseExpectation.SC_OK)
       .compose(HttpClientResponse::body)
     ));
     FakeLoadBalancer.FakeLoadBalancerMetrics<?> endpoint = (FakeLoadBalancer.FakeLoadBalancerMetrics<?>) ((EndpointNode) lb.endpoints().get(0)).metrics();
@@ -451,9 +451,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
     for (int i = 0;i < 10;i++) {
       Future<Buffer> fut = client.request(new RequestOptions().setServer(new FakeAddress("example.com"))).compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> {
-          assertEquals(200, resp.statusCode());
-        }))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body));
       futures.add(fut);
     }
@@ -492,7 +490,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
       .build();
     String res = awaitFuture(client.request(new RequestOptions().setServer(new FakeAddress("example.com"))).compose(req -> req
       .send()
-      .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+      .expecting(HttpResponseExpectation.SC_OK)
       .compose(HttpClientResponse::body)
     )).toString();
     assertEquals("0", res);
@@ -500,7 +498,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
     try {
       awaitFuture(client.request(new RequestOptions().setServer(new FakeAddress("example.com"))).compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
       ));
     } catch (Throwable e) {
@@ -524,7 +522,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
       .build();
     String res = awaitFuture(client.request(new RequestOptions().setServer(new FakeAddress("example.com"))).compose(req -> req
       .send()
-      .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+      .expecting(HttpResponseExpectation.SC_OK)
       .compose(HttpClientResponse::body)
     )).toString();
     assertEquals("0", res);
@@ -548,7 +546,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
     for (int i = 0;i < numRequests;i++) {
       String res = awaitFuture(client.request(new RequestOptions().setServer(new FakeAddress("example.com"))).compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
       )).toString();
       assertEquals("0", res);
@@ -607,7 +605,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
     try {
       String res = awaitFuture(client.request(request).compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
       )).toString();
       assertFalse(expectFailure);
@@ -641,7 +639,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
       String hashingKey = "client-" + idx;
       client.request(new RequestOptions().setServer(new FakeAddress("example.com")).setRoutingKey(hashingKey)).compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
       ).onComplete(onSuccess(v -> {
         responses.compute(idx, (id, list) -> {
@@ -676,7 +674,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
     Set<String> responses = Collections.synchronizedSet(new HashSet<>());
     client.request(new RequestOptions().setServer(new FakeAddress("example.com"))).compose(req -> req
       .send()
-      .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+      .expecting(HttpResponseExpectation.SC_OK)
       .compose(HttpClientResponse::body)
     ).onComplete(onFailure(err -> {
       assertEquals("No results for ServiceName(example.com)", err.getMessage());

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -3509,7 +3509,7 @@ public class NetTest extends VertxTestBase {
     client.request(io.vertx.core.http.HttpMethod.GET, 1234, "localhost", "/somepath")
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)).onComplete(onSuccess(body -> {
         assertEquals("Hello World", body.toString());
         complete();

--- a/src/test/java/io/vertx/core/shareddata/AsyncMapTest.java
+++ b/src/test/java/io/vertx/core/shareddata/AsyncMapTest.java
@@ -18,6 +18,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.test.core.VertxTestBase;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.Serializable;
@@ -25,6 +26,7 @@ import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
+import static io.vertx.test.core.AssertExpectations.that;
 import static io.vertx.test.core.TestUtils.*;
 
 /**
@@ -233,7 +235,7 @@ public abstract class AsyncMapTest extends VertxTestBase {
   public void testMapPutIfAbsentTtl() {
     SharedData sharedData = getVertx().sharedData();
     sharedData.<String, String>getAsyncMap("foo")
-      .compose(map -> map.putIfAbsent("pipo", "molo", 10).andThen(onSuccess(this::assertNull)))
+      .compose(map -> map.putIfAbsent("pipo", "molo", 10).expecting(that(Assert::assertNull)))
       .compose(v -> assertWaitUntilMapContains(sharedData, "foo", "pipo", 15, Objects::isNull))
       .onComplete(onSuccess(v -> testComplete()));
     await();
@@ -247,7 +249,7 @@ public abstract class AsyncMapTest extends VertxTestBase {
         .put("pipo", "molo")
         .compose(v -> map
           .putIfAbsent("pipo", "mili", 10)
-          .andThen(onSuccess(vd -> assertEquals("molo", vd)))))
+          .expecting(that(vd -> assertEquals("molo", vd)))))
       .compose(v -> assertWaitUntilMapContains(sharedData, "foo", "pipo", 15, "molo"::equals)).onComplete(onSuccess(v -> testComplete()));
     await();
   }
@@ -474,7 +476,7 @@ public abstract class AsyncMapTest extends VertxTestBase {
     sharedData.<String, String>getAsyncMap("foo")
       .compose(map -> map
         .replace("pipo", "molo", 10)
-        .andThen(onSuccess(this::assertNull)))
+        .expecting(that(Assert::assertNull)))
       .compose(v -> assertWaitUntilMapContains(sharedData, "foo", "pipo", 15, Objects::isNull))
       .onComplete(onSuccess(v -> testComplete()));
     await();
@@ -485,7 +487,8 @@ public abstract class AsyncMapTest extends VertxTestBase {
     SharedData sharedData = getVertx().sharedData();
     sharedData.<String, String>getAsyncMap("foo")
       .compose(map -> map
-        .put("pipo", "molo").andThen(onSuccess(this::assertNull))
+        .put("pipo", "molo")
+        .expecting(that(Assert::assertNull))
         .compose(vd -> map.replace("pipo", "mili", 10)))
       .compose(v -> assertWaitUntilMapContains(sharedData, "foo", "pipo", 15, Objects::isNull))
       .onComplete(onSuccess(v -> testComplete()));
@@ -569,8 +572,10 @@ public abstract class AsyncMapTest extends VertxTestBase {
     SharedData sharedData = getVertx().sharedData();
     sharedData.<String, String>getAsyncMap("foo")
       .compose(map -> map
-        .put("pipo", "molo").andThen(onSuccess(this::assertNull))
-        .compose(v -> map.replaceIfPresent("pipo", "molo", "mili", 10).andThen(onSuccess(this::assertTrue))))
+        .put("pipo", "molo")
+        .expecting(that(Assert::assertNull))
+        .compose(v -> map.replaceIfPresent("pipo", "molo", "mili", 10)
+          .expecting(that(Assert::assertTrue))))
       .compose(v -> assertWaitUntilMapContains(sharedData, "foo", "pipo", 15, Objects::isNull))
       .onComplete(onSuccess(v -> testComplete()));
     await();
@@ -581,7 +586,7 @@ public abstract class AsyncMapTest extends VertxTestBase {
     getVertx().sharedData().<String, String>getAsyncMap("foo")
       .compose(map -> map
         .replaceIfPresent("pipo", "molo", "mili",10)
-        .andThen(onSuccess(this::assertFalse)))
+        .expecting(that(Assert::assertFalse)))
       .onComplete(onSuccess(vd -> testComplete()));
     await();
   }
@@ -659,7 +664,7 @@ public abstract class AsyncMapTest extends VertxTestBase {
       .compose(v -> sharedData
         .<String, String>getAsyncMap("bar")
         .compose(map -> map.get("foo"))
-        .andThen(onSuccess(this::assertNull)))
+        .expecting(that(Assert::assertNull)))
       .onComplete(onSuccess(res -> testComplete()));
     await();
   }
@@ -683,12 +688,15 @@ public abstract class AsyncMapTest extends VertxTestBase {
     SharedData sharedData = getVertx().sharedData();
     sharedData.<String, String>getAsyncMap("foo")
       .compose(map -> map
-        .size().andThen(onSuccess(size -> assertEquals(0, size.intValue())))
+        .size()
+        .expecting(that(size -> assertEquals(0, size.intValue())))
         .compose(v -> map.put("foo", "bar"))
-        .compose(v -> map.size().andThen(onSuccess(size -> assertEquals(1, size.intValue())))))
+        .compose(v -> map.size()
+          .expecting(that(size -> assertEquals(1, size.intValue())))))
       .compose(v -> sharedData.
           <String, String>getAsyncMap("foo")
-          .compose(map -> map.size().andThen(onSuccess(size -> assertEquals(1, size.intValue())))))
+          .compose(map -> map.size()
+            .expecting(that(size -> assertEquals(1, size.intValue())))))
       .onComplete(onSuccess(v -> testComplete()));
     await();
   }
@@ -712,7 +720,7 @@ public abstract class AsyncMapTest extends VertxTestBase {
     loadData(map, (vertx, asyncMap) -> {
       asyncMap
         .values()
-        .andThen(onSuccess(values -> {
+        .expecting(that(values -> {
           assertEquals(map.values().size(), values.size());
           assertTrue(map.values().containsAll(values));
           assertTrue(values.containsAll(map.values()));
@@ -727,7 +735,8 @@ public abstract class AsyncMapTest extends VertxTestBase {
     Map<JsonObject, Buffer> map = genJsonToBuffer(100);
     loadData(map, (vertx, asyncMap) -> {
       asyncMap
-        .entries().andThen(onSuccess(res -> assertEquals(map.entrySet(), res.entrySet())))
+        .entries()
+        .expecting(that(res -> assertEquals(map.entrySet(), res.entrySet())))
         .onSuccess(res -> testComplete());
     });
     await();
@@ -760,7 +769,7 @@ public abstract class AsyncMapTest extends VertxTestBase {
         .<K, V>getAsyncMap("foo")
         .compose(map -> map
           .get(k))
-        .andThen(onSuccess(res -> assertEquals(v, res))))
+        .expecting(that(res -> assertEquals(v, res))))
       .onComplete(onSuccess(res -> testComplete()));
     await();
   }
@@ -769,13 +778,13 @@ public abstract class AsyncMapTest extends VertxTestBase {
     SharedData sharedData = getVertx().sharedData();
     sharedData.<K, V>getAsyncMap("foo")
       .compose(map -> map.putIfAbsent(k, v))
-      .andThen(onSuccess(this::assertNull))
+      .expecting(that(Assert::assertNull))
       .compose(v_ -> sharedData.<K, V>getAsyncMap("foo"))
       .compose(map -> map
         .get(k)
-        .andThen(onSuccess(res -> assertEquals(v, res)))
+        .expecting(that(res -> assertEquals(v, res)))
         .compose(res2 -> map.putIfAbsent(k, v))
-        .andThen(onSuccess(res -> assertEquals(v, res))))
+        .expecting(that(res -> assertEquals(v, res))))
       .onComplete(onSuccess(res -> testComplete()));
     await();
   }
@@ -783,11 +792,11 @@ public abstract class AsyncMapTest extends VertxTestBase {
   private <K, V> void testMapRemove(K k, V v) {
     SharedData sharedData = getVertx().sharedData();
     sharedData.<K, V>getAsyncMap("foo")
-      .compose(map -> map.put(k, v).andThen(onSuccess(this::assertNull)))
+      .compose(map -> map.put(k, v).expecting(that(Assert::assertNull)))
       .compose(v_ -> sharedData
         .<K, V>getAsyncMap("foo")
         .compose(map -> map.remove(k))
-        .andThen(onSuccess(res -> assertEquals(v, res))))
+        .expecting(that(res -> assertEquals(v, res))))
       .onComplete(onSuccess(res -> testComplete()));
     await();
   }
@@ -796,13 +805,13 @@ public abstract class AsyncMapTest extends VertxTestBase {
     SharedData sharedData = getVertx().sharedData();
     sharedData
       .<K, V>getAsyncMap("foo")
-      .compose(map -> map.put(k, v).andThen(onSuccess(this::assertNull)))
+      .compose(map -> map.put(k, v).expecting(that(Assert::assertNull)))
       .compose(v_ -> sharedData.<K, V>getAsyncMap("foo"))
       .compose(map -> map
         .removeIfPresent(otherKey, v)
-        .andThen(onSuccess(this::assertFalse))
-        .compose(res -> map.removeIfPresent(k, otherValue).andThen(onSuccess(this::assertFalse)))
-        .compose(res -> map.removeIfPresent(k, v).andThen(onSuccess(this::assertTrue))))
+        .expecting(that(Assert::assertFalse))
+        .compose(res -> map.removeIfPresent(k, otherValue).expecting(that(Assert::assertFalse)))
+        .compose(res -> map.removeIfPresent(k, v).expecting(that(Assert::assertTrue))))
       .onComplete(onSuccess(v_ -> testComplete()));
     await();
   }
@@ -811,13 +820,13 @@ public abstract class AsyncMapTest extends VertxTestBase {
     SharedData sharedData = getVertx().sharedData();
     sharedData
       .<K, V>getAsyncMap("foo")
-      .compose(map -> map.put(k, v).andThen(onSuccess(this::assertNull)))
+      .compose(map -> map.put(k, v).expecting(that(Assert::assertNull)))
       .compose(v_ -> sharedData
         .<K, V>getAsyncMap("foo")
-        .compose(map -> map.replace(k, other).andThen(onSuccess(res -> assertEquals(v, res)))
-          .compose(v__ -> map.get(k).andThen(onSuccess(res -> assertEquals(other, res))))
-          .compose(v__ -> map.remove(k)).compose(v__ -> map.replace(k, other).andThen(onSuccess(this::assertNull)))
-          .compose(v__ -> map.get(k).andThen(onSuccess(this::assertNull)))))
+        .compose(map -> map.replace(k, other).expecting(that(res -> assertEquals(v, res)))
+          .compose(v__ -> map.get(k).expecting(that(res -> assertEquals(other, res))))
+          .compose(v__ -> map.remove(k)).compose(v__ -> map.replace(k, other).expecting(that(Assert::assertNull)))
+          .compose(v__ -> map.get(k).expecting(that(Assert::assertNull)))))
       .onComplete(onSuccess(v_ -> testComplete()));
 
     await();
@@ -827,12 +836,12 @@ public abstract class AsyncMapTest extends VertxTestBase {
     SharedData sharedData = getVertx().sharedData();
     sharedData.<K, V>getAsyncMap("foo")
       .compose(map -> map.put(k, v)
-      .andThen(onSuccess(this::assertNull)))
+      .expecting(that(Assert::assertNull)))
       .compose(v_ -> sharedData.<K, V>getAsyncMap("foo"))
       .compose(map -> map
         .replaceIfPresent(k, v, other)
-        .compose(res2 -> map.replaceIfPresent(k, v, other).andThen(onSuccess(this::assertFalse)))
-        .compose(v_ -> map.get(k).andThen(onSuccess(res4 -> assertEquals(other, res4)))))
+        .compose(res2 -> map.replaceIfPresent(k, v, other).expecting(that(Assert::assertFalse)))
+        .compose(v_ -> map.get(k).expecting(that(res4 -> assertEquals(other, res4)))))
       .onComplete(onSuccess(v_ -> testComplete()));
     await();
   }

--- a/src/test/java/io/vertx/core/spi/tracing/HttpTracingTestBase.java
+++ b/src/test/java/io/vertx/core/spi/tracing/HttpTracingTestBase.java
@@ -11,10 +11,7 @@
 package io.vertx.core.spi.tracing;
 
 import io.vertx.core.Context;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpTestBase;
+import io.vertx.core.http.*;
 import io.vertx.test.faketracer.FakeTracer;
 import io.vertx.test.faketracer.Span;
 import org.junit.Test;
@@ -93,7 +90,7 @@ public abstract class HttpTracingTestBase extends HttpTestBase {
         .request(HttpMethod.GET, DEFAULT_HTTP_PORT, "localhost", "/1")
         .compose(req -> req
           .send()
-          .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+          .expecting(HttpResponseExpectation.SC_OK)
           .compose(HttpClientResponse::end))
         .onComplete(onSuccess(v2 -> {
           assertEquals(rootSpan, tracer.activeSpan());

--- a/src/test/java/io/vertx/it/SSLEngineTest.java
+++ b/src/test/java/io/vertx/it/SSLEngineTest.java
@@ -24,6 +24,8 @@ import io.vertx.core.net.impl.SslContextProvider;
 import io.vertx.test.tls.Cert;
 import org.junit.Test;
 
+import static io.vertx.test.core.AssertExpectations.that;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -121,7 +123,7 @@ public class SSLEngineTest extends HttpTestBase {
     client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath")
       .compose(req -> req
         .send()
-        .andThen(onSuccess(resp -> assertEquals(200, resp.statusCode())))
+        .expecting(that(resp -> assertEquals(200, resp.statusCode())))
         .compose(HttpClientResponse::end))
       .onComplete(onSuccess(v -> testComplete()));
     await();

--- a/src/test/java/io/vertx/test/core/AssertExpectations.java
+++ b/src/test/java/io/vertx/test/core/AssertExpectations.java
@@ -1,0 +1,40 @@
+package io.vertx.test.core;
+
+import io.vertx.core.Expectation;
+
+import java.util.function.Consumer;
+
+public class AssertExpectations {
+
+  public static <T> Expectation<T> that(Consumer<? super T> consumer) {
+    return value -> {
+      consumer.accept(value);
+      return true;
+    };
+  }
+
+
+//  public static <T> Expectation<T> assertThat(Matcher<? super T> matcher) {
+//    return assertThat("", matcher);
+//  }
+//
+//  public static <T> Expectation<T> assertThat(String reason, Matcher<? super T> matcher) {
+//    return new Expectation<T>() {
+//      @Override
+//      public boolean test(T actual) {
+//        return matcher.matches(actual);
+//      }
+//      @Override
+//      public Throwable describe(T actual) {
+//        Description description = new StringDescription();
+//        description.appendText(reason)
+//          .appendText("\nExpected: ")
+//          .appendDescriptionOf(matcher)
+//          .appendText("\n     but: ");
+//        matcher.describeMismatch(actual, description);
+//        return new AssertionError(description.toString());
+//      }
+//    };
+//  }
+
+}


### PR DESCRIPTION
Replace future.andThen(onSuccess(A)) by future.expecting(that(P)) in vertx tests.
