### PR TITLE
HTTP client stream should handle a write to a stream which has been reset without having being allocated.

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -5864,6 +5864,20 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
+  public void testResetPartialClientRequest() throws Exception {
+    server.requestHandler(req -> {
+    });
+    startServer(testAddress);
+    client.request(requestOptions).onComplete(onSuccess(req -> {
+      assertTrue(req.reset().succeeded());
+      req.end("body").onComplete(onFailure(err -> {
+        testComplete();
+      }));
+    }));
+    await();
+  }
+
+  @Test
   public void testSimpleCookie() throws Exception {
     testCookies("foo=bar", req -> {
       assertEquals(1, req.cookieCount());


### PR DESCRIPTION
Motivation:

Vert.x HTTP client stream does not allocate a stream when the stream has been reset by the application before its allocation. When such stream is being written, the stream behaves normally and fails since the internal state is not correct.

Changes:

Record the reset state of a stream and guard against writes in such case.
