### PR TITLE
Execute blocking operations and context worker tasks should be concurrent

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -127,7 +127,7 @@ final class DuplicatedContext extends ContextBase implements ContextInternal {
 
   @Override
   public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
-    return delegate.workerPool.executeBlocking(this, blockingCodeHandler, ordered ? delegate.orderedTasks : null);
+    return delegate.workerPool.executeBlocking(this, blockingCodeHandler, ordered ? delegate.executeBlockingTasks : null);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.impl;
 
+import io.vertx.core.Future;
 import io.vertx.core.ThreadingModel;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.EventExecutor;
@@ -42,10 +43,10 @@ public class WorkerExecutor implements EventExecutor {
   }
 
   private final WorkerPool workerPool;
-  private final TaskQueue orderedTasks;
+  private final WorkerTaskQueue orderedTasks;
   private final ThreadLocal<Boolean> inThread = new ThreadLocal<>();
 
-  public WorkerExecutor(WorkerPool workerPool, TaskQueue orderedTasks) {
+  public WorkerExecutor(WorkerPool workerPool, WorkerTaskQueue orderedTasks) {
     this.workerPool = workerPool;
     this.orderedTasks = orderedTasks;
   }
@@ -72,6 +73,10 @@ public class WorkerExecutor implements EventExecutor {
       }
     };
     orderedTasks.execute(task, workerPool.executor());
+  }
+
+  WorkerTaskQueue taskQueue() {
+    return orderedTasks;
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
@@ -62,7 +62,7 @@ class WorkerExecutorImpl implements MetricsProvider, WorkerExecutorInternal {
   public <T> Future<@Nullable T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
     ContextInternal context = vertx.getOrCreateContext();
     ContextImpl impl = context instanceof DuplicatedContext ? ((DuplicatedContext)context).delegate : (ContextImpl) context;
-    return pool.executeBlocking(context, blockingCodeHandler, ordered ? impl.orderedTasks : null);
+    return pool.executeBlocking(context, blockingCodeHandler, ordered ? impl.executeBlockingTasks : null);
   }
 
   @Override

--- a/vertx-core/src/test/java/io/vertx/benchmarks/BenchmarkContext.java
+++ b/vertx-core/src/test/java/io/vertx/benchmarks/BenchmarkContext.java
@@ -42,7 +42,6 @@ public class BenchmarkContext {
       ThreadingModel.WORKER,
       EXECUTOR,
       impl.getWorkerPool(),
-      new WorkerTaskQueue(),
       null,
       null,
       Thread.currentThread().getContextClassLoader()

--- a/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
@@ -401,6 +401,27 @@ public class ContextTest extends VertxTestBase {
   }
 
   @Test
+  public void testExecuteBlockingUseItsOwnTaskQueue() {
+    Context ctx = ((VertxInternal)vertx).createWorkerContext();
+    CountDownLatch latch = new CountDownLatch(1);
+    ctx.runOnContext(v -> {
+      ctx.executeBlocking(() -> {
+        latch.countDown();
+        return 0;
+      });
+      boolean timedOut;
+      try {
+        timedOut = !latch.await(10, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      assertFalse(timedOut);
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
   public void testEventLoopContextDispatchReportsFailure() {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
     RuntimeException failure = new RuntimeException();


### PR DESCRIPTION
Motivation:

Execute blocking operations use the context ordered task queue shared with context worker tasks. This prevents context execute blocking tasks to be executed concurrently with worker tasks, e.g. an execute blocking task prevents virtual thread context tasks to be executed.

Changes:

The context ordered task queue is now encapsulated in the worker event executor and not anymore part of the context. The context now creates an internal task queue for execute blocking tasks. As consequence worker contexts have dedicated task queue for context tasks / execute blocking ordered tasks. Event loop contexts still have a single task queue for execute blocking ordered tasks.
