### PR TITLE
Possibility to use io.vertx.core.VertxBuilder inside io.vertx.core.impl.launcher.VertxLifecycleHooks

### DIFF
--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -20,21 +20,16 @@ import io.vertx.core.dns.DnsClientOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.*;
-import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.VertxBuilder.VertxBuilderBridge;
 import io.vertx.core.impl.VertxImpl;
 import io.vertx.core.metrics.Measured;
-import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.shareddata.SharedData;
 import io.vertx.core.spi.VerticleFactory;
-import io.vertx.core.spi.VertxMetricsFactory;
-import io.vertx.core.spi.VertxTracerFactory;
-import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.streams.ReadStream;
-import io.vertx.core.tracing.TracingOptions;
 
 import java.util.Objects;
 import java.util.Set;
@@ -72,64 +67,7 @@ import java.util.function.Supplier;
 public interface Vertx extends Measured {
 
   static VertxBuilder builder() {
-    return new io.vertx.core.VertxBuilder() {
-      VertxOptions options;
-      VertxTracerFactory tracerFactory;
-      VertxMetricsFactory metricsFactory;
-      ClusterManager clusterManager;
-      @Override
-      public VertxBuilder with(VertxOptions options) {
-        this.options = options;
-        return this;
-      }
-      @Override
-      public VertxBuilder withTracer(VertxTracerFactory factory) {
-        this.tracerFactory = factory;
-        return this;
-      }
-      @Override
-      public VertxBuilder withClusterManager(ClusterManager clusterManager) {
-        this.clusterManager = clusterManager;
-        return this;
-      }
-      @Override
-      public VertxBuilder withMetrics(VertxMetricsFactory factory) {
-        this.metricsFactory = factory;
-        return this;
-      }
-      private io.vertx.core.impl.VertxBuilder internalBuilder() {
-        VertxOptions opts = options != null ? options : new VertxOptions();
-        if (clusterManager != null) {
-          opts.setClusterManager(clusterManager);
-        }
-        if (metricsFactory != null) {
-          MetricsOptions metricsOptions = opts.getMetricsOptions();
-          if (metricsOptions != null) {
-            metricsOptions.setFactory(metricsFactory);
-          } else {
-            opts.setMetricsOptions(new MetricsOptions().setFactory(metricsFactory));
-          }
-          metricsOptions.setEnabled(true);
-        }
-        if (tracerFactory != null) {
-          TracingOptions tracingOptions = opts.getTracingOptions();
-          if (tracingOptions != null) {
-            tracingOptions.setFactory(tracerFactory);
-          } else {
-            opts.setTracingOptions(new TracingOptions().setFactory(tracerFactory));
-          }
-        }
-        return new io.vertx.core.impl.VertxBuilder(opts).init();
-      }
-      @Override
-      public Vertx build() {
-        return internalBuilder().vertx();
-      }
-      @Override
-      public Future<Vertx> buildClustered() {
-        return Future.future(p -> internalBuilder().clusteredVertx(p));
-      }
-    };
+    return new VertxBuilderBridge();
   }
 
   /**

--- a/src/main/java/io/vertx/core/impl/VertxBuilder.java
+++ b/src/main/java/io/vertx/core/impl/VertxBuilder.java
@@ -11,17 +11,24 @@
 
 package io.vertx.core.impl;
 
-import io.vertx.core.*;
-import io.vertx.core.impl.transports.EpollTransport;
-import io.vertx.core.impl.transports.JDKTransport;
-import io.vertx.core.impl.transports.KQueueTransport;
-import io.vertx.core.spi.file.FileResolver;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.ServiceHelper;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.file.impl.FileResolverImpl;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.impl.transports.EpollTransport;
+import io.vertx.core.impl.transports.JDKTransport;
+import io.vertx.core.impl.transports.KQueueTransport;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;
-import io.vertx.core.spi.transport.Transport;
 import io.vertx.core.spi.ExecutorServiceFactory;
 import io.vertx.core.spi.VertxMetricsFactory;
 import io.vertx.core.spi.VertxServiceProvider;
@@ -30,13 +37,11 @@ import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.cluster.NodeSelector;
 import io.vertx.core.spi.cluster.impl.DefaultNodeSelector;
+import io.vertx.core.spi.file.FileResolver;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.spi.transport.Transport;
 import io.vertx.core.tracing.TracingOptions;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
 
 /**
  * Vertx builder for creating vertx instances with SPI overrides.
@@ -475,17 +480,18 @@ public class VertxBuilder {
 					opts.setTracingOptions(new TracingOptions().setFactory(tracerFactory));
 				}
 			}
-			return new io.vertx.core.impl.VertxBuilder(opts).init();
+			
+			return new io.vertx.core.impl.VertxBuilder(opts); 
 		}
 
 		@Override
 		public Vertx build() {
-			return internalBuilder().vertx();
+			return internalBuilder().init().vertx();
 		}
 
 		@Override
 		public Future<Vertx> buildClustered() {
-			return Future.future(p -> internalBuilder().clusteredVertx(p));
+			return Future.future(p -> internalBuilder().init().clusteredVertx(p));
 		}
 	}
   

--- a/src/main/java/io/vertx/core/impl/launcher/VertxLifecycleHooks.java
+++ b/src/main/java/io/vertx/core/impl/launcher/VertxLifecycleHooks.java
@@ -15,6 +15,7 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.impl.VertxBuilder;
+import io.vertx.core.impl.VertxBuilder.VertxBuilderBridge;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tracing.VertxTracer;
 
@@ -40,9 +41,13 @@ public interface VertxLifecycleHooks {
    *
    * @param config the Vert.x options to use, in JSON format
    * @return the Vert.x builder instance
-   */
+   */  
   default VertxBuilder createVertxBuilder(JsonObject config) {
-    return config == null ? new VertxBuilder() : new VertxBuilder(config);
+	  final VertxBuilderBridge vertxBuilder = new VertxBuilder.VertxBuilderBridge();
+	  if (config != null)
+		  vertxBuilder.with(new VertxOptions(config));
+	  
+	  return vertxBuilder.internalBuilder();
   }
 
   /**


### PR DESCRIPTION
Vertx 4.5.10 introduced new "Deprecations and breaking changes", especially: Deprecate setting a MeterRegistry on MicrometerMetricsOptions
https://github.com/vert-x3/wiki/wiki/4.5.10-Deprecations-and-breaking-changes
The new way to configure "MicrometerMetricsFactory" is to use io.vertx.core.VertxBuilder.withMetrics(...) method
But there is no possibility to do this from "io.vertx.core.Launcher" - because only "io.vertx.core.VertxOptions" are accessible for configuration purposes, which is not enough now and code warn about usage of deprecated "io.vertx.micrometer.MicrometerMetricsOptions.setMicrometerRegistry(MeterRegistry)"

Vertx 4.5.11 introduced new method for customizing VertxBuilder inside "io.vertx.core.impl.launcher.VertxLifecycleHooks"
https://github.com/eclipse-vertx/vert.x/pull/5288
But this method allowing to customize internal "io.vertx.core.impl.VertxBuilder" which is not helping to fix deprecations

Currently "io.vertx.core.VertxBuilder" have one implementation, inlined  in Vertx class, which have private method "internalBuilder()" for is creating internal VertxBuilder with provided configuration and initializing it

This PR doing the next:
1. Moving "io.vertx.core.VertxBuilder" implementation from Vertx class to io.vertx.core.impl.VertxBuilder as "VertxBuilderBridge" class (maybe name and place should be adjusted)
2. Method internalBuilder() made public
3. Moved internal builder init() invocation from internalBuilder() method to build() and buildClustered() methods
4. Used "VertxBuilderBridge" class as "io.vertx.core.VertxBuilder" in Vertx class instead of inlined implementation
5. Used "VertxBuilderBridge" class as example in "io.vertx.core.impl.launcher.VertxLifecycleHooks.createVertxBuilder(JsonObject)" default implementation

This is enough to fix new deprecations from inside Launcher API to configure all required things that now require public VertxBuilder by overriding "io.vertx.core.impl.launcher.VertxLifecycleHooks.createVertxBuilder(JsonObject)" and using it in the same way as in default implementation