### PR TITLE
Save intermediate text encoded buffer copies

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -44,6 +44,7 @@ import io.vertx.core.streams.impl.InboundBuffer;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.util.List;
 import java.util.UUID;
@@ -308,7 +309,13 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
 
   @Override
   public Future<Void> writeTextMessage(String text) {
-    return writePartialMessage(WebSocketFrameType.TEXT, Buffer.buffer(text), 0);
+    byte[] utf8Bytes = text.getBytes(StandardCharsets.UTF_8);
+    boolean isFinal = utf8Bytes.length <= maxWebSocketFrameSize;
+    if (isFinal) {
+      return writeFrame(new WebSocketFrameImpl(WebSocketFrameType.TEXT, utf8Bytes, true));
+    }
+    // we could save to copy the byte[] if the unsafe heap version of Netty ByteBuf could expose wrapping byte[] directly
+    return writePartialMessage(WebSocketFrameType.TEXT, Buffer.buffer(utf8Bytes), 0);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/ws/WebSocketFrameImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ws/WebSocketFrameImpl.java
@@ -80,6 +80,15 @@ public class WebSocketFrameImpl implements WebSocketFrameInternal, ReferenceCoun
   }
 
   /**
+   * Creates a new raw frame from with the specified encoded content.
+   */
+  public WebSocketFrameImpl(WebSocketFrameType type, byte[] utf8TextData, boolean isFinalFrame) {
+    this.type = type;
+    this.isFinalFrame = isFinalFrame;
+    this.binaryData = Unpooled.wrappedBuffer(utf8TextData);
+  }
+
+  /**
    * Creates a new text frame from with the specified string.
    */
   public WebSocketFrameImpl(String textData, boolean isFinalFrame) {


### PR DESCRIPTION
Websocket txt messages perform an additional byte[] copy, because:
1. `Buffer::buffer(String)` is performing `String::getBytes` -> first byte[] allocation
2. It than allocates `VertxByteBufAllocator.DEFAULT.heapBuffer`  to write the copy in -> second byte[] allocation + copy

`VertxByteBufAllocator.DEFAULT.heapBuffer` could allocate, based on `Unsafe` presence:
- `UnpooledHeapByteBuf`
- `UnpooledUnsafeHeapByteBuf`

Both the Vertx childrens of these 2 Netty buffers are NOT exposing directly the ability to wrap a given byte[] and that's why we currently perform the copy: in theory `UnpooledHeapByteBuf` vertx variant could be modified to do it, but `UnpooledUnsafeHeapByteBuf` nope, because it doesn't expose its parent constructor which enable setting the byte[] array without copying it (see https://github.com/netty/netty/blob/netty-4.1.114.Final/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java#L69).

Fixing the additional copy should require to change both Vertx and Netty, for not much gains, given that sharing a given byte[] is likely to disappear in Netty 5, regardless, so, not a good solution.

A different path would be to "guesstimate" the length of the utf8 array (there are 2 Netty method for such: eager O(1) or precise O(n)) - and using Netty's `ByteBuf` encoder to perform it: 
this could be beneficial, but not ideal because the JVM can perform String checks to estimate the length of the encoded byte[] way faster thanks to its vectorized instructions. 
This still could be benchmarked, to make sure, is a valid assumption.

For completeness, this same path is used by https://github.com/eclipse-vertx/vert.x/blob/4.5.10/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java#L240 which is using `Unpooled::copiedBuffer` under the hood to do what's described above and allocates `io.netty.buffer.UnpooledByteBufAllocator$InstrumentedUnpooledUnsafeHeapByteBuf` or `io.netty.buffer.UnpooledByteBufAllocator$InstrumentedUnpooledHeapByteBuf`.

The approach taken for this PR is instead to allocates a `UnpooledHeapByteBuf` without performing any copy:
- it has the disadvantages of bringing another Netty buffer type in 
- it has another disadvantages because it is still a Netty reference counted type, while the Vertx heap buffers are modified to not perform reference counting
- it has the advantage of using the (supposly) faster `String::getBytes`  and not performing any additional copy from it (including the wrappers `BufferImpl` and subsequent Netty slices
