### PR TITLE
Re-enable tests

### DIFF
--- a/vertx-core/pom.xml
+++ b/vertx-core/pom.xml
@@ -26,7 +26,7 @@
   <name>Vert.x Core</name>
 
   <properties>
-    <apacheds-protocol-dns.version>2.0.0-M23</apacheds-protocol-dns.version>
+    <apacheds-protocol-dns.version>2.0.0.AM27</apacheds-protocol-dns.version>
     <generated.dir>${project.basedir}/src/main/generated</generated.dir>
     <jmh.version>1.37</jmh.version>
     <vertx.testNativeTransport>false</vertx.testNativeTransport>

--- a/vertx-core/src/test/java/io/vertx/test/fakedns/FakeDNSServer.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakedns/FakeDNSServer.java
@@ -333,7 +333,7 @@ public final class FakeDNSServer extends DnsServer {
     };
 
     UdpTransport udpTransport = new UdpTransport(ipAddress, port);
-    ((DatagramSessionConfig)udpTransport.getAcceptor().getSessionConfig()).setReuseAddress(true);
+    udpTransport.getAcceptor().getSessionConfig().setReuseAddress(true);
     TcpTransport tcpTransport = new TcpTransport(ipAddress, port);
     tcpTransport.getAcceptor().getSessionConfig().setReuseAddress(true);
 

--- a/vertx-core/src/test/java/io/vertx/tests/dns/HostnameResolutionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/dns/HostnameResolutionTest.java
@@ -857,7 +857,6 @@ public class HostnameResolutionTest extends VertxTestBase {
 
   }
 
