### PR TITLE
Shadow context

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/ThreadingModel.java
+++ b/vertx-core/src/main/java/io/vertx/core/ThreadingModel.java
@@ -11,26 +11,30 @@
 package io.vertx.core;
 
 /**
- * The threading model defines how user tasks should be executed.
+ * The threading model defines the scheduler to execute context tasks.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public enum ThreadingModel {
 
   /**
-   * Event-loop threading model.
+   * Tasks are scheduled on the event-loop thread.
    */
   EVENT_LOOP,
 
   /**
-   * Worker threading model
+   * Tasks are scheduled on a worker pool.
    */
   WORKER,
 
   /**
-   * Virtual thread threading model
+   * Tasks are scheduled on a virtual thread.
    */
-  VIRTUAL_THREAD
+  VIRTUAL_THREAD,
 
+  /**
+   * Tasks are scheduled on threads not managed by the current vertx instance.
+   */
+  OTHER
 }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -248,7 +248,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
       if (this.metrics != null) {
         stream.metric = this.metrics.requestBegin(request.uri, request);
       }
-      VertxTracer tracer = context.tracer();
+      VertxTracer tracer = stream.context.tracer();
       if (tracer != null) {
         BiConsumer<String, String> headers = (key, val) -> new HeadersAdaptor(nettyRequest.headers()).add(key, val);
         String operation = request.traceOperation;
@@ -901,7 +901,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
       stream.responseEnded = true;
       check = requests.peek() != stream;
     }
-    VertxTracer tracer = context.tracer();
+    VertxTracer tracer = stream.context.tracer();
     if (tracer != null) {
       tracer.receiveResponse(stream.context, response, stream.trace, null, HttpUtils.CLIENT_RESPONSE_TAG_EXTRACTOR);
     }
@@ -1164,7 +1164,6 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
         evictionHandler.handle(null);
       }
     }
-    VertxTracer tracer = context.tracer();
     List<Stream> allocatedStreams;
     List<Stream> sentStreams;
     synchronized (this) {
@@ -1180,6 +1179,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
         metrics.requestReset(stream.metric);
       }
       Object trace = stream.trace;
+      VertxTracer tracer = stream.context.tracer();
       if (tracer != null && trace != null) {
         tracer.receiveResponse(stream.context, null, trace, HttpUtils.CONNECTION_CLOSED_EXCEPTION, TagExtractor.empty());
       }

--- a/vertx-core/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -37,7 +37,6 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
 
   static final boolean DISABLE_TIMINGS = SysProps.DISABLE_CONTEXT_TIMINGS.getBoolean();
 
-  private final ThreadingModel threadingModel;
   private final VertxInternal owner;
   private final JsonObject config;
   private final Deployment deployment;
@@ -47,23 +46,19 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
   private final EventExecutor executor;
   private ConcurrentMap<Object, Object> data;
   private volatile Handler<Throwable> exceptionHandler;
-  final WorkerPool internalWorkerPool;
   final WorkerPool workerPool;
   final TaskQueue orderedTasks;
 
   public ContextImpl(VertxInternal vertx,
                         Object[] locals,
-                        ThreadingModel threadingModel,
                         EventLoop eventLoop,
                         EventExecutor executor,
-                        WorkerPool internalWorkerPool,
                         WorkerPool workerPool,
                         TaskQueue orderedTasks,
                         Deployment deployment,
                         CloseFuture closeFuture,
                         ClassLoader tccl) {
     super(locals);
-    this.threadingModel = threadingModel;
     this.deployment = deployment;
     this.config = deployment != null ? deployment.config() : new JsonObject();
     this.eventLoop = eventLoop;
@@ -72,7 +67,6 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
     this.owner = vertx;
     this.workerPool = workerPool;
     this.closeFuture = closeFuture;
-    this.internalWorkerPool = internalWorkerPool;
     this.orderedTasks = orderedTasks;
   }
 
@@ -100,7 +94,7 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
 
   @Override
   public <T> Future<T> executeBlockingInternal(Callable<T> action) {
-    return executeBlocking(this, action, internalWorkerPool, null);
+    return executeBlocking(this, action, null, null);
   }
 
   @Override
