### PR TITLE
Small content-length values caching

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -737,8 +737,7 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
     } else {
       // Set content-length header automatically
       if (contentLength >= 0 && !headers.contains(HttpHeaders.CONTENT_LENGTH) && !headers.contains(HttpHeaders.TRANSFER_ENCODING)) {
-        String value = contentLength == 0 ? "0" : String.valueOf(contentLength);
-        headers.set(HttpHeaders.CONTENT_LENGTH, value);
+        headers.set(HttpHeaders.CONTENT_LENGTH, HttpUtils.positiveLongToString(contentLength));
       }
     }
     if (headersEndHandler != null) {

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -462,7 +462,7 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
         chunk = Unpooled.EMPTY_BUFFER;
       }
       if (end && !headWritten && needsContentLengthHeader()) {
-        headers().set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(chunk.readableBytes()));
+        headers().set(HttpHeaderNames.CONTENT_LENGTH, HttpUtils.positiveLongToString(chunk.readableBytes()));
       }
       boolean sent = checkSendHeaders(end && !hasBody && trailers == null, !hasBody);
       if (hasBody || (!sent && end)) {
@@ -631,7 +631,7 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
         long fileLength = file.getReadLength();
         long contentLength = Math.min(length, fileLength);
         if (headers.get(HttpHeaderNames.CONTENT_LENGTH) == null) {
-          putHeader(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(contentLength));
+          putHeader(HttpHeaderNames.CONTENT_LENGTH, HttpUtils.positiveLongToString(contentLength));
         }
         if (headers.get(HttpHeaderNames.CONTENT_TYPE) == null) {
           String contentType = MimeMapping.getMimeTypeForFilename(filename);

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -483,7 +483,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   private void write(ByteBuf buff, boolean end, Handler<AsyncResult<Void>> completionHandler) {
     if (end) {
       if (buff != null && requiresContentLength()) {
-        headers().set(CONTENT_LENGTH, String.valueOf(buff.readableBytes()));
+        headers().set(CONTENT_LENGTH, HttpUtils.positiveLongToString(buff.readableBytes()));
       }
     } else if (requiresContentLength()) {
       throw new IllegalStateException("You must set the Content-Length header to be the total size of the message "

--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -237,6 +237,30 @@ public final class HttpUtils {
     return false;
   }
 
+  private static final String[] SMALL_POSITIVE_LONGS = new String[256];
+
+  /**
+   * This try hard to cache the first 256 positive longs as strings [0, 255] to avoid the cost of creating a new
+   * string for each of them.<br>
+   * The size/capacity of the cache is subject to change but this method is expected to be used for hot and frequent code paths.
+   */
+  public static String positiveLongToString(long value) {
+    if (value < 0) {
+      throw new IllegalArgumentException("contentLength must be >= 0");
+    }
+    if (value >= SMALL_POSITIVE_LONGS.length) {
+      return Long.toString(value);
+    }
+    final int index = (int) value;
+    String str = SMALL_POSITIVE_LONGS[index];
+    if (str == null) {
+      // it's ok to be racy here, String is immutable hence it benefits from safe publication!
+      str = Long.toString(value);
+      SMALL_POSITIVE_LONGS[index] = str;
+    }
+    return str;
+  }
+
   /**
    * Normalizes a path as per <a href="http://tools.ietf.org/html/rfc3986#section-5.2.4>rfc3986</a>.
    *

--- a/src/test/benchmarks/io/vertx/benchmarks/ContentLengthToString.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/ContentLengthToString.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.benchmarks;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.Random;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.vertx.core.http.impl.HttpUtils;
+
+@Warmup(iterations = 10, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 10, time = 200, timeUnit = MILLISECONDS)
+@Fork(value = 2)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(java.util.concurrent.TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class ContentLengthToString {
+
+  @Param({"255", "511", "1023" })
+  public int maxContentLength;
+  private int[] contentLengthIndexes;
+  private long inputSequence;
+
+  @Setup
+  public void init(Blackhole bh, BenchmarkParams params) {
+    final int MAX_CONTENT_LENGTH_SIZE = 1024;
+    if (maxContentLength >= MAX_CONTENT_LENGTH_SIZE) {
+      throw new IllegalArgumentException("maxContentLength must be < " + MAX_CONTENT_LENGTH_SIZE);
+    }
+    contentLengthIndexes = new int[128 * MAX_CONTENT_LENGTH_SIZE];
+    if (Integer.bitCount(contentLengthIndexes.length) != 1) {
+      throw new IllegalArgumentException("contentLengthIndexes must be a power of 2");
+    }
+    Random rnd = new Random(42);
+    for (int i = 0; i < contentLengthIndexes.length; i++) {
+      contentLengthIndexes[i] = rnd.nextInt(maxContentLength);
+    }
+  }
+
+  private long nextContentLength() {
+      int[] contentLengthIndexes = this.contentLengthIndexes;
+      int nextInputIndex = (int) inputSequence & (contentLengthIndexes.length - 1);
+      int contentLength = contentLengthIndexes[nextInputIndex];
+      inputSequence++;
+      return contentLength;
+  }
+
+  @Benchmark
+  public String contentLengthToString() {
+    return String.valueOf(nextContentLength());
+  }
+
+  @Benchmark
+  public String contentLengthHttpUtils() {
+    return HttpUtils.positiveLongToString(nextContentLength());
+  }
+
+}


### PR DESCRIPTION
Not a biggie, but currently small content-length (0-255) require allocating  (and parsing) a fresh new `String` value.
This is clearly bad for benchmarks - but not only.
I'm adding a lazy cache (of small) content length `String`s, to speeup both http 1.1 and 2.

the benchmark shows 

```Benchmark                                     (maxContentLength)  Mode  Cnt  Score   Error  Units
ContentLengthToString.contentLengthHttpUtils                 255  avgt   20  1.094 ± 0.002  ns/op
ContentLengthToString.contentLengthHttpUtils                 511  avgt   20  7.479 ± 0.164  ns/op
ContentLengthToString.contentLengthHttpUtils                1023  avgt   20  6.822 ± 0.182  ns/op
ContentLengthToString.contentLengthToString                  255  avgt   20  7.876 ± 0.024  ns/op
ContentLengthToString.contentLengthToString                  511  avgt   20  6.304 ± 0.018  ns/op
ContentLengthToString.contentLengthToString                 1023  avgt   20  5.802 ± 0.014  ns/op
```
but interestingly the worse performance of the 511 and 1023 values are not just because of the parsing and allocating of `String` but due to the branch misprediction to the util method, which need to decide if use the cache or not.
In the real world is more like that `HttpUtils.positiveLongToString` method blob (compiled in assembly) will be used by different connections and for different endpoints. hence branch misprediction "could" be a factor -- and the benchmark  is designed to stress it.

The benefits when small content lengths are used are pretty evident, instead i.e. 7X times faster