### PR TITLE
Various JPMS related changes

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -22,6 +22,7 @@ import io.vertx.core.spi.metrics.Metrics;
 import java.lang.ref.Cleaner;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * A lightweight proxy of Vert.x {@link HttpClient} that can be collected by the garbage collector and release
@@ -97,6 +98,11 @@ public class CleanableHttpClient implements HttpClientInternal {
   @Override
   public Metrics getMetrics() {
     return delegate.getMetrics();
+  }
+
+  @Override
+  public Function<HttpClientResponse, Future<RequestOptions>> redirectHandler() {
+    return delegate.redirectHandler();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -427,7 +427,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
       super(context, promise, id);
 
       this.conn = conn;
-      this.queue = new InboundMessageQueue<>(conn.context.nettyEventLoop(), context) {
+      this.queue = new InboundMessageQueue<>(conn.context.eventLoop(), context.executor()) {
         @Override
         protected void handleResume() {
           conn.doResume();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -97,7 +97,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
     this.conn = conn;
     this.context = context;
     this.request = request;
-    this.queue = new InboundMessageQueue<>(context.nettyEventLoop(), context) {
+    this.queue = new InboundMessageQueue<>(context.eventLoop(), context.executor()) {
       @Override
       protected void handleMessage(Object elt) {
         if (elt == InboundBuffer.END_SENTINEL) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -57,7 +57,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
     this.conn = conn;
     this.vertx = conn.vertx();
     this.context = context;
-    this.inboundQueue = new InboundMessageQueue<>(conn.channel().eventLoop(), context) {
+    this.inboundQueue = new InboundMessageQueue<>(conn.context().eventLoop(), context.executor()) {
       @Override
       protected void handleMessage(Object item) {
         if (item instanceof MultiMap) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -102,7 +102,7 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
     this.context = context;
     this.maxWebSocketFrameSize = maxWebSocketFrameSize;
     this.maxWebSocketMessageSize = maxWebSocketMessageSize;
-    this.pending = new InboundMessageQueue<>(context.nettyEventLoop(), context) {
+    this.pending = new InboundMessageQueue<>(context.eventLoop(), context.executor()) {
       @Override
       protected void handleResume() {
         conn.doResume();

--- a/vertx-core/src/main/java/io/vertx/core/impl/ContextBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ContextBase.java
@@ -31,9 +31,6 @@ abstract class ContextBase implements ContextInternal {
     this.locals = locals;
   }
 
-  @Override
-  public abstract EventExecutor executor();
-
   public ContextInternal beginDispatch() {
     VertxImpl vertx = (VertxImpl) owner();
     return vertx.beginDispatch(this);

--- a/vertx-core/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -43,7 +43,7 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
   private final DeploymentContext deployment;
   private final CloseFuture closeFuture;
   private final ClassLoader tccl;
-  private final EventLoop eventLoop;
+  private final EventLoopExecutor eventLoop;
   private final ThreadingModel threadingModel;
   private final EventExecutor executor;
   private ConcurrentMap<Object, Object> data;
@@ -53,7 +53,7 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
 
   public ContextImpl(VertxInternal vertx,
                         Object[] locals,
-                        EventLoop eventLoop,
+                        EventLoopExecutor eventLoop,
                         ThreadingModel threadingModel,
                         EventExecutor executor,
                         WorkerPool workerPool,
@@ -96,7 +96,7 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
   }
 
   public EventLoop nettyEventLoop() {
-    return eventLoop;
+    return eventLoop.eventLoop;
   }
 
   public VertxInternal owner() {
@@ -106,6 +106,11 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
   @Override
   public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
     return workerPool.executeBlocking(this, blockingCodeHandler, ordered ? orderedTasks : null);
+  }
+
+  @Override
+  public EventExecutor eventLoop() {
+    return eventLoop;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -71,6 +71,11 @@ final class DuplicatedContext extends ContextBase implements ContextInternal {
   }
 
   @Override
+  public EventExecutor eventLoop() {
+    return delegate.eventLoop();
+  }
+
+  @Override
   public EventExecutor executor() {
     return delegate.executor();
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/EventLoopExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/EventLoopExecutor.java
@@ -18,12 +18,16 @@ import io.vertx.core.internal.EventExecutor;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class EventLoopExecutor implements EventExecutor {
+public final class EventLoopExecutor implements EventExecutor {
 
-  private final EventLoop eventLoop;
+  final EventLoop eventLoop;
 
   public EventLoopExecutor(EventLoop eventLoop) {
     this.eventLoop = eventLoop;
+  }
+
+  public EventLoop eventLoop() {
+    return eventLoop;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
@@ -54,15 +54,20 @@ final class ShadowContext extends ContextBase {
 
   final VertxInternal owner;
   final ContextBase delegate;
-  private final EventLoop eventLoop;
+  private final EventLoopExecutor eventLoop;
   private final TaskQueue orderedTasks;
 
-  public ShadowContext(VertxInternal owner, EventLoop eventLoop, ContextInternal delegate) {
+  public ShadowContext(VertxInternal owner, EventLoopExecutor eventLoop, ContextInternal delegate) {
     super(((ContextBase)delegate).locals);
     this.owner = owner;
     this.eventLoop = eventLoop;
     this.delegate = (ContextBase) delegate;
     this.orderedTasks = new TaskQueue();
+  }
+
+  @Override
+  public EventExecutor eventLoop() {
+    return eventLoop;
   }
 
   @Override
@@ -72,7 +77,7 @@ final class ShadowContext extends ContextBase {
 
   @Override
   public EventLoop nettyEventLoop() {
-    return eventLoop;
+    return eventLoop.eventLoop;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
@@ -56,6 +56,11 @@ public interface ContextInternal extends Context {
   EventExecutor executor();
 
   /**
+   * @return the event loop executor of this context
+   */
+  EventExecutor eventLoop();
+
+  /**
    * Return the Netty EventLoop used by this Context. This can be used to integrate
    * a Netty Server with a Vert.x runtime, specially the Context part.
    *

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpClientInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpClientInternal.java
@@ -18,6 +18,8 @@ import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.net.NetClientInternal;
 import io.vertx.core.spi.metrics.MetricsProvider;
 
+import java.util.function.Function;
+
 /**
  * Http client internal API.
  */
@@ -27,6 +29,8 @@ public interface HttpClientInternal extends HttpClientAgent, MetricsProvider, Cl
    * @return the vertx, for use in package related classes only.
    */
   VertxInternal vertx();
+
+  Function<HttpClientResponse, Future<RequestOptions>> redirectHandler();
 
   HttpClientOptions options();
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -95,7 +95,7 @@ public class NetSocketImpl extends VertxConnection implements NetSocketInternal 
     this.metrics = metrics;
     this.messageHandler = new DataMessageHandler();
     this.negotiatedApplicationLayerProtocol = negotiatedApplicationLayerProtocol;
-    this.pending = new InboundMessageQueue<>(context.nettyEventLoop(), context) {
+    this.pending = new InboundMessageQueue<>(context.eventLoop(), context.executor()) {
       @Override
       protected void handleResume() {
         NetSocketImpl.this.doResume();

--- a/vertx-core/src/main/java/io/vertx/core/streams/impl/InboundReadQueue.java
+++ b/vertx-core/src/main/java/io/vertx/core/streams/impl/InboundReadQueue.java
@@ -172,6 +172,7 @@ public abstract class InboundReadQueue<E> {
    */
   protected abstract boolean wipCompareAndSet(long expect, long update);
   protected abstract long wipIncrementAndGet();
+  protected abstract long wipDecrementAndGet();
   protected abstract long wipGet();
   protected abstract long wipAddAndGet(long delta);
 
@@ -324,6 +325,11 @@ public abstract class InboundReadQueue<E> {
     }
 
     @Override
+    protected long wipDecrementAndGet() {
+      return --wip;
+    }
+
+    @Override
     protected long wipGet() {
       return wip;
     }
@@ -355,6 +361,11 @@ public abstract class InboundReadQueue<E> {
     @Override
     protected long wipIncrementAndGet() {
       return WIP_UPDATER.incrementAndGet(this);
+    }
+
+    @Override
+    protected long wipDecrementAndGet() {
+      return WIP_UPDATER.decrementAndGet(this);
     }
 
     @Override

--- a/vertx-core/src/test/java/io/vertx/benchmarks/BenchmarkContext.java
+++ b/vertx-core/src/test/java/io/vertx/benchmarks/BenchmarkContext.java
@@ -14,6 +14,7 @@ package io.vertx.benchmarks;
 import io.vertx.core.ThreadingModel;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextImpl;
+import io.vertx.core.impl.EventLoopExecutor;
 import io.vertx.core.internal.EventExecutor;
 import io.vertx.core.impl.TaskQueue;
 import io.vertx.core.impl.VertxImpl;
@@ -40,7 +41,7 @@ public class BenchmarkContext {
     return new ContextImpl(
       impl,
       new Object[0],
-      impl.getEventLoopGroup().next(),
+      new EventLoopExecutor(impl.getEventLoopGroup().next()),
       ThreadingModel.WORKER,
       EXECUTOR,
       impl.getWorkerPool(),

--- a/vertx-core/src/test/java/io/vertx/tests/concurrent/InboundMessageQueueTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/concurrent/InboundMessageQueueTest.java
@@ -39,13 +39,13 @@ public class InboundMessageQueueTest extends VertxTestBase {
     private int size;
 
     public TestQueue(IntConsumer consumer) {
-      super(((ContextInternal) context).nettyEventLoop(), (ContextInternal) context);
+      super(((ContextInternal) context).eventLoop(), ((ContextInternal) context).executor());
       this.consumer = consumer;
       this.writable = true;
     }
 
     public TestQueue(IntConsumer consumer, int lwm, int hwm) {
-      super(((ContextInternal) context).nettyEventLoop(), (ContextInternal) context, lwm, hwm);
+      super(((ContextInternal) context).eventLoop(), ((ContextInternal) context).executor(), lwm, hwm);
       this.consumer = consumer;
       this.writable = true;
     }

--- a/vertx-core/src/test/java/module-info.java
+++ b/vertx-core/src/test/java/module-info.java
@@ -36,7 +36,7 @@ open module io.vertx.core.tests {
   requires io.netty.codec;
   requires io.netty.codec.compression;
   requires io.netty.codec.http;
-  requires io.netty.codec.haproxy;
+  requires static io.netty.codec.haproxy;
   requires io.netty.codec.http2;
   requires io.netty.resolver.dns;
 


### PR DESCRIPTION
- as we want to drop InboundBuffer, make InboundMessageQueue more flexible
- expose redirect handler on HttpClientInternal used by vertx-web-client
