### PR TITLE
Fix a few bugs related to non event-loop thread writes.

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
@@ -338,14 +338,8 @@ class VertxHttp2ConnectionHandler<C extends Http2ConnectionBase> extends Http2Co
         future.setFailure(fut.cause());
       }
     });
-    EventExecutor executor = chctx.executor();
-    if (executor.inEventLoop()) {
-      _writePushPromise(streamId, promisedStreamId, headers, promise);
-    } else {
-      executor.execute(() -> {
-        _writePushPromise(streamId, promisedStreamId, headers, promise);
-      });
-    }
+    _writePushPromise(streamId, promisedStreamId, headers, promise);
+    checkFlush();
     return future;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -98,7 +98,6 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
             conn.consumeCredits(this.stream, len);
           }
         });
-        bytesRead += data.length();
         handleData(data);
       }
     });
@@ -146,6 +145,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
   }
 
   void onData(Buffer data) {
+    bytesRead += data.length();
     conn.reportBytesRead(data.length());
     context.execute(data, pending::write);
   }
@@ -237,10 +237,10 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
   }
 
   void doWriteHeaders(Http2Headers headers, boolean end, boolean checkFlush, Promise<Void> promise) {
-    conn.handler.writeHeaders(stream, headers, end, priority.getDependency(), priority.getWeight(), priority.isExclusive(), checkFlush, (FutureListener<Void>) promise);
     if (end) {
       endWritten();
     }
+    conn.handler.writeHeaders(stream, headers, end, priority.getDependency(), priority.getWeight(), priority.isExclusive(), checkFlush, (FutureListener<Void>) promise);
   }
 
   protected void endWritten() {
@@ -273,10 +273,10 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
     int numOfBytes = chunk.readableBytes();
     bytesWritten += numOfBytes;
     conn.reportBytesWritten(numOfBytes);
-    conn.handler.writeData(stream, chunk, end, (FutureListener<Void>) promise);
     if (end) {
       endWritten();
     }
+    conn.handler.writeData(stream, chunk, end, (FutureListener<Void>) promise);
   }
 
   final void writeReset(long code) {

--- a/src/test/java/io/vertx/core/http/Http1xMetricsTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xMetricsTest.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.http;
 
+import io.vertx.core.ThreadingModel;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -17,7 +18,11 @@ import java.util.concurrent.CountDownLatch;
 public class Http1xMetricsTest extends HttpMetricsTestBase {
 
   public Http1xMetricsTest() {
-    super(HttpVersion.HTTP_1_1);
+    this(ThreadingModel.EVENT_LOOP);
+  }
+
+  protected Http1xMetricsTest(ThreadingModel threadingModel) {
+    super(HttpVersion.HTTP_1_1, threadingModel);
   }
 
   @Test

--- a/src/test/java/io/vertx/core/http/Http1xWorkerMetricsTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xWorkerMetricsTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.core.ThreadingModel;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+public class Http1xWorkerMetricsTest extends Http1xMetricsTest {
+
+  public Http1xWorkerMetricsTest() {
+    super(ThreadingModel.EVENT_LOOP);
+  }
+}

--- a/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
+++ b/src/test/java/io/vertx/core/http/HttpMetricsTestBase.java
@@ -15,6 +15,7 @@ import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.impl.HttpClientInternal;
 import io.vertx.core.http.impl.HttpServerRequestInternal;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.SocketAddress;
@@ -44,9 +45,19 @@ import java.util.concurrent.atomic.AtomicReference;
 public abstract class HttpMetricsTestBase extends HttpTestBase {
 
   private final HttpVersion protocol;
+  private final ThreadingModel threadingModel;
 
-  public HttpMetricsTestBase(HttpVersion protocol) {
+  public HttpMetricsTestBase(HttpVersion protocol, ThreadingModel threadingModel) {
     this.protocol = protocol;
+    this.threadingModel = threadingModel;
+  }
+
+  @Override
+  protected void startServer(SocketAddress bindAddress, Context context, HttpServer server) throws Exception {
+    if (threadingModel == ThreadingModel.WORKER) {
+      context = ((VertxInternal) vertx).createWorkerContext();
+    }
+    super.startServer(bindAddress, context, server);
   }
 
   @Override
@@ -88,6 +99,8 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
       assertTrue(serverMetric.get().socket.connected.get());
       assertNull(serverMetric.get().route.get());
       req.routed("/route/:param");
+      // Worker can wait
+      assertWaitUntil(() -> serverMetric.get().route.get() != null);
       assertEquals("/route/:param", serverMetric.get().route.get());
       req.bodyHandler(buff -> {
         assertEquals(contentLength, buff.length());
@@ -98,14 +111,21 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
         vertx.setPeriodic(1, timerID -> {
           Buffer chunk = TestUtils.randomBuffer(chunkSize);
           if (numBuffer.decrementAndGet() == 0) {
-            resp.end(chunk);
-            assertTrue(serverMetric.get().responseEnded.get());
-            assertEquals(contentLength, serverMetric.get().bytesWritten.get());
-            assertNull(serverMetrics.getRequestMetric(req));
+            resp
+              .end(chunk)
+              .onComplete(onSuccess(v -> {
+                assertTrue(serverMetric.get().responseEnded.get());
+                assertFalse(serverMetric.get().failed.get());
+                assertEquals(contentLength, serverMetric.get().bytesWritten.get());
+                assertNull(serverMetrics.getRequestMetric(req));
+              }));
             vertx.cancelTimer(timerID);
           } else {
-            resp.write(chunk);
-            assertSame(serverMetric.get().response.get(), resp);
+            resp
+              .write(chunk)
+              .onComplete(onSuccess(v -> {
+                assertSame(serverMetric.get().response.get(), resp);
+              }));
           }
         });
       });
@@ -210,9 +230,7 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
         });
       });
     });
-    CountDownLatch listenLatch = new CountDownLatch(1);
-    server.listen(HttpTestBase.DEFAULT_HTTP_PORT, "localhost").onComplete(onSuccess(s -> { listenLatch.countDown(); }));
-    awaitLatch(listenLatch);
+    startServer(testAddress);
     FakeHttpClientMetrics clientMetrics = FakeMetricsBase.getMetrics(client);
     CountDownLatch responseBeginLatch = new CountDownLatch(1);
     CountDownLatch responseEndLatch = new CountDownLatch(1);
@@ -306,8 +324,13 @@ public abstract class HttpMetricsTestBase extends HttpTestBase {
       HttpServerMetric metric = metrics.getRequestMetric(req);
       assertNull(metric.route.get());
       req.routed("MyRoute");
+      // Worker can wait
+      assertWaitUntil(() -> metric.route.get() != null);
       assertEquals("MyRoute", metric.route.get());
+      metric.route.set(null);
       req.routed("MyRoute - rerouted");
+      // Worker can wait
+      assertWaitUntil(() -> metric.route.get() != null);
       assertEquals("MyRoute - rerouted", metric.route.get());
       req.response().end();
       testComplete();


### PR DESCRIPTION
- Incorrect HTTP server metrics report for non event-loop thread writes #5222
- HTTP/2 push is not flushed when written from a non event-loop thread #5223
