### PR TITLE
Save recursive locks on websocket writeFrame

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -399,13 +399,18 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
   @Override
   public Future<Void> writeFrame(WebSocketFrame frame) {
     synchronized (conn) {
-      if (isClosed()) {
-        return context.failedFuture("WebSocket is closed");
-      }
-      PromiseInternal<Void> promise = context.promise();
-      conn.writeToChannel(encodeFrame((WebSocketFrameImpl) frame), promise);
-      return promise.future();
+      return unsafeWriteFrame((WebSocketFrameImpl) frame);
     }
+  }
+
+  protected final Future<Void> unsafeWriteFrame(WebSocketFrameImpl frame) {
+    assert Thread.holdsLock(conn);
+    if (unsafeIsClosed()) {
+      return context.failedFuture("WebSocket is closed");
+    }
+    PromiseInternal<Void> promise = context.promise();
+    conn.writeToChannel(encodeFrame(frame), promise);
+    return promise.future();
   }
 
   public final S writeFrame(WebSocketFrame frame, Handler<AsyncResult<Void>> handler) {
@@ -424,7 +429,7 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
     writeFrame(new WebSocketFrameImpl(str));
   }
 
-  private io.netty.handler.codec.http.websocketx.WebSocketFrame encodeFrame(WebSocketFrameImpl frame) {
+  private static io.netty.handler.codec.http.websocketx.WebSocketFrame encodeFrame(WebSocketFrameImpl frame) {
     ByteBuf buf = safeBuffer(frame.getBinaryData());
     switch (frame.type()) {
       case BINARY:
@@ -452,8 +457,13 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
 
   public boolean isClosed() {
     synchronized (conn) {
-      return closed || closeStatusCode != null;
+      return unsafeIsClosed();
     }
+  }
+
+  private boolean unsafeIsClosed() {
+    assert Thread.holdsLock(conn);
+    return closed || closeStatusCode != null;
   }
 
   void handleFrame(WebSocketFrameInternal frame) {


### PR DESCRIPTION
Vertx is using a nested series of synchronized over the connection field which costs keep on piling-up; this cost is particularly evident while executing writeFrame outside of I/O threads.

https://github.com/franz1981/java-puzzles/blob/583d468a58a6ecaa5e7c7c300895392638f688dd/src/main/java/red/hat/puzzles/concurrent/LockCoarsening.java#L76-L85

contains some microbenchmarks results which show how bad the performance is even in the uncontended case, and it can just become worse under contention.

This is addressing https://github.com/quarkusio/quarkus/issues/39148#issuecomment-2396314537 
by removing the nested serie of synchronized over connection, reducing them to the bare minimum i.e. just 2 in the best case scenario 