### PR TITLE
Support duplicate context duplication.

### DIFF
--- a/src/main/java/io/vertx/core/impl/ContextBase.java
+++ b/src/main/java/io/vertx/core/impl/ContextBase.java
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
  */
 class ContextBase extends AtomicReferenceArray<Object> {
 
-  private final int localsLength;
+  final int localsLength;
 
   ContextBase(int localsLength) {
     super(localsLength);

--- a/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -44,7 +44,7 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
   static final boolean DISABLE_TIMINGS = Boolean.getBoolean(DISABLE_TIMINGS_PROP_NAME);
 
   private final ThreadingModel threadingModel;
-  private final VertxInternal owner;
+  private final VertxImpl owner;
   private final JsonObject config;
   private final Deployment deployment;
   private final CloseFuture closeFuture;
@@ -58,7 +58,7 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
   final WorkerPool workerPool;
   final WorkerTaskQueue executeBlockingTasks;
 
-  public ContextImpl(VertxInternal vertx,
+  public ContextImpl(VertxImpl vertx,
                      int localsLength,
                      ThreadingModel threadingModel,
                      EventLoop eventLoop,
@@ -116,7 +116,7 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
     return eventLoop;
   }
 
-  public VertxInternal owner() {
+  public VertxImpl owner() {
     return owner;
   }
 

--- a/src/main/java/io/vertx/core/impl/ContextInternal.java
+++ b/src/main/java/io/vertx/core/impl/ContextInternal.java
@@ -36,7 +36,7 @@ import static io.vertx.core.impl.ContextImpl.setResultHandler;
  */
 public interface ContextInternal extends Context {
 
-  ContextLocal<ConcurrentMap<Object, Object>> LOCAL_MAP = new ContextLocalImpl<>(0);
+  ContextLocal<ConcurrentMap<Object, Object>> LOCAL_MAP = new ContextLocalImpl<>(0, ConcurrentHashMap::new);
 
   /**
    * @return the current context

--- a/src/main/java/io/vertx/core/impl/ContextLocalImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextLocalImpl.java
@@ -12,18 +12,27 @@ package io.vertx.core.impl;
 
 import io.vertx.core.spi.context.storage.ContextLocal;
 
+import java.util.function.Function;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class ContextLocalImpl<T> implements ContextLocal<T> {
 
-  final int index;
-
-  public ContextLocalImpl(int index) {
-    this.index = index;
+  public static <T> ContextLocal<T> create(Class<T> type, Function<T, T> duplicator) {
+    synchronized (LocalSeq.class) {
+      int idx = LocalSeq.locals.size();
+      ContextLocal<T> local = new ContextLocalImpl<>(idx, duplicator);
+      LocalSeq.locals.add(local);
+      return local;
+    }
   }
 
-  public ContextLocalImpl() {
-    this.index = LocalSeq.next();
+  final int index;
+  final Function<T, T> duplicator;
+
+  public ContextLocalImpl(int index, Function<T, T> duplicator) {
+    this.index = index;
+    this.duplicator = duplicator;
   }
 }

--- a/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -180,7 +180,9 @@ final class DuplicatedContext extends ContextBase implements ContextInternal {
 
   @Override
   public ContextInternal duplicate() {
-    return new DuplicatedContext(delegate);
+    DuplicatedContext duplicate = new DuplicatedContext(delegate);
+    delegate.owner().duplicate(this, duplicate);
+    return duplicate;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/LocalSeq.java
+++ b/src/main/java/io/vertx/core/impl/LocalSeq.java
@@ -10,28 +10,35 @@
  */
 package io.vertx.core.impl;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import io.vertx.core.spi.context.storage.ContextLocal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 class LocalSeq {
 
-  // 0 : reserved slot for local context map
-  private static final AtomicInteger seq = new AtomicInteger(1);
+  static final List<ContextLocal<?>> locals = new ArrayList<>();
+
+  static {
+    reset();
+  }
 
   /**
    * Hook for testing purposes
    */
-  static void reset() {
-    seq.set((1));
+  synchronized static void reset() {
+    // 0 : reserved slot for local context map
+    locals.clear();
+    locals.add(ContextInternal.LOCAL_MAP);
   }
 
-  static int get() {
-    return seq.get();
-  }
-
-  static int next() {
-    return seq.getAndIncrement();
+  synchronized static ContextLocal<?>[] get() {
+    return locals.toArray(new ContextLocal[0]);
   }
 }

--- a/src/main/java/io/vertx/core/spi/context/storage/ContextLocal.java
+++ b/src/main/java/io/vertx/core/spi/context/storage/ContextLocal.java
@@ -14,6 +14,7 @@ import io.vertx.core.Context;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.ContextLocalImpl;
 
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -35,7 +36,16 @@ public interface ContextLocal<T> {
    * @return the context local storage
    */
   static <T> ContextLocal<T> registerLocal(Class<T> type) {
-    return new ContextLocalImpl<>();
+    return ContextLocalImpl.create(type, Function.identity());
+  }
+
+  /**
+   * Registers a context local storage.
+   *
+   * @return the context local storage
+   */
+  static <T> ContextLocal<T> registerLocal(Class<T> type, Function<T, T> duplicator) {
+    return ContextLocalImpl.create(type, duplicator);
   }
 
   /**

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -1238,4 +1238,19 @@ public class ContextTest extends VertxTestBase {
     assertTrue((System.currentTimeMillis() - now) < 2000);
     assertTrue(interrupted.get());
   }
+
+  @Test
+  public void testNestedDuplicate() {
+    ContextInternal ctx = ((ContextInternal) vertx.getOrCreateContext()).duplicate();
+    ctx.putLocal("foo", "bar");
+    Object expected = new Object();
+    ctx.putLocal(contextLocal, AccessMode.CONCURRENT, expected);
+    ContextInternal duplicate = ctx.duplicate();
+    assertEquals("bar", duplicate.getLocal("foo"));
+    assertEquals(expected, duplicate.getLocal(contextLocal));
+    ctx.removeLocal("foo");
+    ctx.removeLocal(contextLocal, AccessMode.CONCURRENT);
+    assertEquals("bar", duplicate.getLocal("foo"));
+    assertEquals(expected, duplicate.getLocal(contextLocal));
+  }
 }


### PR DESCRIPTION
Motivation:

Duplicating a duplicated context is supported but the duplication semantic is not defined.

Changes:

This update the duplicated context duplication by doing a copy of each local in the duplicated duplicate. This introduce a duplicator for each local that is responsible for copying the object when it is not null.