### PR TITLE
Try reuse existing Netty pooled allocator singleton (Fixes #5168)

### DIFF
--- a/src/main/java/io/vertx/core/buffer/impl/VertxByteBufAllocator.java
+++ b/src/main/java/io/vertx/core/buffer/impl/VertxByteBufAllocator.java
@@ -19,12 +19,15 @@ import io.netty.util.internal.PlatformDependent;
 
 public abstract class VertxByteBufAllocator extends AbstractByteBufAllocator {
 
+  private static final boolean REUSE_NETTY_ALLOCATOR = Boolean.getBoolean("vertx.reuseNettyAllocators");
+
   /**
-   * Vert.x pooled allocator.
+   * Vert.x pooled allocator. It should prefers direct buffers, unless {@link PlatformDependent#hasUnsafe()} is {@code false}.
    */
-  public static final ByteBufAllocator POOLED_ALLOCATOR = new PooledByteBufAllocator(true);
+  public static final ByteBufAllocator POOLED_ALLOCATOR = (REUSE_NETTY_ALLOCATOR && PooledByteBufAllocator.defaultPreferDirect()) ?
+    PooledByteBufAllocator.DEFAULT : new PooledByteBufAllocator(true);
   /**
-   * Vert.x shared unpooled allocator.
+   * Vert.x shared unpooled allocator. It prefers non-direct buffers.
    */
   public static final ByteBufAllocator UNPOOLED_ALLOCATOR = new UnpooledByteBufAllocator(false);
 
@@ -42,6 +45,10 @@ public abstract class VertxByteBufAllocator extends AbstractByteBufAllocator {
     }
   };
 
+  /**
+   * Vert.x shared unpooled heap buffers allocator.<br>
+   * Differently from {@link #UNPOOLED_ALLOCATOR}, its buffers are not reference-counted and array-backed.
+   */
   public static final VertxByteBufAllocator DEFAULT = PlatformDependent.hasUnsafe() ? UNSAFE_IMPL : IMPL;
 
   @Override

--- a/src/test/java/io/vertx/core/buffer/impl/VertxByteBufAllocatorTest.java
+++ b/src/test/java/io/vertx/core/buffer/impl/VertxByteBufAllocatorTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.buffer.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+
+public class VertxByteBufAllocatorTest {
+
+
+  @Test
+  public void defaultShouldNotReuseExistingNettyPooledAllocators() {
+    Assert.assertNull(System.getProperty("vertx.reuseNettyAllocators"));
+    Assert.assertNotSame(PooledByteBufAllocator.DEFAULT, VertxByteBufAllocator.POOLED_ALLOCATOR);
+    Assert.assertNotSame(ByteBufAllocator.DEFAULT, VertxByteBufAllocator.POOLED_ALLOCATOR);
+    Assert.assertSame(ByteBufAllocator.DEFAULT, PooledByteBufAllocator.DEFAULT);
+  }
+
+}


### PR DESCRIPTION
Fixes #5168 

This is part of https://github.com/eclipse-vertx/vert.x/pull/5262

non-SSL connections configure `PooledByteBufAllocator.DEFAULT` as per 
https://github.com/eclipse-vertx/vert.x/blob/f42b5d22c5c738cae1db925a06029212b198c398/vertx-core/src/main/java/io/vertx/core/net/impl/NetServerImpl.java#L515-L519

In this scenario, hitting these call sites:

https://github.com/eclipse-vertx/vert.x/blob/65403248e1e5c679d5418d8040aafea5bd09d0ef/src/main/java/io/vertx/core/net/impl/VertxHandler.java#L61 

https://github.com/eclipse-vertx/vert.x/blob/f42b5d22c5c738cae1db925a06029212b198c398/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java#L59

or

https://github.com/eclipse-vertx/vert.x/blob/f42b5d22c5c738cae1db925a06029212b198c398/vertx-core/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java#L49-L54

referencing `VertxByteBufAllocator.DEFAULT` , it triggers the initialization of `VertxByteBufAllocator.POOLED_ALLOCATOR` as well and by consequence its inner structures - making it a GC Root.

It results into a duplication of allocators i.e. `PooledByteBufAllocator.DEFAULT`  and `VertxByteBufAllocator.POOLED_ALLOCATOR`.

This patch aim to reuse the existing singleton i.e. `PooledByteBufAllocator.DEFAULT` if the user doesn't mess-up with `-Dio.netty.noPreferDirect`, in order to guarantee the original behaviour to be preserved.

