### PR TITLE
EventExecutor provide SPI

### DIFF
--- a/vertx-core/pom.xml
+++ b/vertx-core/pom.xml
@@ -543,6 +543,21 @@
             </configuration>
           </execution>
           <execution>
+            <id>custom-event-executor</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>io/vertx/it/eventexecutor/CustomEventExecutorTest.java</include>
+              </includes>
+              <additionalClasspathElements>
+                <additionalClasspathElement>${project.basedir}/src/test/classpath/customeventexecutor</additionalClasspathElement>
+              </additionalClasspathElements>
+            </configuration>
+          </execution>
+          <execution>
             <id>custom-vertx-tracer-factory</id>
             <goals>
               <goal>integration-test</goal>

--- a/vertx-core/src/main/java/io/vertx/core/ThreadingModel.java
+++ b/vertx-core/src/main/java/io/vertx/core/ThreadingModel.java
@@ -18,22 +18,23 @@ package io.vertx.core;
 public enum ThreadingModel {
 
   /**
-   * Tasks are scheduled on the event-loop thread.
+   * Tasks are scheduled on the event-loop thread of the vertx instance.
    */
   EVENT_LOOP,
 
   /**
-   * Tasks are scheduled on a worker pool.
+   * Tasks are scheduled on a worker pool of platform threads managed by the vertx instance.
    */
   WORKER,
 
   /**
-   * Tasks are scheduled on a virtual thread.
+   * Tasks are scheduled on a virtual thread, no assumption on whether virtual threads are pooled.
    */
   VIRTUAL_THREAD,
 
   /**
-   * Tasks are scheduled on threads not managed by the current vertx instance.
+   * Tasks are scheduled on threads not managed by the current vertx instance, the nature of the thread is unknown
+   * to the vertx instance. Note that an event-loop thread of another vertx instance falls in this category.
    */
   OTHER
 }

