### PR TITLE
Add LocalSortedMap, a sorted local map

### DIFF
--- a/src/main/java/io/vertx/core/shareddata/LocalSortedMap.java
+++ b/src/main/java/io/vertx/core/shareddata/LocalSortedMap.java
@@ -1,0 +1,77 @@
+package io.vertx.core.shareddata;
+
+import java.util.SortedMap;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.shareddata.impl.LocalSortedMapImpl;
+
+/**
+ * A {@link LocalMap} which is also sorted.
+ */
+@VertxGen
+public interface LocalSortedMap<K extends Comparable<K>, V> extends LocalMap<K, V>, SortedMap<K, V> {
+
+  /**
+   * Creates a new {@link LocalSortedMapImpl} from this {@link LocalSortedMapImpl}
+   * which
+   * is
+   * a view from the portion of this map whose keys range from {@code fromKey},
+   * inclusive,
+   * to {@code toKey}, exclusive - as defined by
+   * {@link SortedMap#subMap(Object, Object)}.
+   * 
+   * <p>
+   * Additionally, the returned map is added to this Vert.x instance's local maps.
+   * Therefore,
+   * a new name is computed by appending {@code fromKey} and {@code toKey} to this
+   * map's name.
+   * 
+   * <pre>
+   * String subMapName = map.name + "_" + fromKey.hashCode() + "-" + toKey.hashCode();
+   * </pre>
+   * 
+   * <p>
+   * All invocations with the same {@code fromKey} and {@code toKey} are
+   * guaranteed
+   * to return the same sub map instance.
+   * 
+   * @see SortedMap#subMap(Object, Object)
+   */
+  @Override
+  public LocalSortedMap<K, V> subMap(K fromKey, K toKey);
+
+  /**
+   * Creates a new {@link LocalSortedMapImpl} from this {@link LocalSortedMapImpl}
+   * which
+   * is
+   * a view from the portion of this map whose keys are strictly less than
+   * {@code toKey} - as defined by {@link SortedMap#headMap(Object)}.
+   * 
+   * <p>
+   * All invocations with the same {@code toKey} are guaranteed to return the same
+   * sub map instance.
+   * 
+   * @see SortedMap#headMap(Object)
+   * @see #subMap(Object, Object)
+   */
+  @Override
+  public LocalSortedMap<K, V> headMap(K toKey);
+
+  /**
+   * Creates a new {@link LocalSortedMapImpl} from this {@link LocalSortedMapImpl}
+   * which
+   * is
+   * a view from the portion of this map whose keys are greater than or equal
+   * {@code fromKey} - as defined by {@link SortedMap#tailMap(Object)}.
+   * 
+   * <p>
+   * All invocations with the same {@code fromKey} are guaranteed to return the
+   * same sub map instance.
+   * 
+   * @see SortedMap#tailMap(Object)
+   * @see #subMap(Object, Object)
+   */
+  @Override
+  public LocalSortedMap<K, V> tailMap(K fromKey);
+
+}

--- a/src/main/java/io/vertx/core/shareddata/SharedData.java
+++ b/src/main/java/io/vertx/core/shareddata/SharedData.java
@@ -11,6 +11,8 @@
 
 package io.vertx.core.shareddata;
 
+import java.util.Comparator;
+
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -192,5 +194,20 @@ public interface SharedData {
    * @return the map
    */
   <K, V> LocalMap<K, V> getLocalMap(String name);
+
+  /**
+   * Return a <strong>sorted</strong> {@link LocalMap} with the specific {@code name}. The given
+   * {@code comparator} is used to define the sort order.
+   * 
+   * <p>
+   * Calling this method twice with the same {@code name} will return the same {@link LocalSortedMap}
+   * instance. Calling this method with a different {@code comparator} has no effect to an existing 
+   * map.
+   * 
+   * @param  name the name of the map
+   * @param  comparator a {@link Comparator} to define the sort order of the map
+   * @return the map
+   */
+  <K extends Comparable<K>, V> LocalSortedMap<K, V> getLocalSortedMap(String name);
 
 }

