### PR TITLE
The endpoint resolver implementation should better use the address resolver validity check

### DIFF
--- a/vertx-core/src/main/java/examples/HTTPExamples.java
+++ b/vertx-core/src/main/java/examples/HTTPExamples.java
@@ -24,7 +24,7 @@ import io.vertx.core.net.endpoint.LoadBalancer;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
-import io.vertx.core.net.endpoint.EndpointServer;
+import io.vertx.core.net.endpoint.ServerEndpoint;
 import io.vertx.core.streams.Pipe;
 import io.vertx.core.streams.ReadStream;
 
@@ -1448,7 +1448,7 @@ public class HTTPExamples {
       .build();
   }
 
-  private static int indexOfEndpoint(List<? extends EndpointServer> endpoints) {
+  private static int indexOfEndpoint(List<? extends ServerEndpoint> endpoints) {
     return 0;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/endpoint/Endpoint.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/endpoint/Endpoint.java
@@ -20,14 +20,14 @@ public interface Endpoint {
   /**
    * The servers capable of serving requests for this endpoint.
    */
-  List<EndpointServer> servers();
+  List<ServerEndpoint> servers();
 
   /**
    * Select a server.
    *
    * @return the selected server
    */
-  default EndpointServer selectServer() {
+  default ServerEndpoint selectServer() {
     return selectServer(null);
   }
 
@@ -37,6 +37,6 @@ public interface Endpoint {
    * @param key the routing key
    * @return the selected server
    */
-  EndpointServer selectServer(String key);
+  ServerEndpoint selectServer(String key);
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/endpoint/LoadBalancer.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/endpoint/LoadBalancer.java
@@ -58,7 +58,7 @@ public interface LoadBalancer {
     int numberOfRequests = Integer.MAX_VALUE;
     int selected = -1;
     int idx = 0;
-    for (EndpointServer node : servers) {
+    for (ServerEndpoint node : servers) {
       int val = ((DefaultInteractionMetrics)node.metrics()).numberOfInflightRequests();
       if (val < numberOfRequests) {
         numberOfRequests = val;
@@ -125,6 +125,6 @@ public interface LoadBalancer {
    * @param listOfServers the list of servers
    * @return the selector
    */
-  ServerSelector selector(List<? extends EndpointServer> listOfServers);
+  ServerSelector selector(List<? extends ServerEndpoint> listOfServers);
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/endpoint/ServerEndpoint.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/endpoint/ServerEndpoint.java
@@ -20,7 +20,7 @@ import io.vertx.core.net.SocketAddress;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 @VertxGen
-public interface EndpointServer {
+public interface ServerEndpoint {
 
   /**
    * @return the node key for hashing strategies
@@ -28,7 +28,7 @@ public interface EndpointServer {
   String key();
 
   /**
-   * @return the node socket address
+   * @return the server socket address
    */
   SocketAddress address();
 

--- a/vertx-core/src/main/java/io/vertx/core/net/endpoint/impl/ConsistentHashingSelector.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/endpoint/impl/ConsistentHashingSelector.java
@@ -10,7 +10,7 @@
  */
 package io.vertx.core.net.endpoint.impl;
 
-import io.vertx.core.net.endpoint.EndpointServer;
+import io.vertx.core.net.endpoint.ServerEndpoint;
 import io.vertx.core.net.endpoint.ServerSelector;
 
 import java.nio.charset.StandardCharsets;
@@ -27,19 +27,19 @@ import java.util.TreeMap;
  */
 public class ConsistentHashingSelector implements ServerSelector {
 
-  private final List<? extends EndpointServer> endpoints;
-  private final SortedMap<Long, EndpointServer> nodes;
+  private final List<? extends ServerEndpoint> endpoints;
+  private final SortedMap<Long, ServerEndpoint> nodes;
   private final ServerSelector fallbackSelector;
 
-  public ConsistentHashingSelector(List<? extends EndpointServer> endpoints, int numberOfVirtualNodes, ServerSelector fallbackSelector) {
+  public ConsistentHashingSelector(List<? extends ServerEndpoint> endpoints, int numberOfVirtualNodes, ServerSelector fallbackSelector) {
     MessageDigest instance;
     try {
       instance = MessageDigest.getInstance("MD5");
     } catch (NoSuchAlgorithmException e) {
       throw new UnsupportedOperationException(e);
     }
-    SortedMap<Long, EndpointServer> ring = new TreeMap<>();
-    for (EndpointServer node : endpoints) {
+    SortedMap<Long, ServerEndpoint> ring = new TreeMap<>();
+    for (ServerEndpoint node : endpoints) {
       for (int idx = 0;idx < numberOfVirtualNodes;idx++) {
         String nodeId = node.key() + "-" + idx;
         long hash = hash(instance, nodeId.getBytes(StandardCharsets.UTF_8));
@@ -86,14 +86,14 @@ public class ConsistentHashingSelector implements ServerSelector {
       throw new UnsupportedOperationException(e);
     }
     long hash = hash(md, key.getBytes(StandardCharsets.UTF_8));
-    SortedMap<Long, EndpointServer> map = nodes.tailMap(hash);
+    SortedMap<Long, ServerEndpoint> map = nodes.tailMap(hash);
     Long val;
     if (map.isEmpty()) {
       val = nodes.firstKey();
     } else {
       val = map.firstKey();
     }
-    EndpointServer endpoint = nodes.get(val);
+    ServerEndpoint endpoint = nodes.get(val);
     return endpoints.indexOf(endpoint); // TODO IMPROVE THAT
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/endpoint/impl/EndpointResolverImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/endpoint/impl/EndpointResolverImpl.java
@@ -13,7 +13,7 @@ package io.vertx.core.net.endpoint.impl;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.net.endpoint.EndpointResolverInternal;
-import io.vertx.core.net.endpoint.EndpointServer;
+import io.vertx.core.net.endpoint.ServerEndpoint;
 import io.vertx.core.net.endpoint.ServerInteraction;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.endpoint.InteractionMetrics;
@@ -93,13 +93,13 @@ public class EndpointResolverImpl<S, A extends Address, N> implements EndpointRe
       this.lastAccessed = lastAccessed;
     }
     @Override
-    public List<EndpointServer> servers() {
+    public List<ServerEndpoint> servers() {
       return endpointResolver.endpoint(state).servers;
     }
     public void close() {
       endpointResolver.dispose(state);
     }
-    private EndpointServer selectEndpoint(S state, String routingKey) {
+    private ServerEndpoint selectEndpoint(S state, String routingKey) {
       ListOfServers listOfServers = endpointResolver.endpoint(state);
       int idx;
       if (routingKey == null) {
@@ -112,8 +112,8 @@ public class EndpointResolverImpl<S, A extends Address, N> implements EndpointRe
       }
       return null;
     }
-    public EndpointServer selectServer(String key) {
-      EndpointServer endpoint = selectEndpoint(state, key);
+    public ServerEndpoint selectServer(String key) {
+      ServerEndpoint endpoint = selectEndpoint(state, key);
       if (endpoint == null) {
         throw new IllegalStateException("No results for " + address );
       }
@@ -205,15 +205,15 @@ public class EndpointResolverImpl<S, A extends Address, N> implements EndpointRe
     return sFuture.endpoint;
   }
 
-  private static class ListOfServers implements Iterable<EndpointServer> {
-    final List<EndpointServer> servers;
+  private static class ListOfServers implements Iterable<ServerEndpoint> {
+    final List<ServerEndpoint> servers;
     final ServerSelector selector;
-    private ListOfServers(List<EndpointServer> servers, ServerSelector selector) {
+    private ListOfServers(List<ServerEndpoint> servers, ServerSelector selector) {
       this.servers = servers;
       this.selector = selector;
     }
     @Override
-    public Iterator<EndpointServer> iterator() {
+    public Iterator<ServerEndpoint> iterator() {
       return servers.iterator();
     }
     @Override
@@ -222,12 +222,12 @@ public class EndpointResolverImpl<S, A extends Address, N> implements EndpointRe
     }
   }
 
-  public class EndpointServerImpl implements EndpointServer {
+  public class ServerEndpointImpl implements ServerEndpoint {
     final AtomicLong lastAccessed;
     final String key;
     final N endpoint;
     final InteractionMetrics<?> metrics;
-    public EndpointServerImpl(AtomicLong lastAccessed, String key, N endpoint, InteractionMetrics<?> metrics) {
+    public ServerEndpointImpl(AtomicLong lastAccessed, String key, N endpoint, InteractionMetrics<?> metrics) {
       this.lastAccessed = lastAccessed;
       this.key = key;
       this.endpoint = endpoint;
@@ -288,14 +288,14 @@ public class EndpointResolverImpl<S, A extends Address, N> implements EndpointRe
     EndpointBuilder<ListOfServers, N> builder = new EndpointBuilder<>() {
       @Override
       public EndpointBuilder<ListOfServers, N> addServer(N server, String key) {
-        List<EndpointServer> list = new ArrayList<>();
+        List<ServerEndpoint> list = new ArrayList<>();
         InteractionMetrics<?> metrics = loadBalancer.newMetrics();
-        list.add(new EndpointServerImpl(lastAccessed, key, server, metrics));
+        list.add(new ServerEndpointImpl(lastAccessed, key, server, metrics));
         return new EndpointBuilder<>() {
           @Override
           public EndpointBuilder<ListOfServers, N> addServer(N server, String key) {
             InteractionMetrics<?> metrics = loadBalancer.newMetrics();
-            list.add(new EndpointServerImpl(lastAccessed, key, server, metrics));
+            list.add(new ServerEndpointImpl(lastAccessed, key, server, metrics));
             return this;
           }
           @Override

--- a/vertx-core/src/test/java/io/vertx/test/fakeloadbalancer/FakeLoadBalancer.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakeloadbalancer/FakeLoadBalancer.java
@@ -1,6 +1,6 @@
 package io.vertx.test.fakeloadbalancer;
 
-import io.vertx.core.net.endpoint.EndpointServer;
+import io.vertx.core.net.endpoint.ServerEndpoint;
 import io.vertx.core.net.endpoint.ServerSelector;
 import io.vertx.core.net.endpoint.LoadBalancer;
 import io.vertx.core.net.endpoint.InteractionMetrics;
@@ -10,9 +10,9 @@ import java.util.List;
 
 public class FakeLoadBalancer implements LoadBalancer {
 
-  List<? extends EndpointServer> endpoints;
+  List<? extends ServerEndpoint> endpoints;
 
-  public List<? extends EndpointServer> endpoints() {
+  public List<? extends ServerEndpoint> endpoints() {
     return endpoints;
   }
 
@@ -22,7 +22,7 @@ public class FakeLoadBalancer implements LoadBalancer {
   }
 
   @Override
-  public ServerSelector selector(List<? extends EndpointServer> listOfServers) {
+  public ServerSelector selector(List<? extends ServerEndpoint> listOfServers) {
     this.endpoints = listOfServers;
     return LoadBalancer.ROUND_ROBIN.selector(listOfServers);
   }

--- a/vertx-core/src/test/java/io/vertx/test/fakeresolver/FakeEndpointResolver.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakeresolver/FakeEndpointResolver.java
@@ -5,7 +5,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.net.Address;
 import io.vertx.core.net.AddressResolver;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.net.endpoint.EndpointServer;
+import io.vertx.core.net.endpoint.ServerEndpoint;
 import io.vertx.core.spi.endpoint.EndpointResolver;
 import io.vertx.core.spi.endpoint.EndpointBuilder;
 
@@ -63,7 +63,7 @@ public class FakeEndpointResolver<B> implements AddressResolver, EndpointResolve
       Iterator s1 = ((Iterable) state.state.get().endpoints).iterator();
       List<FakeEndpoint> list = new ArrayList<>();
       for (Object o : ((Iterable) state.state.get().endpoints)) {
-        EndpointServer instance = (EndpointServer) o;
+        ServerEndpoint instance = (ServerEndpoint) o;
         list.add((FakeEndpoint) instance.unwrap());
       }
       return list;

--- a/vertx-core/src/test/java/io/vertx/test/fakeresolver/FakeEndpointResolver.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakeresolver/FakeEndpointResolver.java
@@ -16,12 +16,22 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 public class FakeEndpointResolver<B> implements AddressResolver, EndpointResolver<FakeAddress, FakeEndpoint, FakeState<B>, B> {
 
+  public static class Endpoint {
+    final List<SocketAddress> addresses;
+    final boolean valid;
+    public Endpoint(List<SocketAddress> addresses, boolean valid) {
+      this.addresses = addresses;
+      this.valid = valid;
+    }
+  }
+
   class LazyFakeState {
     final String name;
-    volatile List<SocketAddress> endpoints;
+    volatile Supplier<Endpoint> endpointSupplier;
     AtomicReference<FakeState<B>> state = new AtomicReference<>();
     LazyFakeState(String name) {
       this.name = name;
@@ -31,8 +41,12 @@ public class FakeEndpointResolver<B> implements AddressResolver, EndpointResolve
   private final ConcurrentMap<String, LazyFakeState> map = new ConcurrentHashMap<>();
 
   public void registerAddress(String name, List<SocketAddress> endpoints) {
+    registerAddress(name, () -> new Endpoint(endpoints, true));
+  }
+
+  public void registerAddress(String name, Supplier<Endpoint> supplier) {
     LazyFakeState lazy = map.computeIfAbsent(name, LazyFakeState::new);
-    lazy.endpoints = endpoints;
+    lazy.endpointSupplier = supplier;
     FakeState prev = lazy.state.getAndSet(null);
     if (prev != null) {
       prev.isValid = false;
@@ -71,11 +85,13 @@ public class FakeEndpointResolver<B> implements AddressResolver, EndpointResolve
   public Future<FakeState<B>> resolve(FakeAddress address, EndpointBuilder<B, FakeEndpoint> builder) {
     LazyFakeState state = map.get(address.name());
     if (state != null) {
-      if (state.state.get() == null) {
-        for (SocketAddress socketAddress : state.endpoints) {
+      FakeState<B> blah = state.state.get();
+      if (blah == null || !blah.isValid) {
+        Endpoint endpoint = state.endpointSupplier.get();
+        for (SocketAddress socketAddress : endpoint.addresses) {
           builder = builder.addServer(new FakeEndpoint(socketAddress));
         }
-        state.state.set(new FakeState<>(state.name, builder.build()));
+        state.state.set(new FakeState<>(state.name, builder.build(), endpoint.valid));
       }
       return Future.succeededFuture(state.state.get());
     } else {

--- a/vertx-core/src/test/java/io/vertx/test/fakeresolver/FakeState.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakeresolver/FakeState.java
@@ -6,9 +6,9 @@ public class FakeState<B> {
   final B endpoints;
   volatile boolean isValid;
 
-  FakeState(String name, B endpoints) {
+  FakeState(String name, B endpoints, boolean valid) {
     this.name = name;
     this.endpoints = endpoints;
-    this.isValid = true;
+    this.isValid = valid;
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/addressresolver/ResolvingHttpClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/addressresolver/ResolvingHttpClientTest.java
@@ -9,7 +9,7 @@ import io.vertx.core.http.impl.HttpClientImpl;
 import io.vertx.core.internal.http.HttpClientInternal;
 import io.vertx.core.net.endpoint.LoadBalancer;
 import io.vertx.core.net.*;
-import io.vertx.core.net.endpoint.EndpointServer;
+import io.vertx.core.net.endpoint.ServerEndpoint;
 import io.vertx.core.spi.endpoint.EndpointBuilder;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakeloadbalancer.FakeLoadBalancer;
@@ -335,7 +335,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
         .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body)
       ).await();
-    FakeLoadBalancer.FakeLoadBalancerMetrics<?> endpoint = (FakeLoadBalancer.FakeLoadBalancerMetrics<?>) ((EndpointServer) lb.endpoints().get(0)).metrics();
+    FakeLoadBalancer.FakeLoadBalancerMetrics<?> endpoint = (FakeLoadBalancer.FakeLoadBalancerMetrics<?>) ((ServerEndpoint) lb.endpoints().get(0)).metrics();
     FakeLoadBalancer.FakeMetric metric = endpoint.metrics2().get(0);
     assertTrue(metric.requestEnd() - metric.requestBegin() >= 0);
     assertTrue(metric.responseBegin() - metric.requestEnd() >= 500);

--- a/vertx-core/src/test/java/io/vertx/tests/endpoint/LoadBalancingCornerCasesTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/endpoint/LoadBalancingCornerCasesTest.java
@@ -33,13 +33,13 @@ public class LoadBalancingCornerCasesTest {
 
   @Test
   public void testCornerCases() {
-    List<EndpointServer> instances = new ArrayList<>();
+    List<ServerEndpoint> instances = new ArrayList<>();
     ServerSelector selector = loadBalancer.selector(instances);
     // Randomness is involved in some policies.
     for (int i = 0; i < 1000; i++) {
       assertEquals(-1, selector.select());
     }
-    EndpointServer instance = new EndpointServer() {
+    ServerEndpoint instance = new ServerEndpoint() {
       InteractionMetrics<?> metrics = loadBalancer.newMetrics();
       @Override
       public SocketAddress address() {

--- a/vertx-core/src/test/java/io/vertx/tests/endpoint/LoadBalancingTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/endpoint/LoadBalancingTest.java
@@ -25,9 +25,9 @@ import static org.junit.Assert.assertTrue;
 
 public class LoadBalancingTest {
 
-  EndpointServer endpointOf(LoadBalancer loadBalancer) {
+  ServerEndpoint endpointOf(LoadBalancer loadBalancer) {
     InteractionMetrics<?> metrics = loadBalancer.newMetrics();
-    return new EndpointServer() {
+    return new ServerEndpoint() {
       @Override
       public SocketAddress address() {
         return null;
@@ -53,10 +53,10 @@ public class LoadBalancingTest {
 
   @Test
   public void testRoundRobin() throws Exception {
-    EndpointServer e1 = endpointOf(ROUND_ROBIN);
-    EndpointServer e2 = endpointOf(ROUND_ROBIN);
-    EndpointServer e3 = endpointOf(ROUND_ROBIN);
-    List<EndpointServer> metrics = Arrays.asList(e1, e2, e3);
+    ServerEndpoint e1 = endpointOf(ROUND_ROBIN);
+    ServerEndpoint e2 = endpointOf(ROUND_ROBIN);
+    ServerEndpoint e3 = endpointOf(ROUND_ROBIN);
+    List<ServerEndpoint> metrics = Arrays.asList(e1, e2, e3);
     ServerSelector selector = ROUND_ROBIN.selector(metrics);
     assertEquals(0, selector.select());
     assertEquals(1, selector.select());
@@ -68,7 +68,7 @@ public class LoadBalancingTest {
 
   @Test
   public void testLeastRequests() throws Exception {
-    List<EndpointServer> metrics = new ArrayList<>();
+    List<ServerEndpoint> metrics = new ArrayList<>();
     int num = 6;
     for (int i = 0;i < num;i++) {
       metrics.add(endpointOf(LEAST_REQUESTS));
@@ -84,7 +84,7 @@ public class LoadBalancingTest {
 
   @Test
   public void testRandom() throws Exception {
-    List<EndpointServer> metrics = new ArrayList<>();
+    List<ServerEndpoint> metrics = new ArrayList<>();
     int num = 6;
     for (int i = 0;i < num;i++) {
       metrics.add(endpointOf(RANDOM));
@@ -99,15 +99,15 @@ public class LoadBalancingTest {
   @Test
   public void testPowerOfTwoChoices() throws Exception {
     for (int i = 0; i < 1000; i++) {
-      EndpointServer e1 = endpointOf(POWER_OF_TWO_CHOICES);
-      EndpointServer e2 = endpointOf(POWER_OF_TWO_CHOICES);
-      List<EndpointServer> metrics = Arrays.asList(e1, e2);
+      ServerEndpoint e1 = endpointOf(POWER_OF_TWO_CHOICES);
+      ServerEndpoint e2 = endpointOf(POWER_OF_TWO_CHOICES);
+      List<ServerEndpoint> metrics = Arrays.asList(e1, e2);
       e2.metrics().initiateRequest();
       ServerSelector selector = LoadBalancer.POWER_OF_TWO_CHOICES.selector(metrics);
       assertEquals(0, selector.select());
     }
 
-    List<EndpointServer> metrics = new ArrayList<>();
+    List<ServerEndpoint> metrics = new ArrayList<>();
     int num = 6;
     for (int i = 0;i < num;i++) {
       metrics.add(endpointOf(POWER_OF_TWO_CHOICES));
@@ -121,9 +121,9 @@ public class LoadBalancingTest {
 
   @Test
   public void testConsistentHashing() {
-    EndpointServer e1 = endpointOf(CONSISTENT_HASHING);
-    EndpointServer e2 = endpointOf(CONSISTENT_HASHING);
-    EndpointServer e3 = endpointOf(CONSISTENT_HASHING);
+    ServerEndpoint e1 = endpointOf(CONSISTENT_HASHING);
+    ServerEndpoint e2 = endpointOf(CONSISTENT_HASHING);
+    ServerEndpoint e3 = endpointOf(CONSISTENT_HASHING);
     ServerSelector selector = LoadBalancer.CONSISTENT_HASHING.selector(Arrays.asList(e1, e2, e3));
     int num = 100;
     List<String> ids = new ArrayList<>(num);

--- a/vertx-core/src/test/java/io/vertx/tests/endpoint/MappingResolverTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/endpoint/MappingResolverTest.java
@@ -16,7 +16,7 @@ import io.vertx.core.net.Address;
 import io.vertx.core.net.AddressResolver;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.endpoint.Endpoint;
-import io.vertx.core.net.endpoint.EndpointServer;
+import io.vertx.core.net.endpoint.ServerEndpoint;
 import io.vertx.core.net.endpoint.LoadBalancer;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakeresolver.FakeAddress;
@@ -47,7 +47,7 @@ public class MappingResolverTest extends VertxTestBase {
     FakeAddress lookup = new FakeAddress("svc");
     mapping = addr -> Collections.singletonList(SocketAddress.inetSocketAddress(80, addr.toString()));
     Endpoint endpoint = awaitFuture(endpointResolver.resolveEndpoint(lookup));
-    EndpointServer node = endpoint.selectServer();
+    ServerEndpoint node = endpoint.selectServer();
     assertEquals("ServiceName(svc)", node.address().host());
     assertEquals(80, node.address().port());
   }


### PR DESCRIPTION
Currently it checks the state is still valid before accessing it which does not have a lot of value and is debatable.

Instead on each access we should check whether the state remains valid so it can be fetched when the state is not anymore valid.
