### PR TITLE
The outbound message queue should not try to drain its write queue after it has been closed

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/internal/concurrent/OutboundMessageQueue.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/concurrent/OutboundMessageQueue.java
@@ -144,6 +144,9 @@ public class OutboundMessageQueue<M> implements Predicate<M> {
   }
 
   private void drainWriteQueue() {
+    if (closed) {
+      return;
+    }
     startDraining();
     reentrant++;
     int flags;


### PR DESCRIPTION
An outbound message queue might schedule a drain operation and get closed. When the drain happens, it should check that it has not been closed since the queue elements are not present and the queue does not expect a drain.
