### PR TITLE
allow the 'host' header to be used on HTTP/2 requests if the ':authority' header if missing

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -137,6 +137,13 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
       authorityHeaderAsString = authorityHeader.toString();
       authority = HostAndPort.parseAuthority(authorityHeaderAsString, -1);
     }
+    CharSequence hostHeader = null;
+    if (authority == null) {
+      hostHeader = headers.getAndRemove(HttpHeaders.HOST);
+      if (hostHeader != null) {
+        authority = HostAndPort.parseAuthority(hostHeader.toString(), -1);
+      }
+    }
     CharSequence pathHeader = headers.getAndRemove(HttpHeaders.PSEUDO_PATH);
     CharSequence methodHeader = headers.getAndRemove(HttpHeaders.PSEUDO_METHOD);
     return new Http2ServerStream(
@@ -144,7 +151,7 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
       streamContextSupplier.get(),
       headers,
       schemeHeader != null ? schemeHeader.toString() : null,
-      authorityHeader != null,
+      authorityHeader != null || hostHeader != null,
       authority,
       methodHeader != null ? HttpMethod.valueOf(methodHeader.toString()) : null,
       pathHeader != null ? pathHeader.toString() : null,

--- a/src/test/java/io/vertx/core/http/Http2ServerTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ServerTest.java
@@ -39,6 +39,7 @@ import io.netty.handler.codec.http2.Http2EventAdapter;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Flags;
 import io.netty.handler.codec.http2.Http2FrameAdapter;
+import io.netty.handler.codec.http2.Http2FrameListener;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.Http2Stream;
@@ -1273,6 +1274,27 @@ public class Http2ServerTest extends Http2TestBase {
           request.context.flush();
         }
       });
+    });
+    fut.sync();
+    await();
+  }
+
+  @Test
+  public void testHostHeaderInsteadOfAuthorityPseudoHeader() throws Exception {
+    // build the HTTP/2 headers, omit the ":authority" pseudo-header and include the "host" header instead
+    Http2Headers headers = new DefaultHttp2Headers().method("GET").scheme("https").path("/").set("host", DEFAULT_HTTPS_HOST_AND_PORT);
+    server.requestHandler(req -> {
+      // validate that the authority is properly populated
+      assertEquals(DEFAULT_HTTPS_HOST, req.authority().host());
+      assertEquals(DEFAULT_HTTPS_PORT, req.authority().port());
+      testComplete();
+    });
+    startServer();
+    TestClient client = new TestClient();
+    ChannelFuture fut = client.connect(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, request -> {
+      int id = request.nextStreamId();
+      Http2ConnectionEncoder encoder = request.encoder;
+      encoder.writeHeaders(request.context, id, headers, 0, true, request.context.newPromise());
     });
     fut.sync();
     await();


### PR DESCRIPTION
here's a take at solving the issue

happy to take feedback and adjust the solution as needed

see https://github.com/eclipse-vertx/vert.x/issues/5425 for context
