### PR TITLE
Fix a few bugs related to non event-loop thread writes

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.http.impl;
 
+import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http2.Http2Headers;
@@ -19,12 +20,10 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpFrame;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.StreamPriority;
 import io.vertx.core.http.impl.headers.Http2HeadersAdaptor;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.net.HostAndPort;
-import io.vertx.core.net.impl.HostAndPortImpl;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.observability.HttpRequest;
@@ -242,13 +241,23 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
     return metric;
   }
 
-  public HttpServerRequest routed(String route) {
+  public void routed(String route) {
     if (METRICS_ENABLED) {
-      HttpServerMetrics metrics = conn.metrics();
-      if (metrics != null && !responseEnded) {
-        metrics.requestRouted(metric, route);
+      EventLoop eventLoop = vertx.getOrCreateContext().nettyEventLoop();
+      synchronized (this) {
+        if (shouldQueue(eventLoop)) {
+          queueForWrite(eventLoop, () -> routedInternal(route));
+          return;
+        }
       }
+      routedInternal(route);
     }
-    return null;
+  }
+
+  private void routedInternal(String route) {
+    HttpServerMetrics metrics = conn.metrics();
+    if (metrics != null && !responseEnded) {
+      metrics.requestRouted(metric, route);
+    }
   }
 }

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
@@ -335,14 +335,8 @@ class VertxHttp2ConnectionHandler<C extends Http2ConnectionBase> extends Http2Co
         future.setFailure(fut.cause());
       }
     });
-    EventExecutor executor = chctx.executor();
-    if (executor.inEventLoop()) {
-      _writePushPromise(streamId, promisedStreamId, headers, promise);
-    } else {
-      executor.execute(() -> {
-        _writePushPromise(streamId, promisedStreamId, headers, promise);
-      });
-    }
+    _writePushPromise(streamId, promisedStreamId, headers, promise);
+    checkFlush();
     return future;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -71,7 +71,6 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
             conn.consumeCredits(this.stream, len);
           }
         });
-        bytesRead += data.length();
         handleData(data);
       }
     });
@@ -117,6 +116,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
   }
 
   void onData(Buffer data) {
+    bytesRead += data.length();
     conn.reportBytesRead(data.length());
     context.execute(data, pending::write);
   }
@@ -191,10 +191,10 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
 
   void doWriteHeaders(Http2Headers headers, boolean end, boolean checkFlush, Handler<AsyncResult<Void>> handler) {
     FutureListener<Void> promise = handler == null ? null : context.promise(handler);
-    conn.handler.writeHeaders(stream, headers, end, priority.getDependency(), priority.getWeight(), priority.isExclusive(), checkFlush, promise);
     if (end) {
       endWritten();
     }
+    conn.handler.writeHeaders(stream, headers, end, priority.getDependency(), priority.getWeight(), priority.isExclusive(), checkFlush, promise);
   }
 
   protected void endWritten() {
@@ -241,10 +241,10 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
     bytesWritten += numOfBytes;
     conn.reportBytesWritten(numOfBytes);
     FutureListener<Void> promise = handler == null ? null : context.promise(handler);
-    conn.handler.writeData(stream, chunk, end, promise);
     if (end) {
       endWritten();
     }
+    conn.handler.writeData(stream, chunk, end, promise);
   }
 
   final void writeReset(long code) {

--- a/src/test/java/io/vertx/core/http/Http1xMetricsTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xMetricsTest.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.http;
 
+import io.vertx.core.ThreadingModel;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -17,7 +18,11 @@ import java.util.concurrent.CountDownLatch;
 public class Http1xMetricsTest extends HttpMetricsTestBase {
 
   public Http1xMetricsTest() {
-    super(HttpVersion.HTTP_1_1);
+    this(ThreadingModel.EVENT_LOOP);
+  }
+
+  protected Http1xMetricsTest(ThreadingModel threadingModel) {
+    super(HttpVersion.HTTP_1_1, threadingModel);
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/Http1xWorkerMetricsTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xWorkerMetricsTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.core.ThreadingModel;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+public class Http1xWorkerMetricsTest extends Http1xMetricsTest {
+
+  public Http1xWorkerMetricsTest() {
+    super(ThreadingModel.EVENT_LOOP);
+  }
+}


### PR DESCRIPTION
- Incorrect HTTP server metrics report for non event-loop thread writes #5222
- HTTP/2 push is not flushed when written from a non event-loop thread #5223
