### PR TITLE
Support base64 URL encoding methods in io.vertx.core.buffer.Buffer data object

### DIFF
--- a/vertx-core/src/main/generated/io/vertx/core/DeploymentOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/DeploymentOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.DeploymentOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.DeploymentOptions} original class using Vert.x codegen.
  */
 public class DeploymentOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DeploymentOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/VertxOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/VertxOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.VertxOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.VertxOptions} original class using Vert.x codegen.
  */
 public class VertxOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, VertxOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/datagram/DatagramSocketOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/datagram/DatagramSocketOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.datagram.DatagramSocketOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.datagram.DatagramSocketOptions} original class using Vert.x codegen.
  */
 public class DatagramSocketOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DatagramSocketOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/dns/AddressResolverOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/dns/AddressResolverOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.dns.AddressResolverOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.dns.AddressResolverOptions} original class using Vert.x codegen.
  */
 public class AddressResolverOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, AddressResolverOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
@@ -25,7 +21,7 @@ public class AddressResolverOptionsConverter {
           break;
         case "hostsValue":
           if (member.getValue() instanceof String) {
-            obj.setHostsValue(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)member.getValue())));
+            obj.setHostsValue(io.vertx.core.buffer.Buffer.fromJson((String)member.getValue()));
           }
           break;
         case "hostsRefreshPeriod":
@@ -116,7 +112,7 @@ public class AddressResolverOptionsConverter {
       json.put("hostsPath", obj.getHostsPath());
     }
     if (obj.getHostsValue() != null) {
-      json.put("hostsValue", BASE64_ENCODER.encodeToString(obj.getHostsValue().getBytes()));
+      json.put("hostsValue", obj.getHostsValue().toJson());
     }
     json.put("hostsRefreshPeriod", obj.getHostsRefreshPeriod());
     if (obj.getServers() != null) {

--- a/vertx-core/src/main/generated/io/vertx/core/dns/DnsClientOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/dns/DnsClientOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.dns.DnsClientOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.dns.DnsClientOptions} original class using Vert.x codegen.
  */
 public class DnsClientOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DnsClientOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/eventbus/EventBusOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/eventbus/EventBusOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.eventbus.EventBusOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.eventbus.EventBusOptions} original class using Vert.x codegen.
  */
 public class EventBusOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, EventBusOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/file/CopyOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/file/CopyOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.file.CopyOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.file.CopyOptions} original class using Vert.x codegen.
  */
 public class CopyOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, CopyOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/file/FileSystemOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/file/FileSystemOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.file.FileSystemOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.file.FileSystemOptions} original class using Vert.x codegen.
  */
 public class FileSystemOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, FileSystemOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/file/OpenOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/file/OpenOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.file.OpenOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.file.OpenOptions} original class using Vert.x codegen.
  */
 public class OpenOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, OpenOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/http/GoAwayConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/GoAwayConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.http.GoAway}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.http.GoAway} original class using Vert.x codegen.
  */
 public class GoAwayConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, GoAway obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
@@ -30,7 +26,7 @@ public class GoAwayConverter {
           break;
         case "debugData":
           if (member.getValue() instanceof String) {
-            obj.setDebugData(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)member.getValue())));
+            obj.setDebugData(io.vertx.core.buffer.Buffer.fromJson((String)member.getValue()));
           }
           break;
       }
@@ -45,7 +41,7 @@ public class GoAwayConverter {
     json.put("errorCode", obj.getErrorCode());
     json.put("lastStreamId", obj.getLastStreamId());
     if (obj.getDebugData() != null) {
-      json.put("debugData", BASE64_ENCODER.encodeToString(obj.getDebugData().getBytes()));
+      json.put("debugData", obj.getDebugData().toJson());
     }
   }
 }

