### PR TITLE
Improve native dependencies of vertx-core

### DIFF
--- a/vertx-core/pom.xml
+++ b/vertx-core/pom.xml
@@ -86,12 +86,12 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
+      <artifactId>netty-transport-classes-epoll</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-kqueue</artifactId>
+      <artifactId>netty-transport-classes-kqueue</artifactId>
       <optional>true</optional>
     </dependency>
 
@@ -381,9 +381,7 @@
                 <include>io/vertx/it/transport/TransportTest.java</include>
               </includes>
               <classpathDependencyExcludes>
-                <classpathDependencyExclude>io.netty:netty-transport-native-epoll</classpathDependencyExclude>
                 <classpathDependencyExclude>io.netty:netty-transport-classes-epoll</classpathDependencyExclude>
-                <classpathDependencyExclude>io.netty:netty-transport-native-kqueue</classpathDependencyExclude>
                 <classpathDependencyExclude>io.netty:netty-transport-classes-kqueue</classpathDependencyExclude>
               </classpathDependencyExcludes>
             </configuration>

--- a/vertx-core/src/main/java/io/vertx/core/VertxOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/VertxOptions.java
@@ -16,7 +16,6 @@ import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.eventbus.EventBusOptions;
 import io.vertx.core.file.FileSystemOptions;
-import io.vertx.core.impl.SysProps;
 import io.vertx.core.impl.cpu.CpuCoreSensor;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -163,14 +163,15 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   private final TimeUnit maxEventLoopExecTimeUnit;
   private final CloseFuture closeFuture;
   private final Transport transport;
+  private final Throwable transportUnavailabilityCause;
   private final VertxTracer tracer;
   private final ThreadLocal<WeakReference<ContextInternal>> stickyContext = new ThreadLocal<>();
   private final boolean disableTCCL;
   private final Boolean useDaemonThread;
 
   VertxImpl(VertxOptions options, ClusterManager clusterManager, NodeSelector nodeSelector, VertxMetrics metrics,
-            VertxTracer<?, ?> tracer, Transport transport, FileResolver fileResolver, VertxThreadFactory threadFactory,
-            ExecutorServiceFactory executorServiceFactory) {
+            VertxTracer<?, ?> tracer, Transport transport, Throwable transportUnavailabilityCause,
+            FileResolver fileResolver, VertxThreadFactory threadFactory, ExecutorServiceFactory executorServiceFactory) {
     // Sanity check
     if (Vertx.currentContext() != null) {
       log.warn("You're already on a Vert.x context, are you sure you want to create a new Vertx instance?");
@@ -218,6 +219,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     this.threadFactory = threadFactory;
     this.metrics = metrics;
     this.transport = transport;
+    this.transportUnavailabilityCause = transportUnavailabilityCause;
     this.fileResolver = fileResolver;
     this.addressResolverOptions = options.getAddressResolverOptions();
     this.hostnameResolver = new HostnameResolver(this, options.getAddressResolverOptions());
@@ -368,7 +370,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     if (isNativeTransportEnabled()) {
       return null;
     }
-    return transport.unavailabilityCause();
+    return transportUnavailabilityCause;
   }
 
   public FileSystem fileSystem() {


### PR DESCRIPTION
vertx-core does not need to depend on netty-transport-native-XXX instead it can depend on netty-transport-classes-XXX
