### PR TITLE
Deprecate io.vertx.core.ServiceHelper

### DIFF
--- a/src/main/java/io/vertx/core/ServiceHelper.java
+++ b/src/main/java/io/vertx/core/ServiceHelper.java
@@ -17,7 +17,9 @@ import java.util.*;
  * A helper class for loading factories from the classpath.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
+ * @deprecated this utility class is for internal usage of Vert.x and will be moved to an internal vertx package in Vert.x 5
  */
+@Deprecated
 public class ServiceHelper {
 
   public static <T> T loadFactory(Class<T> clazz) {


### PR DESCRIPTION
Motivation:

The ServiceHelper utility class is mostly used internally by vertx service providers to load plugins. Users should not use this class. In addition service loading strategies might change in Vert.x 5 due to the support of JPMS. In addition this reduces the API surface.

Changes:

Deprecate io.vertx.core.ServiceHelper

Result:

ServiceHelper is deprecated.
