### PR TITLE
Handle properly shadow context in worker executor implementation

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
@@ -50,19 +50,23 @@ import java.util.concurrent.ConcurrentMap;
  * middleware running on the actual context interacts with this context resources, middleware running on the shadow context
  * interacts with the shadow context resources.</p>
  */
-final class ShadowContext extends ContextBase {
+public final class ShadowContext extends ContextBase {
 
   final VertxInternal owner;
   final ContextBase delegate;
   private final EventLoopExecutor eventLoop;
-  private final TaskQueue orderedTasks;
+  final TaskQueue orderedTasks;
 
-  public ShadowContext(VertxInternal owner, EventLoopExecutor eventLoop, ContextInternal delegate) {
+  ShadowContext(VertxInternal owner, EventLoopExecutor eventLoop, ContextInternal delegate) {
     super(((ContextBase)delegate).locals);
     this.owner = owner;
     this.eventLoop = eventLoop;
     this.delegate = (ContextBase) delegate;
     this.orderedTasks = new TaskQueue();
+  }
+
+  public ContextInternal delegate() {
+    return delegate;
   }
 
   @Override


### PR DESCRIPTION
Motivation:

The implementation of worker executor assumes that a context is always a `ContextImpl`. Since we added support for shadow contexts, the implementation should handle this case as well.

Changes:

Update the worker executor implementation to handle the case of a shadow context.
