### PR TITLE
Use pre existing response headers to do websocket handshake

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -14,6 +14,7 @@ package io.vertx.core.http.impl;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.vertx.core.AsyncResult;
@@ -189,7 +190,7 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocketImpl> 
     Channel channel = conn.channel();
     Http1xServerResponse response = request.response();
     try {
-      handshaker.handshake(channel, request.nettyRequest());
+      handshaker.handshake(channel, request.nettyRequest(), (HttpHeaders) response.headers(), channel.newPromise());
     } catch (Exception e) {
       response.setStatusCode(BAD_REQUEST.code()).end();
       throw e;


### PR DESCRIPTION
Motivation:

When we upgrade a WebSocket request, the pre-existing headers set on the response are ignored. This PR attempts to fix this issue by reusing the response.header when doing the websocket handshake.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