-  @Ignore("timeout with jpms")
   @Test
   public void testRotationalServerSelection() throws Exception {
     testServerSelection(true, false);
@@ -895,15 +894,10 @@ public class HostnameResolutionTest extends VertxTestBase {
       }
       HostnameResolver resolver = new HostnameResolver(vertx, options);
       for (int i = 0; i < num; i++) {
-        CompletableFuture<InetAddress> result = new CompletableFuture<>();
-        resolver.resolveHostname("vertx.io").onComplete(ar -> {
-          if (ar.succeeded()) {
-            result.complete(ar.result());
-          } else {
-            result.completeExceptionally(ar.cause());
-          }
-        });
-        String resolved = result.get(10, TimeUnit.SECONDS).getHostAddress();
+        String resolved = resolver
+          .resolveHostname("vertx.io")
+          .await(10, TimeUnit.SECONDS)
+          .getHostAddress();
         int expected;
         if (rotateServers && !cache) {
           expected = 1 + i;

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2Test.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2Test.java
@@ -190,7 +190,6 @@ public class Http2Test extends HttpTest {
     await();
   }
 
-  @Ignore("does not pass with modules")
   @Test
   public void testServerOpenSSL() throws Exception {
     HttpServerOptions opts = new HttpServerOptions()
@@ -972,7 +971,6 @@ public class Http2Test extends HttpTest {
     testUnsupportedAlpnVersion(new JdkSSLEngineOptions(), false);
   }
 
-  @Ignore("does not pass in modules")
   @Test
   public void testUnsupportedAlpnVersionOpenSSL() throws Exception {
     testUnsupportedAlpnVersion(new OpenSSLEngineOptions(), true);

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -932,7 +932,7 @@ public class NetTest extends VertxTestBase {
   }
 
   @Test
-  public void testConnectInvalidHost() {
+  public void testConnectInvwalidHost() {
     assertNullPointerException(() -> client.connect(80, null));
     client.connect(1234, "127.0.0.2").onComplete(onFailure(err -> testComplete()));
     await();

--- a/vertx-core/src/test/java/io/vertx/tests/tls/HttpTLSTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tls/HttpTLSTest.java
@@ -370,14 +370,12 @@ public abstract class HttpTLSTest extends HttpTestBase {
     testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_MIM, Trust.NONE).clientVerifyHost().fail();
   }
 
-  @Ignore
   @Test
   // Test host verification with a CN matching localhost
   public void testTLSVerifyMatchingHostOpenSSL() throws Exception {
     testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE).clientVerifyHost().clientOpenSSL().pass();
   }
 
-  @Ignore
   @Test
   // Test host verification with a CN NOT matching localhost
   public void testTLSVerifyNonMatchingHostOpenSSL() throws Exception {
@@ -386,63 +384,54 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   // OpenSSL tests
 
-  @Ignore
   @Test
   // Server uses OpenSSL with JKS
   public void testTLSClientTrustServerCertJKSOpenSSL() throws Exception {
     testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE).serverOpenSSL().pass();
   }
 
-  @Ignore
   @Test
   // Server uses OpenSSL with PKCS12
   public void testTLSClientTrustServerCertPKCS12OpenSSL() throws Exception {
     testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_PKCS12, Trust.NONE).serverOpenSSL().pass();
   }
 
-  @Ignore
   @Test
   // Server uses OpenSSL with PEM
   public void testTLSClientTrustServerCertPEMOpenSSL() throws Exception {
     testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_PEM, Trust.NONE).serverOpenSSL().pass();
   }
 
-  @Ignore
   @Test
   // Client trusts OpenSSL with PEM
   public void testTLSClientTrustServerCertWithJKSOpenSSL() throws Exception {
     testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE).clientOpenSSL().pass();
   }
 
-  @Ignore
   @Test
   // Server specifies cert that the client trusts (not trust all)
   public void testTLSClientTrustServerCertWithPKCS12OpenSSL() throws Exception {
     testTLS(Cert.NONE, Trust.SERVER_PKCS12, Cert.SERVER_JKS, Trust.NONE).clientOpenSSL().pass();
   }
 
-  @Ignore
   @Test
   // Server specifies cert that the client trusts (not trust all)
   public void testTLSClientTrustServerCertWithPEMOpenSSL() throws Exception {
     testTLS(Cert.NONE, Trust.SERVER_PEM, Cert.SERVER_JKS, Trust.NONE).clientOpenSSL().pass();
   }
 
-  @Ignore
   @Test
   // Client specifies cert and it is required
   public void testTLSClientCertRequiredOpenSSL() throws Exception {
     testTLS(Cert.CLIENT_JKS, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.CLIENT_JKS).clientOpenSSL().requiresClientAuth().pass();
   }
 
-  @Ignore
   @Test
   // Client specifies cert and it is required
   public void testTLSClientCertPKCS12RequiredOpenSSL() throws Exception {
     testTLS(Cert.CLIENT_PKCS12, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.CLIENT_JKS).clientOpenSSL().requiresClientAuth().pass();
   }
 
-  @Ignore
   @Test
   // Client specifies cert and it is required
   public void testTLSClientCertPEMRequiredOpenSSL() throws Exception {
@@ -458,7 +447,6 @@ public abstract class HttpTLSTest extends HttpTestBase {
       .serverEnabledSecureTransportProtocol(new String[]{"TLSv1.3"}).pass();
   }
 
-  @Ignore
   @Test
   // TLSv1.3 with OpenSSL
   public void testTLSv1_3OpenSSL() throws Exception {
@@ -479,7 +467,6 @@ public abstract class HttpTLSTest extends HttpTestBase {
       .fail();
   }
 
-  @Ignore
   @Test
   // Disable TLSv1.3 with OpenSSL
   public void testDisableTLSv1_3OpenSSL() throws Exception {
@@ -500,7 +487,6 @@ public abstract class HttpTLSTest extends HttpTestBase {
       .fail();
   }
 
-  @Ignore
   @Test
   // Disable TLSv1.2 with OpenSSL
   public void testDisableTLSv1_2OpenSSL() throws Exception {
@@ -797,7 +783,6 @@ public abstract class HttpTLSTest extends HttpTestBase {
     assertEquals("host2.com", TestUtils.cnOf(cert));
   }
 
-  @Ignore
   @Test
   public void testSNIWithOpenSSL() throws Exception {
     Certificate cert = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_JKS, Trust.NONE)

--- a/vertx-core/src/test/java/io/vertx/tests/tls/SslContextManagerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tls/SslContextManagerTest.java
@@ -54,7 +54,6 @@ public class SslContextManagerTest extends VertxTestBase {
     await();
   }
 
-  @Ignore
   @Test
   public void testUseOpenSSLCiphersWhenNotSpecified() throws Exception {
     Set<String> expected = OpenSsl.availableOpenSslCipherSuites();
@@ -67,13 +66,11 @@ public class SslContextManagerTest extends VertxTestBase {
     await();
   }
 
-  @Ignore("native loading")
   @Test
   public void testDefaultOpenSslServerSessionContext() throws Exception {
     testOpenSslServerSessionContext(true);
   }
 
-  @Ignore("native loading")
   @Test
   public void testUserSetOpenSslServerSessionContext() throws Exception {
     testOpenSslServerSessionContext(false);


### PR DESCRIPTION
Some tests were disabled after JPMS upgrade, they should be re-enabled whenever possible