--- a/vertx-core/src/main/java/io/vertx/core/Vertx.java
+++ b/vertx-core/src/main/java/io/vertx/core/Vertx.java
@@ -162,7 +162,7 @@ public interface Vertx extends Measured {
    * @return The current context or {@code null} if there is no current context
    */
   static @Nullable Context currentContext() {
-    return VertxImpl.currentContext();
+    return VertxImpl.currentContext(Thread.currentThread());
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/impl/ContextBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ContextBase.java
@@ -10,15 +10,12 @@
  */
 package io.vertx.core.impl;
 
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.ThreadingModel;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.EventExecutor;
 import io.vertx.core.spi.context.storage.AccessMode;
 import io.vertx.core.spi.context.storage.ContextLocal;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 /**

--- a/vertx-core/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -14,13 +14,13 @@ package io.vertx.core.impl;
 import io.netty.channel.EventLoop;
 import io.vertx.core.*;
 import io.vertx.core.Future;
+import io.vertx.core.internal.EventExecutor;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
 
 import java.util.concurrent.*;

--- a/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -17,6 +17,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.ThreadingModel;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.EventExecutor;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tracing.VertxTracer;

--- a/vertx-core/src/main/java/io/vertx/core/impl/EventLoopExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/EventLoopExecutor.java
@@ -11,7 +11,7 @@
 package io.vertx.core.impl;
 
 import io.netty.channel.EventLoop;
-import io.vertx.core.ThreadingModel;
+import io.vertx.core.internal.EventExecutor;
 
 /**
  * Execute events on an event-loop.

--- a/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
@@ -15,6 +15,7 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.*;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.EventExecutor;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tracing.VertxTracer;

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxBootstrapImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxBootstrapImpl.java
@@ -16,6 +16,7 @@ import io.vertx.core.impl.transports.EpollTransport;
 import io.vertx.core.impl.transports.JDKTransport;
 import io.vertx.core.impl.transports.KQueueTransport;
 import io.vertx.core.internal.VertxBootstrap;
+import io.vertx.core.spi.context.executor.EventExecutorProvider;
 import io.vertx.core.spi.file.FileResolver;
 import io.vertx.core.file.impl.FileResolverImpl;
 import io.vertx.core.internal.logging.Logger;
@@ -50,6 +51,7 @@ public class VertxBootstrapImpl implements VertxBootstrap {
   private JsonObject config;
   private Transport transport;
   private Throwable transportUnavailabilityCause;
+  private EventExecutorProvider eventExecutorProvider;
   private ClusterManager clusterManager;
   private NodeSelector clusterNodeSelector;
   private VertxTracerFactory tracerFactory;
@@ -88,6 +90,17 @@ public class VertxBootstrapImpl implements VertxBootstrap {
    */
   public JsonObject config() {
     return config;
+  }
+
+  @Override
+  public VertxBootstrap eventExecutorProvider(EventExecutorProvider provider) {
+    this.eventExecutorProvider = provider;
+    return this;
+  }
+
+  @Override
+  public EventExecutorProvider eventExecutorProvider() {
+    return eventExecutorProvider;
   }
 
   /**
@@ -210,7 +223,8 @@ public class VertxBootstrapImpl implements VertxBootstrap {
       transportUnavailabilityCause,
       fileResolver,
       threadFactory,
-      executorServiceFactory);
+      executorServiceFactory,
+      eventExecutorProvider);
     vertx.init();
     return vertx;
   }
@@ -233,7 +247,8 @@ public class VertxBootstrapImpl implements VertxBootstrap {
       transportUnavailabilityCause,
       fileResolver,
       threadFactory,
-      executorServiceFactory);
+      executorServiceFactory,
+      eventExecutorProvider);
     return vertx.initClustered(options);
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxThread.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxThread.java
@@ -24,6 +24,7 @@ public class VertxThread extends FastThreadLocalThread {
 
   private final boolean worker;
   final ThreadInfo info;
+  VertxImpl owner;
   ContextInternal context;
   ClassLoader topLevelTCCL;
 

--- a/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
@@ -12,6 +12,7 @@ package io.vertx.core.impl;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.EventExecutor;
 import io.vertx.core.spi.metrics.PoolMetrics;
 
 import java.util.concurrent.CountDownLatch;

--- a/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
@@ -41,7 +41,7 @@ public interface ContextInternal extends Context {
    * @return the current context
    */
   static ContextInternal current() {
-    return VertxImpl.currentContext();
+    return VertxImpl.currentContext(Thread.currentThread());
   }
 
   @Override
@@ -50,9 +50,9 @@ public interface ContextInternal extends Context {
   }
 
   /**
-   * @return an executor that schedule a task on this context, the thread executing the task will not be associated with this context
+   * @return an event executor that schedule a task on this context, the thread executing the task will not be associated with this context
    */
-  Executor executor();
+  EventExecutor executor();
 
   default ContextInternal asEventLoopContext() {
     if (threadingModel() == ThreadingModel.EVENT_LOOP) {

--- a/vertx-core/src/main/java/io/vertx/core/internal/EventExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/EventExecutor.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.core.impl;
+package io.vertx.core.internal;
 
 import java.util.concurrent.Executor;
 

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxBootstrap.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxBootstrap.java
@@ -19,6 +19,7 @@ import io.vertx.core.spi.VertxMetricsFactory;
 import io.vertx.core.spi.VertxThreadFactory;
 import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.core.spi.context.executor.EventExecutorProvider;
 import io.vertx.core.spi.file.FileResolver;
 import io.vertx.core.spi.transport.Transport;
 
@@ -48,6 +49,19 @@ public interface VertxBootstrap {
    * @return this builder instance
    */
   VertxBootstrap options(VertxOptions options);
+
+  /**
+   * Set an event executor {@code provider} to use.
+   *
+   * @param provider a provider to use
+   * @return this builder instance
+   */
+  VertxBootstrap eventExecutorProvider(EventExecutorProvider provider);
+
+  /**
+   * @return the event executor provider to use
+   */
+  EventExecutorProvider eventExecutorProvider();
 
   /**
    * @return the {@code FileResolver} instance to use

--- a/vertx-core/src/main/java/io/vertx/core/spi/context/executor/EventExecutorProvider.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/context/executor/EventExecutorProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.spi.context.executor;
+
+import io.vertx.codegen.annotations.Unstable;
+import io.vertx.core.internal.EventExecutor;
+import io.vertx.core.internal.VertxBootstrap;
+import io.vertx.core.spi.VertxServiceProvider;
+
+/**
+ * Event executor service provider interface.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@Unstable
+public interface EventExecutorProvider extends VertxServiceProvider {
+
+  @Override
+  default void init(VertxBootstrap builder) {
+    if (builder.eventExecutorProvider() == null) {
+      builder.eventExecutorProvider(this);
+    }
+  }
+
+  /**
+   * Give vertx an event executor for the given {@code thread}.
+   *
+   * @param thread the thread for which an executor is required
+   * @return an event executor suitable for the given thread, tasks executed on this executor will be declared as
+   * running on {@link io.vertx.core.ThreadingModel#OTHER}.
+   */
+  EventExecutor eventExecutorFor(Thread thread);
+
+}

--- a/vertx-core/src/main/java/module-info.java
+++ b/vertx-core/src/main/java/module-info.java
@@ -42,6 +42,7 @@ module io.vertx.core {
   uses io.vertx.core.spi.VerticleFactory;
   uses io.vertx.core.spi.JsonFactory;
   uses io.vertx.core.spi.transport.Transport;
+  uses io.vertx.core.spi.context.executor.EventExecutorProvider;
 
   // API
 
@@ -63,9 +64,13 @@ module io.vertx.core {
   exports io.vertx.core.streams;
   exports io.vertx.core.spi;
   exports io.vertx.core.file;
+
+  // SPI
+
   exports io.vertx.core.spi.tracing;
   exports io.vertx.core.spi.metrics;
   exports io.vertx.core.spi.context.storage;
+  exports io.vertx.core.spi.context.executor;
   exports io.vertx.core.spi.cluster;
   exports io.vertx.core.spi.file;
   exports io.vertx.core.spi.json;

--- a/vertx-core/src/test/benchmarks/io/vertx/benchmarks/BenchmarkContext.java
+++ b/vertx-core/src/test/benchmarks/io/vertx/benchmarks/BenchmarkContext.java
@@ -14,7 +14,7 @@ package io.vertx.benchmarks;
 import io.vertx.core.ThreadingModel;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextImpl;
-import io.vertx.core.impl.EventExecutor;
+import io.vertx.core.internal.EventExecutor;
 import io.vertx.core.impl.TaskQueue;
 import io.vertx.core.impl.VertxImpl;
 import io.vertx.core.internal.ContextInternal;

--- a/vertx-core/src/test/classpath/customeventexecutor/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/vertx-core/src/test/classpath/customeventexecutor/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,1 @@
+io.vertx.it.eventexecutor.CustomEventExecutorProvider

--- a/vertx-core/src/test/java/io/vertx/it/eventexecutor/CustomEventExecutorProvider.java
+++ b/vertx-core/src/test/java/io/vertx/it/eventexecutor/CustomEventExecutorProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.it.eventexecutor;
+
+import io.vertx.core.internal.EventExecutor;
+import io.vertx.core.spi.context.executor.EventExecutorProvider;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.NoSuchElementException;
+
+public class CustomEventExecutorProvider implements EventExecutorProvider, EventExecutor {
+
+  private static final Deque<Runnable> tasks = new LinkedList<>();
+  private static volatile Thread executing;
+
+  static synchronized boolean hasNext() {
+    return !tasks.isEmpty();
+  }
+
+  synchronized static Runnable next() {
+    Runnable task = tasks.poll();
+    if (task != null) {
+      return new Runnable() {
+        boolean executed;
+        @Override
+        public void run() {
+          synchronized (CustomEventExecutorProvider.class) {
+            if (executed) {
+              throw new IllegalStateException();
+            }
+            executed = true;
+            executing = Thread.currentThread();
+            try {
+              task.run();
+            } finally {
+              executing = null;
+            }
+          }
+        }
+      };
+    }
+    throw new NoSuchElementException();
+  }
+
+  @Override
+  public boolean inThread() {
+    return executing == Thread.currentThread();
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    synchronized (CustomEventExecutorProvider.class) {
+      tasks.add(command);
+    }
+  }
+
+  @Override
+  public EventExecutor eventExecutorFor(Thread thread) {
+    if (thread instanceof CustomThread) {
+      return this;
+    } else {
+      return null;
+    }
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/it/eventexecutor/CustomEventExecutorTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/eventexecutor/CustomEventExecutorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.it.eventexecutor;
+
+import io.vertx.core.Context;
+import io.vertx.core.ThreadingModel;
+import io.vertx.core.Vertx;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CustomEventExecutorTest {
+
+  private Vertx vertx;
+  private Context context;
+
+  @Before
+  public void before() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void after() {
+    vertx.close();
+  }
+
+  @Test
+  public void testCustomEventExecutor() throws Exception {
+    CustomThread thread = new CustomThread(() -> {
+      context = vertx.getOrCreateContext();
+    });
+    thread.start();
+    thread.join();
+    assertEquals(ThreadingModel.OTHER, context.threadingModel());
+    int[] executions = new int[1];
+    context.runOnContext(v -> {
+      executions[0]++;
+    });
+    assertTrue(CustomEventExecutorProvider.hasNext());
+    Runnable runnable = CustomEventExecutorProvider.next();
+    runnable.run();
+    assertFalse(CustomEventExecutorProvider.hasNext());
+    assertEquals(1, executions[0]);
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/it/eventexecutor/CustomThread.java
+++ b/vertx-core/src/test/java/io/vertx/it/eventexecutor/CustomThread.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.it.eventexecutor;
+
+public class CustomThread extends Thread {
+
+  public CustomThread(Runnable task) {
+    super(task);
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/tests/context/EventExecutorProviderTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/EventExecutorProviderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.context;
+
+import io.vertx.core.Context;
+import io.vertx.core.ThreadingModel;
+import io.vertx.core.Vertx;
+import io.vertx.core.internal.EventExecutor;
+import io.vertx.core.internal.VertxBootstrap;
+import io.vertx.test.core.AsyncTestBase;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+public class EventExecutorProviderTest extends AsyncTestBase {
+
+  @Test
+  public void testExecuteTasks() {
+    Deque<Runnable> toRun = new ConcurrentLinkedDeque<>();
+    VertxBootstrap bootstrap = VertxBootstrap.create();
+    bootstrap.eventExecutorProvider(thread -> new EventExecutor() {
+      @Override
+      public boolean inThread() {
+        return thread == Thread.currentThread();
+      }
+      @Override
+      public void execute(Runnable command) {
+        toRun.add(command);
+      }
+    });
+    bootstrap.init();
+    Vertx vertx = bootstrap.vertx();
+    Context ctx = vertx.getOrCreateContext();
+    assertEquals(ThreadingModel.OTHER, ctx.threadingModel());
+    assertEquals(0, toRun.size());
+    int[] cnt = new int[1];
+    ctx.runOnContext(v -> {
+      assertSame(ctx, Vertx.currentContext());
+      assertSame(ctx, vertx.getOrCreateContext());
+      cnt[0]++;
+    });
+    assertEquals(1, toRun.size());
+    toRun.pop().run();
+    assertEquals(1, cnt[0]);
+    assertNull(Vertx.currentContext());
+    // Sticky context
+    assertSame(ctx, vertx.getOrCreateContext());
+  }
+
+  @Test
+  public void testEventExecutorReturnsNull() {
+    VertxBootstrap bootstrap = VertxBootstrap.create();
+    bootstrap.eventExecutorProvider(thread -> null);
+    bootstrap.init();
+    Vertx vertx = bootstrap.vertx();
+    Context ctx = vertx.getOrCreateContext();
+    assertEquals(ThreadingModel.EVENT_LOOP, ctx.threadingModel());
+  }
+}


### PR DESCRIPTION
An SPI that associates `EventExecutor` for non Vertx thread.

The use case is the utilisation of vertx based middleware from a non vertx thread, allowing callbacks from vertx (futures/event) to be processed by an executor provided by the framework, i.e. let the embedder execute the tasks on the thread of their choice instead of an event-loop context.
