### PR TITLE
Use 3 nodes for clustered all tests

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/shareddata/ClusteredAsyncMapTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/shareddata/ClusteredAsyncMapTest.java
@@ -19,20 +19,36 @@ import io.vertx.core.Vertx;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.test.fakecluster.FakeClusterManager;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class ClusteredAsyncMapTest extends AsyncMapTest {
 
-  int pos;
+  protected final int numNodes = 3;
+  AtomicInteger pos = new AtomicInteger();
+
+  public void setUp() throws Exception {
+    super.setUp();
+    startNodes(numNodes);
+  }
+
+  @Override
+  protected ClusterManager getClusterManager() {
+    return new FakeClusterManager();
+  }
 
   @Override
   protected Vertx getVertx() {
-    Vertx vertx = vertices[pos];
-    if (++pos == getNumNodes()) {
-      pos = 0;
-    }
-    return vertx;
+    int i = pos.incrementAndGet();
+    i = mod(i, numNodes);
+    return vertices[i];
+  }
+
+  private int mod(int idx, int size) {
+    int i = idx % size;
+    return i < 0 ? i + size : i;
   }
 
   @Test
@@ -59,17 +75,4 @@ public class ClusteredAsyncMapTest extends AsyncMapTest {
     await();
   }
 
-  public void setUp() throws Exception {
-    super.setUp();
-    startNodes(getNumNodes());
-  }
-
-  protected int getNumNodes() {
-    return 2;
-  }
-
-  @Override
-  protected ClusterManager getClusterManager() {
-    return new FakeClusterManager();
-  }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/shareddata/ClusteredAsynchronousLockTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/shareddata/ClusteredAsynchronousLockTest.java
@@ -30,19 +30,18 @@ import java.util.function.Consumer;
  */
 public class ClusteredAsynchronousLockTest extends AsynchronousLockTest {
 
-  @Override
-  protected ClusterManager getClusterManager() {
-    return new FakeClusterManager();
-  }
-
   protected final int numNodes = 3;
+  AtomicInteger pos = new AtomicInteger();
 
   public void setUp() throws Exception {
     super.setUp();
     startNodes(numNodes);
   }
 
-  AtomicInteger pos = new AtomicInteger();
+  @Override
+  protected ClusterManager getClusterManager() {
+    return new FakeClusterManager();
+  }
 
   @Override
   protected Vertx getVertx() {

--- a/vertx-core/src/test/java/io/vertx/tests/shareddata/ClusteredSharedCounterTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/shareddata/ClusteredSharedCounterTest.java
@@ -19,21 +19,36 @@ import io.vertx.core.Vertx;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.test.fakecluster.FakeClusterManager;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class ClusteredSharedCounterTest extends SharedCounterTest {
+
+  protected final int numNodes = 3;
+  AtomicInteger pos = new AtomicInteger();
+
+  public void setUp() throws Exception {
+    super.setUp();
+    startNodes(numNodes);
+  }
 
   @Override
   protected ClusterManager getClusterManager() {
     return new FakeClusterManager();
   }
 
-  protected final int numNodes = 2;
+  @Override
+  protected Vertx getVertx() {
+    int i = pos.incrementAndGet();
+    i = mod(i, numNodes);
+    return vertices[i];
+  }
 
-  public void setUp() throws Exception {
-    super.setUp();
-    startNodes(numNodes);
+  private int mod(int idx, int size) {
+    int i = idx % size;
+    return i < 0 ? i + size : i;
   }
 
   @Test
@@ -56,16 +71,5 @@ public class ClusteredSharedCounterTest extends SharedCounterTest {
     }));
     await();
   }
-
-  int pos;
-  @Override
-  protected Vertx getVertx() {
-    Vertx vertx = vertices[pos];
-    if (++pos == numNodes) {
-      pos = 0;
-    }
-    return vertx;
-  }
-
 
 }


### PR DESCRIPTION
Motivation:

`ClusteredSharedCounterTest` uses only 2 nodes. When testing with Hazelcast CP subsystem, we need 3 nodes, using 3 nodes makes it easier for us to re-use the test.

I have also unified the common parts in the clustered tests. There is some code duplication, but we can't simply create a common parent to move the code there, because they already extend other classes. Maybe a junit rule would make sense here. Let me know if you want to do something with the duplication, it was already there before this PR.