### PR TITLE
HTTP stream reset should be asynchronous.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -437,7 +437,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    *
    * @see #reset(long)
    */
-  default boolean reset() {
+  default Future<Void> reset() {
     return reset(0L);
   }
 
@@ -455,7 +455,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    * @param code the error code
    * @return {@code true} when reset has been performed
    */
-  boolean reset(long code);
+  Future<Void> reset(long code);
 
   /**
    * Reset this request:
@@ -472,7 +472,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    * @param cause an optional cause that can be attached to the error code
    * @return true when reset has been performed
    */
-  boolean reset(long code, Throwable cause);
+  Future<Void> reset(long code, Throwable cause);
 
   /**
    * @return the {@link HttpConnection} associated with this request

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -468,7 +468,7 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   /**
    * Reset this HTTP/2 stream with the error code {@code 0}.
    */
-  default boolean reset() {
+  default Future<Void> reset() {
     return reset(0L);
   }
 
@@ -485,7 +485,7 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    * @param code the error code
    * @return {@code true} when reset has been performed
    */
-  boolean reset(long code);
+  Future<Void> reset(long code);
 
   /**
    * Write an HTTP/2 frame to the response, allowing to extend the HTTP/2 protocol.<p>

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -693,14 +693,14 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public boolean reset(long code) {
+  public Future<Void> reset(long code) {
     synchronized (conn) {
       if (written) {
-        return false;
+        return context.failedFuture("Response written");
       }
     }
     conn.close();
-    return true;
+    return context.succeededFuture();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -177,7 +177,7 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
         stream = createStream(headers, endOfStream);
       }
       if (isMalformedRequest(stream)) {
-        handler.writeReset(streamId, Http2Error.PROTOCOL_ERROR.code());
+        handler.writeReset(streamId, Http2Error.PROTOCOL_ERROR.code(), null);
         return;
       }
       initStream(streamId, stream);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -608,9 +608,8 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
-  public boolean reset(long code) {
-    stream.writeReset(code);
-    return true;
+  public Future<Void> reset(long code) {
+    return stream.writeReset(code);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
@@ -145,9 +145,11 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
   }
 
   @Override
-  protected void doWriteReset(long code) {
+  protected void doWriteReset(long code, Promise<Void> promise) {
     if (!requestEnded || !responseEnded) {
-      super.doWriteReset(code);
+      super.doWriteReset(code, promise);
+    } else {
+      promise.fail("Request ended");
     }
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -229,8 +229,8 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
     }
 
     @Override
-    public void reset(Throwable cause) {
-      delegate.reset(cause);
+    public Future<Void> reset(Throwable cause) {
+      return delegate.reset(cause);
     }
 
     @Override
@@ -749,11 +749,11 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
     }
 
     @Override
-    public void reset(Throwable cause) {
+    public Future<Void> reset(Throwable cause) {
       if (upgradedStream != null) {
-        upgradedStream.reset(cause);
+        return upgradedStream.reset(cause);
       } else {
-        upgradingStream.reset(cause);
+        return upgradingStream.reset(cause);
       }
     }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -225,24 +225,23 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   }
 
   @Override
-  public boolean reset(long code) {
+  public Future<Void> reset(long code) {
     return reset(new StreamResetException(code));
   }
 
   @Override
-  public boolean reset(long code, Throwable cause) {
+  public Future<Void> reset(long code, Throwable cause) {
     return reset(new StreamResetException(code, cause));
   }
 
-  private boolean reset(Throwable cause) {
+  private Future<Void> reset(Throwable cause) {
     synchronized (this) {
       if (reset != null) {
-        return false;
+        return context.failedFuture("Already reset");
       }
       reset = cause;
     }
-    stream.reset(cause);
-    return true;
+    return stream.reset(cause);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -80,7 +80,7 @@ public interface HttpClientStream extends WriteStream<Buffer> {
   void doPause();
   void doFetch(long amount);
 
-  void reset(Throwable cause);
+  Future<Void> reset(Throwable cause);
 
   StreamPriority priority();
   void updatePriority(StreamPriority streamPriority);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
@@ -171,8 +171,8 @@ class StatisticsGatheringHttpClientStream implements HttpClientStream {
   }
 
   @Override
-  public void reset(Throwable cause) {
-    delegate.reset(cause);
+  public Future<Void> reset(Throwable cause) {
+    return delegate.reset(cause);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandler.java
@@ -287,8 +287,9 @@ class VertxHttp2ConnectionHandler<C extends Http2ConnectionBase> extends Http2Co
     checkFlush();
   }
 
-  void writeReset(int streamId, long code) {
-    encoder().writeRstStream(chctx, streamId, code, chctx.newPromise());
+  void writeReset(int streamId, long code, FutureListener<Void> listener) {
+    ChannelPromise promise = listener == null ? chctx.voidPromise() : chctx.newPromise().addListener(listener);
+    encoder().writeRstStream(chctx, streamId, code, promise);
     checkFlush();
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -2818,7 +2818,7 @@ public class Http1xTest extends HttpTest {
       req1.response().onComplete(onFailure(err -> {
         // Should never happen
       }));
-      assertTrue(req1.reset(0));
+      assertTrue(req1.reset(0).succeeded());
       for (String uri : Arrays.asList("/second", "/third")) {
         client
           .request(new RequestOptions(requestOptions).setURI(uri))
@@ -3007,13 +3007,14 @@ public class Http1xTest extends HttpTest {
           .onComplete(onSuccess(req -> {
             req.response().onComplete(onFailure(err -> {
             }));
-            assertTrue(req.reset());
-            client.request(new RequestOptions(requestOptions).setURI("some-uri"))
-              .compose(HttpClientRequest::send)
-              .onComplete(resp -> {
-                assertEquals(1, numReq.get());
-                complete();
-              });
+            req.reset().onComplete(onSuccess(v2 -> {
+              client.request(new RequestOptions(requestOptions).setURI("some-uri"))
+                .compose(HttpClientRequest::send)
+                .onComplete(resp -> {
+                  assertEquals(1, numReq.get());
+                  complete();
+                });
+            }));
           }));
       });
       await();
@@ -3075,7 +3076,7 @@ public class Http1xTest extends HttpTest {
             req2
               .response().onComplete(onFailure(err -> complete()));
             req2.sendHead().onComplete(onSuccess(v -> {
-              assertTrue(req2.reset());
+              assertTrue(req2.reset().succeeded());
             }));
           });
       }));
@@ -3142,7 +3143,7 @@ public class Http1xTest extends HttpTest {
           req2.response().onComplete(onFailure(resp -> complete()));
           req2.sendHead();
           doReset.thenAccept(v2 -> {
-            assertTrue(req2.reset());
+            assertTrue(req2.reset().succeeded());
           });
         }));
       });
@@ -3230,11 +3231,11 @@ public class Http1xTest extends HttpTest {
                 }));
             });
             req1.sendHead().onComplete(v -> {
-              assertTrue(req1.reset());
+              assertTrue(req1.reset().succeeded());
             });
           } else {
             req1.sendHead().onComplete(v -> {
-              assertTrue(req1.reset());
+              assertTrue(req1.reset().succeeded());
             });
             client.request(new RequestOptions(requestOptions).setURI("/somepath"))
               .compose(req -> req

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2Test.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2Test.java
@@ -227,7 +227,7 @@ public class Http2Test extends HttpTest {
     startServer(testAddress);
     client.request(requestOptions).onComplete(onSuccess(req -> {
       req.response().onComplete(onFailure(err -> complete()));
-      assertTrue(req.reset());
+      assertTrue(req.reset().succeeded());
     }));
     await();
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -4455,8 +4455,8 @@ public abstract class HttpTest extends HttpTestBase {
       public Future<Void> end(Buffer chunk) { throw new UnsupportedOperationException(); }
       public HttpClientRequest idleTimeout(long timeoutMs) { throw new UnsupportedOperationException(); }
       public HttpClientRequest pushHandler(Handler<HttpClientRequest> handler) { throw new UnsupportedOperationException(); }
-      public boolean reset(long code) { return false; }
-      public boolean reset(long code, Throwable cause) { return false; }
+      public Future<Void> reset(long code) { return Future.failedFuture(new UnsupportedOperationException()); }
+      public Future<Void> reset(long code, Throwable cause) { return Future.failedFuture(new UnsupportedOperationException()); }
       public HttpClientConnection connection() { throw new UnsupportedOperationException(); }
       public Future<Void> writeCustomFrame(int type, int flags, Buffer payload) { throw new UnsupportedOperationException(); }
       public boolean writeQueueFull() { throw new UnsupportedOperationException(); }
@@ -6276,7 +6276,7 @@ public abstract class HttpTest extends HttpTestBase {
     client = vertx.createHttpClient(createBaseClientOptions(), new PoolOptions().setHttp1MaxSize(1));
     Buffer chunk = Buffer.buffer(TestUtils.randomAlphaString(1024));
     client.request(requestOptions).onComplete(onSuccess(req1 -> {
-      assertTrue(req1.reset());
+      assertTrue(req1.reset().succeeded());
       new Thread(() -> {
         Context ctx = vertx.getOrCreateContext();
         ctx.runOnContext(v1 -> {


### PR DESCRIPTION
Motivation:

HTTP stream reset API was incorrectly designed to return a synchronous boolean indicating the outcome of the reset. Resetting a stream involves an interaction with the HTTP connection and instead should be asynchrnous.

Changes:

Change the HTTP stream API to asynchronous.
