### PR TITLE
Provide access to the default redirect handler

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientAgent.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientAgent.java
@@ -1,9 +1,12 @@
 package io.vertx.core.http;
 
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
+import io.vertx.core.http.impl.DefaultRedirectHandler;
 import io.vertx.core.metrics.Measured;
 import io.vertx.core.net.ClientSSLOptions;
+import java.util.function.Function;
 
 /**
  * An asynchronous HTTP client.
@@ -33,6 +36,13 @@ import io.vertx.core.net.ClientSSLOptions;
  */
 @VertxGen
 public interface HttpClientAgent extends HttpClient, Measured {
+
+  /**
+   * Constant containing the default redirect handler of used by the client.
+   * This is useful for building redirect handlers that need to delegate to the default behavior.
+   */
+  @GenIgnore
+  Function<HttpClientResponse, Future<RequestOptions>> DEFAULT_REDIRECT_HANDLER = new DefaultRedirectHandler();
 
   /**
    * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/DefaultRedirectHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/DefaultRedirectHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import static io.vertx.core.http.HttpHeaders.CONTENT_LENGTH;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import java.net.URI;
+import java.util.function.Function;
+
+
+public class DefaultRedirectHandler implements Function<HttpClientResponse, Future<RequestOptions>> {
+
+  public DefaultRedirectHandler() {
+  }
+
+  @Override
+  public Future<RequestOptions> apply(HttpClientResponse resp) {
+    try {
+      int statusCode = resp.statusCode();
+      String location = resp.getHeader(HttpHeaders.LOCATION);
+      if (location != null && (statusCode == 301 || statusCode == 302 || statusCode == 303 || statusCode == 307
+                               || statusCode == 308)) {
+        HttpMethod m = resp.request().getMethod();
+        if (statusCode == 303) {
+          m = HttpMethod.GET;
+        } else if (m != HttpMethod.GET && m != HttpMethod.HEAD) {
+          return null;
+        }
+        URI uri = HttpUtils.resolveURIReference(resp.request().absoluteURI(), location);
+        boolean ssl;
+        int port = uri.getPort();
+        String protocol = uri.getScheme();
+        char chend = protocol.charAt(protocol.length() - 1);
+        if (chend == 'p') {
+          ssl = false;
+          if (port == -1) {
+            port = 80;
+          }
+        } else if (chend == 's') {
+          ssl = true;
+          if (port == -1) {
+            port = 443;
+          }
+        } else {
+          return null;
+        }
+        String requestURI = uri.getPath();
+        if (requestURI == null || requestURI.isEmpty()) {
+          requestURI = "/";
+        }
+        String query = uri.getQuery();
+        if (query != null) {
+          requestURI += "?" + query;
+        }
+        RequestOptions options = new RequestOptions();
+        options.setMethod(m);
+        options.setHost(uri.getHost());
+        options.setPort(port);
+        options.setSsl(ssl);
+        options.setURI(requestURI);
+        options.setHeaders(resp.request().headers());
+        options.removeHeader(CONTENT_LENGTH);
+        return Future.succeededFuture(options);
+      }
+      return null;
+    } catch (Exception e) {
+      return Future.failedFuture(e);
+    }
+  }
+}


### PR DESCRIPTION
_Motivation:_

This is useful for building redirect handlers
for clients that need to delegate to the default behavior. In Quarkus we will leverage this to get rid of the deprecated (and since removed) [calls](https://github.com/quarkusio/quarkus/blob/3.15.1/independent-projects/resteasy-reactive/client/runtime/src/main/java/org/jboss/resteasy/reactive/client/impl/ClientImpl.java#L209-L210) to redirectHandler