### PR TITLE
Do consume messages on the correct thread after resume

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
@@ -152,7 +152,7 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
     if (handler == null) {
       throw new NullPointerException();
     }
-    context.dispatch(msg, handler);
+    context.emit(msg, handler);
   }
 
   private void deliver(Handler<Message<T>> theHandler, Message<T> message) {

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/MessageConsumerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/MessageConsumerTest.java
@@ -1,0 +1,62 @@
+package io.vertx.tests.eventbus;
+
+import io.vertx.core.*;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+public class MessageConsumerTest extends VertxTestBase {
+
+
+  @Test
+  public void testMessageConsumptionStayOnWorkerThreadAfterResume() throws Exception {
+    TestVerticle verticle = new TestVerticle(2);
+    Future<String> deployVerticle = vertx.deployVerticle(verticle, new DeploymentOptions().setThreadingModel(ThreadingModel.WORKER));
+
+    CountDownLatch startLatch = new CountDownLatch(1);
+    deployVerticle.onComplete(onSuccess(cf -> startLatch.countDown()));
+    awaitLatch(startLatch);
+
+    vertx.eventBus().send("testAddress", "message1");
+    vertx.eventBus().send("testAddress", "message2");
+
+    awaitLatch(verticle.msgLatch);
+
+    assertEquals(2, verticle.messageArrivedOnWorkerThread.size());
+    assertTrue("message1 should be processed on worker thread", verticle.messageArrivedOnWorkerThread.get("message1"));
+    assertTrue("message2 should be processed on worker thread", verticle.messageArrivedOnWorkerThread.get("message2"));
+  }
+
+
+  private static class TestVerticle extends AbstractVerticle {
+
+    private final CountDownLatch msgLatch;
+
+    private final Map<String, Boolean> messageArrivedOnWorkerThread = new HashMap<>();
+
+    private TestVerticle(Integer numberOfExpectedMessages) {
+      this.msgLatch = new CountDownLatch(numberOfExpectedMessages);
+    }
+
+    @Override
+    public void start() {
+      MessageConsumer<String> consumer = vertx.eventBus().localConsumer("testAddress");
+      handleMessages(consumer);
+    }
+
+    private void handleMessages(MessageConsumer<String> consumer) {
+      consumer.handler(msg -> {
+        consumer.pause();
+        messageArrivedOnWorkerThread.putIfAbsent(msg.body(), Context.isOnWorkerThread());
+        msgLatch.countDown();
+        vertx.setTimer(20, id -> {
+          consumer.resume();
+        });
+      });
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

In our code we do pause the consumer and later resume it. something as below
```MessageConsumer<Message> consumer = ...
consumer.pause();
Uni<Void> processing = ....
processing
.eventually(consumer::resume)
.subscribe()
.with(UniHelper.NOOP);
```

when we call resume the next msg processed on event loop regardless the consumption meant to be on worker thread based on the Verticle deployment.
Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