--- a/src/main/java/io/vertx/core/shareddata/impl/AbstractLocalMapImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/AbstractLocalMapImpl.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.shareddata.impl;
+
+import static io.vertx.core.shareddata.impl.Checker.checkType;
+import static io.vertx.core.shareddata.impl.Checker.copyIfRequired;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import io.vertx.core.shareddata.LocalMap;
+
+/**
+ * Encapsulates methods used commonly among {@link LocalMap} implementations.
+ * 
+ * @param <S> points to self, required for dealing with the
+ *            {@link #getAllLocalMaps() map of local maps}
+ */
+abstract class AbstractLocalMapImpl<K, V, S extends LocalMap<?, ?>> implements LocalMap<K, V> {
+
+  abstract String getName();
+
+  abstract ConcurrentMap<K, V> getInternalMap();
+
+  abstract ConcurrentMap<String, S> getAllLocalMaps();
+
+  @Override
+  public V get(Object key) {
+    return copyIfRequired(getInternalMap().get(key));
+  }
+
+  @Override
+  public V put(K key, V value) {
+    checkType(key);
+    checkType(value);
+    return getInternalMap().put(key, value);
+  }
+
+  @Override
+  public V remove(Object key) {
+    return copyIfRequired(getInternalMap().remove(key));
+  }
+
+  @Override
+  public void clear() {
+    getInternalMap().clear();
+  }
+
+  @Override
+  public int size() {
+    return getInternalMap().size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return getInternalMap().isEmpty();
+  }
+
+  @Override
+  public V putIfAbsent(K key, V value) {
+    checkType(key);
+    checkType(value);
+    return copyIfRequired(getInternalMap().putIfAbsent(key, value));
+  }
+
+  @Override
+  public boolean remove(Object key, Object value) {
+    return getInternalMap().remove(key, value);
+  }
+
+  @Override
+  public boolean replace(K key, V oldValue, V newValue) {
+    return getInternalMap().replace(key, oldValue, newValue);
+  }
+
+  @Override
+  public boolean removeIfPresent(K key, V value) {
+    return remove(key, value);
+  }
+
+  @Override
+  public boolean replaceIfPresent(K key, V oldValue, V newValue) {
+    checkType(key);
+    checkType(oldValue);
+    checkType(newValue);
+    return getInternalMap().replace(key, oldValue, newValue);
+  }
+
+  @Override
+  public V replace(K key, V value) {
+    checkType(key);
+    checkType(value);
+    return copyIfRequired(getInternalMap().replace(key, value));
+  }
+
+  @Override
+  public void replaceAll(BiFunction<? super K, ? super V, ? extends V> f) {
+    getInternalMap().replaceAll((k, v) -> {
+      checkType(k);
+      checkType(v);
+      V output = f.apply(k, v);
+      if (output != null) {
+        checkType(output);
+      }
+      return output;
+    });
+  }
+
+  @Override
+  public void close() {
+    getAllLocalMaps().remove(getName());
+  }
+
+  @Override
+  public Set<K> keySet() {
+    Set<K> keys = new HashSet<>(getInternalMap().size());
+    for (K k : getInternalMap().keySet()) {
+      keys.add(copyIfRequired(k));
+    }
+    return keys;
+  }
+
+  @Override
+  public Collection<V> values() {
+    List<V> values = new ArrayList<>(getInternalMap().size());
+    for (V v : getInternalMap().values()) {
+      values.add(copyIfRequired(v));
+    }
+    return values;
+  }
+
+  /**
+   * Composes the given bi-function ({@code f(a,b)}) with a function checking the
+   * type of the output:
+   * {@code checkType(f(a,b))}. So the output of the given function is checked to
+   * verify that it uses a valid type.
+   *
+   * @param function the function
+   * @return the composition
+   */
+  private BiFunction<? super K, ? super V, ? extends V> typeChecked(
+      BiFunction<? super K, ? super V, ? extends V> function) {
+    return (k, v) -> {
+      checkType(k);
+      V output = function.apply(k, v);
+      if (output != null) {
+        checkType(output);
+      }
+      return output;
+    };
+  }
+
+  /**
+   * Composes the given function ({@code f(a)}) with a function checking the type
+   * of the output. So the output of the
+   * given function is checked to verify that is uses a valid type.
+   *
+   * @param function the function
+   * @return the composition
+   */
+  private Function<? super K, ? extends V> typeChecked(Function<? super K, ? extends V> function) {
+    return k -> {
+      checkType(k);
+      V output = function.apply(k);
+      if (output != null) {
+        checkType(output);
+      }
+      return output;
+    };
+  }
+
+  @Override
+  public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+    return getInternalMap().compute(key, typeChecked(remappingFunction));
+  }
+
+  @Override
+  public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+    return getInternalMap().computeIfAbsent(key, typeChecked(mappingFunction));
+  }
+
+  @Override
+  public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+    return getInternalMap().computeIfPresent(key, typeChecked(remappingFunction));
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return getInternalMap().containsKey(key);
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return getInternalMap().containsValue(value);
+  }
+
+  @Override
+  public Set<Entry<K, V>> entrySet() {
+    Set<Entry<K, V>> entries = new HashSet<>(getInternalMap().size());
+    for (Map.Entry<K, V> entry : getInternalMap().entrySet()) {
+      entries.add(new Map.Entry<K, V>() {
+
+        @Override
+        public K getKey() {
+          return copyIfRequired(entry.getKey());
+        }
+
+        @Override
+        public V getValue() {
+          return copyIfRequired(entry.getValue());
+        }
+
+        @Override
+        public V setValue(V value) {
+          throw new UnsupportedOperationException();
+        }
+      });
+    }
+    return entries;
+  }
+
+  @Override
+  public void forEach(BiConsumer<? super K, ? super V> action) {
+    // Cannot delegate, it needs to copy the objects to avoid modifications
+    for (Map.Entry<K, V> entry : entrySet()) {
+      action.accept(entry.getKey(), entry.getValue());
+    }
+  }
+
+  @Override
+  public V getOrDefault(Object key, V defaultValue) {
+    return copyIfRequired(getInternalMap().getOrDefault(key, defaultValue));
+  }
+
+  @Override
+  public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+    checkType(key);
+    checkType(value);
+    return getInternalMap().merge(key, value, (k, v) -> {
+      // No need to check the key, already check above.
+      V output = remappingFunction.apply(k, v);
+      if (output != null) {
+        checkType(output);
+      }
+      return output;
+    });
+  }
+
+  @Override
+  public void putAll(Map<? extends K, ? extends V> m) {
+    // Iterate over the set to entry and call `put` on each entry to validate the
+    // types
+    for (Entry<? extends K, ? extends V> entry : m.entrySet()) {
+      put(entry.getKey(), entry.getValue());
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getInternalMap().toString();
+  }
+
+}

--- a/src/main/java/io/vertx/core/shareddata/impl/LocalMapImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/LocalMapImpl.java
@@ -13,20 +13,13 @@ package io.vertx.core.shareddata.impl;
 
 import io.vertx.core.shareddata.LocalMap;
 
