### PR TITLE
Async file should stop reading the file when the handler is null

### DIFF
--- a/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -368,8 +368,7 @@ public class AsyncFileImpl implements AsyncFile {
     if (exceptionHandler != null && t instanceof Exception) {
       exceptionHandler.handle(t);
     } else {
-      log.error("Unhandled exception", t);
-
+      context.reportException(t);
     }
   }
 
@@ -398,6 +397,9 @@ public class AsyncFileImpl implements AsyncFile {
   }
 
   private synchronized void doRead(ByteBuffer bb) {
+    if (handler == null) {
+      return;
+    }
     Buffer buff = Buffer.buffer(readBufferSize);
     int readSize = (int) Math.min((long)readBufferSize, readLength);
     bb.limit(readSize);


### PR DESCRIPTION
The `AsyncFile` implementation will continue to read the file when the handler is set to null, instead it should stop reading. In addition report async file exception to the context when no exception handler is set.