--- a/vertx-core/src/main/generated/io/vertx/core/http/Http2SettingsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/Http2SettingsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.http.Http2Settings}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.http.Http2Settings} original class using Vert.x codegen.
  */
 public class Http2SettingsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, Http2Settings obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.http.HttpClientOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.http.HttpClientOptions} original class using Vert.x codegen.
  */
 public class HttpClientOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, HttpClientOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/http/HttpConnectOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/HttpConnectOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.http.HttpConnectOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.http.HttpConnectOptions} original class using Vert.x codegen.
  */
 public class HttpConnectOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, HttpConnectOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.http.HttpServerOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.http.HttpServerOptions} original class using Vert.x codegen.
  */
 public class HttpServerOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, HttpServerOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/http/PoolOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/PoolOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.http.PoolOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.http.PoolOptions} original class using Vert.x codegen.
  */
 public class PoolOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, PoolOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/http/RequestOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/RequestOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.http.RequestOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.http.RequestOptions} original class using Vert.x codegen.
  */
 public class RequestOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, RequestOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/http/WebSocketClientOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/WebSocketClientOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.http.WebSocketClientOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.http.WebSocketClientOptions} original class using Vert.x codegen.
  */
 public class WebSocketClientOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, WebSocketClientOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/http/WebSocketConnectOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/WebSocketConnectOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.http.WebSocketConnectOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.http.WebSocketConnectOptions} original class using Vert.x codegen.
  */
 public class WebSocketConnectOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, WebSocketConnectOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/metrics/MetricsOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/metrics/MetricsOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.metrics.MetricsOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.metrics.MetricsOptions} original class using Vert.x codegen.
  */
 public class MetricsOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, MetricsOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/net/ClientOptionsBaseConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/ClientOptionsBaseConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.ClientOptionsBase}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.ClientOptionsBase} original class using Vert.x codegen.
  */
 public class ClientOptionsBaseConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ClientOptionsBase obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/net/ClientSSLOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/ClientSSLOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.ClientSSLOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.ClientSSLOptions} original class using Vert.x codegen.
  */
 public class ClientSSLOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ClientSSLOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/net/JksOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/JksOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.JksOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.JksOptions} original class using Vert.x codegen.
  */
 public class JksOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, JksOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
@@ -30,7 +26,7 @@ public class JksOptionsConverter {
           break;
         case "value":
           if (member.getValue() instanceof String) {
-            obj.setValue(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)member.getValue())));
+            obj.setValue(io.vertx.core.buffer.Buffer.fromJson((String)member.getValue()));
           }
           break;
         case "alias":
@@ -59,7 +55,7 @@ public class JksOptionsConverter {
       json.put("path", obj.getPath());
     }
     if (obj.getValue() != null) {
-      json.put("value", BASE64_ENCODER.encodeToString(obj.getValue().getBytes()));
+      json.put("value", obj.getValue().toJson());
     }
     if (obj.getAlias() != null) {
       json.put("alias", obj.getAlias());

--- a/vertx-core/src/main/generated/io/vertx/core/net/KeyStoreOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/KeyStoreOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.KeyStoreOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.KeyStoreOptions} original class using Vert.x codegen.
  */
 public class KeyStoreOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, KeyStoreOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
@@ -30,7 +26,7 @@ public class KeyStoreOptionsConverter {
           break;
         case "value":
           if (member.getValue() instanceof String) {
-            obj.setValue(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)member.getValue())));
+            obj.setValue(io.vertx.core.buffer.Buffer.fromJson((String)member.getValue()));
           }
           break;
         case "alias":
@@ -69,7 +65,7 @@ public class KeyStoreOptionsConverter {
       json.put("path", obj.getPath());
     }
     if (obj.getValue() != null) {
-      json.put("value", BASE64_ENCODER.encodeToString(obj.getValue().getBytes()));
+      json.put("value", obj.getValue().toJson());
     }
     if (obj.getAlias() != null) {
       json.put("alias", obj.getAlias());

--- a/vertx-core/src/main/generated/io/vertx/core/net/NetClientOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/NetClientOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.NetClientOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.NetClientOptions} original class using Vert.x codegen.
  */
 public class NetClientOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, NetClientOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/net/NetServerOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/NetServerOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.NetServerOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.NetServerOptions} original class using Vert.x codegen.
  */
 public class NetServerOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, NetServerOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/net/NetworkOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/NetworkOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.NetworkOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.NetworkOptions} original class using Vert.x codegen.
  */
 public class NetworkOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, NetworkOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/net/OpenSSLEngineOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/OpenSSLEngineOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.OpenSSLEngineOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.OpenSSLEngineOptions} original class using Vert.x codegen.
  */
 public class OpenSSLEngineOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, OpenSSLEngineOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/net/PemKeyCertOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/PemKeyCertOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.PemKeyCertOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.PemKeyCertOptions} original class using Vert.x codegen.
  */
 public class PemKeyCertOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, PemKeyCertOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
