### PR TITLE
Fix wrong inherited javadoc of AsyncFile#exceptionHandler

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/file/AsyncFile.java
+++ b/vertx-core/src/main/java/io/vertx/core/file/AsyncFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,7 +21,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -55,6 +54,12 @@ public interface AsyncFile extends ReadStream<Buffer>, WriteStream<Buffer> {
   @Override
   AsyncFile drainHandler(Handler<Void> handler);
 
+  /**
+   * Set an exception handler on the read stream and on the write stream.
+   *
+   * @param handler the handler
+   * @return a reference to this, so the API can be used fluently
+   */
   @Override
   AsyncFile exceptionHandler(Handler<Throwable> handler);
 


### PR DESCRIPTION
Motivation:

See
https://vertx.io/docs/5.0.0.CR3/apidocs/io/vertx/core/file/AsyncFile.html#exceptionHandler(io.vertx.core.Handler) The inherited javadoc say that it sets the exception handler on the read stream only.

Fix: Mention that is also sets it on the write stream.

Conformance:

* [x] You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
* [x] Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
