### PR TITLE
Discuss how onComplete or onSuccess/onFailure can be used

### DIFF
--- a/vertx-core/src/main/asciidoc/futures.adoc
+++ b/vertx-core/src/main/asciidoc/futures.adoc
@@ -12,6 +12,27 @@ You cannot interact directly with the result of a future, instead you need to se
 {@link examples.CoreExamples#exampleFuture1}
 ----
 
+Instead of using `onComplete` with `if (ar.succeeded()) { … } else { … }` you can use the `onSuccess` and `onFailure` handlers:
+
+[source,$lang]
+----
+{@link examples.CoreExamples#exampleFuture2}
+----
+
+Frequently the future variable can be avoided. Often the lambda parameter type is not needed by compiler and code readers, allowing to replace `(FileProps fileProps)` with `fileProps`. In a lambda code block with a single statement the semicolon and the curly braces can be removed. This yields a more concise code:
+
+[source,$lang]
+----
+{@link examples.CoreExamples#exampleFuture3}
+----
+
+`.onSuccess` and `.onFailure` can be combined into the two parameter method `.onComplete`. This is slightly faster and takes slightly less memory, but might be less readable:
+
+[source,$lang]
+----
+{@link examples.CoreExamples#exampleFuture4}
+----
+
 [CAUTION]
 ====
 Do not confuse _futures_ with _promises_.


### PR DESCRIPTION
Motivation:

Simplify the code by replacing onComplete + if-ar.succeeded-else with
either onComplete(res, e) or with other processing.

Avoiding onComplete + if-ar.succeeded-else results in more concise and understandable
code because it avoids the additional nesting of the if-else clause.

Extend the `exampleFuture*` code to discuss all possibilities how onComplete and
onSuccess/onFailure might be used.

Conformance:

* [x] You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
* [x] Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