@@ -35,7 +31,7 @@ public class PemKeyCertOptionsConverter {
           break;
         case "keyValue":
           if (member.getValue() instanceof String) {
-            obj.setKeyValue(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)member.getValue())));
+            obj.setKeyValue(io.vertx.core.buffer.Buffer.fromJson((String)member.getValue()));
           }
           break;
         case "keyValues":
@@ -43,7 +39,7 @@ public class PemKeyCertOptionsConverter {
             java.util.ArrayList<io.vertx.core.buffer.Buffer> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                list.add(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)item)));
+                list.add(io.vertx.core.buffer.Buffer.fromJson((String)item));
             });
             obj.setKeyValues(list);
           }
@@ -65,7 +61,7 @@ public class PemKeyCertOptionsConverter {
           break;
         case "certValue":
           if (member.getValue() instanceof String) {
-            obj.setCertValue(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)member.getValue())));
+            obj.setCertValue(io.vertx.core.buffer.Buffer.fromJson((String)member.getValue()));
           }
           break;
         case "certValues":
@@ -73,7 +69,7 @@ public class PemKeyCertOptionsConverter {
             java.util.ArrayList<io.vertx.core.buffer.Buffer> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                list.add(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)item)));
+                list.add(io.vertx.core.buffer.Buffer.fromJson((String)item));
             });
             obj.setCertValues(list);
           }
@@ -94,7 +90,7 @@ public class PemKeyCertOptionsConverter {
     }
     if (obj.getKeyValues() != null) {
       JsonArray array = new JsonArray();
-      obj.getKeyValues().forEach(item -> array.add(BASE64_ENCODER.encodeToString(item.getBytes())));
+      obj.getKeyValues().forEach(item -> array.add(item.toJson()));
       json.put("keyValues", array);
     }
     if (obj.getCertPaths() != null) {
@@ -104,7 +100,7 @@ public class PemKeyCertOptionsConverter {
     }
     if (obj.getCertValues() != null) {
       JsonArray array = new JsonArray();
-      obj.getCertValues().forEach(item -> array.add(BASE64_ENCODER.encodeToString(item.getBytes())));
+      obj.getCertValues().forEach(item -> array.add(item.toJson()));
       json.put("certValues", array);
     }
   }

--- a/vertx-core/src/main/generated/io/vertx/core/net/PemTrustOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/PemTrustOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.PemTrustOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.PemTrustOptions} original class using Vert.x codegen.
  */
 public class PemTrustOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, PemTrustOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
@@ -30,7 +26,7 @@ public class PemTrustOptionsConverter {
           if (member.getValue() instanceof JsonArray) {
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                obj.addCertValue(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)item)));
+                obj.addCertValue(io.vertx.core.buffer.Buffer.fromJson((String)item));
             });
           }
           break;
@@ -50,7 +46,7 @@ public class PemTrustOptionsConverter {
     }
     if (obj.getCertValues() != null) {
       JsonArray array = new JsonArray();
-      obj.getCertValues().forEach(item -> array.add(BASE64_ENCODER.encodeToString(item.getBytes())));
+      obj.getCertValues().forEach(item -> array.add(item.toJson()));
       json.put("certValues", array);
     }
   }

--- a/vertx-core/src/main/generated/io/vertx/core/net/PfxOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/PfxOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.PfxOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.PfxOptions} original class using Vert.x codegen.
  */
 public class PfxOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, PfxOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
@@ -30,7 +26,7 @@ public class PfxOptionsConverter {
           break;
         case "value":
           if (member.getValue() instanceof String) {
-            obj.setValue(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)member.getValue())));
+            obj.setValue(io.vertx.core.buffer.Buffer.fromJson((String)member.getValue()));
           }
           break;
         case "alias":
@@ -59,7 +55,7 @@ public class PfxOptionsConverter {
       json.put("path", obj.getPath());
     }
     if (obj.getValue() != null) {
-      json.put("value", BASE64_ENCODER.encodeToString(obj.getValue().getBytes()));
+      json.put("value", obj.getValue().toJson());
     }
     if (obj.getAlias() != null) {
       json.put("alias", obj.getAlias());

--- a/vertx-core/src/main/generated/io/vertx/core/net/ProxyOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/ProxyOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.ProxyOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.ProxyOptions} original class using Vert.x codegen.
  */
 public class ProxyOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ProxyOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/net/SSLOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/SSLOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.SSLOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.SSLOptions} original class using Vert.x codegen.
  */
 public class SSLOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, SSLOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
