### PR TITLE
Rename test build properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,18 @@ Tests can be run with specified HTTP port and/or HTTPS port.
 Vert.x supports native transport on BSD and Linux, to run the tests with native transport
 
 ```
-> mvn test -PtestNativeTransport
+> mvn test -PNativeEpoll
+> mvn test -PNativeIoUring
+> mvn test -PNativeKQueue
 ```
 
 Vert.x supports domain sockets on Linux exclusively, to run the tests with domain sockets
 
 ```
-> mvn test -PtestDomainSockets
+> mvn test -PNativeEpoll+DomainSockets
 ```
 
-Vert.x has a few integrations tests that run a differently configured JVM (classpath, system properties, etc....)
-for ALPN, native and logging
+Vert.x has integrations tests that run a differently configured JVM (classpath, system properties, etc....)
 
 ```
 > vertx verify -Dtest=FooTest # FooTest does not exists, its only purpose is to execute no tests during the test phase

--- a/vertx-core/pom.xml
+++ b/vertx-core/pom.xml
@@ -29,8 +29,8 @@
     <apacheds-protocol-dns.version>2.0.0.AM27</apacheds-protocol-dns.version>
     <generated.dir>${project.basedir}/src/main/generated</generated.dir>
     <jmh.version>1.37</jmh.version>
-    <vertx.testTransport>jdk</vertx.testTransport>
-    <vertx.testDomainSockets>false</vertx.testDomainSockets>
+    <vertx.surefire.nettyTransport>jdk</vertx.surefire.nettyTransport>
+    <vertx.surefire.useDomainSockets>false</vertx.surefire.useDomainSockets>
   </properties>
 
   <dependencies>
@@ -252,8 +252,8 @@
               <buildDirectory>${project.build.directory}</buildDirectory>
               <vertx.version>${project.version}</vertx.version>
               <vertx.handle100Continue>true</vertx.handle100Continue>
-              <vertx.transport>${vertx.testTransport}</vertx.transport>
-              <vertx.useDomainSockets>${vertx.testDomainSockets}</vertx.useDomainSockets>
+              <vertx.transport>${vertx.surefire.nettyTransport}</vertx.transport>
+              <vertx.useDomainSockets>${vertx.surefire.useDomainSockets}</vertx.useDomainSockets>
               <vertx.threadChecks>true</vertx.threadChecks>
             </systemPropertyVariables>
             <!-- Needs to be small enough to run in a EC2 1.7GB small instance -->
@@ -696,17 +696,17 @@
     <profile>
       <id>NativeEpoll</id>
       <properties>
-        <vertx.testTransport>epoll</vertx.testTransport>
-        <vertx.testDomainSockets>false</vertx.testDomainSockets>
-        <vertx.testUseModulePath>false</vertx.testUseModulePath>
+        <vertx.surefire.nettyTransport>epoll</vertx.surefire.nettyTransport>
+        <vertx.surefire.useDomainSockets>false</vertx.surefire.useDomainSockets>
+        <vertx.surefire.useModulePath>false</vertx.surefire.useModulePath>
       </properties>
     </profile>
 
     <profile>
       <id>NativeIoUring</id>
       <properties>
-        <vertx.testTransport>io_uring</vertx.testTransport>
-        <vertx.testDomainSockets>false</vertx.testDomainSockets>
+        <vertx.surefire.nettyTransport>io_uring</vertx.surefire.nettyTransport>
+        <vertx.surefire.useDomainSockets>false</vertx.surefire.useDomainSockets>
         <vertx.surefire.useModulePath>false</vertx.surefire.useModulePath>
       </properties>
     </profile>
@@ -714,8 +714,8 @@
     <profile>
       <id>NativeEpoll+DomainSockets</id>
       <properties>
-        <vertx.testTransport>epoll</vertx.testTransport>
-        <vertx.testDomainSockets>true</vertx.testDomainSockets>
+        <vertx.surefire.nettyTransport>epoll</vertx.surefire.nettyTransport>
+        <vertx.surefire.useDomainSockets>true</vertx.surefire.useDomainSockets>
         <vertx.surefire.useModulePath>false</vertx.surefire.useModulePath>
       </properties>
     </profile>
@@ -723,18 +723,18 @@
     <profile>
       <id>NativeKQueue</id>
       <properties>
-        <vertx.testTransport>kqueue</vertx.testTransport>
-        <vertx.testDomainSockets>false</vertx.testDomainSockets>
-        <vertx.testUseModulePath>false</vertx.testUseModulePath>
+        <vertx.surefire.nettyTransport>kqueue</vertx.surefire.nettyTransport>
+        <vertx.surefire.useDomainSockets>false</vertx.surefire.useDomainSockets>
+        <vertx.surefire.useModulePath>false</vertx.surefire.useModulePath>
       </properties>
     </profile>
 
     <profile>
       <id>NativeKQueue+DomainSockets</id>
       <properties>
-        <vertx.testTransport>kqueue</vertx.testTransport>
-        <vertx.testDomainSockets>true</vertx.testDomainSockets>
-        <vertx.testUseModulePath>false</vertx.testUseModulePath>
+        <vertx.surefire.nettyTransport>kqueue</vertx.surefire.nettyTransport>
+        <vertx.surefire.useDomainSockets>true</vertx.surefire.useDomainSockets>
+        <vertx.surefire.useModulePath>false</vertx.surefire.useModulePath>
       </properties>
     </profile>
 


### PR DESCRIPTION
Motivation:

The `useModulePath` property for testing is now provided by vertx5-parent and is named `vertx.surefire.useModulePath`. Rename vertx-core specific properties to follow the same pattern.

Changes:

- `vertx.testUseDomainSockets` -> vertx.surefire.useDomainSockets`
- `vertx.testTransport` -> `vertx.surefire.nettyTransport`
- update README accordingly
