### PR TITLE
Unregistration of an event-bus consumer is performed on the consumer context

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -77,7 +77,7 @@ public abstract class HandlerRegistration<T> implements Closeable {
   }
 
   public Future<Void> unregister() {
-    Promise<Void> promise = context.promise();
+    Promise<Void> promise = context.owner().promise();
     synchronized (this) {
       if (registered != null) {
         registered.accept(promise);


### PR DESCRIPTION
Instead it should be on the caller context.
