### PR TITLE
 Fixes updates to traffic shaping options with shared servers

### DIFF
--- a/src/main/java/io/vertx/core/net/TrafficShapingOptions.java
+++ b/src/main/java/io/vertx/core/net/TrafficShapingOptions.java
@@ -222,4 +222,28 @@ public class TrafficShapingOptions {
   public TimeUnit getCheckIntervalForStatsTimeUnit() {
     return checkIntervalForStatsTimeUnit;
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    TrafficShapingOptions that = (TrafficShapingOptions) obj;
+    return inboundGlobalBandwidth == that.inboundGlobalBandwidth &&
+           outboundGlobalBandwidth == that.outboundGlobalBandwidth &&
+           peakOutboundGlobalBandwidth == that.peakOutboundGlobalBandwidth &&
+           maxDelayToWait == that.maxDelayToWait &&
+           maxDelayToWaitTimeUnit == that.maxDelayToWaitTimeUnit &&
+           checkIntervalForStats == that.checkIntervalForStats &&
+           checkIntervalForStatsTimeUnit == that.checkIntervalForStatsTimeUnit;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(inboundGlobalBandwidth,
+                        outboundGlobalBandwidth,
+                        peakOutboundGlobalBandwidth,
+                        maxDelayToWait,
+                        maxDelayToWaitTimeUnit,
+                        checkIntervalForStats,
+                        checkIntervalForStatsTimeUnit);
+  }
+
 }

--- a/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
+++ b/src/test/java/io/vertx/core/http/HttpBandwidthLimitingTest.java
@@ -243,7 +243,7 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
     awaitLatch(waitForResponse);
     TrafficShapingOptions updatedTrafficOptions = new TrafficShapingOptions()
                                              .setInboundGlobalBandwidth(INBOUND_LIMIT) // unchanged
-                                             .setOutboundGlobalBandwidth(OUTBOUND_LIMIT);
+                                             .setOutboundGlobalBandwidth(2 * OUTBOUND_LIMIT);
 
     for (int i = 0; i < numEventLoops; i++) {
       servers.forEach(s -> s.updateTrafficShapingOptions(updatedTrafficOptions));


### PR DESCRIPTION
Motivation:

This fixes the update-path for traffic shaping options to check for the existence of the traffic shaping handler only for the actual server. Currently, updating traffic-shaping options in a shared-server setting results in `IllegalStateException`, as the traffic-shaping handler is not set for the worker (non-main) servers.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
