### PR TITLE
Calling Future#await() from a non vertx thread should be allowed.

### DIFF
--- a/vertx-core/src/test/java/io/vertx/it/tls/ConnectToTLSTrustedServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/tls/ConnectToTLSTrustedServerTest.java
@@ -34,11 +34,11 @@ public class ConnectToTLSTrustedServerTest {
     try {
       HttpServer server = vertx.createHttpServer(serverOptions)
         .requestHandler(req -> req.response().end(req.isSSL() + "/" + req.version()));
-      server.listen(8443, "localhost").toCompletionStage().toCompletableFuture().get();
+      server.listen(8443, "localhost").await();
       HttpClient client = vertx.createHttpClient(new HttpClientOptions().setUseAlpn(true).setProtocolVersion(HttpVersion.HTTP_2));
       Future<HttpClientRequest> fut = client.request(new RequestOptions().setAbsoluteURI("https://localhost:8443"));
       Future<Buffer> buff = fut.compose(req -> req.send().compose(HttpClientResponse::body));
-      return buff.toCompletionStage().toCompletableFuture().get().toString();
+      return buff.await().toString();
     } finally {
       vertx.close();
     }

--- a/vertx-core/src/test/java/io/vertx/it/vertx/ExecutorServiceFactoryTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/vertx/ExecutorServiceFactoryTest.java
@@ -41,7 +41,7 @@ public class ExecutorServiceFactoryTest extends VertxTestBase {
       }
       awaitLatch(latch);
     } finally {
-      vertx.close().toCompletionStage().toCompletableFuture().get(30, TimeUnit.SECONDS);
+      vertx.close().await(30, TimeUnit.SECONDS);
     }
     assertEquals(initialValue, CustomExecutorServiceFactory.NUM.get());
   }

--- a/vertx-core/src/test/java/io/vertx/test/proxy/HttpProxy.java
+++ b/vertx-core/src/test/java/io/vertx/test/proxy/HttpProxy.java
@@ -190,9 +190,7 @@ public class HttpProxy extends TestProxyBase<HttpProxy> {
     });
     server
       .listen()
-      .toCompletionStage()
-      .toCompletableFuture()
-      .get(10, TimeUnit.SECONDS);
+      .await(10, TimeUnit.SECONDS);
     return this;
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
@@ -1009,7 +1009,7 @@ public class ContextTest extends VertxTestBase {
 
   @Test
   public void testAwaitFromWorkerThread() {
-    testAwaitFromContextThread(ThreadingModel.WORKER, false);
+    testAwaitFromContextThread(ThreadingModel.WORKER, true);
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/deployment/VirtualThreadDeploymentTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/deployment/VirtualThreadDeploymentTest.java
@@ -112,9 +112,7 @@ public class VirtualThreadDeploymentTest extends VertxTestBase {
           server.listen(HttpTestBase.DEFAULT_HTTP_PORT, "localhost").await();
         }
       }, new DeploymentOptions().setThreadingModel(ThreadingModel.VIRTUAL_THREAD))
