### PR TITLE
allow the 'host' header to be used on HTTP/2 requests if the ':authority' header if missing [5.x]

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -136,6 +136,13 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
       authorityHeaderAsString = authorityHeader.toString();
       authority = HostAndPort.parseAuthority(authorityHeaderAsString, -1);
     }
+    CharSequence hostHeader = null;
+    if (authority == null) {
+      hostHeader = headers.getAndRemove(HttpHeaders.HOST);
+      if (hostHeader != null) {
+        authority = HostAndPort.parseAuthority(hostHeader.toString(), -1);
+      }
+    }
     CharSequence pathHeader = headers.getAndRemove(HttpHeaders.PSEUDO_PATH);
     CharSequence methodHeader = headers.getAndRemove(HttpHeaders.PSEUDO_METHOD);
     return new Http2ServerStream(
@@ -143,7 +150,7 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
       streamContextSupplier.get(),
       headers,
       schemeHeader != null ? schemeHeader.toString() : null,
-      authorityHeader != null,
+      authorityHeader != null || hostHeader != null,
       authority,
       methodHeader != null ? HttpMethod.valueOf(methodHeader.toString()) : null,
       pathHeader != null ? pathHeader.toString() : null,


### PR DESCRIPTION
See https://github.com/eclipse-vertx/vert.x/issues/5425

Corresponding PR for 4.x: https://github.com/eclipse-vertx/vert.x/pull/5426