### PR TITLE
Futurize MyVerticle start/stop example - backport to 4.x

### DIFF
--- a/src/main/asciidoc/override/verticles.adoc
+++ b/src/main/asciidoc/override/verticles.adoc
@@ -52,6 +52,7 @@ public class MyVerticle extends AbstractVerticle {
 
   private HttpServer server;
 
+  @Override
   public void start(Promise<Void> startPromise) {
     server = vertx.createHttpServer().requestHandler(req -> {
       req.response()
@@ -60,13 +61,9 @@ public class MyVerticle extends AbstractVerticle {
       });
 
     // Now bind the server:
-    server.listen(8080, res -> {
-      if (res.succeeded()) {
-        startPromise.complete();
-      } else {
-        startPromise.fail(res.cause());
-      }
-    });
+    server.listen(8080)
+      .<Void>mapEmpty()
+      .onComplete(startPromise);
   }
 }
 ----
@@ -77,18 +74,11 @@ cleanup that takes some time.
 ----
 public class MyVerticle extends AbstractVerticle {
 
-  public void start() {
-    // Do something
-  }
-
+  @Override
   public void stop(Promise<Void> stopPromise) {
-    obj.doSomethingThatTakesTime(res -> {
-      if (res.succeeded()) {
-        stopPromise.complete();
-      } else {
-        stopPromise.fail();
-      }
-    });
+    doSomethingThatTakesTime()
+      .<Void>mapEmpty()
+      .onComplete(stopPromise);
   }
 }
 ----


### PR DESCRIPTION
(cherry picked from commit 31a03d7ae8075d29519272214989e111ef4e374e)

Motivation:

Avoid callback handlers in the MyVerticle examples, use a Future instead.

Conformance:

- [X] You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
- [X] Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
