### PR TITLE
Set request context before recording metrics

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -610,7 +610,7 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
 
   private void reportRequestReset(Throwable err) {
     if (conn.metrics != null) {
-      conn.metrics.requestReset(metric);
+      context.dispatch(event -> conn.metrics.requestReset(metric));
     }
     VertxTracer tracer = context.tracer();
     if (tracer != null) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
@@ -165,7 +165,7 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
     if (METRICS_ENABLED) {
       HttpServerMetrics metrics = conn.metrics();
       if (metrics != null) {
-        metrics.responseEnd(metric, request.response(), bytesWritten());
+        context.dispatch(event -> metrics.responseEnd(metric, request.response(), bytesWritten()));
       }
     }
   }
@@ -213,7 +213,7 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
       HttpServerMetrics metrics = conn.metrics();
       // Null in case of push response : handle this case
       if (metrics != null && (!requestEnded || !responseEnded)) {
-        metrics.requestReset(metric);
+        context.dispatch(event -> metrics.requestReset(metric));
       }
     }
     request.onClose();


### PR DESCRIPTION
Closes #5355

Motivation:

This sets the context so that the logic in Quarkus will know that this call is traced via OpenTracing, and then records and exemplar for the metrics.

I've been monkey-patching Keycloak 26 with a changed `Http1xServerConnection#reportResponseComplete()` and it worked for me in in a manual test. 

I've been looking for other places of `metrics.requestReset()` and `metrics.responseEnd()` and fixing them the same way.

~Draft PR for now, as I didn't add any tests, and would probably need help writing some if they would be required. Also waiting for a results that the build returns.~

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