-      .toCompletionStage()
-      .toCompletableFuture()
-      .get();
+      .await();
     HttpClient client = vertx.createHttpClient();
     int numReq = 10;
     waitFor(numReq);

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/MessageQueueOnWorkerThreadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/MessageQueueOnWorkerThreadTest.java
@@ -40,7 +40,7 @@ public class MessageQueueOnWorkerThreadTest extends VertxTestBase {
     CustomNodeSelector selector = new CustomNodeSelector();
     VertxBootstrapImpl factory = new VertxBootstrapImpl().init().clusterNodeSelector(selector);
     Future<Vertx> fut = factory.clusteredVertx();
-    vertx = fut.toCompletionStage().toCompletableFuture().get();
+    vertx = fut.await();
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/future/FutureAwaitTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/future/FutureAwaitTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.tests.future;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class FutureAwaitTest extends VertxTestBase {
+
+  @Test
+  public void testAwaitFromEventLoopThread() {
+    Promise<String> promise = Promise.promise();
+    Future<String> future = promise.future();
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    ctx.nettyEventLoop().execute(() -> {
+      try {
+        future.await();
+      } catch (IllegalStateException expected) {
+        testComplete();
+      }
+    });
+    await();
+  }
+
+  @Test
+  public void testAwaitFromNonVertxThread() {
+    Promise<String> promise = Promise.promise();
+    Future<String> future = promise.future();
+    Thread current = Thread.currentThread();
+    new Thread(() -> {
+      while (current.getState() != Thread.State.WAITING) {
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException ignore) {
+        }
+      }
+      promise.complete("the-result");
+    }).start();
+    String res = future.await();
+    assertEquals("the-result", res);
+  }
+
+  @Test
+  public void testAwaitWithTimeout() {
+    Promise<String> promise = Promise.promise();
+    Future<String> future = promise.future();
+    long now = System.currentTimeMillis();
+    try {
+      future.await(100, TimeUnit.MILLISECONDS);
+      fail();
+    } catch (TimeoutException expected) {
+    }
+    assertTrue((System.currentTimeMillis() - now) >= 100);
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/tests/future/FutureTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/future/FutureTest.java
@@ -1819,15 +1819,6 @@ public class FutureTest extends FutureTestBase {
   }
 
   @Test
-  public void testAwaitFromPlainThread() {
-    try {
-      Promise.promise().future().await();
-      fail();
-    } catch (IllegalStateException e) {
-    }
-  }
-
-  @Test
   public void contextFutureTimeoutFires() {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
     Promise<String> promise = ctx.promise();

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -1087,9 +1087,7 @@ public class Http1xTest extends HttpTest {
 
     server
       .listen(testAddress)
-      .toCompletionStage()
-      .toCompletableFuture()
-      .get(20, TimeUnit.SECONDS);
+      .await(20, TimeUnit.SECONDS);
 
     AtomicInteger responses = new AtomicInteger();
     for (int i = 0;i < requests;i++) {

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpClientTimeoutTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpClientTimeoutTest.java
@@ -42,7 +42,7 @@ public abstract class HttpClientTimeoutTest extends HttpTestBase {
     startServer(testAddress);
     List<HttpClientRequest> requests = new ArrayList<>();
     for (int i = 0;i < 5;i++) {
-      HttpClientRequest request = client.request(new RequestOptions(requestOptions)).toCompletionStage().toCompletableFuture().get();
+      HttpClientRequest request = client.request(new RequestOptions(requestOptions)).await();
       requests.add(request);
     }
     long now = System.currentTimeMillis();
@@ -64,7 +64,7 @@ public abstract class HttpClientTimeoutTest extends HttpTestBase {
     startServer(testAddress);
     List<HttpClientRequest> requests = new ArrayList<>();
     for (int i = 0;i < 5;i++) {
-      HttpClientRequest request = client.request(new RequestOptions(requestOptions)).toCompletionStage().toCompletableFuture().get();
+      HttpClientRequest request = client.request(new RequestOptions(requestOptions)).await();
       requests.add(request);
     }
     vertx.setTimer(timeout * ratio / 100, id -> {
@@ -119,10 +119,7 @@ public abstract class HttpClientTimeoutTest extends HttpTestBase {
 
     CountDownLatch latch = new CountDownLatch(requests);
 
-    server.listen(testAddress)
-      .toCompletionStage()
-      .toCompletableFuture()
-      .get(20, TimeUnit.SECONDS);
+    server.listen(testAddress).await(20, TimeUnit.SECONDS);
 
     for(int count = 0; count < requests; count++) {
 

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -2677,7 +2677,7 @@ public abstract class HttpTest extends HttpTestBase {
     });
     startServer(testAddress);
     try {
-      CompletionStage<MultiMap> result = client
+      Future<MultiMap> result = client
         .request(new RequestOptions(requestOptions).setMethod(method)).compose(req ->
           req
             .setFollowRedirects(false)
@@ -2690,8 +2690,8 @@ public abstract class HttpTest extends HttpTestBase {
                   return Future.succeededFuture(resp.headers());
                 }
               })
-            )).toCompletionStage();
-      return result.toCompletableFuture().get(20, TimeUnit.SECONDS);
+            ));
+      return result.await(20, TimeUnit.SECONDS);
     } finally {
       client.close();
     }
@@ -3398,9 +3398,7 @@ public abstract class HttpTest extends HttpTestBase {
           .onComplete(startPromise);
       }
     })
-      .toCompletionStage()
-      .toCompletableFuture()
-      .get(20, TimeUnit.SECONDS);
+      .await(20, TimeUnit.SECONDS);
     vertx.deployVerticle(new AbstractVerticle() {
       HttpClient client;
       @Override
@@ -3447,9 +3445,7 @@ public abstract class HttpTest extends HttpTestBase {
           .onComplete(startPromise);
       }
     }, new DeploymentOptions().setThreadingModel(ThreadingModel.WORKER))
-      .toCompletionStage()
-      .toCompletableFuture()
-      .get(20, TimeUnit.SECONDS);
+      .await(20, TimeUnit.SECONDS);
     vertx.deployVerticle(new AbstractVerticle() {
       HttpClient client;
       @Override
@@ -6874,7 +6870,7 @@ public abstract class HttpTest extends HttpTestBase {
       }));
       await();
     } finally {
-      vertx.close().toCompletionStage().toCompletableFuture().get();
+      vertx.close().await();
       server.stop();
     }
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/VirtualThreadHttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/VirtualThreadHttpTest.java
@@ -40,7 +40,7 @@ public class VirtualThreadHttpTest extends VertxTestBase {
     server.requestHandler(req -> {
       req.response().end("Hello World");
     });
-    server.listen(8088, "localhost").toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+    server.listen(8088, "localhost").await(10, TimeUnit.SECONDS);
     vertx.createVirtualThreadContext().runOnContext(v -> {
       HttpClient client = vertx.createHttpClient();
       for (int i = 0; i < 100; ++i) {
@@ -63,7 +63,7 @@ public class VirtualThreadHttpTest extends VertxTestBase {
     server.requestHandler(req -> {
       req.response().end("Hello World");
     });
-    server.listen(8088, "localhost").toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+    server.listen(8088, "localhost").await(10, TimeUnit.SECONDS);
     HttpClient client = vertx.createHttpClient();
     vertx.createVirtualThreadContext().runOnContext(v -> {
       for (int i = 0; i < 100; ++i) {
@@ -83,8 +83,8 @@ public class VirtualThreadHttpTest extends VertxTestBase {
     try {
       await();
     } finally {
-      server.close().toCompletionStage().toCompletableFuture().get();
-      client.close().toCompletionStage().toCompletableFuture().get();
+      server.close().await();
+      client.close().await();
     }
   }
 
@@ -94,7 +94,7 @@ public class VirtualThreadHttpTest extends VertxTestBase {
     HttpServer server = vertx.createHttpServer();
     server.requestHandler(req -> {
     });
-    server.listen(8088, "localhost").toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+    server.listen(8088, "localhost").await(10, TimeUnit.SECONDS);
     vertx.createVirtualThreadContext().runOnContext(v -> {
       HttpClient client = vertx.createHttpClient();
       ContextInternal ctx = vertx.getOrCreateContext();

--- a/vertx-core/src/test/java/io/vertx/tests/http/WebSocketTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/WebSocketTest.java
@@ -1742,9 +1742,7 @@ public class WebSocketTest extends VertxTestBase {
 
       })
       .listen(1234, DEFAULT_HTTP_HOST)
-      .toCompletionStage()
-      .toCompletableFuture()
-      .get(20, TimeUnit.SECONDS);
+      .await(20, TimeUnit.SECONDS);
     try {
       client = vertx.createWebSocketClient(new WebSocketClientOptions().setConnectTimeout(1000));
       WebSocketConnectOptions options = new WebSocketConnectOptions()

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsTest.java
@@ -769,9 +769,7 @@ public class MetricsTest extends VertxTestBase {
       .compose(req -> req.send()
         .compose(HttpClientResponse::end)
         .compose(v ->  req.connection().close()))
-      .toCompletionStage()
-      .toCompletableFuture()
-      .get(20, TimeUnit.SECONDS);
+      .await(20, TimeUnit.SECONDS);
     assertWaitUntil(() -> endpointMetrics.get().connectionCount.get() == 0);
     assertEquals(0, endpointMetrics.get().requestCount.get());
     assertEquals(0, queueMetrics.get().pending());
@@ -1203,7 +1201,8 @@ public class MetricsTest extends VertxTestBase {
     HttpServer server = vertx.createHttpServer(options);
     server.requestHandler(req -> {
 
-    }).listen().toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+    }).listen()
+      .await(20, TimeUnit.SECONDS);
     FakeHttpServerMetrics metrics = FakeVertxMetrics.getMetrics(server);
     NetClient client = vertx.createNetClient(new NetClientOptions()
       .setSslEngineOptions(new JdkSSLEngineOptions())

--- a/vertx-core/src/test/java/io/vertx/tests/tls/HttpTLSTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tls/HttpTLSTest.java
@@ -1846,18 +1846,18 @@ public abstract class HttpTLSTest extends HttpTestBase {
       clients[i] = vertx.createHttpClient(createBaseClientOptions().setVerifyHost(false).setTrustOptions(Trust.SERVER_JKS.get()));
     }
     for (int i = 0;i < num;i++) {
-      Buffer body = clients[i].request(requestOptions).compose(req -> req.send().compose(HttpClientResponse::body)).toCompletionStage().toCompletableFuture().get();
+      Buffer body = clients[i].request(requestOptions).compose(req -> req.send().compose(HttpClientResponse::body)).await();
       assertEquals("Hello World " + i, body.toString());
     }
     for (int i = 0;i < num;i++) {
-      servers[i].updateSSLOptions(createBaseServerOptions().setKeyCertOptions(Cert.SERVER_PKCS12.get()).getSslOptions()).toCompletionStage().toCompletableFuture().get();
+      servers[i].updateSSLOptions(createBaseServerOptions().setKeyCertOptions(Cert.SERVER_PKCS12.get()).getSslOptions()).await();
     }
     for (int i = 0;i < num;i++) {
       clients[i].close();
       clients[i] = vertx.createHttpClient(createBaseClientOptions().setVerifyHost(false).setTrustOptions(Trust.SERVER_JKS.get()));
     }
     for (int i = 0;i < num;i++) {
-      Buffer body = clients[i].request(requestOptions).compose(req -> req.send().compose(HttpClientResponse::body)).toCompletionStage().toCompletableFuture().get();
+      Buffer body = clients[i].request(requestOptions).compose(req -> req.send().compose(HttpClientResponse::body)).await();
       assertEquals("Hello World " + i, body.toString());
     }
   }

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/CloseFutureTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/CloseFutureTest.java
@@ -94,7 +94,6 @@ public class CloseFutureTest extends AsyncTestBase {
         if (blocking) {
           Promise<Void> promise = Promise.promise();
           resource.close(promise);
-          promise.future().toCompletionStage().toCompletableFuture();
         } else {
           resource.close(Promise.promise());
         }

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxBootstrapTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxBootstrapTest.java
@@ -177,7 +177,7 @@ public class VertxBootstrapTest {
       .executorServiceFactory(new CustomExecutorServiceFactory())
       .init()
       .vertx()
-      .close().toCompletionStage().toCompletableFuture().join();
+      .close().await();
   }
 
   private class CustomExecutorServiceFactory implements ExecutorServiceFactory {

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
@@ -367,19 +367,18 @@ public class VertxTest extends AsyncTestBase {
       vertx.createSharedWorkerExecutor("LeakTest").executeBlocking(() -> {
         threads[0] = Thread.currentThread();
         return null;
-      }).toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+      }).await(20, TimeUnit.SECONDS);
       vertx.createSharedWorkerExecutor("LeakTest").executeBlocking(() -> {
         threads[1] = Thread.currentThread();
         return null;
-      }).toCompletionStage().toCompletableFuture().get(20, TimeUnit.SECONDS);
+      }).await(20, TimeUnit.SECONDS);
       runGC();
       assertFalse(threads[0].isAlive());
       assertFalse(threads[1].isAlive());
     } finally {
       vertx
         .close()
-        .toCompletionStage().toCompletableFuture()
-        .get(20, TimeUnit.SECONDS);
+        .await(20, TimeUnit.SECONDS);
     }
   }
 
@@ -487,8 +486,8 @@ public class VertxTest extends AsyncTestBase {
       WorkerExecutor exec = vertx.createSharedWorkerExecutor("pool");
       WeakReference<Thread> ref = exec.executeBlocking(() -> {
         return new WeakReference<>(Thread.currentThread());
-      }).toCompletionStage().toCompletableFuture().get();
-      exec.close().toCompletionStage().toCompletableFuture().get();
+      }).await();
+      exec.close().await();
       long now = System.currentTimeMillis();
       do {
         assertTrue(System.currentTimeMillis() - now < 20_000);


### PR DESCRIPTION
Motivation:

`Future#await()` was initially meant to be called by a vertx virtual thread and reject any other  thread. However this method can facilitate the workflow of synchrononous thread interacting with a vertx runtime, e.g. a unit test, from non-vertx threads.

Changes:

Change the implementation of `Future#await()` to permit non-vertx thread to block until the future completes. In addition a variant with a timeout has been added which can be useful for testing.

Results:

Any non-vertx thread can now await a future.