@@ -38,7 +34,7 @@ public class SSLOptionsConverter {
           if (member.getValue() instanceof JsonArray) {
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                obj.addCrlValue(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)item)));
+                obj.addCrlValue(io.vertx.core.buffer.Buffer.fromJson((String)item));
             });
           }
           break;
@@ -98,7 +94,7 @@ public class SSLOptionsConverter {
     }
     if (obj.getCrlValues() != null) {
       JsonArray array = new JsonArray();
-      obj.getCrlValues().forEach(item -> array.add(BASE64_ENCODER.encodeToString(item.getBytes())));
+      obj.getCrlValues().forEach(item -> array.add(item.toJson()));
       json.put("crlValues", array);
     }
     json.put("useAlpn", obj.isUseAlpn());

--- a/vertx-core/src/main/generated/io/vertx/core/net/ServerSSLOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/ServerSSLOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.ServerSSLOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.ServerSSLOptions} original class using Vert.x codegen.
  */
 public class ServerSSLOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ServerSSLOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.TCPSSLOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.TCPSSLOptions} original class using Vert.x codegen.
  */
 public class TCPSSLOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, TCPSSLOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
@@ -78,7 +74,7 @@ public class TCPSSLOptionsConverter {
           if (member.getValue() instanceof JsonArray) {
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                obj.addCrlValue(io.vertx.core.buffer.Buffer.buffer(BASE64_DECODER.decode((String)item)));
+                obj.addCrlValue(io.vertx.core.buffer.Buffer.fromJson((String)item));
             });
           }
           break;
@@ -158,7 +154,7 @@ public class TCPSSLOptionsConverter {
     }
     if (obj.getCrlValues() != null) {
       JsonArray array = new JsonArray();
-      obj.getCrlValues().forEach(item -> array.add(BASE64_ENCODER.encodeToString(item.getBytes())));
+      obj.getCrlValues().forEach(item -> array.add(item.toJson()));
       json.put("crlValues", array);
     }
     json.put("useAlpn", obj.isUseAlpn());

--- a/vertx-core/src/main/generated/io/vertx/core/net/TrafficShapingOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/TrafficShapingOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.net.TrafficShapingOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.TrafficShapingOptions} original class using Vert.x codegen.
  */
 public class TrafficShapingOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, TrafficShapingOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/generated/io/vertx/core/tracing/TracingOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/tracing/TracingOptionsConverter.java
@@ -4,16 +4,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 
 /**
  * Converter and mapper for {@link io.vertx.core.tracing.TracingOptions}.
  * NOTE: This class has been automatically generated from the {@link io.vertx.core.tracing.TracingOptions} original class using Vert.x codegen.
  */
 public class TracingOptionsConverter {
-
-  private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, TracingOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {

--- a/vertx-core/src/main/java/io/vertx/core/buffer/Buffer.java
+++ b/vertx-core/src/main/java/io/vertx/core/buffer/Buffer.java
@@ -19,6 +19,7 @@ import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.shareddata.ClusterSerializable;
 import io.vertx.core.shareddata.Shareable;
 
@@ -37,6 +38,16 @@ import java.nio.charset.Charset;
  */
 @DataObject
 public interface Buffer extends ClusterSerializable, Shareable {
+
+  /**
+   * Create a buffer from the base 64 URL encoded {@code value}
+   * @param value the base64 encoded value
+   * @return the buffer
+   */
+  static Buffer fromJson(String value) {
+    byte[] bytes = JsonUtil.BASE64_DECODER.decode(value);
+    return buffer(bytes);
+  }
 
   /**
    * Create a new, empty buffer.
@@ -128,11 +139,10 @@ public interface Buffer extends ClusterSerializable, Shareable {
   }
 
   /**
-   * @deprecated instead use {@link #toJsonValue()}
+   * Encode the buffer bytes to their base 64 URL encoded representation.
    */
-  @Deprecated
-  default Object toJson() {
-    return toJsonValue();
+  default String toJson() {
+    return JsonUtil.BASE64_ENCODER.encodeToString(getBytes());
   }
 
   /**


### PR DESCRIPTION
Motivation:

Since `io.vertx.core.buffer.Buffer` is a data object in Vert.x 5, we do not need anymore the special handling of data object members of type buffer and instead we can add `fromJson`/`toJson` to the buffer interface.

Changes:

Add/update `fromJson`/`toJson` in `io.vertx.core.buffer.Buffer` to enable data object conversion in converter generation.

Result:

Data object generated converter code for buffers now uses the data object json encoding declared in the buffer interface instead of the special handling.
