### PR TITLE
Vertx lifecycle hook for VertxBuilder customization

### DIFF
--- a/src/main/java/io/vertx/core/impl/launcher/VertxLifecycleHooks.java
+++ b/src/main/java/io/vertx/core/impl/launcher/VertxLifecycleHooks.java
@@ -14,7 +14,9 @@ package io.vertx.core.impl.launcher;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.impl.VertxBuilder;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.tracing.VertxTracer;
 
 /**
  * Interface that let sub-classes of launcher to be notified on different events.
@@ -30,6 +32,18 @@ public interface VertxLifecycleHooks {
    * @param config the json config file passed via -conf on the command line, an empty json object is not set.
    */
   void afterConfigParsed(JsonObject config);
+
+  /**
+   * Default implementation for the {@link VertxBuilder} creation.
+   * <p>
+   * This can be overridden in order to customize, for example, the tracer, with {@link VertxBuilder#tracer(VertxTracer)}.
+   *
+   * @param config the Vert.x options to use, in JSON format
+   * @return the Vert.x builder instance
+   */
+  default VertxBuilder createVertxBuilder(JsonObject config) {
+    return config == null ? new VertxBuilder() : new VertxBuilder(config);
+  }
 
   /**
    * Hook for sub-classes of the {@link io.vertx.core.Launcher} class before the vertx instance is started. Options

--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
@@ -201,15 +201,8 @@ public class BareCommand extends ClasspathHandler {
   protected Vertx startVertx() {
     JsonObject optionsJson = getJsonFromFileOrString(vertxOptions, "options");
 
-    EventBusOptions eventBusOptions;
-    VertxBuilder builder;
-    if (optionsJson == null) {
-      eventBusOptions = getEventBusOptions();
-      builder = new VertxBuilder();
-    } else {
-      eventBusOptions = getEventBusOptions(optionsJson.getJsonObject("eventBusOptions"));
-      builder = new VertxBuilder(optionsJson);
-    }
+    EventBusOptions eventBusOptions = optionsJson == null ? getEventBusOptions() : getEventBusOptions(optionsJson.getJsonObject("eventBusOptions"));
+    VertxBuilder builder = createVertxBuilder(optionsJson);
     options = builder.options();
     options.setEventBusOptions(eventBusOptions);
 
@@ -336,6 +329,14 @@ public class BareCommand extends ClasspathHandler {
     if (main instanceof VertxLifecycleHooks) {
       ((VertxLifecycleHooks) main).beforeStartingVertx(options);
     }
+  }
+
+  protected VertxBuilder createVertxBuilder(JsonObject config) {
+    Object main = executionContext.main();
+    if (main instanceof VertxLifecycleHooks) {
+      return ((VertxLifecycleHooks) main).createVertxBuilder(config);
+    }
+    return config == null ? new VertxBuilder() : new VertxBuilder(config);
   }
 
   /**

--- a/src/test/java/io/vertx/core/impl/launcher/LauncherExtensibilityTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/LauncherExtensibilityTest.java
@@ -16,6 +16,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.cli.CLIException;
 import io.vertx.core.cli.annotations.Name;
+import io.vertx.core.impl.VertxBuilder;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.launcher.commands.CommandTestBase;
 import io.vertx.core.impl.launcher.commands.HttpTestVerticle;
@@ -38,7 +39,7 @@ import static org.junit.Assert.assertSame;
  */
 public class LauncherExtensibilityTest extends CommandTestBase {
 
-  private static AtomicReference<Boolean> spy = new AtomicReference<>();
+  private static final AtomicReference<Boolean> spy = new AtomicReference<>();
 
   private Vertx vertx;
 
@@ -218,8 +219,8 @@ public class LauncherExtensibilityTest extends CommandTestBase {
       }
 
       @Override
-      public void beforeStartingVertx(VertxOptions options) {
-        options.setClusterManager(clusterManager);
+      public VertxBuilder createVertxBuilder(JsonObject config) {
+        return super.createVertxBuilder(config).clusterManager(clusterManager);
       }
     };
 


### PR DESCRIPTION
Given methods like TracingOptions#setTracer have been deprecated, a new hook can help users configure the Vert.x instance.