### PR TITLE
Support snappy compression

### DIFF
--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -391,7 +391,7 @@ options when creating the server.
 
 Snappy is supported without external dependencies.
 
-You need to have Brotli4j on the classpath to decompress Brotli:
+You need to have Brotli4j on the classpath to decompress Brotli, and Zstd-jni for Zstandard:
 
 * Maven (in your `pom.xml`):
 
@@ -402,6 +402,11 @@ You need to have Brotli4j on the classpath to decompress Brotli:
   <artifactId>brotli4j</artifactId>
   <version>${brotli4j.version}</version>
 </dependency>
+<dependency>
+  <groupId>com.github.luben</groupId>
+  <artifactId>zstd-jni</artifactId>
+  <version>${zstd-jini.version}</version>
+</dependency>
 ----
 * Gradle (in your `build.gradle` file):
 
@@ -410,6 +415,7 @@ You need to have Brotli4j on the classpath to decompress Brotli:
 dependencies {
   implementation 'com.aayushatharva.brotli4j:brotli4j:${brotli4j.version}'
   runtimeOnly 'com.aayushatharva.brotli4j:native-$system-and-arch:${brotli4j.version}'
+  implementation 'com.github.luben:zstd-jni:${zstd-jini.version}'
 }
 ----
 

--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -389,6 +389,8 @@ algorithms.
 To enable decompression set {@link io.vertx.core.http.HttpServerOptions#setDecompressionSupported(boolean)} on the
 options when creating the server.
 
+Snappy is supported without external dependencies.
+
 You need to have Brotli4j on the classpath to decompress Brotli:
 
 * Maven (in your `pom.xml`):

--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -777,7 +777,7 @@ but the parameter can be configured to address any case with {@link io.vertx.cor
 
 Vert.x supports out of the box deflate and gzip.
 
-Brotli and zstandard can also be used.
+Brotli, snappy and zstandard can also be used.
 
 [source,$lang]
 ----
@@ -786,7 +786,7 @@ Brotli and zstandard can also be used.
 
 NOTE: use {@link io.netty.handler.codec.compression.StandardCompressionOptions} static methods to create {@link io.netty.handler.codec.compression.CompressionOptions}
 
-Brotli and zstandard libraries need to be added to the classpath.
+Brotli and zstandard libraries need to be added to the classpath, snappy is provided by default.
 
 * Maven (in your `pom.xml`):
 

--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -383,7 +383,7 @@ Here's an example of querying and adding cookies:
 
 ==== Handling compressed body
 
-Vert.x can handle compressed body payloads which are encoded by the client with the _deflate_, _gzip_ or _brotli_
+Vert.x can handle compressed body payloads which are encoded by the client with the _deflate_, _gzip_, _snappy_ or _brotli_
 algorithms.
 
 To enable decompression set {@link io.vertx.core.http.HttpServerOptions#setDecompressionSupported(boolean)} on the

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -417,7 +417,7 @@ public interface HttpHeaders {
    * deflate,gzip,zstd,br header value
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  CharSequence DEFLATE_GZIP_ZSTD_BR = createOptimized("deflate, gzip, zstd, br");
+  CharSequence DEFLATE_GZIP_ZSTD_BR_SNAPPY = createOptimized("deflate, gzip, zstd, br, snappy");
 
   /**
    * deflate,gzip,zstd header value

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -216,7 +216,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
 
   static CharSequence determineCompressionAcceptEncoding() {
     if (isBrotliAvailable() && isZstdAvailable()) {
-      return DEFLATE_GZIP_ZSTD_BR;
+      return DEFLATE_GZIP_ZSTD_BR_SNAPPY;
     }
     else if (!isBrotliAvailable() && isZstdAvailable()) {
       return DEFLATE_GZIP_ZSTD;

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
@@ -1403,7 +1403,7 @@ public class Http2ClientTest extends Http2TestBase {
     in.close();
     byte[] compressed = baos.toByteArray();
     server.requestHandler(req -> {
-      assertEquals(enabled ? "deflate, gzip, zstd, br" : null, req.getHeader(HttpHeaderNames.ACCEPT_ENCODING));
+      assertEquals(enabled ? "deflate, gzip, zstd, br, snappy" : null, req.getHeader(HttpHeaderNames.ACCEPT_ENCODING));
       req.response().putHeader(HttpHeaderNames.CONTENT_ENCODING.toLowerCase(), "gzip").end(Buffer.buffer(compressed));
     });
     startServer();

--- a/vertx-core/src/test/java/io/vertx/tests/http/compression/Http1xSnappyCompressionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/compression/Http1xSnappyCompressionTest.java
@@ -1,0 +1,36 @@
+package io.vertx.tests.http.compression;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.handler.codec.compression.SnappyFrameEncoder;
+import io.netty.handler.codec.compression.StandardCompressionOptions;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServerOptions;
+
+public class Http1xSnappyCompressionTest extends HttpCompressionTest {
+
+  @Override
+  protected HttpServerOptions createBaseServerOptions() {
+    return new HttpServerOptions().setPort(DEFAULT_HTTP_PORT).setHost(DEFAULT_HTTP_HOST);
+  }
+
+  @Override
+  protected HttpClientOptions createBaseClientOptions() {
+    return new HttpClientOptions().setDefaultPort(DEFAULT_HTTP_PORT).setDefaultHost(DEFAULT_HTTP_HOST);
+  }
+
+  @Override
+  protected MessageToByteEncoder<ByteBuf> encoder() {
+    return new SnappyFrameEncoder();
+  }
+
+  @Override
+  protected String encoding() {
+    return "snappy";
+  }
+
+  @Override
+  protected void configureServerCompression(HttpServerOptions options) {
+    options.setCompressionSupported(true).addCompressor(StandardCompressionOptions.snappy());
+  }
+}


### PR DESCRIPTION
Motivation:

Support snappy as a compression mechanism 

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Similar to https://github.com/eclipse-vertx/vert.x/pull/5176/files but Snappy support is already inside netty so I don't need to include any other dependencies

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
