### PR TITLE
Completable/Deployment prototype.

### DIFF
--- a/vertx-core/src/main/java/examples/CoreExamples.java
+++ b/vertx-core/src/main/java/examples/CoreExamples.java
@@ -141,7 +141,7 @@ public class CoreExamples {
   }
 
   public void promiseAsHandler() {
-    Future<String> greeting = Future.future(promise -> legacyGreetAsync(promise));
+    Future<String> greeting = Future.future(promise -> legacyGreetAsync(promise::handle));
   }
 
   public void promiseCallbackOrder(Future<Void> future) {

--- a/vertx-core/src/main/java/io/vertx/core/Completable.java
+++ b/vertx-core/src/main/java/io/vertx/core/Completable.java
@@ -1,0 +1,20 @@
+package io.vertx.core;
+
+@FunctionalInterface
+public interface Completable<T> {
+
+  default void succeed() {
+    complete(null, null);
+  }
+
+  default void succeed(T result) {
+    complete(result, null);
+  }
+
+  default void fail(Throwable err) {
+    complete(null, err);
+  }
+
+  void complete(T result, Throwable err);
+
+}

--- a/vertx-core/src/main/java/io/vertx/core/Deployment1.java
+++ b/vertx-core/src/main/java/io/vertx/core/Deployment1.java
@@ -1,0 +1,11 @@
+package io.vertx.core;
+
+@FunctionalInterface
+public interface Deployment1 {
+
+  void start(Completable<Object> completable);
+
+  default void stop(Completable<Object> completable) {
+    completable.succeed(null);
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/Deployment2.java
+++ b/vertx-core/src/main/java/io/vertx/core/Deployment2.java
@@ -1,0 +1,11 @@
+package io.vertx.core;
+
+@FunctionalInterface
+public interface Deployment2 {
+
+  Future<?> start();
+
+  default Future<?> stop() {
+    return Future.succeededFuture();
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/Future.java
+++ b/vertx-core/src/main/java/io/vertx/core/Future.java
@@ -270,6 +270,11 @@ public interface Future<T> extends AsyncResult<T> {
   @Fluent
   Future<T> onComplete(Handler<AsyncResult<T>> handler);
 
+  @Fluent
+  default Future<T> onComplete(Completable<? super T> completable) {
+    return onComplete(ar -> completable.complete(ar.succeeded() ? ar.result() : null, ar.succeeded() ? null : ar.cause()));
+  }
+
   /**
    * Add handlers to be notified on succeeded result and failed result.
    * <p>

--- a/vertx-core/src/main/java/io/vertx/core/Promise.java
+++ b/vertx-core/src/main/java/io/vertx/core/Promise.java
@@ -27,7 +27,7 @@ import io.vertx.core.impl.future.PromiseImpl;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 @VertxGen
-public interface Promise<T> extends Handler<AsyncResult<T>> {
+public interface Promise<T> extends Completable<T> {
 
   /**
    * Create a promise that hasn't completed yet
@@ -39,13 +39,17 @@ public interface Promise<T> extends Handler<AsyncResult<T>> {
     return new PromiseImpl<>();
   }
 
+  @Override
+  default void complete(T result, Throwable err) {
+    throw new UnsupportedOperationException();
+  }
+
   /**
    * Succeed or fail this promise with the {@link AsyncResult} event.
    *
    * @param asyncResult the async result to handle
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  @Override
   default void handle(AsyncResult<T> asyncResult) {
     if (asyncResult.succeeded()) {
       complete(asyncResult.result());

--- a/vertx-core/src/main/java/io/vertx/core/Vertx.java
+++ b/vertx-core/src/main/java/io/vertx/core/Vertx.java
@@ -37,6 +37,7 @@ import io.vertx.core.spi.cluster.ClusterManager;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -489,6 +490,16 @@ public interface Vertx extends Measured {
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Future<String> deployVerticle(Supplier<Verticle> verticleSupplier, DeploymentOptions options);
+
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default Future<String> deploy1(Function<Context, Deployment1> supplier, DeploymentOptions options) {
+    return null;
+  }
+
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default Future<String> deploy2(Function<Context, Deployment2> supplier, DeploymentOptions options) {
+    return null;
+  }
 
   /**
    * Deploy a verticle instance given a name.

--- a/vertx-core/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -125,14 +125,14 @@ public class AsyncFileImpl implements AsyncFile {
   @Override
   public Future<Void> close() {
     Promise<Void> promise = context.promise();
-    closeInternal(promise);
+    closeInternal(promise::handle);
     return promise.future();
   }
 
   @Override
   public Future<Void> end() {
     Promise<Void> promise = context.promise();
-    closeInternal(promise);
+    closeInternal(promise::handle);
     return promise.future();
   }
 
@@ -158,7 +158,7 @@ public class AsyncFileImpl implements AsyncFile {
   @Override
   public Future<Void> write(Buffer buffer, long position) {
     Promise<Void> promise = context.promise();
-    doWrite(buffer, position, promise);
+    doWrite(buffer, position, promise::handle);
     return promise.future();
   }
 
@@ -217,7 +217,7 @@ public class AsyncFileImpl implements AsyncFile {
   public synchronized Future<Void> write(Buffer buffer) {
     Promise<Void> promise = context.promise();
     int length = buffer.length();
-    doWrite(buffer, writePos, promise);
+    doWrite(buffer, writePos, promise::handle);
     writePos += length;
     return promise.future();
   }
@@ -299,7 +299,7 @@ public class AsyncFileImpl implements AsyncFile {
   @Override
   public Future<Void> flush() {
     Promise<Void> promise = context.promise();
-    doFlush(promise);
+    doFlush(promise::handle);
     return promise.future();
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/future/Tests.java
+++ b/vertx-core/src/main/java/io/vertx/core/future/Tests.java
@@ -1,0 +1,45 @@
+package io.vertx.core.future;
+
+import io.vertx.core.*;
+
+public class Tests {
+
+  public void useCase(Future<String> fut, Completable<Object> completable) {
+    fut.onComplete(completable);
+  }
+
+  public void another(Future<?> fut, Completable<Object> completable) {
+    fut.onComplete(completable);
+  }
+
+  public void another2(Future<String> fut, Completable<Object> completable) {
+    fut.onComplete(completable);
+  }
+
+  public void lambda(Future<String> fut) {
+    fut.onComplete((re, err) -> {
+
+    });
+  }
+
+  public void varianceWithPromise(Future<String> fut, Promise<Object> completable) {
+    fut.onComplete(completable);
+  }
+
+  public void testDeploymentAPI1(Vertx vertx) {
+
+    vertx.deploy1(ctx -> Completable::succeed, new DeploymentOptions());
+
+    vertx.deploy1(ctx -> completable -> vertx.timer(100).onComplete(completable), new DeploymentOptions());
+
+  }
+
+  public void testDeploymentAPI2(Vertx vertx) {
+
+    vertx.deploy2(ctx -> Future::succeededFuture, new DeploymentOptions());
+
+    vertx.deploy2(ctx -> () -> vertx.timer(100), new DeploymentOptions());
+
+  }
+
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -504,7 +504,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
       pipeline.addAfter("codec", null, new UpgradeRequestHandler());
       pipeline.addAfter("codec", null, upgradeHandler);
       PromiseInternal<Void> promise = upgradingStream.getContext().promise();
-      doWriteHead(request, chunked, buf, end, priority, connect, promise);
+      doWriteHead(request, chunked, buf, end, priority, connect, promise::handle);
       return promise.future();
     }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -387,7 +387,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
             .compose(v -> next, err -> next)
             .onComplete(ar1 -> {
               if (ar1.succeeded()) {
-                handleNextRequest(ar1.result(), promise, timeoutMs);
+                handleNextRequest(ar1.result(), promise::handle, timeoutMs);
               } else {
                 fail(ar1.cause());
               }

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -790,7 +790,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   public Future<String> deployVerticle(String name, DeploymentOptions options) {
     if (options.isHa() && haManager() != null) {
       Promise<String> promise = getOrCreateContext().promise();
-      haManager().deployVerticle(name, options, promise);
+      haManager().deployVerticle(name, options, promise::handle);
       return promise.future();
     } else {
       return verticleManager.deployVerticle(name, options).map(Deployment::deploymentID);

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTestBase.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTestBase.java
@@ -46,7 +46,7 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
   @Override
   protected void clusteredVertx(VertxOptions options, ClusterManager clusterManager, Handler<AsyncResult<Vertx>> ar) {
     Promise<Vertx> promise = Promise.promise();
-    super.clusteredVertx(options, clusterManager, promise);
+    super.clusteredVertx(options, clusterManager, promise::handle);
     promise.future().onSuccess(vertx -> {
       ImmutableObjectCodec immutableObjectCodec = new ImmutableObjectCodec();
       vertx.eventBus().registerCodec(immutableObjectCodec);

--- a/vertx-core/src/test/java/io/vertx/tests/future/FutureTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/future/FutureTest.java
@@ -178,7 +178,7 @@ public class FutureTest extends FutureTestBase {
   public void testResolveFutureToHandler() {
     Consumer<Handler<AsyncResult<String>>> consumer = handler -> handler.handle(io.vertx.core.Future.succeededFuture("the-result"));
     Promise<String> promise = Promise.promise();
-    consumer.accept(promise);
+    consumer.accept(promise::handle);
     assertTrue(promise.future().isComplete());
     assertTrue(promise.future().succeeded());
     assertEquals("the-result", promise.future().result());
@@ -191,7 +191,7 @@ public class FutureTest extends FutureTestBase {
       handler.handle(io.vertx.core.Future.failedFuture(cause));
     };
     Promise<String> promise = Promise.promise();
-    consumer.accept(promise);
+    consumer.accept(promise::handle);
     assertTrue(promise.future().isComplete());
     assertTrue(promise.future().failed());
     assertEquals(cause, promise.future().cause());
@@ -1239,13 +1239,13 @@ public class FutureTest extends FutureTestBase {
   public void testSetNullHandler() throws Exception {
     Promise<String> promise = Promise.promise();
     try {
-      promise.future().onComplete(null);
+      promise.future().onComplete((Handler<AsyncResult<String>>) null);
       fail();
     } catch (NullPointerException ignore) {
     }
     promise.complete();
     try {
-      promise.future().onComplete(null);
+      promise.future().onComplete((Handler<AsyncResult<String>>) null);
       fail();
     } catch (NullPointerException ignore) {
     }

--- a/vertx-core/src/test/java/io/vertx/tests/pool/ConnectionPoolTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/pool/ConnectionPoolTest.java
@@ -1202,7 +1202,7 @@ public class ConnectionPoolTest extends VertxTestBase {
     @Override
     public Future<ConnectResult<Connection>> connect(ContextInternal context, Listener listener) {
       Promise<ConnectResult<Connection>> promise = Promise.promise();
-      requests.add(new ConnectionRequest(context, listener, promise));
+      requests.add(new ConnectionRequest(context, listener, promise::handle));
       return promise.future();
     }
 

--- a/vertx-core/src/test/java/io/vertx/tests/streams/PipeTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/streams/PipeTest.java
@@ -273,7 +273,7 @@ public class PipeTest extends AsyncTestBase {
     FakeStream<Object> src = new FakeStream<>();
     Pipe<Object> pipe = src.pipe();
     List<AsyncResult<Void>> res = new ArrayList<>();
-    pipe.to(dst).onComplete(res::add);
+    pipe.to(dst).onComplete(ar -> res.add(ar));
     assertEquals(Collections.emptyList(), res);
     pipe.close();
     assertEquals(1, res.size());


### PR DESCRIPTION
## Future event variance

Motivation:

The Vert.x future API does not support variance, e.g.

```java
Promise<Object> promise = ...;
Future<String> future = ...;
future.onComplete(promise); // Compilation error
```

This problems seems complex to solve with the current `Handler<AsyncResult<T>>` pattern, here is how the `onComplete` method should be changed:

```java
Future<T> onComplete(Handler<? extends AsyncResult<? super T>> handler);
```

which has its own problems: the handler will get .. tbc