-import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-
-import static io.vertx.core.shareddata.impl.Checker.checkType;
-import static io.vertx.core.shareddata.impl.Checker.copyIfRequired;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-class LocalMapImpl<K, V> implements LocalMap<K, V> {
+class LocalMapImpl<K, V> extends AbstractLocalMapImpl<K, V, LocalMap<?, ?>> {
 
   private final ConcurrentMap<String, LocalMap<?, ?>> maps;
   private final String name;
@@ -38,235 +31,18 @@ class LocalMapImpl<K, V> implements LocalMap<K, V> {
   }
 
   @Override
-  public V get(Object key) {
-    return copyIfRequired(map.get(key));
+  String getName() {
+    return name;
   }
 
   @Override
-  public V put(K key, V value) {
-    checkType(key);
-    checkType(value);
-    return map.put(key, value);
+  ConcurrentMap<K, V> getInternalMap() {
+    return map;
   }
 
   @Override
-  public V remove(Object key) {
-    return copyIfRequired(map.remove(key));
+  ConcurrentMap<String, LocalMap<?, ?>> getAllLocalMaps() {
+    return maps;
   }
 
-  @Override
-  public void clear() {
-    map.clear();
-  }
-
-  @Override
-  public int size() {
-    return map.size();
-  }
-
-  @Override
-  public boolean isEmpty() {
-    return map.isEmpty();
-  }
-
-  @Override
-  public V putIfAbsent(K key, V value) {
-    checkType(key);
-    checkType(value);
-    return copyIfRequired(map.putIfAbsent(key, value));
-  }
-
-  @Override
-  public boolean remove(Object key, Object value) {
-    return map.remove(key, value);
-  }
-
-  @Override
-  public boolean replace(K key, V oldValue, V newValue) {
-    return map.replace(key, oldValue, newValue);
-  }
-
-  @Override
-  public boolean removeIfPresent(K key, V value) {
-    return map.remove(key, value);
-  }
-
-  @Override
-  public boolean replaceIfPresent(K key, V oldValue, V newValue) {
-    checkType(key);
-    checkType(oldValue);
-    checkType(newValue);
-    return map.replace(key, oldValue, newValue);
-  }
-
-  @Override
-  public V replace(K key, V value) {
-    checkType(key);
-    checkType(value);
-    return copyIfRequired(map.replace(key, value));
-  }
-
-  @Override
-  public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
-    map.replaceAll((k, v) -> {
-      checkType(k);
-      checkType(v);
-      V output = function.apply(k, v);
-      if (output != null) {
-        checkType(output);
-      }
-      return output;
-    });
-  }
-
-  @Override
-  public void close() {
-    maps.remove(name);
-  }
-
-  @Override
-  public Set<K> keySet() {
-    Set<K> keys = new HashSet<>(map.size());
-    for (K k : map.keySet()) {
-      keys.add(copyIfRequired(k));
-    }
-    return keys;
-  }
-
-  @Override
-  public Collection<V> values() {
-    List<V> values = new ArrayList<>(map.size());
-    for (V v : map.values()) {
-      values.add(copyIfRequired(v));
-    }
-    return values;
-  }
-
-  /**
-   * Composes the given bi-function ({@code f(a,b)}) with a function checking the type of the output:
-   * {@code checkType(f(a,b))}. So the output of the given function is checked to verify that it uses a valid type.
-   *
-   * @param function the function
-   * @return the composition
-   */
-  private BiFunction<? super K, ? super V, ? extends V> typeChecked(BiFunction<? super K, ? super V, ? extends V>
-                                                                        function) {
-    return (k, v) -> {
-      checkType(k);
-      V output = function.apply(k, v);
-      if (output != null) {
-        checkType(output);
-      }
-      return output;
-    };
-  }
-
-  /**
-   * Composes the given function ({@code f(a)}) with a function checking the type of the output. So the output of the
-   * given function is checked to verify that is uses a valid type.
-   *
-   * @param function the function
-   * @return the composition
-   */
-  private Function<? super K, ? extends V> typeChecked(Function<? super K, ? extends V>
-                                                           function) {
-    return k -> {
-      checkType(k);
-      V output = function.apply(k);
-      if (output != null) {
-        checkType(output);
-      }
-      return output;
-    };
-  }
-
-  @Override
-  public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
-    return map.compute(key, typeChecked(remappingFunction));
-  }
-
-  @Override
-  public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
-    return map.computeIfAbsent(key, typeChecked(mappingFunction));
-  }
-
-  @Override
-  public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
-    return map.computeIfPresent(key, typeChecked(remappingFunction));
-  }
-
-  @Override
-  public boolean containsKey(Object key) {
-    return map.containsKey(key);
-  }
-
-  @Override
-  public boolean containsValue(Object value) {
-    return map.containsValue(value);
-  }
-
-  @Override
-  public Set<Entry<K, V>> entrySet() {
-    Set<Entry<K, V>> entries = new HashSet<>(map.size());
-    for (Map.Entry<K, V> entry : map.entrySet()) {
-      entries.add(new Map.Entry<K, V>() {
-
-        @Override
-        public K getKey() {
-          return copyIfRequired(entry.getKey());
-        }
-
-        @Override
-        public V getValue() {
-          return copyIfRequired(entry.getValue());
-        }
-
-        @Override
-        public V setValue(V value) {
-          throw new UnsupportedOperationException();
-        }
-      });
-    }
-    return entries;
-  }
-
-  @Override
-  public void forEach(BiConsumer<? super K, ? super V> action) {
-    // Cannot delegate, it needs to copy the objects to avoid modifications
-    for (Map.Entry<K, V> entry : entrySet()) {
-      action.accept(entry.getKey(), entry.getValue());
-    }
-  }
-
-  @Override
-  public V getOrDefault(Object key, V defaultValue) {
-    return copyIfRequired(map.getOrDefault(key, defaultValue));
-  }
-
-  @Override
-  public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
-    checkType(key);
-    checkType(value);
-    return map.merge(key, value, (k, v) -> {
-      // No need to check the key, already check above.
-      V output = remappingFunction.apply(k, v);
-      if (output != null) {
-        checkType(output);
-      }
-      return output;
-    });
-  }
-
-  @Override
-  public void putAll(Map<? extends K, ? extends V> m) {
-    // Iterate over the set to entry and call `put` on each entry to validate the types
-    for (Entry<? extends K, ? extends V> entry : m.entrySet()) {
-      put(entry.getKey(), entry.getValue());
-    }
-  }
-
-  @Override
-  public String toString() {
-    return map.toString();
-  }
 }

--- a/src/main/java/io/vertx/core/shareddata/impl/LocalSortedMapImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/LocalSortedMapImpl.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.shareddata.impl;
+
+import java.util.Comparator;
+import java.util.SortedMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+import io.vertx.core.shareddata.LocalSortedMap;
+
+@SuppressWarnings("unchecked")
+public class LocalSortedMapImpl<K extends Comparable<K>, V>
+    extends AbstractLocalMapImpl<K, V, LocalSortedMap<?, ?>>
+    implements LocalSortedMap<K, V> {
+
+  private final String name;
+  private final ConcurrentNavigableMap<K, V> map;
+  private final ConcurrentMap<String, LocalSortedMap<?, ?>> maps;
+
+  LocalSortedMapImpl(String name, ConcurrentMap<String, LocalSortedMap<?, ?>> maps) {
+    this(name, new ConcurrentSkipListMap<>(), maps);
+  }
+
+  private LocalSortedMapImpl(
+      String name,
+      ConcurrentNavigableMap<K, V> map,
+      ConcurrentMap<String, LocalSortedMap<?, ?>> maps) {
+    this.name = name;
+    this.map = map;
+    this.maps = maps;
+  }
+
+  @Override
+  String getName() {
+    return name;
+  }
+
+  @Override
+  ConcurrentMap<K, V> getInternalMap() {
+    return map;
+  }
+
+  @Override
+  ConcurrentMap<String, LocalSortedMap<?, ?>> getAllLocalMaps() {
+    return maps;
+  }
+
+  @Override
+  public Comparator<? super K> comparator() {
+    return ((SortedMap<K, V>) map).comparator();
+  }
+
+  @Override
+  public LocalSortedMapImpl<K, V> subMap(K fromKey, K toKey) {
+    ConcurrentNavigableMap<K, V> sortedMap = (ConcurrentSkipListMap<K, V>) map;
+    ConcurrentNavigableMap<K, V> subMap = sortedMap.subMap(fromKey, toKey);
+    String name = this.name + "_" + fromKey.hashCode() + "-" + toKey.hashCode();
+
+    return (LocalSortedMapImpl<K, V>) this.maps
+        .computeIfAbsent(name, _ignored -> new LocalSortedMapImpl<>(name, subMap, maps));
+  }
+
+  @Override
+  public LocalSortedMapImpl<K, V> headMap(K toKey) {
+    return subMap(this.firstKey(), toKey);
+  }
+
+  @Override
+  public LocalSortedMapImpl<K, V> tailMap(K fromKey) {
+    return subMap(fromKey, this.lastKey());
+  }
+
+  @Override
+  public K firstKey() {
+    return ((SortedMap<K, V>) this.map).firstKey();
+  }
+
+  @Override
+  public K lastKey() {
+    return ((SortedMap<K, V>) this.map).lastKey();
+  }
+
+}

