### PR TITLE
Decouple the handshake part ServerWebSocket API

### DIFF
--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -1989,14 +1989,13 @@ When a WebSocket connection is made to the server, the handler will be called, p
 {@link examples.HTTPExamples#example51}
 ----
 
-You can choose to reject the WebSocket by calling {@link io.vertx.core.http.ServerWebSocket#reject()}.
+===== Server WebSocket handshake
 
-[source,$lang]
-----
-{@link examples.HTTPExamples#example52}
-----
+By default, the server accepts any inbound WebSocket.
 
-You can perform an asynchronous handshake by calling {@link io.vertx.core.http.ServerWebSocket#setHandshake} with a `Future`:
+You can set a WebSocket handshake handler to control the outcome of a WebSocket handshake, i.e. accept or reject an incoming WebSocket.
+
+You can choose to reject the WebSocket by calling {@link io.vertx.core.http.ServerWebSocketHandshake#accept()} or {@link io.vertx.core.http.ServerWebSocketHandshake#reject()}.
 
 [source,$lang]
 ----

--- a/vertx-core/src/main/java/examples/HTTPExamples.java
+++ b/vertx-core/src/main/java/examples/HTTPExamples.java
@@ -1049,29 +1049,20 @@ public class HTTPExamples {
     });
   }
 
-  public void example52(HttpServer server) {
-
-    server.webSocketHandler(webSocket -> {
-      if (webSocket.path().equals("/myapi")) {
-        webSocket.reject();
-      } else {
-        // Do something
-      }
-    });
-  }
-
   public void exampleAsynchronousHandshake(HttpServer server) {
-    server.webSocketHandler(webSocket -> {
-      Promise<Integer> promise = Promise.promise();
-      webSocket.setHandshake(promise.future());
-      authenticate(webSocket.headers(), ar -> {
+    server.webSocketHandshakeHandler(handshake -> {
+      authenticate(handshake.headers(), ar -> {
         if (ar.succeeded()) {
-          // Terminate the handshake with the status code 101 (Switching Protocol)
-          // Reject the handshake with 401 (Unauthorized)
-          promise.complete(ar.result() ? 101 : 401);
+          if (ar.result()) {
+            // Terminate the handshake with the status code 101 (Switching Protocol)
+            handshake.accept();
+          } else {
+            // Reject the handshake with 401 (Unauthorized)
+            handshake.reject(401);
+          }
         } else {
           // Will send a 500 error
-          promise.fail(ar.cause());
+          handshake.reject(500);
         }
       });
     });

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServer.java
@@ -17,7 +17,6 @@ import io.vertx.core.Handler;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.metrics.Measured;
-import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.TrafficShapingOptions;
@@ -77,6 +76,18 @@ public interface HttpServer extends Measured {
    */
   @Fluent
   HttpServer connectionHandler(Handler<HttpConnection> handler);
+
+  /**
+   * Set a handler for WebSocket handshake.
+   *
+   * <p>When an inbound HTTP request presents a WebSocket upgrade, this handler is called first. The handler
+   * can chose to {@link ServerWebSocketHandshake#accept()} or {@link ServerWebSocketHandshake#reject()} the request.</p>
+   *
+   * <p>Setting no handler, implicitly accepts any HTTP request connection presenting an upgrade header and upgrades it
+   * to a WebSocket.</p>
+   */
+  @Fluent
+  HttpServer webSocketHandshakeHandler(Handler<ServerWebSocketHandshake> handler);
 
   /**
    * Set an exception handler called for socket errors happening before the HTTP connection

--- a/vertx-core/src/main/java/io/vertx/core/http/ServerWebSocket.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/ServerWebSocket.java
@@ -94,61 +94,6 @@ public interface ServerWebSocket extends WebSocket {
   String query();
 
   /**
-   * Accept the WebSocket and terminate the WebSocket handshake.
-   * <p/>
-   * This method should be called from the WebSocket handler to explicitly accept the WebSocket and
-   * terminate the WebSocket handshake.
-   *
-   * @throws IllegalStateException when the WebSocket handshake is already set
-   */
-  void accept();
-
-  /**
-   * Reject the WebSocket.
-   * <p>
-   * Calling this method from the WebSocket handler when it is first passed to you gives you the opportunity to reject
-   * the WebSocket, which will cause the WebSocket handshake to fail by returning
-   * a {@literal 502} response code.
-   * <p>
-   * You might use this method, if for example you only want to accept WebSockets with a particular path.
-   *
-   * @throws IllegalStateException when the WebSocket handshake is already set
-   */
-  default void reject() {
-    // SC_BAD_GATEWAY
-    reject(502);
-  }
-
-  /**
-   * Like {@link #reject()} but with a {@code status}.
-   */
-  void reject(int status);
-
-  /**
-   * Set an asynchronous result for the handshake, upon completion of the specified {@code future}, the
-   * WebSocket will either be
-   *
-   * <ul>
-   *   <li>accepted when the {@code future} succeeds with the HTTP {@literal 101} status code</li>
-   *   <li>rejected when the {@code future} is succeeds with an HTTP status code different than {@literal 101}</li>
-   *   <li>rejected when the {@code future} fails with the HTTP status code {@code 500}</li>
-   * </ul>
-   *
-   * The provided future might be completed by the WebSocket itself, e.g calling the {@link #close()} method
-   * will try to accept the handshake and close the WebSocket afterward. Thus it is advised to try to complete
-   * the {@code future} with {@link Promise#tryComplete} or {@link Promise#tryFail}.
-   * <p>
-   * This method should be called from the WebSocket handler to explicitly set an asynchronous handshake.
-   * <p>
-   * Calling this method will override the {@code future} completion handler.
-   *
-   * @param future the future to complete with
-   * @return a future notified when the handshake has completed
-   * @throws IllegalStateException when the WebSocket has already an asynchronous result
-   */
-  Future<Integer> setHandshake(Future<Integer> future);
-
-  /**
    * {@inheritDoc}
    *
    * <p>

--- a/vertx-core/src/main/java/io/vertx/core/http/ServerWebSocketHandshake.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/ServerWebSocketHandshake.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.CacheReturn;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.net.HostAndPort;
+import io.vertx.core.net.SocketAddress;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.security.cert.Certificate;
+import java.util.List;
+
+/**
+ * A server WebSocket handshake, allows to control acceptance or rejection of a WebSocket.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface ServerWebSocketHandshake {
+
+  /**
+   *  Returns the HTTP headers.
+   *
+   * @return the headers
+   */
+  MultiMap headers();
+
+  /**
+   * @return the WebSocket handshake scheme
+   */
+  @Nullable
+  String scheme();
+
+  /**
+   * @return the WebSocket handshake authority
+   */
+  @Nullable
+  HostAndPort authority();
+
+  /*
+   * @return the WebSocket handshake URI. This is a relative URI.
+   */
+  String uri();
+
+  /**
+   * @return the WebSocket handshake path.
+   */
+  String path();
+
+  /**
+   * @return the WebSocket handshake query string.
+   */
+  @Nullable
+  String query();
+
+  /**
+   * Accept the WebSocket and terminate the WebSocket handshake.
+   * <p/>
+   * This method should be called from the WebSocket handler to explicitly accept the WebSocket and
+   * terminate the WebSocket handshake.
+   *
+   * @throws IllegalStateException when the WebSocket handshake is already set
+   */
+  Future<ServerWebSocket> accept();
+
+  /**
+   * Reject the WebSocket.
+   * <p>
+   * Calling this method from the WebSocket handler when it is first passed to you gives you the opportunity to reject
+   * the WebSocket, which will cause the WebSocket handshake to fail by returning
+   * a {@literal 502} response code.
+   * <p>
+   * You might use this method, if for example you only want to accept WebSockets with a particular path.
+   *
+   * @throws IllegalStateException when the WebSocket handshake is already set
+   */
+  default Future<Void> reject() {
+    // SC_BAD_GATEWAY
+    return reject(502);
+  }
+
+  /**
+   * Like {@link #reject()} but with a {@code status}.
+   */
+  Future<Void> reject(int status);
+
+  /**
+   * @return the remote address for this connection, possibly {@code null} (e.g a server bound on a domain socket).
+   * If {@code useProxyProtocol} is set to {@code true}, the address returned will be of the actual connecting client.
+   */
+  @CacheReturn
+  SocketAddress remoteAddress();
+
+  /**
+   * @return the local address for this connection, possibly {@code null} (e.g a server bound on a domain socket)
+   * If {@code useProxyProtocol} is set to {@code true}, the address returned will be of the proxy.
+   */
+  @CacheReturn
+  SocketAddress localAddress();
+
+  /**
+   * @return true if this {@link io.vertx.core.http.HttpConnection} is encrypted via SSL/TLS.
+   */
+  boolean isSsl();
+
+  /**
+   * @return SSLSession associated with the underlying socket. Returns null if connection is
+   *         not SSL.
+   * @see javax.net.ssl.SSLSession
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  SSLSession sslSession();
+
+  /**
+   * @return an ordered list of the peer certificates. Returns null if connection is
+   *         not SSL.
+   * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
+   * @see SSLSession#getPeerCertificates() ()
+   * @see #sslSession()
+   */
+  @GenIgnore()
+  List<Certificate> peerCertificates() throws SSLPeerUnverifiedException;
+
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/WebSocketConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/WebSocketConnection.java
@@ -1,0 +1,9 @@
+package io.vertx.core.http;
+
+public interface WebSocketConnection {
+
+  void accept();
+
+  void reject();
+
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -994,8 +994,8 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
         }
         if (future.isSuccess()) {
 
-          VertxHandler<WebSocketConnection> handler = VertxHandler.create(ctx -> {
-            WebSocketConnection conn = new WebSocketConnection(context, ctx, false, TimeUnit.SECONDS.toMillis(options.getClosingTimeout()), client.metrics());
+          VertxHandler<WebSocketConnectionImpl> handler = VertxHandler.create(ctx -> {
+            WebSocketConnectionImpl conn = new WebSocketConnectionImpl(context, ctx, false, TimeUnit.SECONDS.toMillis(options.getClosingTimeout()), client.metrics());
             WebSocketImpl webSocket = new WebSocketImpl(
               context,
               conn,

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -31,10 +31,10 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.ServerWebSocketHandshake;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.net.NetSocket;
@@ -280,7 +280,7 @@ public class Http1xServerConnection extends Http1xConnection implements HttpServ
     return serverOrigin;
   }
 
-  void createWebSocket(Http1xServerRequest request, PromiseInternal<ServerWebSocket> promise) {
+  void createWebSocket(Http1xServerRequest request, PromiseInternal<ServerWebSocketHandshake> promise) {
     context.execute(() -> {
       if (request != responseInProgress) {
         promise.fail("Invalid request");

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -386,17 +386,14 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
 
   @Override
   public Future<ServerWebSocket> toWebSocket() {
-    return webSocket().map(ws -> {
-      ws.accept();
-      return ws;
-    });
+    return webSocket().compose(handshake -> handshake.accept());
   }
 
   /**
    * @return a future of the un-accepted WebSocket
    */
-  Future<ServerWebSocket> webSocket() {
-    PromiseInternal<ServerWebSocket> promise = context.promise();
+  Future<ServerWebSocketHandshake> webSocket() {
+    PromiseInternal<ServerWebSocketHandshake> promise = context.promise();
     webSocket(promise);
     return promise.future();
   }
@@ -404,7 +401,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   /**
    * Handle the request when a WebSocket upgrade header is present.
    */
-  private void webSocket(PromiseInternal<ServerWebSocket> promise) {
+  private void webSocket(PromiseInternal<ServerWebSocketHandshake> promise) {
     BufferInternal body = BufferInternal.buffer();
     boolean[] failed = new boolean[1];
     handler(buff -> {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerRequestHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerRequestHandler.java
@@ -13,6 +13,7 @@ package io.vertx.core.http.impl;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.http.ServerWebSocketHandshake;
 
 import static io.vertx.core.http.HttpHeaders.UPGRADE;
 import static io.vertx.core.http.HttpHeaders.WEBSOCKET;
@@ -37,17 +38,20 @@ public class Http1xServerRequestHandler implements Handler<HttpServerRequest> {
 
   @Override
   public void handle(HttpServerRequest req) {
-    Handler<ServerWebSocket> wsHandler = handlers.wsHandler;
+    Handler<ServerWebSocket> wsHandler = handlers.webSocketHandler;
+    Handler<ServerWebSocketHandshake> wsHandshakeHandler = handlers.webSocketHandshakeHandler;
     Handler<HttpServerRequest> reqHandler = handlers.requestHandler;
     if (wsHandler != null ) {
       if (req.headers().contains(UPGRADE, WEBSOCKET, true) && handlers.server.wsAccept()) {
         // Missing upgrade header + null request handler will be handled when creating the handshake by sending a 400 error
-        // handle((Http1xServerRequest) req, wsHandler);
         ((Http1xServerRequest)req).webSocket().onComplete(ar -> {
           if (ar.succeeded()) {
-            ServerWebSocketHandshaker ws = (ServerWebSocketHandshaker) ar.result();
-            wsHandler.handle(ws);
-            ws.tryAccept();
+            ServerWebSocketHandshake handshake = ar.result();
+            if (wsHandshakeHandler != null) {
+              wsHandshakeHandler.handle(handshake);
+            } else {
+              handshake.accept().onSuccess(wsHandler);
+            }
           } else {
             // ????
           }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerConnectionHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerConnectionHandler.java
@@ -21,6 +21,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.http.ServerWebSocketHandshake;
 import io.vertx.core.internal.ContextInternal;
 
 import java.util.ArrayList;
@@ -35,7 +36,8 @@ class HttpServerConnectionHandler implements Handler<HttpServerConnection> {
   final HttpServerImpl server;
   final Handler<HttpServerRequest> requestHandler;
   final Handler<HttpServerRequest> invalidRequestHandler;
-  final Handler<ServerWebSocket> wsHandler;
+  final Handler<ServerWebSocket> webSocketHandler;
+  final Handler<ServerWebSocketHandshake> webSocketHandshakeHandler;
   final Handler<HttpConnection> connectionHandler;
   final Handler<Throwable> exceptionHandler;
 
@@ -43,13 +45,15 @@ class HttpServerConnectionHandler implements Handler<HttpServerConnection> {
     HttpServerImpl server,
     Handler<HttpServerRequest> requestHandler,
     Handler<HttpServerRequest> invalidRequestHandler,
-    Handler<ServerWebSocket> wsHandler,
+    Handler<ServerWebSocket> webSocketHandler,
+    Handler<ServerWebSocketHandshake> webSocketHandshakeHandler,
     Handler<HttpConnection> connectionHandler,
     Handler<Throwable> exceptionHandler) {
     this.server = server;
     this.requestHandler = requestHandler;
     this.invalidRequestHandler = invalidRequestHandler == null ? HttpServerRequest.DEFAULT_INVALID_REQUEST_HANDLER : invalidRequestHandler;
-    this.wsHandler = wsHandler;
+    this.webSocketHandler = webSocketHandler;
+    this.webSocketHandshakeHandler = webSocketHandshakeHandler;
     this.connectionHandler = connectionHandler;
     this.exceptionHandler = exceptionHandler;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -46,6 +46,7 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
   final HttpServerOptions options;
   private Handler<HttpServerRequest> requestHandler;
   private Handler<ServerWebSocket> webSocketHandler;
+  private Handler<ServerWebSocketHandshake> webSocketHandhakeHandler;
   private Handler<HttpServerRequest> invalidRequestHandler;
   private Handler<HttpConnection> connectionHandler;
   private Handler<Throwable> exceptionHandler;
@@ -115,6 +116,15 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
       throw new IllegalStateException("Please set handler before server is listening");
     }
     webSocketHandler = handler;
+    return this;
+  }
+
+  @Override
+  public HttpServer webSocketHandshakeHandler(Handler<ServerWebSocketHandshake> handler) {
+    if (isListening()) {
+      throw new IllegalStateException("Please set handler before server is listening");
+    }
+    webSocketHandhakeHandler = handler;
     return this;
   }
 
@@ -196,6 +206,7 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
         requestHandler,
         invalidRequestHandler,
         webSocketHandler,
+        webSocketHandhakeHandler,
         connectionHandler,
         exceptionHandler);
       HttpServerConnectionInitializer initializer = new HttpServerConnectionInitializer(

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/ServerWebSocketHandshaker.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/ServerWebSocketHandshaker.java
@@ -30,6 +30,7 @@ import io.vertx.core.net.impl.VertxHandler;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import java.security.cert.Certificate;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -38,435 +39,120 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
 
 /**
- * Implementation that models a proxies a lazy {@link ServerWebSocket} since the API allows to reject a WebSocket
- * handshake.
+ * WebSocket handshaker.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class ServerWebSocketHandshaker implements ServerWebSocket {
+public class ServerWebSocketHandshaker implements ServerWebSocketHandshake, ServerWebSocket {
 
-  private static final int ST_PENDING = 0, ST_ACCEPTED = 1, ST_REJECTED = 2;
-
-  private Http1xServerRequest request;
-  private HttpServerOptions options;
-  private WebSocketServerHandshaker handshaker;
-  private int status;
-  private ServerWebSocket webSocket;
-  private Future<Integer> futureHandshake;
-  private Handler<Throwable> exceptionHandler;
-  private Handler<Buffer> dataHandler;
-  private Handler<Void> endHandler;
-  private Handler<Void> closeHandler;
-  private Handler<Void> shutdownHandler;
-  private Handler<Void> drainHandler;
-  private Handler<WebSocketFrame> frameHandler;
-  private Handler<String> textMessageHandler;
-  private Handler<Buffer> binaryMessageHandler;
-  private Handler<Buffer> pongHandler;
+  private final Http1xServerRequest request;
+  private final HttpServerOptions options;
+  private final WebSocketServerHandshaker handshaker;
+  private boolean done;
 
   public ServerWebSocketHandshaker(Http1xServerRequest request, WebSocketServerHandshaker handshaker, HttpServerOptions options) {
     this.request = request;
     this.handshaker = handshaker;
     this.options = options;
-    this.status = ST_PENDING;
   }
 
   @Override
   public @Nullable String scheme() {
-    Http1xServerRequest r = request;
-    if (r != null) {
-      return r.scheme();
-    } else {
-      return webSocket.scheme();
-    }
+    return request.scheme();
   }
 
   @Override
   public @Nullable HostAndPort authority() {
-    Http1xServerRequest r = request;
-    if (r != null) {
-      return r.authority();
-    } else {
-      return webSocket.authority();
-    }
+    return request.authority();
   }
 
   @Override
   public String uri() {
-    Http1xServerRequest r = request;
-    if (r != null) {
-      return r.uri();
-    } else {
-      return webSocket.uri();
-    }
+    return request.uri();
   }
 
   @Override
   public String path() {
-    Http1xServerRequest r = request;
-    if (r != null) {
-      return r.path();
-    } else {
-      return webSocket.path();
-    }
+    return request.path();
   }
 
   @Override
-  public @Nullable String query() {
-    Http1xServerRequest r = request;
-    if (r != null) {
-      return r.query();
-    } else {
-      return webSocket.query();
-    }
+  public String query() {
+    return request.query();
   }
 
   @Override
-  public void accept() {
-    webSocketOrDie();
-  }
-
-  void tryAccept() {
-    resolveWebSocket();
-  }
-
-  @Override
-  public void reject(int sc) {
-    // Check SC is valid
+  public Future<ServerWebSocket> accept() {
     synchronized (this) {
-        if (status == ST_PENDING) {
-            status = ST_REJECTED;
-        } else {
-            throw new IllegalStateException();
-        }
-    }
-    rejectHandshake(sc);
-  }
-
-  @Override
-  public Future<Integer> setHandshake(Future<Integer> future) {
-    Future<Integer> ret;
-    synchronized (this) {
-      if (status != ST_PENDING || futureHandshake != null) {
+      if (done) {
         throw new IllegalStateException();
       }
-      ret = future.andThen(ar -> {
-        if (ar.succeeded()) {
-          int sc = ar.result();
-          if (sc == 101) {
-            synchronized (this) {
-              futureHandshake = null;
-              accept();
-            }
+      done = true;
+    }
+    ServerWebSocket ws;
+    try {
+      ws = acceptHandshake();
+    } catch (Exception e) {
+      e.printStackTrace(System.out);
+      return rejectHandshake(BAD_REQUEST.code())
+        .transform(ar -> {
+          if (ar.succeeded()) {
+            return request.context.failedFuture(e);
           } else {
-            synchronized (this) {
-              status = ST_REJECTED;
-            }
-            reject(sc);
+            // result is null
+            return (Future) ar;
           }
-        }
-      });
-      futureHandshake = ret;
+        });
     }
-    return ret;
+    return request.context.succeededFuture(ws);
   }
 
   @Override
-  public ServerWebSocket exceptionHandler(Handler<Throwable> handler) {
-    exceptionHandler = handler;
-    WebSocket ws = webSocket;
-    if (ws != null) {
-      ws.exceptionHandler(handler);
+  public Future<Void> reject(int sc) {
+    // Check SC is valid
+    synchronized (this) {
+      if (done) {
+        throw new IllegalStateException();
+      }
+      done = true;
     }
-    return this;
-  }
-
-  @Override
-  public ServerWebSocket handler(Handler<Buffer> handler) {
-    dataHandler = handler;
-    WebSocket ws = webSocket;
-    if (ws != null) {
-      ws.handler(handler);
-    }
-    return this;
-  }
-
-  @Override
-  public ServerWebSocket pause() {
-    webSocketOrDie().pause();
-    return this;
-  }
-
-  @Override
-  public ServerWebSocket fetch(long amount) {
-    webSocketOrDie().fetch(amount);
-    return this;
-  }
-
-  @Override
-  public ServerWebSocket endHandler(Handler<Void> handler) {
-    endHandler = handler;
-    WebSocket ws = webSocket;
-    if (ws != null) {
-      ws.endHandler(handler);
-    }
-    return this;
-  }
-
-  @Override
-  public ServerWebSocket setWriteQueueMaxSize(int maxSize) {
-    webSocketOrDie().setWriteQueueMaxSize(maxSize);
-    return this;
-  }
-
-  @Override
-  public ServerWebSocket drainHandler(Handler<Void> handler) {
-    drainHandler = handler;
-    WebSocket ws = webSocket;
-    if (ws != null) {
-      ws.drainHandler(handler);
-    }
-    return this;
-  }
-
-  @Override
-  public ServerWebSocket closeHandler(Handler<Void> handler) {
-    closeHandler = handler;
-    WebSocket ws = webSocket;
-    if (ws != null) {
-      ws.closeHandler(handler);
-    }
-    return this;
-  }
-
-  @Override
-  public WebSocket shutdownHandler(Handler<Void> handler) {
-    shutdownHandler = handler;
-    WebSocket ws = webSocket;
-    if (ws != null) {
-      ws.shutdownHandler(handler);
-    }
-    return this;
-  }
-
-  @Override
-  public ServerWebSocket frameHandler(Handler<WebSocketFrame> handler) {
-    frameHandler = handler;
-    WebSocket ws = webSocket;
-    if (ws != null) {
-      ws.frameHandler(handler);
-    }
-    return this;
-  }
-
-  @Override
-  public String binaryHandlerID() {
-    return webSocketOrDie().binaryHandlerID();
-  }
-
-  @Override
-  public String textHandlerID() {
-    return webSocketOrDie().textHandlerID();
-  }
-
-  @Override
-  public String subProtocol() {
-    ServerWebSocket ws = webSocket;
-    if (ws == null) {
-      return null;
-    } else {
-      return ws.subProtocol();
-    }
-  }
-
-  @Override
-  public Short closeStatusCode() {
-    return webSocketOrDie().closeStatusCode();
-  }
-
-  @Override
-  public String closeReason() {
-    return webSocketOrDie().closeReason();
+    return rejectHandshake(sc);
   }
 
   @Override
   public MultiMap headers() {
-    return webSocketOrDie().headers();
-  }
-
-  @Override
-  public Future<Void> writeFrame(WebSocketFrame frame) {
-    return webSocketOrDie().writeFrame(frame);
-  }
-
-  @Override
-  public Future<Void> writeFinalTextFrame(String text) {
-    return webSocketOrDie().writeFinalTextFrame(text);
-  }
-
-  @Override
-  public Future<Void> writeFinalBinaryFrame(Buffer data) {
-    return webSocketOrDie().writeFinalBinaryFrame(data);
-  }
-
-  @Override
-  public Future<Void> writeBinaryMessage(Buffer data) {
-    return webSocketOrDie().writeBinaryMessage(data);
-  }
-
-  @Override
-  public Future<Void> writeTextMessage(String text) {
-    return webSocketOrDie().writeTextMessage(text);
-  }
-
-  @Override
-  public Future<Void> writePing(Buffer data) {
-    return webSocketOrDie().writePing(data);
-  }
-
-  @Override
-  public Future<Void> writePong(Buffer data) {
-    return webSocketOrDie().writePong(data);
-  }
-
-  @Override
-  public ServerWebSocket textMessageHandler(@Nullable Handler<String> handler) {
-    textMessageHandler = handler;
-    WebSocket ws = webSocket;
-    if (ws != null) {
-      ws.textMessageHandler(handler);
-    }
-    return this;
-  }
-
-  @Override
-  public ServerWebSocket binaryMessageHandler(@Nullable Handler<Buffer> handler) {
-    binaryMessageHandler = handler;
-    WebSocket ws = webSocket;
-    if (ws != null) {
-      ws.binaryMessageHandler(handler);
-    }
-    return this;
-  }
-
-  @Override
-  public ServerWebSocket pongHandler(@Nullable Handler<Buffer> handler) {
-    pongHandler = handler;
-    WebSocket ws = webSocket;
-    if (ws != null) {
-      ws.pongHandler(handler);
-    }
-    return this;
-  }
-
-  @Override
-  public Future<Void> end() {
-    return webSocketOrDie().end();
-  }
-
-  @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit, short statusCode, @Nullable String reason) {
-    WebSocket delegate = webSocketOrDie();
-    return delegate.shutdown(timeout, unit, statusCode, reason);
+    return request.headers();
   }
 
   @Override
   public SocketAddress remoteAddress() {
-    return webSocketOrDie().remoteAddress();
+    return request.remoteAddress();
   }
 
   @Override
   public SocketAddress localAddress() {
-    return webSocketOrDie().localAddress();
+    return request.localAddress();
   }
 
   @Override
   public boolean isSsl() {
-    return webSocketOrDie().isSsl();
-  }
-
-  @Override
-  public boolean isClosed() {
-    return webSocketOrDie().isClosed();
+    return request.isSSL();
   }
 
   @Override
   public SSLSession sslSession() {
-    return webSocketOrDie().sslSession();
+    return request.sslSession();
   }
 
   @Override
   public List<Certificate> peerCertificates() throws SSLPeerUnverifiedException {
-    return webSocketOrDie().peerCertificates();
+    return Arrays.asList(sslSession().getPeerCertificates());
   }
 
-  @Override
-  public Future<Void> write(Buffer data) {
-    return webSocketOrDie().write(data);
-  }
-
-  @Override
-  public boolean writeQueueFull() {
-    return webSocketOrDie().writeQueueFull();
-  }
-
-  private WebSocket webSocketOrDie() {
-    WebSocket ws = resolveWebSocket();
-    if (ws == null) {
-      throw new IllegalStateException("WebSocket handshake failed");
-    }
-    return ws;
-  }
-
-  private WebSocket resolveWebSocket() {
-    boolean reject = false;
-    try {
-      if (futureHandshake != null) {
-        return null;
-      }
-      synchronized (this) {
-        switch (status) {
-          case ST_PENDING:
-            ServerWebSocket ws;
-            try {
-              ws = acceptHandshake();
-            } catch (Exception e) {
-              status = ST_REJECTED;
-              reject = true;
-              throw e;
-            }
-            ws.handler(dataHandler);
-            ws.binaryMessageHandler(binaryMessageHandler);
-            ws.textMessageHandler(textMessageHandler);
-            ws.endHandler(endHandler);
-            ws.closeHandler(closeHandler);
-            ws.shutdownHandler(shutdownHandler);
-            ws.exceptionHandler(exceptionHandler);
-            ws.drainHandler(drainHandler);
-            ws.frameHandler(frameHandler);
-            ws.pongHandler(pongHandler);
-            status = ST_ACCEPTED;
-            webSocket = ws;
-            return ws;
-          case ST_REJECTED:
-            return null;
-          case ST_ACCEPTED:
-            return webSocket;
-          default:
-            throw new UnsupportedOperationException();
-        }
-      }
-    } finally {
-      if (reject) {
-        rejectHandshake(BAD_REQUEST.code());
-      }
-    }
-  }
-
-  private void rejectHandshake(int sc) {
+  private Future<Void> rejectHandshake(int sc) {
     HttpResponseStatus status = HttpResponseStatus.valueOf(sc);
     Http1xServerResponse response = request.response();
-    response.setStatusCode(sc).end(status.reasonPhrase());
+    return response.setStatusCode(sc).end(status.reasonPhrase());
   }
 
   private ServerWebSocket acceptHandshake() {
@@ -475,12 +161,7 @@ public class ServerWebSocketHandshaker implements ServerWebSocket {
     Channel channel = chctx.channel();
     Http1xServerResponse response = request.response();
     Object requestMetric = request.metric;
-    try {
-      handshaker.handshake(channel, request.nettyRequest(), (HttpHeaders) response.headers(), channel.newPromise());
-    } catch (Exception e) {
-      rejectHandshake(BAD_REQUEST.code());
-      throw e;
-    }
+    handshaker.handshake(channel, request.nettyRequest(), (HttpHeaders) response.headers(), channel.newPromise());
     response.completeHandshake();
     // remove compressor as it's not needed anymore once connection was upgraded to websockets
     ChannelPipeline pipeline = channel.pipeline();
@@ -488,9 +169,9 @@ public class ServerWebSocketHandshaker implements ServerWebSocket {
     if (compressor != null) {
       pipeline.remove(compressor);
     }
-    VertxHandler<WebSocketConnection> handler = VertxHandler.create(ctx -> {
+    VertxHandler<WebSocketConnectionImpl> handler = VertxHandler.create(ctx -> {
       long closingTimeoutMS = options.getWebSocketClosingTimeout() >= 0 ? options.getWebSocketClosingTimeout() * 1000L : 0L;
-      WebSocketConnection webSocketConn = new WebSocketConnection(request.context, ctx, true, closingTimeoutMS,httpConn.metrics);
+      WebSocketConnectionImpl webSocketConn = new WebSocketConnectionImpl(request.context, ctx, true, closingTimeoutMS,httpConn.metrics);
       ServerWebSocketImpl webSocket = new ServerWebSocketImpl(
         (ContextInternal) request.context(),
         webSocketConn,
@@ -523,5 +204,155 @@ public class ServerWebSocketHandshaker implements ServerWebSocket {
     }
     webSocket.registerHandler(httpConn.context().owner().eventBus());
     return webSocket;
+  }
+
+  @Override
+  public ServerWebSocket exceptionHandler(Handler<Throwable> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ServerWebSocket handler(Handler<Buffer> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ServerWebSocket pause() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ServerWebSocket fetch(long amount) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ServerWebSocket endHandler(Handler<Void> endHandler) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ServerWebSocket setWriteQueueMaxSize(int maxSize) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ServerWebSocket drainHandler(Handler<Void> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ServerWebSocket closeHandler(Handler<Void> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ServerWebSocket frameHandler(Handler<WebSocketFrame> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public WebSocket shutdownHandler(Handler<Void> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public WebSocket textMessageHandler(@Nullable Handler<String> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public WebSocket binaryMessageHandler(@Nullable Handler<Buffer> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public WebSocket pongHandler(@Nullable Handler<Buffer> handler) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String binaryHandlerID() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String textHandlerID() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String subProtocol() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Short closeStatusCode() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String closeReason() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Future<Void> writeFrame(WebSocketFrame frame) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Future<Void> writeFinalTextFrame(String text) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Future<Void> writeFinalBinaryFrame(Buffer data) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Future<Void> writeBinaryMessage(Buffer data) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Future<Void> writeTextMessage(String text) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Future<Void> writePing(Buffer data) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Future<Void> writePong(Buffer data) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Future<Void> end() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Future<Void> shutdown(long timeout, TimeUnit unit, short statusCode, @Nullable String reason) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isClosed() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Future<Void> write(Buffer data) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean writeQueueFull() {
+    throw new UnsupportedOperationException();
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -74,19 +74,4 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocketImpl> 
     return query;
   }
 
-  @Override
-  public Future<Integer> setHandshake(Future<Integer> future) {
-    throw new IllegalStateException("WebSocket already sent");
-  }
-
-  @Override
-  public void accept() {
-    throw new IllegalStateException("WebSocket already sent");
-  }
-
-  @Override
-  public void reject(int sc) {
-    throw new IllegalStateException("WebSocket already sent");
-  }
-
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketConnectionImpl.java
@@ -36,7 +36,7 @@ import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-final class WebSocketConnection extends VertxConnection {
+final class WebSocketConnectionImpl extends VertxConnection {
 
   private final long closingTimeoutMS;
   private ScheduledFuture<?> closingTimeout;
@@ -48,7 +48,7 @@ final class WebSocketConnection extends VertxConnection {
   private Object closeReason;
   private boolean closeReceived;
 
-  WebSocketConnection(ContextInternal context, ChannelHandlerContext chctx, boolean server, long closingTimeoutMS, TCPMetrics metrics) {
+  WebSocketConnectionImpl(ContextInternal context, ChannelHandlerContext chctx, boolean server, long closingTimeoutMS, TCPMetrics metrics) {
     super(context, chctx);
     this.closingTimeoutMS = closingTimeoutMS;
     this.metrics = metrics;
@@ -59,7 +59,7 @@ final class WebSocketConnection extends VertxConnection {
     return webSocket;
   }
 
-  WebSocketConnection webSocket(WebSocketImplBase<?> webSocket) {
+  WebSocketConnectionImpl webSocket(WebSocketImplBase<?> webSocket) {
     this.webSocket = webSocket;
     return this;
   }

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeHttpServerMetrics.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeHttpServerMetrics.java
@@ -29,11 +29,11 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class FakeHttpServerMetrics extends FakeTCPMetrics implements HttpServerMetrics<HttpServerMetric, WebSocketMetric, SocketMetric> {
 
-  private final ConcurrentMap<WebSocketBase, WebSocketMetric> webSockets = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, WebSocketMetric> webSockets = new ConcurrentHashMap<>();
   private final Set<HttpServerMetric> requests = ConcurrentHashMap.newKeySet();
 
   public WebSocketMetric getWebSocketMetric(ServerWebSocket ws) {
-    return webSockets.get(ws);
+    return webSockets.get(ws.path());
   }
 
   public HttpServerMetric getRequestMetric(HttpServerRequest request) {
@@ -86,7 +86,7 @@ public class FakeHttpServerMetrics extends FakeTCPMetrics implements HttpServerM
   @Override
   public WebSocketMetric connected(SocketMetric socketMetric, HttpServerMetric requestMetric, ServerWebSocket serverWebSocket) {
     WebSocketMetric metric = new WebSocketMetric(serverWebSocket);
-    if (webSockets.put(serverWebSocket, metric) != null) {
+    if (webSockets.put(serverWebSocket.path(), metric) != null) {
       throw new AssertionError();
     }
     return metric;
@@ -94,7 +94,7 @@ public class FakeHttpServerMetrics extends FakeTCPMetrics implements HttpServerM
 
   @Override
   public void disconnected(WebSocketMetric serverWebSocketMetric) {
-    webSockets.remove(serverWebSocketMetric.ws);
+    webSockets.remove(((ServerWebSocket)serverWebSocketMetric.ws).path());
   }
 
   @Override

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsTest.java
@@ -573,7 +573,6 @@ public class MetricsTest extends VertxTestBase {
     CountDownLatch latch = new CountDownLatch(1);
     server.webSocketHandler(ws -> {
       wsRef.set(ws);
-      ws.accept();
       FakeHttpServerMetrics metrics = FakeMetricsBase.getMetrics(server);
       WebSocketMetric metric = metrics.getWebSocketMetric(ws);
       assertNotNull(metric);


### PR DESCRIPTION
Motivation:

The server WebSocket API can control handshake implicitly (e.g. sending a message) or explicitly (accept or any WebSocket interaction). This result in a more complex implementation than it should be for such API.

Changes:

Extract the handshake API of the `ServerWebSocket` API in a new `ServerWebSocketHandshake` API for which an handler can be set when WebSocket handshake needs to be controlled.
