### PR TITLE
Move Context methods getLocal/removeLocal/putLocal to ContextInternal and deprecate them for removal

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/Context.java
+++ b/vertx-core/src/main/java/io/vertx/core/Context.java
@@ -218,33 +218,6 @@ public interface Context {
   boolean remove(Object key);
 
   /**
-   * Get some local data from the context.
-   *
-   * @param key  the key of the data
-   * @param <T>  the type of the data
-   * @return the data
-   */
-  <T> T getLocal(Object key);
-
-  /**
-   * Put some local data in the context.
-   * <p>
-   * This can be used to share data between different handlers that share a context
-   *
-   * @param key  the key of the data
-   * @param value  the data
-   */
-  void putLocal(Object key, Object value);
-
-  /**
-   * Remove some local data from the context.
-   *
-   * @param key  the key to remove
-   * @return true if removed successfully, false otherwise
-   */
-  boolean removeLocal(Object key);
-
-  /**
    * @return The Vertx instance that created the context
    */
   Vertx owner();

--- a/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
@@ -364,21 +364,27 @@ public interface ContextInternal extends Context {
     putLocal(key, accessMode, null);
   }
 
-  @Deprecated
+  /**
+   * @deprecated instead use {@link #getLocal(ContextLocal, AccessMode)}
+   */
+  @Deprecated(forRemoval = true)
   @SuppressWarnings("unchecked")
-  @Override
   default <T> T getLocal(Object key) {
     return (T) localContextData().get(key);
   }
 
-  @Deprecated
-  @Override
+  /**
+   * @deprecated instead use {@link #putLocal(ContextLocal, AccessMode, Object)}
+   */
+  @Deprecated(forRemoval = true)
   default void putLocal(Object key, Object value) {
     localContextData().put(key, value);
   }
 
-  @Deprecated
-  @Override
+  /**
+   * @deprecated instead use {@link #removeLocal(ContextLocal, AccessMode)}
+   */
+  @Deprecated(forRemoval = true)
   default boolean removeLocal(Object key) {
     return localContextData().remove(key) != null;
   }


### PR DESCRIPTION
Motivation:

Context local methods should not have been part of the contract of Context initially. This API has been replaced by the ContextLocal API which should be used instead. This API is not going away in 5.0 but we want to get the opportunity to remove it at any time.