--- a/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
@@ -22,12 +22,14 @@ import io.vertx.core.shareddata.*;
 import io.vertx.core.spi.cluster.ClusterManager;
 
 import java.io.Serializable;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -42,6 +44,7 @@ public class SharedDataImpl implements SharedData {
   private final ConcurrentMap<String, LocalAsyncMapImpl<?, ?>> localAsyncMaps = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, Counter> localCounters = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, LocalMap<?, ?>> localMaps = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, LocalSortedMap<?, ?>> localSortedMaps = new ConcurrentHashMap<>();
 
   public SharedDataImpl(VertxInternal vertx, ClusterManager clusterManager) {
     this.vertx = vertx;
@@ -162,6 +165,21 @@ public class SharedDataImpl implements SharedData {
   @Override
   public <K, V> LocalMap<K, V> getLocalMap(String name) {
     return (LocalMap<K, V>) localMaps.computeIfAbsent(name, n -> new LocalMapImpl<>(n, localMaps));
+  }
+
+  /**
+   * Return a <strong>sorted</strong> map with the specific {@code name} and the
+   * given
+   * {@code comparator} defining the sort order. All incovations of this method
+   * with the
+   * same value of {@code name} are guaranteed to return the same
+   * {@link LocalSortedMap} instance.
+   */
+  @SuppressWarnings("unchecked")
+  @Override
+  public <K extends Comparable<K>, V> LocalSortedMap<K, V> getLocalSortedMap(String name) {
+    return (LocalSortedMap<K, V>) localSortedMaps.computeIfAbsent(name,
+        n -> new LocalSortedMapImpl<>(name, localSortedMaps));
   }
 
   @Override

--- a/src/test/java/io/vertx/core/shareddata/LocalSharedDataTest.java
+++ b/src/test/java/io/vertx/core/shareddata/LocalSharedDataTest.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.shareddata;
 
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -20,12 +21,18 @@ import io.vertx.core.shareddata.AsyncMapTest.SomeSerializableObject;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Suite;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Suite.SuiteClasses;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import static io.vertx.test.core.TestUtils.assertIllegalArgumentException;
 import static io.vertx.test.core.TestUtils.assertNullPointerException;
@@ -33,361 +40,505 @@ import static io.vertx.test.core.TestUtils.assertNullPointerException;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
+@RunWith(Suite.class)
+@SuiteClasses({ 
+  LocalSharedDataTest.LocalMapsTest.class, 
+  LocalSharedDataTest.LocalMapTest.class, 
+  LocalSharedDataTest.LocalSortedMapTest.class,
+})
 public class LocalSharedDataTest extends VertxTestBase {
 
-  private SharedData sharedData;
+  @RunWith(Parameterized.class)
+  public static class LocalMapsTest extends VertxTestBase {
 
-  public void setUp() throws Exception {
-    super.setUp();
-    sharedData = vertx.sharedData();
+    @Parameters
+    public static Collection<Function<Vertx, LocalMap<String, Object>>> localMaps() {
+      return Arrays.asList(
+          vertx -> vertx.sharedData().getLocalMap("test-map"),
+          vertx -> vertx.sharedData().getLocalSortedMap("test-map"));
+    }
+
+    private LocalMap<String, Object> map;
+    private final Function<Vertx, LocalMap<String, Object>> mapFactory;
+
+    public LocalMapsTest(Function<Vertx, LocalMap<String, Object>> mapFactory) {
+      this.mapFactory = mapFactory;
+    }
+
+    @Override
+    public void setUp() throws Exception {
+      super.setUp();
+      this.map = mapFactory.apply(vertx);
+    }
+
+    @Test
+    public void deleteElementOnComputeFunctionReturningNull() {
+      // put an initial value
+      map.put("hello", "world");
+
+      // retuning null we should remove the entry
+      map.computeIfPresent("hello", (key, oldValue) -> null);
+      assertFalse(map.containsKey("hello"));
+
+      // Same for LocalMap#compute and LocalMap#compute
+      map.compute("hello", (key, oldValue) -> null);
+      assertFalse(map.containsKey("hello"));
+
+      // put a value one more time
+      map.put("hello", "world");
+      map.merge("hello", "world!!!!!!", (key, oldValue) -> null);
+      assertFalse(map.containsKey("hello"));
+
+      map.computeIfAbsent("hello", key -> null);
+      assertFalse(map.containsKey("hello"));
+    }
+
+    @Test
+    public void testLocalMaps() {
+      assertNotNull(map);
+      assertTrue(map.isEmpty());
+      assertEquals(map.size(), 0);
+      assertEquals(map.entrySet().size(), 0);
+      assertEquals(map.values().size(), 0);
+      assertEquals(map.keySet().size(), 0);
+
+      assertEquals(map.getOrDefault("foo", "miss"), "miss");
+      assertNull(map.putIfAbsent("foo", "there"));
+      assertNotNull(map.putIfAbsent("foo", "there"));
+      assertEquals(map.getOrDefault("foo", "miss"), "there");
+      assertEquals(map.get("foo"), "there");
+      assertNull(map.get("missing"));
+
+      assertFalse(map.isEmpty());
+      assertEquals(map.size(), 1);
+      assertEquals(map.entrySet().size(), 1);
+      assertEquals(map.values().size(), 1);
+      assertEquals(map.keySet().size(), 1);
+
+      assertFalse(map.removeIfPresent("missing", "nope"));
+      assertTrue(map.removeIfPresent("foo", "there"));
+
+      assertNull(map.put("foo", "there"));
+      assertFalse(map.replaceIfPresent("missing", "nope", "something"));
+      assertTrue(map.replaceIfPresent("foo", "there", "something"));
+      assertEquals(map.get("foo"), "something");
+
+      map.compute("foo", (k, v) -> "something else");
+      assertEquals(map.get("foo"), "something else");
+      map.compute("bar", (k, v) -> v == null ? "was null" : "was not null");
+      assertEquals(map.get("bar"), "was null");
+
+      map.computeIfAbsent("foo", (k) -> "was not there");
+      assertEquals(map.get("foo"), "something else");
+      map.computeIfAbsent("baz", (k) -> "was not there");
+      assertEquals(map.get("baz"), "was not there");
+
+      assertEquals(map.remove("baz"), "was not there");
+
+      map.computeIfPresent("foo", (k, v) -> v.equals("something else") ? "replaced" : "wrong");
+      assertEquals(map.get("foo"), "replaced");
+
+      map.computeIfAbsent("foo", k -> "was not there");
+      assertEquals(map.get("foo"), "replaced");
+      map.computeIfAbsent("baz", k -> "was not there");
+      assertTrue(map.remove("baz", "was not there"));
+
+      assertTrue(map.toString().contains("bar"));
+      assertTrue(map.toString().contains("replaced"));
+
+      AtomicInteger count = new AtomicInteger();
+      map.forEach((k, v) -> count.incrementAndGet());
+      assertEquals(count.get(), 2);
+
+      Map<String, String> another = new HashMap<>();
+      another.put("foo", "value");
+      another.put("new", "another value");
+      map.putAll(another);
+
+      assertTrue(map.containsKey("new"));
+      assertTrue(map.containsValue("value"));
+
+      map.merge("new", "another value", (k, v) -> "replaced");
+      assertEquals(map.get("new"), "replaced");
+      map.merge("bar", "another value", (k, v) -> "inserted");
+      assertEquals(map.get("bar"), "inserted");
+
+      map.replace("bar", "replaced");
+      assertEquals(map.get("bar"), "replaced");
+      map.replace("bar", "replaced", "replaced 2");
+      assertEquals(map.get("bar"), "replaced 2");
+      map.replace("bar", "replaced", "replaced 2");
+      assertEquals(map.get("bar"), "replaced 2");
+
+      map.replaceAll((k, v) -> {
+        if (k.equals("new")) {
+          return "new";
+        }
+        return v;
+      });
+      assertEquals(map.get("new"), "new");
+
+      map.clear();
+      assertTrue(map.isEmpty());
+
+      map.close();
+    }
+
+    @Test
+    public void testMapTypes() throws Exception {
+      String key = "key";
+      assertNullPointerException(() -> map.put(key, null));
+
+      double d = new Random().nextDouble();
+      map.put(key, d);
+      assertEquals(d, map.get(key));
+
+      float f = new Random().nextFloat();
+      map.put(key, f);
+      assertEquals(f, map.get(key));
+
+      byte b = (byte) new Random().nextInt();
+      map.put(key, b);
+      assertEquals(b, map.get(key));
+
+      short s = (short) new Random().nextInt();
+      map.put(key, s);
+      assertEquals(s, map.get(key));
+
+      int i = new Random().nextInt();
+      map.put(key, i);
+      assertEquals(i, map.get(key));
+
+      long l = new Random().nextLong();
+      map.put(key, l);
+      assertEquals(l, map.get(key));
+
+      map.put(key, true);
+      assertTrue((Boolean) map.get(key));
+
+      map.put(key, false);
+      assertFalse((Boolean) map.get(key));
+
+      char c = (char) new Random().nextLong();
+      map.put(key, c);
+      assertEquals(c, map.get(key));
+
+      Buffer buff = TestUtils.randomBuffer(100);
+      map.put(key, buff);
+      Buffer got1 = (Buffer) map.get(key);
+      assertTrue(got1 != buff); // Make sure it's copied
+      assertEquals(buff, map.get(key));
+      Buffer got2 = (Buffer) map.get(key);
+      assertTrue(got1 != got2); // Should be copied each time
+      assertTrue(got2 != buff);
+      assertEquals(buff, map.get(key));
+
+      byte[] bytes = TestUtils.randomByteArray(100);
+      map.put(key, bytes);
+      byte[] bgot1 = (byte[]) map.get(key);
+      assertTrue(bgot1 != bytes);
+      assertTrue(TestUtils.byteArraysEqual(bytes, bgot1));
+      byte[] bgot2 = (byte[]) map.get(key);
+      assertTrue(bgot2 != bytes);
+      assertTrue(bgot1 != bgot2);
+      assertTrue(TestUtils.byteArraysEqual(bytes, bgot2));
+
+      assertIllegalArgumentException(() -> map.put(key, new SomeOtherClass()));
+
+      JsonObject obj = new JsonObject().put("foo", "bar");
+      map.put("obj", obj);
+      JsonObject other = (JsonObject) map.get("obj");
+      assertEquals(obj, other);
+      assertNotSame(obj, other); // Should be copied
+
+      JsonArray arr = new JsonArray().add("foo");
+      map.put("arr", arr);
+      JsonArray otherArr = (JsonArray) map.get("arr");
+      assertEquals(arr, otherArr);
+      assertNotSame(arr, otherArr); // Should be copied
+
+      BigInteger bi = BigInteger.valueOf(new Random().nextLong());
+      map.put(key, bi);
+      BigInteger otherBi = (BigInteger) map.get(key);
+      assertSame(bi, otherBi);
+
+      BigDecimal bd = BigDecimal.valueOf(new Random().nextDouble());
+      map.put(key, bd);
+      BigDecimal otherBd = (BigDecimal) map.get(key);
+      assertSame(bd, otherBd);
+
+      SomeSerializableObject so = new SomeSerializableObject(TestUtils.randomAlphaString(15));
+      map.put(key, so);
+      SomeSerializableObject otherSo = (SomeSerializableObject) map.get(key);
+      assertEquals(so, otherSo);
+      assertNotSame(so, otherSo);
+
+      SomeClusterSerializableObject cso = new SomeClusterSerializableObject(TestUtils.randomAlphaString(15));
+      map.put(key, cso);
+      SomeClusterSerializableObject otherCso = (SomeClusterSerializableObject) map.get(key);
+      assertEquals(cso, otherCso);
+      assertNotSame(cso, otherCso);
+
+      SomeClusterSerializableImplObject csio = new SomeClusterSerializableImplObject(TestUtils.randomAlphaString(15));
+      map.put(key, csio);
+      SomeClusterSerializableImplObject otherCsio = (SomeClusterSerializableImplObject) map.get(key);
+      assertEquals(csio, otherCsio);
+      assertNotSame(csio, otherCsio);
+    }
+
+    @Test
+    public void testKeys() {
+      map.put("foo1", "val1");
+      map.put("foo2", "val2");
+      map.put("foo3", "val3");
+      assertEquals(3, map.size());
+      Set<String> keys = map.keySet();
+      assertEquals(3, keys.size());
+      assertTrue(keys.contains("foo1"));
+      assertTrue(keys.contains("foo2"));
+      assertTrue(keys.contains("foo3"));
+    }
+
+    class SomeOtherClass {
+    }
   }
 
-  @Test
-  public void deleteElementOnComputeFunctionReturningNull() {
-    LocalMap<String, String> map = sharedData.getLocalMap("foo");
+  public static class LocalMapTest extends VertxTestBase {
 
-    // put an initial value
-    map.put("hello", "world");
+    private SharedData sharedData;
+  
+    @Override
+    public void setUp() throws Exception {
+      super.setUp();
+      sharedData = vertx.sharedData();
+    }
 
-    // retuning null we should remove the entry
-    map.computeIfPresent("hello", (key, oldValue) -> null);
-    assertFalse(map.containsKey("hello"));
+    @Test
+    public void testMap() throws Exception {
+      assertNullPointerException(() -> sharedData.getLocalMap(null));
+      LocalMap<String, String> map = sharedData.getLocalMap("foo");
+      LocalMap<String, String> map2 = sharedData.getLocalMap("foo");
+      assertTrue(map == map2);
+      LocalMap<String, String> map3 = sharedData.getLocalMap("bar");
+      assertFalse(map3 == map2);
+      map.close();
+      LocalMap<String, String> map4 = sharedData.getLocalMap("foo");
+      assertFalse(map4 == map3);
+    }
 
-    // Same for LocalMap#compute and LocalMap#compute
-    map.compute("hello", (key, oldValue) -> null);
-    assertFalse(map.containsKey("hello"));
+    @Test
+    public void testKeysCopied() {
+      LocalMap<JsonObject, String> map = sharedData.getLocalMap("foo");
+  
+      JsonObject json1 = new JsonObject().put("foo1", "val1");
+      JsonObject json2 = new JsonObject().put("foo2", "val1");
+      JsonObject json3 = new JsonObject().put("foo3", "val1");
+  
+      map.put(json1, "val1");
+      map.put(json2, "val2");
+      map.put(json3, "val3");
+  
+      assertEquals(3, map.size());
+      Set<JsonObject> keys = map.keySet();
+      assertEquals(3, keys.size());
+      assertTrue(keys.contains(json1));
+      assertTrue(keys.contains(json2));
+      assertTrue(keys.contains(json3));
+  
+      // copied
+      assertFalse(containsExact(keys, json1));
+      assertFalse(containsExact(keys, json2));
+      assertFalse(containsExact(keys, json3));
+    }
+  
+    @Test
+    public void testValues() {
+      LocalMap<String, String> map = sharedData.getLocalMap("foo");
+      map.put("foo1", "val1");
+      map.put("foo2", "val2");
+      map.put("foo3", "val3");
+      assertEquals(3, map.size());
+      Collection<String> values = map.values();
+      assertEquals(3, values.size());
+      assertTrue(values.contains("val1"));
+      assertTrue(values.contains("val2"));
+      assertTrue(values.contains("val3"));
+    }
 
-    // put a value one more time
-    map.put("hello", "world");
-    map.merge("hello", "world!!!!!!", (key, oldValue) -> null);
-    assertFalse(map.containsKey("hello"));
+    @Test
+    public void testValuesCopied() {
+      LocalMap<String, JsonObject> map = sharedData.getLocalMap("foo");
+      JsonObject json1 = new JsonObject().put("foo1", "val1");
+      JsonObject json2 = new JsonObject().put("foo2", "val1");
+      JsonObject json3 = new JsonObject().put("foo3", "val1");
+  
+      map.put("key1", json1);
+      map.put("key2", json2);
+      map.put("key3", json3);
+  
+      assertEquals(3, map.size());
+      Collection<JsonObject> values = map.values();
+      assertEquals(3, values.size());
+      assertTrue(values.contains(json1));
+      assertTrue(values.contains(json2));
+      assertTrue(values.contains(json3));
+  
+      // copied
+      assertFalse(containsExact(values, json1));
+      assertFalse(containsExact(values, json2));
+      assertFalse(containsExact(values, json3));
+    }
 
-    map.computeIfAbsent("hello", key -> null);
-    assertFalse(map.containsKey("hello"));
+    @Test
+    public void testCopyOnGet() {
+      testMapOperationResult(LocalMap::get);
+    }
+
+    @Test
+    public void testCopyOnPutIfAbsent() {
+      testMapOperationResult((map, key) -> map.putIfAbsent(key, new ShareableObject("some other test data")));
+    }
+  
+    @Test
+    public void testCopyOnRemove() {
+      testMapOperationResult(LocalMap::remove);
+    }
+
+    private void testMapOperationResult(BiFunction<LocalMap<String, ShareableObject>, String, ShareableObject> operation) {
+      final String key = "key";
+      final ShareableObject value = new ShareableObject("some test data");
+      final LocalMap<String, ShareableObject> map = sharedData.getLocalMap("foo");
+      assertNull(map.put(key, value));
+  
+      final ShareableObject result = operation.apply(map, key);
+  
+      assertEquals(value, result);
+      assertNotSame(value, result);
+    }
+
   }
 
-  @Test
-  public void testMap() throws Exception {
-    assertNullPointerException(() -> sharedData.getLocalMap(null));
-    LocalMap<String, String> map = sharedData.getLocalMap("foo");
-    LocalMap<String, String> map2 = sharedData.getLocalMap("foo");
-    assertTrue(map == map2);
-    LocalMap<String, String> map3 = sharedData.getLocalMap("bar");
-    assertFalse(map3 == map2);
-    map.close();
-    LocalMap<String, String> map4 = sharedData.getLocalMap("foo");
-    assertFalse(map4 == map3);
+  public static class LocalSortedMapTest extends VertxTestBase {
+
+    private SharedData sharedData;
+  
+    @Override
+    public void setUp() throws Exception {
+      super.setUp();
+      sharedData = vertx.sharedData();
+    }
+
+    @Test
+    public void testSortedMap() throws Exception {
+      assertNullPointerException(() -> sharedData.getLocalSortedMap(null));
+      LocalSortedMap<String, String> map1 = sharedData.getLocalSortedMap("foo");
+      LocalSortedMap<String, String> map2 = sharedData.getLocalSortedMap("foo");
+      assertTrue(map1 == map2);
+      LocalSortedMap<String, String> map3 = sharedData.getLocalSortedMap("bar");
+      assertFalse(map2 == map3);
+      map1.close();
+      LocalSortedMap<String, String> map4 = sharedData.getLocalSortedMap("foo");
+      assertFalse(map4 == map1);
+    }
+
+    @Test
+    public void testKeysCopiedSortedMap() {
+      LocalSortedMap<Date, String> sortedMap = sharedData.getLocalSortedMap("foo");
+      Date date1 = new GregorianCalendar(1985, 2, 20).getTime();
+      Date date2 = new GregorianCalendar(2017, 2, 12).getTime();
+      Date date3 = new GregorianCalendar(2020, 1, 11).getTime();
+  
+      sortedMap.put(date1, "val1");
+      sortedMap.put(date2, "val2");
+      sortedMap.put(date3, "val3");
+  
+      assertEquals(3, sortedMap.size());
+      Set<Date> keys = sortedMap.keySet();
+      assertEquals(3, keys.size());
+      assertTrue(keys.contains(date1));
+      assertTrue(keys.contains(date2));
+      assertTrue(keys.contains(date3));
+  
+      // copied
+      assertFalse(containsExact(keys, date1));
+      assertFalse(containsExact(keys, date2));
+      assertFalse(containsExact(keys, date3));
+    }
+
+    @Test
+    public void testValuesSortedMap() {
+      LocalSortedMap<String, String> map = sharedData.getLocalSortedMap("foo");
+      map.put("foo1", "val1");
+      map.put("foo2", "val2");
+      map.put("foo3", "val3");
+      assertEquals(3, map.size());
+      Collection<String> values = map.values();
+      assertEquals(3, values.size());
+      assertTrue(values.contains("val1"));
+      assertTrue(values.contains("val2"));
+      assertTrue(values.contains("val3"));
+    }
+
+
+    @Test
+    public void testValuesCopiedSortedMap() {
+      LocalSortedMap<String, JsonObject> map = sharedData.getLocalSortedMap("foo");
+      JsonObject json1 = new JsonObject().put("foo1", "val1");
+      JsonObject json2 = new JsonObject().put("foo2", "val1");
+      JsonObject json3 = new JsonObject().put("foo3", "val1");
+
+      map.put("key1", json1);
+      map.put("key2", json2);
+      map.put("key3", json3);
+
+      assertEquals(3, map.size());
+      Collection<JsonObject> values = map.values();
+      assertEquals(3, values.size());
+      assertTrue(values.contains(json1));
+      assertTrue(values.contains(json2));
+      assertTrue(values.contains(json3));
+
+      // copied
+      assertFalse(containsExact(values, json1));
+      assertFalse(containsExact(values, json2));
+      assertFalse(containsExact(values, json3));
+    }
+
+    @Test
+    public void testCopyOnGetSortedMap() {
+      testMapOperationResult(LocalSortedMap::get);
+    }
+
+    @Test
+    public void testCopyOnPutIfAbsentSortedMap() {
+      testMapOperationResult((map, key) -> map.putIfAbsent(key, new ShareableObject("some other test data")));
+    }
+
+    @Test
+    public void testCopyOnRemoveSortedMap() {
+      testMapOperationResult(LocalSortedMap::remove);
+    }
+
+    private void testMapOperationResult(BiFunction<LocalSortedMap<String, ShareableObject>, String, ShareableObject> operation) {
+      final String key = "key";
+      final ShareableObject value = new ShareableObject("some test data");
+      final LocalSortedMap<String, ShareableObject> map = sharedData.getLocalSortedMap("foo");
+      assertNull(map.put(key, value));
+  
+      final ShareableObject result = operation.apply(map, key);
+  
+      assertEquals(value, result);
+      assertNotSame(value, result);
+    }
   }
 
-  @Test
-  public void testLocalMaps() {
-    LocalMap<String, String> map = sharedData.getLocalMap("test-map");
-    assertNotNull(map);
-    assertTrue(map.isEmpty());
-    assertEquals(map.size(), 0);
-    assertEquals(map.entrySet().size(), 0);
-    assertEquals(map.values().size(), 0);
-    assertEquals(map.keySet().size(), 0);
-
-    assertEquals(map.getOrDefault("foo", "miss"), "miss");
-    assertNull(map.putIfAbsent("foo", "there"));
-    assertNotNull(map.putIfAbsent("foo", "there"));
-    assertEquals(map.getOrDefault("foo", "miss"), "there");
-    assertEquals(map.get("foo"), "there");
-    assertNull(map.get("missing"));
-
-    assertFalse(map.isEmpty());
-    assertEquals(map.size(), 1);
-    assertEquals(map.entrySet().size(), 1);
-    assertEquals(map.values().size(), 1);
-    assertEquals(map.keySet().size(), 1);
-
-    assertFalse(map.removeIfPresent("missing", "nope"));
-    assertTrue(map.removeIfPresent("foo", "there"));
-
-    assertNull(map.put("foo", "there"));
-    assertFalse(map.replaceIfPresent("missing", "nope", "something"));
-    assertTrue(map.replaceIfPresent("foo", "there", "something"));
-    assertEquals(map.get("foo"), "something");
-
-    map.compute("foo", (k, v) -> "something else");
-    assertEquals(map.get("foo"), "something else");
-    map.compute("bar", (k, v) -> v == null ? "was null" : "was not null");
-    assertEquals(map.get("bar"), "was null");
-
-    map.computeIfAbsent("foo", (k) -> "was not there");
-    assertEquals(map.get("foo"), "something else");
-    map.computeIfAbsent("baz", (k) -> "was not there");
-    assertEquals(map.get("baz"), "was not there");
-
-    assertEquals(map.remove("baz"), "was not there");
-
-    map.computeIfPresent("foo", (k, v) -> v.equals("something else") ? "replaced" : "wrong");
-    assertEquals(map.get("foo"), "replaced");
-
-    map.computeIfAbsent("foo", k -> "was not there");
-    assertEquals(map.get("foo"), "replaced");
-    map.computeIfAbsent("baz", k -> "was not there");
-    assertTrue(map.remove("baz", "was not there"));
-
-    assertTrue(map.toString().contains("bar"));
-    assertTrue(map.toString().contains("replaced"));
-
-    AtomicInteger count = new AtomicInteger();
-    map.forEach((k, v) -> count.incrementAndGet());
-    assertEquals(count.get(), 2);
-
-    Map<String, String> another = new HashMap<>();
-    another.put("foo", "value");
-    another.put("new", "another value");
-    map.putAll(another);
-
-    assertTrue(map.containsKey("new"));
-    assertTrue(map.containsValue("value"));
-
-    map.merge("new", "another value", (k, v) -> "replaced");
-    assertEquals(map.get("new"), "replaced");
-    map.merge("bar", "another value", (k, v) -> "inserted");
-    assertEquals(map.get("bar"), "inserted");
-
-    map.replace("bar", "replaced");
-    assertEquals(map.get("bar"), "replaced");
-    map.replace("bar", "replaced", "replaced 2");
-    assertEquals(map.get("bar"), "replaced 2");
-    map.replace("bar", "replaced", "replaced 2");
-    assertEquals(map.get("bar"), "replaced 2");
-
-    map.replaceAll((k, v) -> {
-      if (k.equals("new")) {
-        return "new";
-      }
-      return v;
-    });
-    assertEquals(map.get("new"), "new");
-
-    map.clear();
-    assertTrue(map.isEmpty());
-
-    map.close();
-  }
-
-  @Test
-  public void testMapTypes() throws Exception {
-
-    LocalMap<Object, Object> map = sharedData.getLocalMap("foo");
-
-    String key = "key";
-
-    assertNullPointerException(() -> map.put(key, null));
-
-    double d = new Random().nextDouble();
-    map.put(key, d);
-    assertEquals(d, map.get(key));
-
-    float f = new Random().nextFloat();
-    map.put(key, f);
-    assertEquals(f, map.get(key));
-
-    byte b = (byte) new Random().nextInt();
-    map.put(key, b);
-    assertEquals(b, map.get(key));
-
-    short s = (short)new Random().nextInt();
-    map.put(key, s);
-    assertEquals(s, map.get(key));
-
-    int i = new Random().nextInt();
-    map.put(key, i);
-    assertEquals(i, map.get(key));
-
-    long l = new Random().nextLong();
-    map.put(key, l);
-    assertEquals(l, map.get(key));
-
-    map.put(key, true);
-    assertTrue((Boolean)map.get(key));
-
-    map.put(key, false);
-    assertFalse((Boolean) map.get(key));
-
-    char c = (char)new Random().nextLong();
-    map.put(key, c);
-    assertEquals(c, map.get(key));
-
-    Buffer buff = TestUtils.randomBuffer(100);
-    map.put(key, buff);
-    Buffer got1 = (Buffer)map.get(key);
-    assertTrue(got1 != buff); // Make sure it's copied
-    assertEquals(buff, map.get(key));
-    Buffer got2 = (Buffer)map.get(key);
-    assertTrue(got1 != got2); // Should be copied each time
-    assertTrue(got2 != buff);
-    assertEquals(buff, map.get(key));
-
-
-    byte[] bytes = TestUtils.randomByteArray(100);
-    map.put(key, bytes);
-    byte[] bgot1 = (byte[]) map.get(key);
-    assertTrue(bgot1 != bytes);
-    assertTrue(TestUtils.byteArraysEqual(bytes, bgot1));
-    byte[] bgot2 = (byte[]) map.get(key);
-    assertTrue(bgot2 != bytes);
-    assertTrue(bgot1 != bgot2);
-    assertTrue(TestUtils.byteArraysEqual(bytes, bgot2));
-
-    assertIllegalArgumentException(() -> map.put(key, new SomeOtherClass()));
-
-    JsonObject obj = new JsonObject().put("foo", "bar");
-    map.put("obj", obj);
-    JsonObject other = (JsonObject) map.get("obj");
-    assertEquals(obj, other);
-    assertNotSame(obj, other); // Should be copied
-
-    JsonArray arr = new JsonArray().add("foo");
-    map.put("arr", arr);
-    JsonArray otherArr = (JsonArray) map.get("arr");
-    assertEquals(arr, otherArr);
-    assertNotSame(arr, otherArr); // Should be copied
-
-    BigInteger bi = BigInteger.valueOf(new Random().nextLong());
-    map.put(key, bi);
-    BigInteger otherBi = (BigInteger) map.get(key);
-    assertSame(bi, otherBi);
-
-    BigDecimal bd = BigDecimal.valueOf(new Random().nextDouble());
-    map.put(key, bd);
-    BigDecimal otherBd = (BigDecimal) map.get(key);
-    assertSame(bd, otherBd);
-
-    SomeSerializableObject so = new SomeSerializableObject(TestUtils.randomAlphaString(15));
-    map.put(key, so);
-    SomeSerializableObject otherSo = (SomeSerializableObject) map.get(key);
-    assertEquals(so, otherSo);
-    assertNotSame(so, otherSo);
-
-    SomeClusterSerializableObject cso = new SomeClusterSerializableObject(TestUtils.randomAlphaString(15));
-    map.put(key, cso);
-    SomeClusterSerializableObject otherCso = (SomeClusterSerializableObject) map.get(key);
-    assertEquals(cso, otherCso);
-    assertNotSame(cso, otherCso);
-
-    SomeClusterSerializableImplObject csio = new SomeClusterSerializableImplObject(TestUtils.randomAlphaString(15));
-    map.put(key, csio);
-    SomeClusterSerializableImplObject otherCsio = (SomeClusterSerializableImplObject) map.get(key);
-    assertEquals(csio, otherCsio);
-    assertNotSame(csio, otherCsio);
-  }
-
-  @Test
-  public void testKeys() {
-    LocalMap<String, String> map = sharedData.getLocalMap("foo");
-    map.put("foo1", "val1");
-    map.put("foo2", "val2");
-    map.put("foo3", "val3");
-    assertEquals(3, map.size());
-    Set<String> keys = map.keySet();
-    assertEquals(3, keys.size());
-    assertTrue(keys.contains("foo1"));
-    assertTrue(keys.contains("foo2"));
-    assertTrue(keys.contains("foo3"));
-  }
-
-  @Test
-  public void testKeysCopied() {
-    LocalMap<JsonObject, String> map = sharedData.getLocalMap("foo");
-    JsonObject json1 = new JsonObject().put("foo1", "val1");
-    JsonObject json2 = new JsonObject().put("foo2", "val1");
-    JsonObject json3 = new JsonObject().put("foo3", "val1");
-
-    map.put(json1, "val1");
-    map.put(json2, "val2");
-    map.put(json3, "val3");
-
-    assertEquals(3, map.size());
-    Set<JsonObject> keys = map.keySet();
-    assertEquals(3, keys.size());
-    assertTrue(keys.contains(json1));
-    assertTrue(keys.contains(json2));
-    assertTrue(keys.contains(json3));
-
-    // copied
-    assertFalse(containsExact(keys, json1));
-    assertFalse(containsExact(keys, json2));
-    assertFalse(containsExact(keys, json3));
-  }
-
-  private boolean containsExact(Collection<JsonObject> coll, JsonObject obj) {
-    for (JsonObject j: coll) {
+  private static <T> boolean containsExact(Collection<T> coll, T obj) {
+    for (T j : coll) {
       if (j == obj) {
         return true;
       }
     }
     return false;
-  }
-
-  @Test
-  public void testValues() {
-    LocalMap<String, String> map = sharedData.getLocalMap("foo");
-    map.put("foo1", "val1");
-    map.put("foo2", "val2");
-    map.put("foo3", "val3");
-    assertEquals(3, map.size());
-    Collection<String> values = map.values();
-    assertEquals(3, values.size());
-    assertTrue(values.contains("val1"));
-    assertTrue(values.contains("val2"));
-    assertTrue(values.contains("val3"));
-  }
-
-  @Test
-  public void testValuesCopied() {
-    LocalMap<String, JsonObject> map = sharedData.getLocalMap("foo");
-    JsonObject json1 = new JsonObject().put("foo1", "val1");
-    JsonObject json2 = new JsonObject().put("foo2", "val1");
-    JsonObject json3 = new JsonObject().put("foo3", "val1");
-
-    map.put("key1", json1);
-    map.put("key2", json2);
-    map.put("key3", json3);
-
-    assertEquals(3, map.size());
-    Collection<JsonObject> values = map.values();
-    assertEquals(3, values.size());
-    assertTrue(values.contains(json1));
-    assertTrue(values.contains(json2));
-    assertTrue(values.contains(json3));
-
-    // copied
-    assertFalse(containsExact(values, json1));
-    assertFalse(containsExact(values, json2));
-    assertFalse(containsExact(values, json3));
-  }
-
-  @Test
-  public void testCopyOnGet() {
-    testMapOperationResult(LocalMap::get);
-  }
-
-  @Test
-  public void testCopyOnPutIfAbsent() {
-    testMapOperationResult((map, key) -> map.putIfAbsent(key, new ShareableObject("some other test data")));
-  }
-
-  @Test
-  public void testCopyOnRemove() {
-    testMapOperationResult(LocalMap::remove);
-  }
-
-  private void testMapOperationResult(BiFunction<LocalMap<String, ShareableObject>, String, ShareableObject> operation) {
-    final String key = "key";
-    final ShareableObject value = new ShareableObject("some test data");
-    final LocalMap<String, ShareableObject> map = vertx.sharedData().getLocalMap("foo");
-    assertNull(map.put(key, value));
-
-    final ShareableObject result = operation.apply(map, key);
-
-    assertEquals(value, result);
-    assertNotSame(value, result);
   }
 
   private static class ShareableObject implements Shareable {
@@ -414,9 +565,6 @@ public class LocalSharedDataTest extends VertxTestBase {
     public int hashCode() {
       return data.hashCode();
     }
-  }
-
-  class SomeOtherClass {
   }
 
 }


### PR DESCRIPTION
Motivation:

See #5420

A sorted local map can come in handy when operating on sorted data provides a performance advantage over operating on unordered data.