### PR TITLE
Remove thread sticky context feature

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -170,7 +170,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   private final Throwable transportUnavailabilityCause;
   private final VertxTracer tracer;
   private final ThreadLocal<WeakReference<EventLoop>> stickyEventLoop = new ThreadLocal<>();
-  private final ThreadLocal<WeakReference<ContextInternal>> stickyContext = new ThreadLocal<>();
   private final boolean disableTCCL;
   private final Boolean useDaemonThread;
 
@@ -521,7 +520,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       } else {
         ctx = createEventLoopContext(eventLoop, workerPool, Thread.currentThread().getContextClassLoader());
       }
-      stickyContext.set(new WeakReference<>(ctx));
       return ctx;
     }
   }
@@ -706,10 +704,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
         return new ShadowContext(this, new EventLoopExecutor(eventLoop), context);
       }
     } else {
-      WeakReference<ContextInternal> ref = stickyContext.get();
-      if (ref != null) {
-        return ref.get();
-      }
       return null;
     }
   }

--- a/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
@@ -918,9 +918,8 @@ public class ContextTest extends VertxTestBase {
   }
 
   @Test
-  public void testSticky() {
+  public void testStickiness() {
     Context ctx = vertx.getOrCreateContext();
-    assertSame(ctx, vertx.getOrCreateContext());
     assertSame(((ContextInternal)ctx).nettyEventLoop(), ((ContextInternal)vertx.getOrCreateContext()).nettyEventLoop());
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/context/EventExecutorProviderTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/EventExecutorProviderTest.java
@@ -46,8 +46,6 @@ public class EventExecutorProviderTest extends AsyncTestBase {
     toRun.pop().run();
     assertEquals(1, cnt[0]);
     assertNull(Vertx.currentContext());
-    // Sticky context
-    assertSame(ctx, vertx.getOrCreateContext());
   }
 
   @Test


### PR DESCRIPTION
Motivation:

Thread sticky context was introduced in Vert.x 4 in order to maintain callback ordering when submitting tasks from a non vertx thread.

Vert.x 5 introduces the sticky event-loop feature that implements the same idea for shadow contexts.

In addition shadow context references cannot be reasonnably maintained.

Dropping sticky context support does not break the original intent of the feature and brings behavior consistency when deadling with foreign contexts.

Changes:

Drop stick context feature.
