### PR TITLE
HTTP client stream should handle a write to a stream which has been reset without having being allocated

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -546,6 +546,9 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
 
     @Override
     public void writeHead(HttpRequestHead request, boolean chunked, ByteBuf buf, boolean end, StreamPriority priority, boolean connect, Handler<AsyncResult<Void>> handler) {
+      if (checkReset(handler)) {
+        return;
+      }
       priority(priority);
       ContextInternal ctx = conn.getContext();
       EventLoop eventLoop = ctx.nettyEventLoop();
@@ -629,6 +632,9 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
 
     @Override
     public void writeBuffer(ByteBuf buf, boolean end, Handler<AsyncResult<Void>> listener) {
+      if (checkReset(listener)) {
+        return;
+      }
       if (buf != null) {
         int size = buf.readableBytes();
         synchronized (this) {

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -5855,6 +5855,20 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
+  public void testResetPartialClientRequest() throws Exception {
+    server.requestHandler(req -> {
+    });
+    startServer(testAddress);
+    client.request(requestOptions).onComplete(onSuccess(req -> {
+      assertTrue(req.reset());
+      req.end("body").onComplete(onFailure(err -> {
+        testComplete();
+      }));
+    }));
+    await();
+  }
+
+  @Test
   public void testSimpleCookie() throws Exception {
     testCookies("foo=bar", req -> {
       assertEquals(1, req.cookieCount());


### PR DESCRIPTION
Motivation:

Vert.x HTTP client stream does not allocate a stream when the stream has been reset by the application before its allocation. When such stream is being written, the stream behaves normally and fails since the internal state is not correct.

Changes:

Record the reset state of a stream and guard against writes in such case.
