### PR TITLE
Decouple the cluster manager interface from NodeSelector and make this class an implementation details

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
@@ -628,10 +628,10 @@ public class EventBusOptions extends TCPSSLOptions {
   /**
    * User-supplied information about this node when Vert.x is clustered.
    * <p>
-   * The data may be used by the {@link io.vertx.core.spi.cluster.NodeSelector} to select a node for a given message.
+   * The data may be to select a node for a given message.
    * For example, it could be used to implement a partioning strategy.
    * <p>
-   * The default {@link io.vertx.core.spi.cluster.NodeSelector} does not use the node metadata.
+   * Not used by default.
    *
    * @return user-supplied information about this node when Vert.x is clustered
    */
@@ -642,10 +642,10 @@ public class EventBusOptions extends TCPSSLOptions {
   /**
    * Set information about this node when Vert.x is clustered.
    * <p>
-   * The data may be used by the {@link io.vertx.core.spi.cluster.NodeSelector} to select a node for a given message.
+   * The data may be used to select a node for a given message.
    * For example, it could be used to implement a partioning strategy.
    * <p>
-   * The default {@link io.vertx.core.spi.cluster.NodeSelector} does not use the node metadata.
+   * Not used by default.
    *
    * @param clusterNodeMetadata user-supplied information about this node when Vert.x is clustered
    * @return a reference to this, so the API can be used fluently

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -37,7 +37,7 @@ import io.vertx.core.net.impl.NetClientBuilder;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.cluster.NodeInfo;
-import io.vertx.core.spi.cluster.NodeSelector;
+import io.vertx.core.spi.cluster.impl.NodeSelector;
 import io.vertx.core.spi.cluster.RegistrationInfo;
 import io.vertx.core.spi.metrics.VertxMetrics;
 

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxBootstrapImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxBootstrapImpl.java
@@ -30,7 +30,7 @@ import io.vertx.core.spi.VertxServiceProvider;
 import io.vertx.core.spi.VertxThreadFactory;
 import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.spi.cluster.ClusterManager;
-import io.vertx.core.spi.cluster.NodeSelector;
+import io.vertx.core.spi.cluster.impl.NodeSelector;
 import io.vertx.core.spi.cluster.impl.DefaultNodeSelector;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -58,7 +58,7 @@ import io.vertx.core.spi.ExecutorServiceFactory;
 import io.vertx.core.spi.VerticleFactory;
 import io.vertx.core.spi.VertxThreadFactory;
 import io.vertx.core.spi.cluster.ClusterManager;
-import io.vertx.core.spi.cluster.NodeSelector;
+import io.vertx.core.spi.cluster.impl.NodeSelector;
 import io.vertx.core.spi.tracing.VertxTracer;
 
 import java.io.File;
@@ -246,7 +246,8 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   Future<Vertx> initClustered(VertxOptions options) {
     nodeSelector.init(this, clusterManager);
-    clusterManager.init(this, nodeSelector);
+    clusterManager.registrationListener(nodeSelector);
+    clusterManager.init(this);
     Promise<Void> initPromise = Promise.promise();
     Promise<Void> joinPromise = Promise.promise();
     joinPromise.future().onComplete(ar -> {

--- a/vertx-core/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
@@ -52,14 +52,10 @@ public interface ClusterManager extends VertxServiceProvider {
 
   /**
    * Invoked before this cluster node tries to join the cluster.
-   * <p>
-   * Implementations must signal the provided {@code nodeSelector} when messaging handler registrations are added or removed
-   * by sending a {@link RegistrationUpdateEvent} with {@link NodeSelector#registrationsUpdated(RegistrationUpdateEvent)}.
    *
    * @param vertx        the Vert.x instance
-   * @param nodeSelector the {@link NodeSelector} that must receive {@link RegistrationUpdateEvent}.
    */
-  void init(Vertx vertx, NodeSelector nodeSelector);
+  void init(Vertx vertx);
 
   /**
    * Return an {@link AsyncMap} for the given {@code name}.
@@ -129,6 +125,14 @@ public interface ClusterManager extends VertxServiceProvider {
    * @return true if active, false otherwise
    */
   boolean isActive();
+
+  /**
+   * Implementations must signal the provided {@code registrationListener} when messaging handler registrations are added or removed
+   * by sending a {@link RegistrationUpdateEvent} with {@link RegistrationListener#registrationsUpdated(RegistrationUpdateEvent)}.
+   *
+   * @param registrationListener the registration listener
+   */
+  void registrationListener(RegistrationListener registrationListener);
 
   /**
    * Share a new messaging handler registration with other nodes in the cluster.

--- a/vertx-core/src/main/java/io/vertx/core/spi/cluster/RegistrationListener.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/cluster/RegistrationListener.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.spi.cluster;
+
+/**
+ * Registration listener used by the cluster manager to keep the clustered event bus updated with the registration changes.
+ */
+public interface RegistrationListener {
+
+  /**
+   * Invoked by the {@link ClusterManager} when messaging handler registrations are added or removed.
+   */
+  default void registrationsUpdated(RegistrationUpdateEvent event) {
+  }
+
+  /**
+   * Invoked by the {@link ClusterManager} when some handler registrations have been lost.
+   */
+  default void registrationsLost() {
+  }
+
+  /**
+   * Invoked by the {@link ClusterManager} to determine if the node selector wants updates for the given {@code address}.
+   *
+   * @param address the event bus address
+   * @return {@code true} if the node selector wants updates for the given {@code address}, {@code false} otherwise
+   */
+  default boolean wantsUpdatesFor(String address) {
+    return true;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/spi/cluster/impl/DefaultNodeSelector.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/cluster/impl/DefaultNodeSelector.java
@@ -14,7 +14,6 @@ package io.vertx.core.spi.cluster.impl;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.spi.cluster.ClusterManager;
-import io.vertx.core.spi.cluster.NodeSelector;
 import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
 import io.vertx.core.spi.cluster.impl.selector.Selectors;
 

--- a/vertx-core/src/main/java/io/vertx/core/spi/cluster/impl/NodeSelector.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/cluster/impl/NodeSelector.java
@@ -9,10 +9,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
-package io.vertx.core.spi.cluster;
+package io.vertx.core.spi.cluster.impl;
 
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.core.spi.cluster.RegistrationListener;
 
 /**
  * Used by the {@link io.vertx.core.eventbus.EventBus clustered EventBus} to select a node for a given message.
@@ -20,7 +22,7 @@ import io.vertx.core.Vertx;
  * This selector is skipped only when the user raises the {@link io.vertx.core.eventbus.DeliveryOptions#setLocalOnly(boolean)} flag.
  * Consequently, implementations must be aware of local {@link io.vertx.core.eventbus.EventBus} registrations.
  */
-public interface NodeSelector {
+public interface NodeSelector extends RegistrationListener {
 
   /**
    * Invoked before the {@code vertx} instance tries to join the cluster.
@@ -47,25 +49,5 @@ public interface NodeSelector {
    * as it might completed outside the selector.
    */
   void selectForPublish(String address, Promise<Iterable<String>> promise);
-
-  /**
-   * Invoked by the {@link ClusterManager} when messaging handler registrations are added or removed.
-   */
-  void registrationsUpdated(RegistrationUpdateEvent event);
-
-  /**
-   * Invoked by the {@link ClusterManager} when some handler registrations have been lost.
-   */
-  void registrationsLost();
-
-  /**
-   * Invoked by the {@link ClusterManager} to determine if the node selector wants updates for the given {@code address}.
-   *
-   * @param address the event bus address
-   * @return {@code true} if the node selector wants updates for the given {@code address}, {@code false} otherwise
-   */
-  default boolean wantsUpdatesFor(String address) {
-    return true;
-  }
 
 }

--- a/vertx-core/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
@@ -47,13 +47,12 @@ public class FakeClusterManager implements ClusterManager {
 
   private volatile String nodeID;
   private NodeListener nodeListener;
+  private RegistrationListener registrationListener;
   private VertxInternal vertx;
-  private NodeSelector nodeSelector;
 
   @Override
-  public void init(Vertx vertx, NodeSelector nodeSelector) {
+  public void init(Vertx vertx) {
     this.vertx = (VertxInternal) vertx;
-    this.nodeSelector = nodeSelector;
   }
 
   private static void doJoin(String nodeID, FakeClusterManager node) {
@@ -202,8 +201,8 @@ public class FakeClusterManager implements ClusterManager {
       synchronized (this) {
         if (nodeID != null) {
           nodeInfos.remove(nodeID);
-          if (nodeListener != null) {
-            nodeListener = null;
+          if (registrationListener != null) {
+            registrationListener = null;
           }
           doLeave(nodeID);
           this.nodeID = null;
@@ -221,7 +220,7 @@ public class FakeClusterManager implements ClusterManager {
       for (RegistrationUpdateEvent event : events) {
         FakeClusterManager clusterManager = nodes.get(nid);
         if (clusterManager != null && clusterManager.isActive()) {
-          clusterManager.nodeSelector.registrationsUpdated(event);
+          clusterManager.registrationListener.registrationsUpdated(event);
         }
       }
     }
@@ -230,6 +229,11 @@ public class FakeClusterManager implements ClusterManager {
   @Override
   public boolean isActive() {
     return nodeID != null;
+  }
+
+  @Override
+  public void registrationListener(RegistrationListener registrationListener) {
+    this.registrationListener = registrationListener;
   }
 
   @Override

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTest.java
@@ -14,9 +14,10 @@ package io.vertx.tests.eventbus;
 import io.vertx.core.*;
 import io.vertx.core.eventbus.*;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.spi.cluster.RegistrationListener;
 import io.vertx.tests.shareddata.AsyncMapTest.SomeClusterSerializableObject;
 import io.vertx.tests.shareddata.AsyncMapTest.SomeSerializableObject;
-import io.vertx.core.spi.cluster.NodeSelector;
+import io.vertx.core.spi.cluster.impl.NodeSelector;
 import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.tls.Cert;
@@ -395,8 +396,8 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
     CountDownLatch updateLatch = new CountDownLatch(3);
     startNodes(2, () -> new WrappedClusterManager(getClusterManager()) {
       @Override
-      public void init(Vertx vertx, NodeSelector nodeSelector) {
-        super.init(vertx, new WrappedNodeSelector(nodeSelector) {
+      public void registrationListener(RegistrationListener registrationListener) {
+        super.registrationListener(new WrappedNodeSelector((NodeSelector) registrationListener) {
           @Override
           public void registrationsUpdated(RegistrationUpdateEvent event) {
             super.registrationsUpdated(event);
@@ -488,9 +489,9 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
     AtomicReference<NodeSelector> nodeSelectorRef = new AtomicReference<>();
     startNodes(1, () -> new WrappedClusterManager(getClusterManager()) {
       @Override
-      public void init(Vertx vertx, NodeSelector nodeSelector) {
-        nodeSelectorRef.set(nodeSelector);
-        super.init(vertx, nodeSelector);
+      public void registrationListener(RegistrationListener registrationListener) {
+        nodeSelectorRef.set((NodeSelector) registrationListener);
+        super.registrationListener(registrationListener);
       }
     });
     assertNotNull(nodeSelectorRef.get());
@@ -506,9 +507,8 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
     AtomicReference<NodeSelector> nodeSelectorRef = new AtomicReference<>();
     startNodes(1, () -> new WrappedClusterManager(getClusterManager()) {
       @Override
-      public void init(Vertx vertx, NodeSelector nodeSelector) {
-        nodeSelectorRef.set(nodeSelector);
-        super.init(vertx, nodeSelector);
+      public void registrationListener(RegistrationListener registrationListener) {
+        nodeSelectorRef.set((NodeSelector) registrationListener);
       }
     });
     assertNotNull(nodeSelectorRef.get());

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTestBase.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTestBase.java
@@ -18,9 +18,10 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.*;
+import io.vertx.core.spi.cluster.RegistrationListener;
 import io.vertx.tests.shareddata.AsyncMapTest;
 import io.vertx.core.spi.cluster.ClusterManager;
-import io.vertx.core.spi.cluster.NodeSelector;
+import io.vertx.core.spi.cluster.impl.NodeSelector;
 import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.fakecluster.FakeClusterManager;
@@ -130,8 +131,8 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
     CountDownLatch updateLatch = new CountDownLatch(3);
     startNodes(2, () -> new WrappedClusterManager(getClusterManager()) {
       @Override
-      public void init(Vertx vertx, NodeSelector nodeSelector) {
-        super.init(vertx, new WrappedNodeSelector(nodeSelector) {
+      public void registrationListener(RegistrationListener registrationListener) {
+        super.registrationListener(new WrappedNodeSelector((NodeSelector) registrationListener) {
           @Override
           public void registrationsUpdated(RegistrationUpdateEvent event) {
             super.registrationsUpdated(event);

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/CustomNodeSelectorTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/CustomNodeSelectorTest.java
@@ -18,8 +18,7 @@ import io.vertx.core.internal.VertxBootstrap;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.cluster.NodeInfo;
-import io.vertx.core.spi.cluster.NodeSelector;
-import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
+import io.vertx.core.spi.cluster.impl.NodeSelector;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
@@ -131,14 +130,6 @@ public class CustomNodeSelectorTest extends VertxTestBase {
         }
         return res;
       }).onComplete(promise);
-    }
-
-    @Override
-    public void registrationsUpdated(RegistrationUpdateEvent event) {
-    }
-
-    @Override
-    public void registrationsLost() {
     }
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/MessageQueueOnWorkerThreadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/MessageQueueOnWorkerThreadTest.java
@@ -15,8 +15,7 @@ import io.vertx.core.*;
 import io.vertx.core.eventbus.impl.clustered.Serializer;
 import io.vertx.core.impl.VertxBootstrapImpl;
 import io.vertx.core.spi.cluster.ClusterManager;
-import io.vertx.core.spi.cluster.NodeSelector;
-import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
+import io.vertx.core.spi.cluster.impl.NodeSelector;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
@@ -101,14 +100,6 @@ public class MessageQueueOnWorkerThreadTest extends VertxTestBase {
     @Override
     public void selectForPublish(String address, Promise<Iterable<String>> promise) {
       throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void registrationsUpdated(RegistrationUpdateEvent event) {
-    }
-
-    @Override
-    public void registrationsLost() {
     }
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/WrappedClusterManager.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/WrappedClusterManager.java
@@ -30,8 +30,8 @@ public class WrappedClusterManager implements ClusterManager {
   }
 
   @Override
-  public void init(Vertx vertx, NodeSelector nodeSelector) {
-    delegate.init(vertx, nodeSelector);
+  public void init(Vertx vertx) {
+    delegate.init(vertx);
   }
 
   @Override
@@ -97,6 +97,11 @@ public class WrappedClusterManager implements ClusterManager {
   @Override
   public boolean isActive() {
     return delegate.isActive();
+  }
+
+  @Override
+  public void registrationListener(RegistrationListener registrationListener) {
+    delegate.registrationListener(registrationListener);
   }
 
   @Override

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/WrappedNodeSelector.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/WrappedNodeSelector.java
@@ -14,8 +14,8 @@ package io.vertx.tests.eventbus;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.spi.cluster.ClusterManager;
-import io.vertx.core.spi.cluster.NodeSelector;
 import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
+import io.vertx.core.spi.cluster.impl.NodeSelector;
 
 public class WrappedNodeSelector implements NodeSelector {
 

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/WriteHandlerLookupFailureTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/WriteHandlerLookupFailureTest.java
@@ -17,7 +17,7 @@ import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.MessageProducer;
 import io.vertx.core.impl.VertxBootstrapImpl;
 import io.vertx.core.internal.VertxBootstrap;
-import io.vertx.core.spi.cluster.NodeSelector;
+import io.vertx.core.spi.cluster.impl.NodeSelector;
 import io.vertx.core.spi.cluster.impl.DefaultNodeSelector;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;


### PR DESCRIPTION
Motivation:

The `NodeSelector` interface has currently a single implementation and is exposed to the cluster manager. The `NodeSelector` interface combines two API, an API selecting node used by the event bus, an API for broadcasting changes to the node selector implementation used by the cluster manager. The cluster manager exposed API should be reduced to the methods it is intended to use, this also allows to reduce the SPI surface of the cluster manager SPI.

Changes:

Extract the `RegistrationListener` out of `NodeSelector`, the `ClusterManager` interface gets getter/setter for the registration listener, similar to the `NodeListener`.

The `NodeSelector` is moved to the cluster manager SPI impl package and is not exposed anymore.

This is an SPI breaking change.
