### PR TITLE
Use pre-existing response headers to do websocket handshake

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/ServerWebSocketHandshaker.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/ServerWebSocketHandshaker.java
@@ -14,6 +14,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
@@ -475,7 +476,7 @@ public class ServerWebSocketHandshaker implements ServerWebSocket {
     Http1xServerResponse response = request.response();
     Object requestMetric = request.metric;
     try {
-      handshaker.handshake(channel, request.nettyRequest());
+      handshaker.handshake(channel, request.nettyRequest(), (HttpHeaders) response.headers(), channel.newPromise());
     } catch (Exception e) {
       rejectHandshake(BAD_REQUEST.code());
       throw e;


### PR DESCRIPTION
Motivation:

Same as #5324 but on master.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