@@ -115,16 +109,16 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
 
   @Override
   public boolean isEventLoopContext() {
-    return threadingModel == ThreadingModel.EVENT_LOOP;
+    return executor.threadingModel() == ThreadingModel.EVENT_LOOP;
   }
 
   @Override
   public boolean isWorkerContext() {
-    return threadingModel == ThreadingModel.WORKER;
+    return executor.threadingModel() == ThreadingModel.WORKER;
   }
 
   public ThreadingModel threadingModel() {
-    return threadingModel;
+    return executor.threadingModel();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -23,7 +23,6 @@ import io.vertx.core.spi.tracing.VertxTracer;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executor;
 
 /**
  * A context that forwards most operations to a delegate. This context
@@ -49,11 +48,6 @@ final class DuplicatedContext extends ContextBase implements ContextInternal {
   }
 
   @Override
-  public boolean inThread() {
-    return delegate.inThread();
-  }
-
-  @Override
   public CloseFuture closeFuture() {
     return delegate.closeFuture();
   }
@@ -75,7 +69,7 @@ final class DuplicatedContext extends ContextBase implements ContextInternal {
   }
 
   @Override
-  public Executor executor() {
+  public EventExecutor executor() {
     return delegate.executor();
   }
 
@@ -120,33 +114,8 @@ final class DuplicatedContext extends ContextBase implements ContextInternal {
   }
 
   @Override
-  public <T> Future<T> executeBlockingInternal(Callable<T> action) {
-    return ContextImpl.executeBlocking(this, action, delegate.owner().getInternalWorkerPool(), null);
-  }
-
-  @Override
   public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
-    return ContextImpl.executeBlocking(this, blockingCodeHandler, delegate.workerPool, ordered ? delegate.orderedTasks : null);
-  }
-
-  @Override
-  public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, TaskQueue queue) {
-    return ContextImpl.executeBlocking(this, blockingCodeHandler, delegate.workerPool, queue);
-  }
-
-  @Override
-  public <T> void execute(T argument, Handler<T> task) {
-    delegate.execute(this, argument, task);
-  }
-
-  @Override
-  public <T> void emit(T argument, Handler<T> task) {
-    delegate.emit(this, argument, task);
-  }
-
-  @Override
-  public void execute(Runnable task) {
-    delegate.execute(this, task);
+    return delegate.workerPool.executeBlocking(this, blockingCodeHandler, ordered ? delegate.orderedTasks : null);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -121,7 +121,7 @@ final class DuplicatedContext extends ContextBase implements ContextInternal {
 
   @Override
   public <T> Future<T> executeBlockingInternal(Callable<T> action) {
-    return ContextImpl.executeBlocking(this, action, delegate.internalWorkerPool, null);
+    return ContextImpl.executeBlocking(this, action, delegate.owner().getInternalWorkerPool(), null);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/EventExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/EventExecutor.java
@@ -10,19 +10,12 @@
  */
 package io.vertx.core.impl;
 
-import io.vertx.core.ThreadingModel;
-
 import java.util.concurrent.Executor;
 
 /**
  * The Vert.x context event executor.
  */
 public interface EventExecutor extends Executor {
-
-  /**
-   * @return the executor threading model
-   */
-  ThreadingModel threadingModel();
 
   /**
    * @return whether the current thread is one of the event executor thread

--- a/vertx-core/src/main/java/io/vertx/core/impl/EventExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/EventExecutor.java
@@ -10,12 +10,19 @@
  */
 package io.vertx.core.impl;
 
+import io.vertx.core.ThreadingModel;
+
 import java.util.concurrent.Executor;
 
 /**
  * The Vert.x context event executor.
  */
 public interface EventExecutor extends Executor {
+
+  /**
+   * @return the executor threading model
+   */
+  ThreadingModel threadingModel();
 
   /**
    * @return whether the current thread is one of the event executor thread

--- a/vertx-core/src/main/java/io/vertx/core/impl/EventLoopExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/EventLoopExecutor.java
@@ -27,11 +27,6 @@ public class EventLoopExecutor implements EventExecutor {
   }
 
   @Override
-  public ThreadingModel threadingModel() {
-    return ThreadingModel.EVENT_LOOP;
-  }
-
-  @Override
   public boolean inThread() {
     return eventLoop.inEventLoop();
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/EventLoopExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/EventLoopExecutor.java
@@ -11,6 +11,7 @@
 package io.vertx.core.impl;
 
 import io.netty.channel.EventLoop;
+import io.vertx.core.ThreadingModel;
 
 /**
  * Execute events on an event-loop.
@@ -23,6 +24,11 @@ public class EventLoopExecutor implements EventExecutor {
 
   public EventLoopExecutor(EventLoop eventLoop) {
     this.eventLoop = eventLoop;
+  }
+
+  @Override
+  public ThreadingModel threadingModel() {
+    return ThreadingModel.EVENT_LOOP;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl;
+
+import io.netty.channel.EventLoop;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.*;
+import io.vertx.core.internal.CloseFuture;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.tracing.VertxTracer;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * <p>A shadow context represents a context from a different Vert.x instance than the {@link #owner} instance.</p>
+ *
+ * <p>The primary use case for shadow context, is the integration of a Vert.x client within a Vert.x server with
+ * two distinct instances of Vert.x.</p>
+ *
+ * <p>When {@link Vertx#getOrCreateContext()} is invoked on an instance and the current thread is associated with a context
+ * of another instance, a shadow context is returned with an event-loop thread of the called vertx instance.</p>
+ *
+ * <p>When a thread is associated with a shadow context, {@link Vertx#getOrCreateContext()} returns the context tha
+ * was created by the corresponding instance.</p>
+ *
+ * <p>The following can be expected of a shadow context
+ * <ul>
+ *   <li>{@link #threadingModel()} returns the {@link ThreadingModel#OTHER}</li>
+ *   <li>{@link #nettyEventLoop()} returns an event-loop of the {@link #owner()}</li>
+ *   <li>{@link #owner()} returns the Vertx instance that created it</li>
+ *   <li>{@link #executor()} returns the event executor of the shadowed context</li>
+ *   <li>{@link #workerPool()} returns the {@link #owner()} worker pool</li>
+ * </ul>
+ * </p>
+ *
+ * <p>When a task is scheduled on a shadow context, that task is scheduled on the actual context event executor, therefore
+ * middleware running on the actual context interacts with this context resources, middleware running on the shadow context
+ * interacts with the shadow context resources.</p>
+ */
+final class ShadowContext extends ContextBase {
+
+  final VertxInternal owner;
+  final ContextBase delegate;
+  private final EventLoop eventLoop;
+  private final TaskQueue orderedTasks;
+
+  public ShadowContext(VertxInternal owner, EventLoop eventLoop, ContextInternal delegate) {
+    super(((ContextBase)delegate).locals);
+    this.owner = owner;
+    this.eventLoop = eventLoop;
+    this.delegate = (ContextBase) delegate;
+    this.orderedTasks = new TaskQueue();
+  }
+
+  @Override
+  public EventExecutor executor() {
+    return delegate.executor();
+  }
+
+  @Override
+  public EventLoop nettyEventLoop() {
+    return eventLoop;
+  }
+
+  @Override
+  public Deployment getDeployment() {
+    return null;
+  }
+
+  @Override
+  public VertxInternal owner() {
+    return owner;
+  }
+
+  @Override
+  public void reportException(Throwable t) {
+    // Not sure of that
+    delegate.reportException(t);
+  }
+
+  @Override
+  public ConcurrentMap<Object, Object> contextData() {
+    return delegate.contextData();
+  }
+
+  @Override
+  public ClassLoader classLoader() {
+    return delegate.classLoader();
+  }
+
+  @Override
+  public WorkerPool workerPool() {
+    return owner.getWorkerPool();
+  }
+
+  @Override
+  public VertxTracer tracer() {
+    return delegate.tracer();
+  }
+
+  @Override
+  public ContextInternal duplicate() {
+    return new ShadowContext(owner, eventLoop, delegate.duplicate());
+  }
+
+  @Override
+  public ContextInternal unwrap() {
+    if (isDuplicate()) {
+      return new ShadowContext(owner, eventLoop, delegate.unwrap());
+    } else {
+      return this;
+    }
+  }
+
+  @Override
+  public boolean isDuplicate() {
+    return delegate.isDuplicate();
+  }
+
+  @Override
+  public CloseFuture closeFuture() {
+    return owner.closeFuture();
+  }
+
+  @Override
+  public <T> Future<@Nullable T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
+    return owner.getWorkerPool().executeBlocking(this, blockingCodeHandler, ordered ? orderedTasks : null);
+  }
+
+  @Override
+  public @Nullable JsonObject config() {
+    return null;
+  }
+
+  @Override
+  public boolean isEventLoopContext() {
+    return false;
+  }
+
+  @Override
+  public boolean isWorkerContext() {
+    return false;
+  }
+
+  @Override
+  public ThreadingModel threadingModel() {
+    return ThreadingModel.OTHER;
+  }
+
+  @Override
+  public Context exceptionHandler(@Nullable Handler<Throwable> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public @Nullable Handler<Throwable> exceptionHandler() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -527,7 +527,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   private ContextImpl createEventLoopContext(EventLoop eventLoop, CloseFuture closeFuture, WorkerPool workerPool, Deployment deployment, ClassLoader tccl) {
-    return new ContextImpl(this, createContextLocals(), ThreadingModel.EVENT_LOOP, eventLoop, new EventLoopExecutor(eventLoop), internalWorkerPool, workerPool != null ? workerPool : this.workerPool, new TaskQueue(), deployment, closeFuture, disableTCCL ? null : tccl);
+    return new ContextImpl(this, createContextLocals(), eventLoop, new EventLoopExecutor(eventLoop), workerPool != null ? workerPool : this.workerPool, new TaskQueue(), deployment, closeFuture, disableTCCL ? null : tccl);
   }
 
   @Override
@@ -554,7 +554,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   public ContextImpl createWorkerContext(Deployment deployment, CloseFuture closeFuture, EventLoop eventLoop, WorkerPool workerPool, ClassLoader tccl) {
     TaskQueue orderedTasks = new TaskQueue();
     WorkerPool wp = workerPool != null ? workerPool : this.workerPool;
-    return new ContextImpl(this, createContextLocals(), ThreadingModel.WORKER, eventLoop, new WorkerExecutor(wp, orderedTasks), internalWorkerPool, wp, orderedTasks, deployment, closeFuture, disableTCCL ? null : tccl);
+    return new ContextImpl(this, createContextLocals(), eventLoop, new WorkerExecutor(wp, false, orderedTasks), wp, orderedTasks, deployment, closeFuture, disableTCCL ? null : tccl);
   }
 
   @Override
@@ -572,7 +572,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       throw new IllegalStateException("This Java runtime does not support virtual threads");
     }
     TaskQueue orderedTasks = new TaskQueue();
-    return new ContextImpl(this, createContextLocals(), ThreadingModel.VIRTUAL_THREAD, eventLoop, new WorkerExecutor(virtualThreaWorkerPool, orderedTasks), internalWorkerPool, virtualThreaWorkerPool, orderedTasks, deployment, closeFuture, disableTCCL ? null : tccl);
+    return new ContextImpl(this, createContextLocals(), eventLoop, new WorkerExecutor(virtualThreaWorkerPool, true, orderedTasks), virtualThreaWorkerPool, orderedTasks, deployment, closeFuture, disableTCCL ? null : tccl);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.impl;
 
+import io.vertx.core.ThreadingModel;
 import io.vertx.core.Vertx;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.spi.metrics.PoolMetrics;
@@ -39,12 +40,19 @@ public class WorkerExecutor implements EventExecutor {
   }
 
   private final WorkerPool workerPool;
+  private final boolean virtualThread;
   private final TaskQueue orderedTasks;
   private final ThreadLocal<Boolean> inThread = new ThreadLocal<>();
 
-  public WorkerExecutor(WorkerPool workerPool, TaskQueue orderedTasks) {
+  public WorkerExecutor(WorkerPool workerPool, boolean virtualThread, TaskQueue orderedTasks) {
     this.workerPool = workerPool;
     this.orderedTasks = orderedTasks;
+    this.virtualThread = virtualThread;
+  }
+
+  @Override
+  public ThreadingModel threadingModel() {
+    return virtualThread ? ThreadingModel.VIRTUAL_THREAD : ThreadingModel.WORKER;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
@@ -10,7 +10,6 @@
  */
 package io.vertx.core.impl;
 
-import io.vertx.core.ThreadingModel;
 import io.vertx.core.Vertx;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.spi.metrics.PoolMetrics;
@@ -40,19 +39,12 @@ public class WorkerExecutor implements EventExecutor {
   }
 
   private final WorkerPool workerPool;
-  private final boolean virtualThread;
   private final TaskQueue orderedTasks;
   private final ThreadLocal<Boolean> inThread = new ThreadLocal<>();
 
-  public WorkerExecutor(WorkerPool workerPool, boolean virtualThread, TaskQueue orderedTasks) {
+  public WorkerExecutor(WorkerPool workerPool, TaskQueue orderedTasks) {
     this.workerPool = workerPool;
     this.orderedTasks = orderedTasks;
-    this.virtualThread = virtualThread;
-  }
-
-  @Override
-  public ThreadingModel threadingModel() {
-    return virtualThread ? ThreadingModel.VIRTUAL_THREAD : ThreadingModel.WORKER;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
@@ -62,7 +62,7 @@ class WorkerExecutorImpl implements MetricsProvider, WorkerExecutorInternal {
   public <T> Future<@Nullable T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
     ContextInternal context = vertx.getOrCreateContext();
     ContextImpl impl = context instanceof DuplicatedContext ? ((DuplicatedContext)context).delegate : (ContextImpl) context;
-    return ContextImpl.executeBlocking(context, blockingCodeHandler, pool, ordered ? impl.orderedTasks : null);
+    return pool.executeBlocking(context, blockingCodeHandler, ordered ? impl.orderedTasks : null);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
@@ -125,12 +125,16 @@ public interface ContextInternal extends Context {
    * Like {@link #executeBlocking(Callable, boolean)} but uses the {@code queue} to order the tasks instead
    * of the internal queue of this context.
    */
-  <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, TaskQueue queue);
+  default <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, TaskQueue queue) {
+    return workerPool().executeBlocking(this, blockingCodeHandler, queue);
+  }
 
   /**
    * Execute an internal task on the internal blocking ordered executor.
    */
-  <T> Future<T> executeBlockingInternal(Callable<T> action);
+  default <T> Future<T> executeBlockingInternal(Callable<T> action) {
+    return owner().getInternalWorkerPool().executeBlocking(this, action, null);
+  }
 
   /**
    * @return the deployment associated with this context or {@code null}

--- a/vertx-core/src/test/benchmarks/io/vertx/benchmarks/BenchmarkContext.java
+++ b/vertx-core/src/test/benchmarks/io/vertx/benchmarks/BenchmarkContext.java
@@ -26,6 +26,10 @@ public class BenchmarkContext {
 
   private static final EventExecutor EXECUTOR = new EventExecutor() {
     @Override
+    public ThreadingModel threadingModel() {
+      return ThreadingModel.WORKER;
+    }
+    @Override
     public boolean inThread() {
       throw new UnsupportedOperationException();
     }
@@ -40,11 +44,9 @@ public class BenchmarkContext {
     return new ContextImpl(
       impl,
       new Object[0],
-      ThreadingModel.WORKER,
       impl.getEventLoopGroup().next(),
       EXECUTOR,
-      impl.getInternalWorkerPool(),
-      impl.getWorkerPool(),
+            impl.getWorkerPool(),
       new TaskQueue(),
       null,
       null,

--- a/vertx-core/src/test/benchmarks/io/vertx/benchmarks/BenchmarkContext.java
+++ b/vertx-core/src/test/benchmarks/io/vertx/benchmarks/BenchmarkContext.java
@@ -26,10 +26,6 @@ public class BenchmarkContext {
 
   private static final EventExecutor EXECUTOR = new EventExecutor() {
     @Override
-    public ThreadingModel threadingModel() {
-      return ThreadingModel.WORKER;
-    }
-    @Override
     public boolean inThread() {
       throw new UnsupportedOperationException();
     }
@@ -45,8 +41,9 @@ public class BenchmarkContext {
       impl,
       new Object[0],
       impl.getEventLoopGroup().next(),
+      ThreadingModel.WORKER,
       EXECUTOR,
-            impl.getWorkerPool(),
+      impl.getWorkerPool(),
       new TaskQueue(),
       null,
       null,

--- a/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
@@ -895,7 +895,8 @@ public class ContextTest extends VertxTestBase {
   @Test
   public void testSticky() {
     Context ctx = vertx.getOrCreateContext();
-    assertSame(ctx, vertx.getOrCreateContext());
+    assertNotSame(ctx, vertx.getOrCreateContext());
+    assertSame(((ContextInternal)ctx).nettyEventLoop(), ((ContextInternal)vertx.getOrCreateContext()).nettyEventLoop());
   }
 
   @Test
@@ -908,7 +909,7 @@ public class ContextTest extends VertxTestBase {
       Promise<Object> p1 = Promise.promise();
       PromiseInternal<Object> p2 = supplier.apply(p1);
       assertNotSame(p1, p2);
-      assertSame(ctx, p2.context());
+      // assertSame(ctx, p2.context());
       Object result = new Object();
       p2.complete(result);
       assertWaitUntil(() -> p1.future().isComplete());

--- a/vertx-core/src/test/java/io/vertx/tests/context/ShadowContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ShadowContextTest.java
@@ -1,0 +1,486 @@
+package io.vertx.tests.context;
+
+import io.netty.channel.EventLoop;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.ThreadingModel;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.http.*;
+import io.vertx.core.impl.LocalSeq;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetServer;
+import io.vertx.core.spi.context.storage.AccessMode;
+import io.vertx.core.spi.context.storage.ContextLocal;
+import io.vertx.core.spi.tracing.SpanKind;
+import io.vertx.test.core.AsyncTestBase;
+import io.vertx.test.faketracer.FakeTracer;
+import io.vertx.test.faketracer.Span;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ShadowContextTest extends AsyncTestBase {
+
+  ContextLocal<Object> contextLocal;
+  VertxInternal shadowVertx;
+  VertxInternal actualVertx;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    contextLocal = ContextLocal.registerLocal(Object.class);
+    shadowVertx = (VertxInternal) Vertx.vertx();
+    actualVertx = (VertxInternal) Vertx.vertx();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    awaitFuture(shadowVertx.close());
+    awaitFuture(actualVertx.close());
+    LocalSeq.reset();
+    super.tearDown();
+  }
+
+  @Test
+  public void testGetOrCreate() {
+    ContextInternal actualCtx = actualVertx.getOrCreateContext();
+    actualCtx.runOnContext(v1 -> {
+      Thread expected = Thread.currentThread();
+      ContextInternal shadowCtx = shadowVertx.getOrCreateContext();
+      assertSame(actualCtx, actualVertx.getOrCreateContext());
+      assertNotSame(shadowCtx, actualCtx);
+      assertNotSame(shadowCtx.nettyEventLoop(), actualCtx.nettyEventLoop());
+      shadowCtx.runOnContext(v2 -> {
+        assertSame(expected, Thread.currentThread());
+        assertSame(shadowCtx, shadowVertx.getOrCreateContext());
+        assertSame(actualCtx, actualVertx.getOrCreateContext());
+        testComplete();
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testEmitFromOriginatingThread() {
+    ContextInternal actualCtx = actualVertx.getOrCreateContext();
+    actualCtx.runOnContext(v1 -> {
+      ContextInternal shadowCtx = shadowVertx.getOrCreateContext();
+      AtomicBoolean inThread = new AtomicBoolean(true);
+      shadowCtx.emit(v2 -> {
+        assertSame(shadowCtx, Vertx.currentContext());
+        assertTrue(inThread.get());
+        testComplete();
+      });
+      inThread.set(false);
+    });
+    await();
+  }
+
+  @Test
+  public void testEmitFromEventLoop() {
+    Context eventLoop = shadowVertx.getOrCreateContext();
+    ContextInternal actualCtx = actualVertx.getOrCreateContext();
+    actualCtx.runOnContext(v1 -> {
+      ContextInternal shadowCtx = shadowVertx.getOrCreateContext();
+      AtomicBoolean inThread = new AtomicBoolean(true);
+      eventLoop.runOnContext(v -> {
+        shadowCtx.emit(v2 -> {
+          assertSame(shadowCtx, Vertx.currentContext());
+          assertWaitUntil(() -> !inThread.get());
+          testComplete();
+        });
+        inThread.set(false);
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testThreadingModel() {
+    ContextInternal actualCtx = actualVertx.getOrCreateContext();
+    actualCtx.runOnContext(v1 -> {
+      ContextInternal shadowCtx = shadowVertx.getOrCreateContext();
+      assertEquals(ThreadingModel.OTHER, shadowCtx.threadingModel());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testPiggyBack() {
+    Context actualCtx = actualVertx.getOrCreateContext();
+    actualCtx.runOnContext(v1 -> {
+      shadowVertx.runOnContext(v2 -> {
+        Context shadowContext = shadowVertx.getOrCreateContext();
+        assertSame(shadowContext, Vertx.currentContext());
+        shadowVertx.runOnContext(v3 -> {
+          assertSame(shadowContext, Vertx.currentContext());
+          actualVertx.runOnContext(v -> {
+            assertSame(actualCtx, Vertx.currentContext());
+            testComplete();
+          });
+        });
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testStickyEventLoop() {
+    AtomicReference<EventLoop> eventLoop1 = new AtomicReference<>();
+    AtomicReference<EventLoop> eventLoop2 = new AtomicReference<>();
+    Context ctx1 = actualVertx.getOrCreateContext();
+    Context ctx2 = actualVertx.getOrCreateContext();
+    ctx1.runOnContext(v1 -> {
+      ContextInternal ctx = shadowVertx.getOrCreateContext();
+      eventLoop1.set(ctx.nettyEventLoop());
+      complete();
+    });
+    ctx2.runOnContext(v1 -> {
+      ContextInternal ctx = (ContextInternal) shadowVertx.getOrCreateContext();
+      eventLoop2.set(ctx.nettyEventLoop());
+    });
+    assertWaitUntil(() -> eventLoop1.get() != null && eventLoop2.get() != null);
+    Assert.assertSame(eventLoop1.get(), eventLoop2.get());
+  }
+
+  @Test
+  public void testHttpClient() throws Exception {
+    HttpServer server = shadowVertx.createHttpServer().requestHandler(req -> {
+      HttpServerResponse resp = req.response();
+      resp.setChunked(true);
+      for (int i = 0;i < 8;i++) {
+        resp.write("chunk-" + i);
+      }
+      resp.end();
+    });
+    awaitFuture(server.listen(8080, "localhost"));
+    HttpClientAgent client = shadowVertx.createHttpClient();
+    Context ctx = actualVertx.getOrCreateContext();
+    ctx.runOnContext(v1 -> {
+      Thread expected = Thread.currentThread();
+      client.request(HttpMethod.GET, 8080, "localhost", "/")
+        .onComplete(onSuccess(req -> {
+          Context shadow = Vertx.currentContext();
+          assertEquals(ThreadingModel.OTHER, shadow.threadingModel());
+          assertSame(shadow, shadowVertx.getOrCreateContext());
+          assertSame(expected, Thread.currentThread());
+          assertSame(ctx, actualVertx.getOrCreateContext());
+          req
+            .send()
+            .onComplete(onSuccess(resp -> {
+              assertSame(expected, Thread.currentThread());
+              assertSame(ctx, actualVertx.getOrCreateContext());
+              AtomicInteger idx = new AtomicInteger();
+              resp.handler(buff -> {
+                assertSame(expected, Thread.currentThread());
+                assertSame(ctx, actualVertx.getOrCreateContext());
+                assertEquals("chunk-" + idx.getAndIncrement(), buff.toString());
+              });
+              resp.endHandler(v2 -> {
+                assertSame(expected, Thread.currentThread());
+                assertSame(ctx, actualVertx.getOrCreateContext());
+                testComplete();
+              });
+            }));
+        }));
+    });
+    await();
+  }
+
+  @Test
+  public void testHttpServer() throws Exception {
+    Context actualCtx = actualVertx.getOrCreateContext();
+    CountDownLatch latch = new CountDownLatch(1);
+    actualCtx.runOnContext(v1 -> {
+      HttpServer server = shadowVertx.createHttpServer().requestHandler(req -> {
+        ContextInternal shadowDuplicate = shadowVertx.getOrCreateContext();
+        assertEquals(ThreadingModel.OTHER, shadowDuplicate.threadingModel());
+        assertTrue(shadowDuplicate.isDuplicate());
+        ContextInternal shadowDuplicateUnwrap = shadowDuplicate.unwrap();
+        assertEquals(ThreadingModel.OTHER, shadowDuplicateUnwrap.threadingModel());
+        assertFalse(shadowDuplicateUnwrap.isDuplicate());
+        ContextInternal duplicate = actualVertx.getOrCreateContext();
+        assertTrue(duplicate.isDuplicate());
+        assertSame(actualCtx, duplicate.unwrap());
+        HttpServerResponse resp = req.response();
+        resp.end("Hello World");
+      });
+      server.listen(8080, "localhost").onComplete(onSuccess(v -> {
+        assertSame(actualCtx, actualVertx.getOrCreateContext());
+        latch.countDown();
+      }));
+    });
+    awaitLatch(latch);
+    HttpClientAgent client = shadowVertx.createHttpClient();
+    Future<Buffer> fut = client.request(new RequestOptions().setPort(8080).setHost("localhost"))
+      .compose(req -> req
+        .send()
+        .compose(HttpClientResponse::body));
+    Buffer body = awaitFuture(fut);
+    assertEquals("Hello World", body.toString());
+  }
+
+  @Test
+  public void testSegregatedHttpProxy() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    try {
+      HttpServer server = vertx
+        .createHttpServer()
+        .requestHandler(req -> {
+          req.response().end("Hello World");
+        });
+      awaitFuture(server.listen(8081, "localhost"));
+      HttpClient client = vertx.createHttpClient();
+      Set<Context> clientProxyContexts = Collections.synchronizedSet(new HashSet<>());
+      HttpClientAgent clientProxy = shadowVertx
+        .httpClientBuilder()
+        .withConnectHandler(conn -> {
+          clientProxyContexts.add(Vertx.currentContext());
+        })
+        .build();
+      HttpServer serverProxy = actualVertx
+        .createHttpServer()
+        .requestHandler(inboundReq -> {
+          ContextInternal actualCtx = actualVertx.getContext();
+          inboundReq.body().compose(body -> clientProxy
+            .request(inboundReq.method(), 8081, "localhost", inboundReq.uri())
+            .compose(outboundReq -> outboundReq
+              .send(body)
+              .compose(HttpClientResponse::body)
+            )).onComplete(ar -> {
+            assertSame(actualCtx, actualVertx.getOrCreateContext());
+            ContextInternal shadowCtx = shadowVertx.getOrCreateContext();
+            assertNotSame(actualCtx, shadowCtx);
+            if (ar.succeeded()) {
+              inboundReq.response().end(ar.result());
+            } else {
+              inboundReq.response().setStatusCode(500).end();
+            }
+          });
+        });
+      awaitFuture(serverProxy.listen(8080, "localhost"));
+      Future<Buffer> fut = client.request(new RequestOptions().setPort(8080).setHost("localhost"))
+        .compose(req -> req
+          .send()
+          .expecting(HttpResponseExpectation.SC_OK)
+          .compose(HttpClientResponse::body));
+      Buffer body = awaitFuture(fut);
+      assertEquals("Hello World", body.toString());
+      assertEquals(1, clientProxyContexts.size());
+    } finally {
+      awaitFuture(vertx.close());
+    }
+  }
+
+  @Test
+  public void testNetSocketClient() throws Exception {
+    int num = 8;
+    waitFor(2 + 8);
+    NetServer server = shadowVertx.createNetServer().connectHandler(so -> {
+      Buffer received = Buffer.buffer();
+      so.handler(buff -> {
+        received.appendBuffer(buff);
+        if (received.length() == num * ("msg-x").length()) {
+          so.write(received);
+          shadowVertx.setTimer(10, id -> so.end());
+        }
+      });
+    });
+    awaitFuture(server.listen(1234, "localhost"));
+    NetClient client = shadowVertx.createNetClient();
+    Context actualCtx = actualVertx.getOrCreateContext();
+    actualCtx.runOnContext(v1 -> {
+      Thread expected = Thread.currentThread();
+      client.connect(1234, "localhost").onComplete(onSuccess(so -> {
+        Context shadow = Vertx.currentContext();
+        assertEquals(ThreadingModel.OTHER, shadow.threadingModel());
+        assertSame(shadow, shadowVertx.getOrCreateContext());
+        assertSame(actualCtx, actualVertx.getOrCreateContext());
+        assertSame(expected, Thread.currentThread());
+        for (int i = 0;i < num;i++) {
+          so.write("msg-" + num)
+            .onComplete(onSuccess(v2 -> {
+              assertSame(shadow, shadowVertx.getOrCreateContext());
+              assertSame(actualCtx, actualVertx.getOrCreateContext());
+              assertSame(expected, Thread.currentThread());
+              complete();
+            }));
+        }
+        so.handler(buff -> {
+          assertSame(shadow, shadowVertx.getOrCreateContext());
+          assertSame(actualCtx, actualVertx.getOrCreateContext());
+          assertSame(expected, Thread.currentThread());
+          complete();
+        });
+        so.endHandler(v -> {
+          assertSame(shadow, shadowVertx.getOrCreateContext());
+          assertSame(actualCtx, actualVertx.getOrCreateContext());
+          assertSame(expected, Thread.currentThread());
+          complete();
+        });
+      }));
+    });
+    await();
+  }
+
+  @Test
+  public void testSetTimer() {
+    ContextInternal actualCtx = actualVertx.getOrCreateContext();
+    actualCtx.runOnContext(v1 -> {
+      Thread expected = Thread.currentThread();
+      shadowVertx.setTimer(100, id -> {
+        assertSame(expected, Thread.currentThread());
+        assertEquals(ThreadingModel.OTHER, Vertx.currentContext().threadingModel());
+        assertSame(actualCtx, actualVertx.getOrCreateContext());
+        testComplete();
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testEventBus() {
+    ContextInternal actualCtx = actualVertx.getOrCreateContext();
+    EventBus eventBus = shadowVertx.eventBus();
+    eventBus.consumer("the-address", msg -> msg.reply(msg.body()));
+    actualCtx.runOnContext(v1 -> {
+      Thread expected = Thread.currentThread();
+      eventBus
+        .request("the-address", "msg")
+        .onComplete(onSuccess(reply -> {
+          assertSame(expected, Thread.currentThread());
+          assertSame(actualCtx, actualVertx.getOrCreateContext());
+          Context shadow = shadowVertx.getOrCreateContext();
+          assertNotSame(actualCtx, shadow);
+          assertSame(Vertx.currentContext(), shadow);
+        testComplete();
+      }));
+    });
+    await();
+  }
+
+  @Test
+  public void testPeriodic() {
+    ContextInternal actualCtx = actualVertx.getOrCreateContext();
+    actualCtx.runOnContext(v -> {
+      shadowVertx.setPeriodic(10, id -> {
+        ContextInternal callbackCtx = actualVertx.getOrCreateContext();
+        assertTrue(callbackCtx.isDuplicate());
+        assertSame(actualCtx, callbackCtx.unwrap());
+        assertSame(actualCtx.nettyEventLoop(), callbackCtx.nettyEventLoop());
+        ContextInternal shadowCtx = (ContextInternal) Vertx.currentContext();
+        assertEquals(ThreadingModel.OTHER, shadowCtx.threadingModel());
+        assertTrue(shadowCtx.isDuplicate());
+        ContextInternal shadowUnwrapCtx = shadowCtx.unwrap();
+        assertFalse(shadowUnwrapCtx.isDuplicate());
+        assertTrue(shadowVertx.cancelTimer(id));
+        testComplete();
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testTracePropagation() throws Exception {
+    FakeTracer tracer = new FakeTracer();
+    awaitFuture(actualVertx.close());
+    actualVertx = (VertxInternal) Vertx.builder().withTracer(options -> tracer).build();
+    Span rootSpan = tracer.newTrace();
+    HttpServer server = shadowVertx.createHttpServer().requestHandler(req -> req.response().end());
+    awaitFuture(server.listen(8080, "localhost"));
+    HttpClientAgent client = shadowVertx.createHttpClient();
+    Context actualCtx = actualVertx.getOrCreateContext();
+    actualCtx.runOnContext(v -> {
+      tracer.activate(rootSpan);
+      client.request(HttpMethod.GET, 8080, "localhost", "/")
+        .compose(req -> req.send()
+          .expecting(HttpResponseExpectation.SC_OK)
+          .compose(HttpClientResponse::body))
+        .onComplete(onSuccess(body -> {
+          testComplete();
+        }));
+    });
+    await();
+    waitUntil(() -> tracer.getFinishedSpans().size() == 1);
+    Span span = tracer.getFinishedSpans().get(0);
+    Assert.assertEquals(SpanKind.RPC, span.kind);
+    Assert.assertEquals(span.traceId, rootSpan.traceId);
+    Assert.assertEquals(span.parentId, rootSpan.id);
+  }
+
+  @Test
+  public void testContextLocalData() {
+    Object expected = new Object();
+    ContextInternal actualCtx = shadowVertx.getOrCreateContext();
+    actualCtx.putLocal(contextLocal, AccessMode.CONCURRENT, expected);
+    actualCtx.runOnContext(v -> {
+      actualVertx.runOnContext(v2 -> {
+        ContextInternal shadowCtx = actualVertx.getOrCreateContext();
+        assertSame(expected, shadowCtx.getLocal(contextLocal));
+        testComplete();
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testContextData() {
+    Object expected = new Object();
+    ContextInternal actualCtx = shadowVertx.getOrCreateContext();
+    actualCtx.put("key", expected);
+    actualCtx.runOnContext(v -> {
+      actualVertx.runOnContext(v2 -> {
+        ContextInternal shadowCtx = actualVertx.getOrCreateContext();
+        assertSame(expected, shadowCtx.get("key"));
+        testComplete();
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testDuplication1() {
+    ContextInternal actualCtx = actualVertx.getOrCreateContext();
+    actualCtx.runOnContext(v -> {
+      ContextInternal shadowCtx = shadowVertx.getOrCreateContext();
+      ContextInternal shadowDuplicateCtx = shadowCtx.duplicate();
+      assertEquals(ThreadingModel.OTHER, shadowDuplicateCtx.threadingModel());
+      assertTrue(shadowDuplicateCtx.isDuplicate());
+      ContextInternal shadowUnwrapCtx = shadowDuplicateCtx.unwrap();
+      shadowUnwrapCtx.runOnContext(v2 -> {
+        assertSame(actualCtx, actualVertx.getOrCreateContext());
+        testComplete();
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testDuplication2() {
+    ContextInternal actualCtx = actualVertx.getOrCreateContext();
+    ContextInternal duplicateCtx = actualCtx.duplicate();
+    duplicateCtx.runOnContext(v1 -> {
+      ContextInternal shadowOfDuplicateCtx = shadowVertx.getOrCreateContext();
+      assertTrue(shadowOfDuplicateCtx.isDuplicate());
+      shadowOfDuplicateCtx
+        .unwrap()
+        .runOnContext(v2 -> {
+          assertSame(actualCtx, actualVertx.getOrCreateContext());
+          testComplete();
+      });
+    });
+    await();
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTest.java
@@ -192,7 +192,7 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
     MessageConsumer<String> consumer = vertices[0].eventBus().<String>consumer("foobar").handler(msg -> {
       if (!sending.get()) {
         sending.set(true);
-        vertx.setTimer(4000, id -> {
+        vertices[1].setTimer(4000, id -> {
           vertices[1].eventBus().send("foobar", "whatever2");
         });
       } else {

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/EventBusInterceptorTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/EventBusInterceptorTest.java
@@ -377,9 +377,8 @@ public class EventBusInterceptorTest extends VertxTestBase {
     });
     eb.consumer("some-address", msg -> {
     });
-    Context ctx = vertx.getOrCreateContext();
     AtomicReference<Throwable> caught = new AtomicReference<>();
-    ctx.exceptionHandler(err -> caught.set(err));
+    vertx.exceptionHandler(err -> caught.set(err));
     eb.send("some-address", "armadillo");
     assertSame(expected, caught.get());
   }
@@ -417,9 +416,8 @@ public class EventBusInterceptorTest extends VertxTestBase {
     });
     eb.consumer("some-address", msg -> {
     });
-    Context ctx = vertx.getOrCreateContext();
     AtomicReference<Throwable> caught = new AtomicReference<>();
-    ctx.exceptionHandler(err -> caught.set(err));
+    vertx.exceptionHandler(err -> caught.set(err));
     eb.send("some-address", "armadillo");
     waitUntil(() -> caught.get() != null);
     assertSame(expected, caught.get());

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -2623,7 +2623,6 @@ public class NetTest extends VertxTestBase {
     server.close().onComplete(onSuccess(ar -> {
       Context closeContext = Vertx.currentContext();
       assertFalse(contexts.contains(closeContext));
-      assertSame(serverConnectContext.get(), closeContext);
       assertFalse(contexts.contains(listenContext.get()));
       assertSame(serverConnectContext.get(), listenContext.get());
       testComplete();

--- a/vertx-core/src/test/java/io/vertx/tests/timer/TimerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/timer/TimerTest.java
@@ -375,10 +375,10 @@ public class TimerTest extends VertxTestBase {
   @Test
   public void testTimerFireOnContext1() {
     new Thread(() -> {
-      Context ctx = vertx.getOrCreateContext();
+      ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
       Timer timer = vertx.timer(10, TimeUnit.MILLISECONDS);
       timer.onComplete(onSuccess(v -> {
-        assertSame(ctx, Vertx.currentContext());
+        assertSame(ctx.nettyEventLoop(), ((ContextInternal)Vertx.currentContext()).nettyEventLoop());
         testComplete();
       }));
     }).start();

--- a/vertx-core/src/test/java/module-info.java
+++ b/vertx-core/src/test/java/module-info.java
@@ -1,10 +1,7 @@
 import io.vertx.core.spi.VerticleFactory;
 import io.vertx.core.spi.VertxServiceProvider;
 import io.vertx.test.fakecluster.FakeClusterManager;
-import io.vertx.it.servicehelper.FakeFactory;
 import io.vertx.tests.deployment.ClasspathVerticleFactory;
-import io.vertx.it.servicehelper.FakeFactoryImplA;
-import io.vertx.it.servicehelper.FakeFactoryImplB;
 
 open module io.vertx.tests {
   requires io.vertx.codegen.api;


### PR DESCRIPTION
A shadow context is a vertx context that references a context belonging to a different vertx instance.

Such context enables the usage of a vertx instance (e.g. a client) from another vertx instance and ensure that callbacks are on the correct thread.

One use case is the usage of a Vert.x client from a Vert.x server with different instances. This provides event-loop segregation between vertx instance ensuring that the server event-loop only process server IO and are disjoint from the client io operations.

Shadow context happens when a context is obtained from a vertx thread of another vertx instance:

```java
Context ctx = vertx1.getOrCreateContext();
ctx.runOnContext(v1 -> {
  Thread expected = Thread.currentThread();
  Context shadowCtx = vertx2.getOrCreateContext();
  shadowCtx.runOnContext(v2 -> {
    assertSame(expect, Thread.currentThread());
    assertSame(ctx, vertx1.getOrCreateContext());
    assertSame(shadowCtx, vertx2.getOrCreateContext());
  });
});
```

Noticeable changes

- Sticky context becomes a stick event-loop so the context implementation is not tied to the current thread, this provides the same intended behaviour with the benefit to avoid keeping the reference to a context which implies the rewrite of a few tests (the tests setting an exception handler outside the event-loop)


Possible extension

- an SPI to provide context implementations for non vertx thread, allowing a runtime to be called back on the executor of its choice could be implemented
