### PR TITLE
Use a single event-loop per worker/virtual-thread verticle deployment instances

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -547,20 +547,21 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     return createEventLoopContext(null, closeFuture, null, Thread.currentThread().getContextClassLoader());
   }
 
-  private ContextImpl createWorkerContext(EventLoop eventLoop, CloseFuture closeFuture, WorkerPool workerPool, Deployment deployment, ClassLoader tccl) {
+  @Override
+  public ContextImpl createWorkerContext(EventLoop eventLoop, WorkerPool workerPool, ClassLoader tccl) {
+    return createWorkerContext(null, closeFuture, eventLoop, workerPool, tccl);
+  }
+
+  @Override
+  public ContextImpl createWorkerContext(Deployment deployment, CloseFuture closeFuture, EventLoop eventLoop, WorkerPool workerPool, ClassLoader tccl) {
     TaskQueue orderedTasks = new TaskQueue();
     WorkerPool wp = workerPool != null ? workerPool : this.workerPool;
     return new ContextImpl(this, createContextLocals(), ThreadingModel.WORKER, eventLoop, new WorkerExecutor(wp, orderedTasks), internalWorkerPool, wp, orderedTasks, deployment, closeFuture, disableTCCL ? null : tccl);
   }
 
   @Override
-  public ContextInternal createWorkerContext(EventLoop eventLoop, WorkerPool workerPool, ClassLoader tccl) {
-    return createWorkerContext(eventLoop, closeFuture, workerPool, null, tccl);
-  }
-
-  @Override
   public ContextImpl createWorkerContext(Deployment deployment, CloseFuture closeFuture, WorkerPool workerPool, ClassLoader tccl) {
-    return createWorkerContext(eventLoopGroup.next(), closeFuture, workerPool, deployment, tccl);
+    return createWorkerContext(deployment, closeFuture, eventLoopGroup.next(), workerPool, tccl);
   }
 
   @Override
@@ -568,7 +569,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     return createWorkerContext(null, closeFuture, null, Thread.currentThread().getContextClassLoader());
   }
 
-  private ContextImpl createVirtualThreadContext(EventLoop eventLoop, CloseFuture closeFuture, Deployment deployment, ClassLoader tccl) {
+  public ContextImpl createVirtualThreadContext(Deployment deployment, CloseFuture closeFuture, EventLoop eventLoop, ClassLoader tccl) {
     if (!isVirtualThreadAvailable()) {
       throw new IllegalStateException("This Java runtime does not support virtual threads");
     }
@@ -578,12 +579,12 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public ContextImpl createVirtualThreadContext(Deployment deployment, CloseFuture closeFuture, ClassLoader tccl) {
-    return createVirtualThreadContext(eventLoopGroup.next(), closeFuture, deployment, tccl);
+    return createVirtualThreadContext(deployment, closeFuture, eventLoopGroup.next(), tccl);
   }
 
   @Override
   public ContextImpl createVirtualThreadContext(EventLoop eventLoop, ClassLoader tccl) {
-    return createVirtualThreadContext(eventLoop, closeFuture, null, tccl);
+    return createVirtualThreadContext(null, closeFuture, eventLoop, tccl);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxInternal.java
@@ -121,6 +121,11 @@ public interface VertxInternal extends Vertx {
   /**
    * @return worker context
    */
+  ContextInternal createWorkerContext(Deployment deployment, CloseFuture closeFuture, EventLoop eventLoop, WorkerPool workerPool, ClassLoader tccl);
+
+  /**
+   * @return worker context
+   */
   ContextInternal createWorkerContext(Deployment deployment, CloseFuture closeFuture, WorkerPool workerPool, ClassLoader tccl);
 
   /**
@@ -132,6 +137,11 @@ public interface VertxInternal extends Vertx {
    * @return worker context
    */
   ContextInternal createWorkerContext();
+
+  /**
+   * @return virtual thread context
+   */
+  ContextInternal createVirtualThreadContext(Deployment deployment, CloseFuture closeFuture, EventLoop eventLoop, ClassLoader tccl);
 
   /**
    * @return virtual thread context

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxWrapper.java
@@ -334,8 +334,18 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
+  public ContextInternal createVirtualThreadContext(Deployment deployment, CloseFuture closeFuture, EventLoop eventLoop, ClassLoader tccl) {
+    return delegate.createVirtualThreadContext(deployment, closeFuture, eventLoop, tccl);
+  }
+
+  @Override
   public ContextInternal createVirtualThreadContext() {
     return delegate.createVirtualThreadContext();
+  }
+
+  @Override
+  public ContextInternal createWorkerContext(Deployment deployment, CloseFuture closeFuture, EventLoop eventLoop, WorkerPool workerPool, ClassLoader tccl) {
+    return delegate.createWorkerContext(deployment, closeFuture, eventLoop, workerPool, tccl);
   }
 
   @Override


### PR DESCRIPTION
The deployment manager will create an event-loop per worker verticle instance, like it does for event-loop verticles.

As consequence a worker server will be scaled on that number of event-loop while being processed on the same number of workers.

There is no strong interest for this use case and a single event-loop might actually work better and consume less resources.

This modify the worker deployment to use a single event-loop per worker instances in a deployment.

We might add later a setting to control this, e.g. specify the number of event-loop that shall be created per worker deployment.
