### PR TITLE
Improve documentation consistency #5369

### DIFF
--- a/vertx-core/src/main/java/examples/CoreExamples.java
+++ b/vertx-core/src/main/java/examples/CoreExamples.java
@@ -50,8 +50,7 @@ public class CoreExamples {
   public void example4(HttpServerRequest request) {
     HttpServerResponse response = request.response();
     response.putHeader("Content-Type", "text/plain");
-    response.write("some text");
-    response.end();
+    response.end("some text");
   }
 
   public void example5(Vertx vertx) {


### PR DESCRIPTION
Motivation:

As described in #5369 :

The documentation at https://vertx.io/docs/vertx-core/java/#_are_you_fluent compares two code snippets; (1) using a fluent API:

```Java
  public void example3(HttpServerRequest request) {
    request.response().putHeader("Content-Type", "text/plain").end("some text");
  }
```

(2) and the non-fluent approach:

```Java
  public void example4(HttpServerRequest request) {
    HttpServerResponse response = request.response();
    response.putHeader("Content-Type", "text/plain");
    response.write("some text");
    response.end();
  }
```

The first example writes using the `end` method, while the second example also call `write`. I suggest making both examples write in the same way, so that the focus stays on the difference in style.

This PR changes the second example to:

```Java
  public void example4(HttpServerRequest request) {
    HttpServerResponse response = request.response();
    response.putHeader("Content-Type", "text/plain");
    response.end("some text");
  }
```