### PR TITLE
HTTP client form submission

### DIFF
--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -1130,6 +1130,31 @@ no need to set the `Content-Length` of the request up-front.
 {@link examples.HTTPExamples#example41}
 ----
 
+==== Form submissions
+
+You can send http form submissions bodies with the {@link io.vertx.core.http.HttpClientRequest#send(io.vertx.core.http.ClientForm)}
+variant.
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#sendForm}
+----
+
+By default, the form is submitted with the `application/x-www-form-urlencoded` content type header. You can set
+the `content-type` header to `multipart/form-data` instead
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#sendMultipart}
+----
+
+If you want to upload files and send attributes, you can create a {@link io.vertx.core.http.ClientMultipartForm} instead.
+
+[source,$lang]
+----
+{@link examples.HTTPExamples#sendMultipartWithFileUpload}
+----
+
 ==== Request timeouts
 
 You can set an idle timeout to prevent your application from unresponsive servers using {@link io.vertx.core.http.RequestOptions#setIdleTimeout(long)} or {@link io.vertx.core.http.HttpClientRequest#idleTimeout(long)}. When the request does not return any data within the timeout period an exception will fail the result and the request will be reset.

--- a/vertx-core/src/main/java/examples/HTTPExamples.java
+++ b/vertx-core/src/main/java/examples/HTTPExamples.java
@@ -557,6 +557,50 @@ public class HTTPExamples {
     request.end();
   }
 
+  public void sendForm(HttpClientRequest request) {
+    ClientForm form = ClientForm.form();
+    form.attribute("firstName", "Dale");
+    form.attribute("lastName", "Cooper");
+
+    // Submit the form as a form URL encoded body
+    request
+      .send(form)
+      .onSuccess(res -> {
+        // OK
+      });
+  }
+
+  public void sendMultipart(HttpClientRequest request) {
+    ClientForm form = ClientForm.form();
+    form.attribute("firstName", "Dale");
+    form.attribute("lastName", "Cooper");
+
+    // Submit the form as a multipart form body
+    request
+      .putHeader("content-type", "multipart/form-data")
+      .send(form)
+      .onSuccess(res -> {
+        // OK
+      });
+  }
+
+  public void sendMultipartWithFileUpload(HttpClientRequest request) {
+    ClientMultipartForm form = ClientMultipartForm.multipartForm()
+      .attribute("imageDescription", "a very nice image")
+      .binaryFileUpload(
+        "imageFile",
+        "image.jpg",
+        "/path/to/image",
+        "image/jpeg");
+
+    // Submit the form as a multipart form body
+    request
+      .send(form)
+      .onSuccess(res -> {
+        // OK
+      });
+  }
+
   public void clientIdleTimeout(HttpClient client, int port, String host, String uri, int timeoutMS) {
     Future<Buffer> fut = client
       .request(new RequestOptions()

--- a/vertx-core/src/main/java/io/vertx/core/http/ClientForm.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/ClientForm.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.impl.ClientMultipartFormImpl;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * A form: a container for attributes.
+ */
+@VertxGen
+public interface ClientForm {
+
+  /**
+   * @return a blank form
+   */
+  static ClientForm form() {
+    ClientMultipartFormImpl form = new ClientMultipartFormImpl(false);
+    form.charset(StandardCharsets.UTF_8);
+    return form;
+  }
+
+  /**
+   * @param initial the initial content of the form
+   * @return a form populated after the {@code initial} multimap
+   */
+  static ClientForm form(MultiMap initial) {
+    ClientMultipartFormImpl form = new ClientMultipartFormImpl(false);
+    for (Map.Entry<String, String> attribute : initial) {
+      form.attribute(attribute.getKey(), attribute.getValue());
+    }
+    form.charset(StandardCharsets.UTF_8);
+    return form;
+  }
+
+  @Fluent
+  ClientForm attribute(String name, String value);
+
+  /**
+   * Set the {@code charset} to use when encoding the form. The default charset is {@link java.nio.charset.StandardCharsets#UTF_8}.
+   *
+   * @param charset the charset to use
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ClientForm charset(String charset);
+
+  /**
+   * Set the {@code charset} to use when encoding the form. The default charset is {@link java.nio.charset.StandardCharsets#UTF_8}.
+   *
+   * @param charset the charset to use
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  ClientForm charset(Charset charset);
+
+  /**
+   * @return the charset to use when encoding the form
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Charset charset();
+
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/ClientMultipartForm.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/ClientMultipartForm.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.impl.ClientMultipartFormImpl;
+
+import java.nio.charset.Charset;
+
+/**
+ * A multipart form, providing file upload capabilities.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface ClientMultipartForm extends ClientForm {
+
+  /**
+   * @return a blank multipart form
+   */
+  static ClientMultipartForm multipartForm() {
+    return new ClientMultipartFormImpl(true);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Fluent
+  ClientMultipartForm attribute(String name, String value);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Fluent
+  ClientMultipartForm charset(String charset);
+
+  /**
+   * {@inheritDoc}
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  ClientMultipartForm charset(Charset charset);
+
+  /**
+   * Allow or disallow multipart mixed encoding when files are sharing the same file name.
+   * <br/>
+   * The default value is {@code true}.
+   * <br/>
+   * Set to {@code false} if you want to achieve the behavior for <a href="http://www.w3.org/TR/html5/forms.html#multipart-form-data">HTML5</a>.
+   *
+   * @param allow {@code true} allows use of multipart mixed encoding
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ClientMultipartForm mixed(boolean allow);
+
+  /**
+   * @return whether multipart mixed encoding is allowed
+   */
+  boolean mixed();
+
+  /**
+   * Add a text file upload form data part.
+   *
+   * @param name      name of the parameter
+   * @param filename  filename of the file
+   * @param mediaType the MIME type of the file
+   * @param content   the content of the file
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ClientMultipartForm textFileUpload(String name, String filename, String mediaType, Buffer content);
+
+  /**
+   * Add a binary file upload form data part.
+   *
+   * @param name      name of the parameter
+   * @param filename  filename of the file
+   * @param mediaType the MIME type of the file
+   * @param content   the content of the file
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ClientMultipartForm binaryFileUpload(String name, String filename, String mediaType, Buffer content);
+
+  /**
+   * Add a text file upload form data part.
+   *
+   * @param name      name of the parameter
+   * @param filename  filename of the file
+   * @param mediaType the MIME type of the file
+   * @param pathname  the pathname of the file
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ClientMultipartForm textFileUpload(String name, String filename, String mediaType, String pathname);
+
+  /**
+   * Add a binary file upload form data part.
+   *
+   * @param name      name of the parameter
+   * @param filename  filename of the file
+   * @param mediaType the MIME type of the file
+   * @param pathname  the pathname of the file
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  ClientMultipartForm binaryFileUpload(String name, String filename, String mediaType, String pathname);
+
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -313,7 +313,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   /**
    * Send the request with an empty body.
    *
-   * @return a future notified when the last bytes of the request is written
+   * @return a future notified when the HTTP response is available
    */
   default Future<HttpClientResponse> send() {
     end();
@@ -323,7 +323,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   /**
    * Send the request with a string {@code body}.
    *
-   * @return a future notified when the last bytes of the request is written
+   * @return a future notified when the HTTP response is available
    */
   default Future<HttpClientResponse> send(String body) {
     end(body);
@@ -333,7 +333,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   /**
    * Send the request with a buffer {@code body}.
    *
-   * @return a future notified when the last bytes of the request is written
+   * @return a future notified when the HTTP response is available
    */
   default Future<HttpClientResponse> send(Buffer body) {
     end(body);
@@ -341,12 +341,21 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   }
 
   /**
+   * Like {@link #send()} but with a {@code form}. The content will be set to {@code application/x-www-form-urlencoded}
+   * or {@code multipart/form-data} according to the nature of the form.
+   *
+   * @param form the form to send
+   * @return a future notified when the HTTP response is available
+   */
+  Future<HttpClientResponse> send(ClientForm form);
+
+  /**
    * Send the request with a stream {@code body}.
    *
    * <p> If the {@link HttpHeaders#CONTENT_LENGTH} is set then the request assumes this is the
    * length of the {stream}, otherwise the request will set a chunked {@link HttpHeaders#CONTENT_ENCODING}.
    *
-   * @return a future notified when the last bytes of the request is written
+   * @return a future notified when the HTTP response is available
    */
   default Future<HttpClientResponse> send(ReadStream<Buffer> body) {
     MultiMap headers = headers();

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -353,6 +353,12 @@ public interface HttpHeaders {
   CharSequence APPLICATION_X_WWW_FORM_URLENCODED = HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED;
 
   /**
+   * multipart/form-data header value
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence MULTIPART_FORM_DATA = HttpHeaderValues.MULTIPART_FORM_DATA;
+
+  /**
    * chunked header value
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/ClientMultipartFormDataPart.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/ClientMultipartFormDataPart.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.vertx.core.buffer.Buffer;
+
+public class ClientMultipartFormDataPart {
+
+  final String name;
+  final String value;
+  final String filename;
+  final String mediaType;
+  final Buffer content;
+  final String pathname;
+  final Boolean text;
+
+  public ClientMultipartFormDataPart(String name, String value) {
+    if (name == null) {
+      throw new NullPointerException();
+    }
+    if (value == null) {
+      throw new NullPointerException();
+    }
+    this.name = name;
+    this.value = value;
+    this.filename = null;
+    this.content = null;
+    this.pathname = null;
+    this.mediaType = null;
+    this.text = null;
+  }
+
+
+  public ClientMultipartFormDataPart(String name, String filename, Buffer content, String mediaType, boolean text) {
+    if (name == null) {
+      throw new NullPointerException();
+    }
+    if (filename == null) {
+      throw new NullPointerException();
+    }
+    if (content == null) {
+      throw new NullPointerException();
+    }
+    if (mediaType == null) {
+      throw new NullPointerException();
+    }
+    this.name = name;
+    this.value = null;
+    this.filename = filename;
+    this.content = content;
+    this.pathname = null;
+    this.mediaType = mediaType;
+    this.text = text;
+  }
+
+  public ClientMultipartFormDataPart(String name, String filename, String pathname, String mediaType, boolean text) {
+    if (name == null) {
+      throw new NullPointerException();
+    }
+    if (filename == null) {
+      throw new NullPointerException();
+    }
+    if (pathname == null) {
+      throw new NullPointerException();
+    }
+    if (mediaType == null) {
+      throw new NullPointerException();
+    }
+    this.name = name;
+    this.value = null;
+    this.filename = filename;
+    this.content = null;
+    this.pathname = pathname;
+    this.mediaType = mediaType;
+    this.text = text;
+  }
+
+  /**
+   * @return the name
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * @return {@code true} when this part is an attribute
+   */
+  public boolean isAttribute() {
+    return value != null;
+  }
+
+  /**
+   * @return {@code true} when this part is a file upload
+   */
+  public boolean isFileUpload() {
+    return value == null;
+  }
+
+  /**
+   * @return the value when the part for a form attribute otherwise {@code null}
+   */
+  public String value() {
+    return value;
+  }
+
+  /**
+   * @return the filename when this part is a file upload otherwise {@code null}
+   */
+  public String filename() {
+    return filename;
+  }
+
+  /**
+   * @return the pathname when this part is a file upload created with a pathname otherwise {@code null}
+   */
+  public String pathname() {
+    return pathname;
+  }
+
+  /**
+   * @return the content when this part is a file upload created with a buffer otherwise {@code null}
+   */
+  public Buffer content() {
+    return content;
+  }
+
+  /**
+   * @return the media type when this part is a file upload otherwise {@code null}
+   */
+  public String mediaType() {
+    return mediaType;
+  }
+
+  /**
+   * @return whether the file upload is text or binary when this part is a file upload otherwise {@code null}
+   */
+  public Boolean isText() {
+    return text;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/ClientMultipartFormImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/ClientMultipartFormImpl.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.ClientMultipartForm;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class ClientMultipartFormImpl implements ClientMultipartForm, Iterable<ClientMultipartFormDataPart> {
+
+  private Charset charset = StandardCharsets.UTF_8;
+  private final List<ClientMultipartFormDataPart> parts = new ArrayList<>();
+  private final boolean multipart;
+  private boolean mixed;
+
+  public ClientMultipartFormImpl(boolean multipart) {
+    this.multipart = multipart;
+    this.mixed = true;
+  }
+
+  public boolean isMultipart() {
+    return multipart;
+  }
+
+  @Override
+  public Iterator<ClientMultipartFormDataPart> iterator() {
+    return parts.iterator();
+  }
+
+  @Override
+  public ClientMultipartForm attribute(String name, String value) {
+    parts.add(new ClientMultipartFormDataPart(name, value));
+    return this;
+  }
+
+  @Override
+  public ClientMultipartFormImpl charset(String charset) {
+    return charset(charset != null ? Charset.forName(charset) : null);
+  }
+
+  @Override
+  public ClientMultipartFormImpl charset(Charset charset) {
+    this.charset = charset;
+    return this;
+  }
+
+  @Override
+  public ClientMultipartForm mixed(boolean allow) {
+    this.mixed = allow;
+    return this;
+  }
+
+  @Override
+  public boolean mixed() {
+    return mixed;
+  }
+
+  @Override
+  public Charset charset() {
+    return charset;
+  }
+
+  @Override
+  public ClientMultipartForm textFileUpload(String name, String filename, String mediaType, Buffer content) {
+    parts.add(new ClientMultipartFormDataPart(name, filename, content, mediaType, true));
+    return this;
+  }
+
+  @Override
+  public ClientMultipartForm binaryFileUpload(String name, String filename, String mediaType, Buffer content) {
+    parts.add(new ClientMultipartFormDataPart(name, filename, content, mediaType, false));
+    return this;
+  }
+
+  @Override
+  public ClientMultipartForm textFileUpload(String name, String filename, String mediaType, String pathname) {
+    parts.add(new ClientMultipartFormDataPart(name, filename, pathname, mediaType, true));
+    return this;
+  }
+
+  @Override
+  public ClientMultipartForm binaryFileUpload(String name, String filename, String mediaType, String pathname) {
+    parts.add(new ClientMultipartFormDataPart(name, filename, pathname, mediaType, false));
+    return this;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/ClientMultipartFormUpload.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/ClientMultipartFormUpload.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.multipart.*;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.buffer.BufferInternal;
+import io.vertx.core.internal.concurrent.InboundMessageQueue;
+import io.vertx.core.internal.http.HttpHeadersInternal;
+import io.vertx.core.streams.Pipe;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+/**
+ * A stream that sends a multipart form.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class ClientMultipartFormUpload implements ReadStream<Buffer> {
+
+  private static final Object END_SENTINEL = new Object();
+
+  private static final UnpooledByteBufAllocator ALLOC = new UnpooledByteBufAllocator(false);
+
+  private DefaultFullHttpRequest request;
+  private HttpPostRequestEncoder encoder;
+  private Handler<Throwable> exceptionHandler;
+  private Handler<Buffer> dataHandler;
+  private Handler<Void> endHandler;
+  private final InboundMessageQueue<Object> pending;
+  private boolean writable;
+  private boolean ended;
+  private final ContextInternal context;
+
+  public ClientMultipartFormUpload(ContextInternal context,
+                                   ClientMultipartFormImpl parts,
+                                   boolean multipart,
+                                   HttpPostRequestEncoder.EncoderMode encoderMode) throws Exception {
+    this.context = context;
+    this.writable = true;
+    this.pending = new InboundMessageQueue<>(context.executor(), context.executor()) {
+      @Override
+      protected void handleResume() {
+        writable = true;
+        pump();
+      }
+      @Override
+      protected void handlePause() {
+        writable = false;
+      }
+      @Override
+      protected void handleMessage(Object msg) {
+        handleChunk(msg);
+      }
+    };
+    this.request = new DefaultFullHttpRequest(
+      HttpVersion.HTTP_1_1,
+      HttpMethod.POST,
+      "/");
+    parts.charset();
+    Charset charset = parts.charset() != null ? parts.charset() : HttpConstants.DEFAULT_CHARSET;
+    this.encoder = new HttpPostRequestEncoder(
+      new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE, charset) {
+        @Override
+        public Attribute createAttribute(HttpRequest request, String name, String value) {
+          try {
+            return new MemoryAttribute(name, value, charset);
+          } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+          }
+        }
+
+        @Override
+        public FileUpload createFileUpload(HttpRequest request, String name, String filename, String contentType, String contentTransferEncoding, Charset _charset, long size) {
+          if (_charset == null) {
+            _charset = charset;
+          }
+          return super.createFileUpload(request, name, filename, contentType, contentTransferEncoding, _charset, size);
+        }
+      },
+      request,
+      multipart,
+      charset,
+      encoderMode);
+    for (ClientMultipartFormDataPart formDataPart : parts) {
+      if (formDataPart.isAttribute()) {
+        encoder.addBodyAttribute(formDataPart.name(), formDataPart.value());
+      } else {
+        String pathname = formDataPart.pathname();
+        if (pathname != null) {
+          encoder.addBodyFileUpload(formDataPart.name(),
+            formDataPart.filename(), new File(formDataPart.pathname()),
+            formDataPart.mediaType(), formDataPart.isText());
+        } else {
+          String contentType = formDataPart.mediaType();
+          if (formDataPart.mediaType() == null) {
+            if (formDataPart.isText()) {
+              contentType = "text/plain";
+            } else {
+              contentType = "application/octet-stream";
+            }
+          }
+          String transferEncoding = formDataPart.isText() ? null : "binary";
+          MemoryFileUpload fileUpload = new MemoryFileUpload(
+            formDataPart.name(),
+            formDataPart.filename(),
+            contentType, transferEncoding, null, formDataPart.content().length());
+          fileUpload.setContent(((BufferInternal)formDataPart.content()).getByteBuf());
+          encoder.addBodyHttpData(fileUpload);
+        }
+      }
+    }
+    encoder.finalizeRequest();
+  }
+
+  private void handleChunk(Object item) {
+    Handler handler;
+    synchronized (ClientMultipartFormUpload.this) {
+      if (item instanceof Buffer) {
+        handler = dataHandler;
+      } else if (item instanceof Throwable) {
+        handler = exceptionHandler;
+      } else if (item == END_SENTINEL) {
+        handler = endHandler;
+        item = null;
+      } else {
+        return;
+      }
+    }
+    handler.handle(item);
+  }
+
+  public void pump() {
+    if (!context.inThread()) {
+      throw new IllegalArgumentException();
+    }
+    while (!ended) {
+      if (encoder.isChunked()) {
+        try {
+          HttpContent chunk = encoder.readChunk(ALLOC);
+          ByteBuf content = chunk.content();
+          Buffer buff = BufferInternal.buffer(content);
+          pending.write(buff);
+          if (encoder.isEndOfInput()) {
+            ended = true;
+            request = null;
+            encoder = null;
+            pending.write(END_SENTINEL);
+          } else if (!writable) {
+            break;
+          }
+        } catch (Exception e) {
+          ended = true;
+          request = null;
+          encoder = null;
+          pending.write(e);
+          break;
+        }
+      } else {
+        ByteBuf content = request.content();
+        Buffer buffer = BufferInternal.buffer(content);
+        request = null;
+        encoder = null;
+        pending.write(buffer);
+        ended = true;
+        pending.write(END_SENTINEL);
+      }
+    }
+  }
+
+  public MultiMap headers() {
+    return HttpHeadersInternal.headers(request.headers());
+  }
+
+  @Override
+  public synchronized ClientMultipartFormUpload exceptionHandler(Handler<Throwable> handler) {
+    exceptionHandler = handler;
+    return this;
+  }
+
+  @Override
+  public synchronized ClientMultipartFormUpload handler(Handler<Buffer> handler) {
+    dataHandler = handler;
+    return this;
+  }
+
+  @Override
+  public synchronized ClientMultipartFormUpload pause() {
+    pending.pause();
+    return this;
+  }
+
+  @Override
+  public ReadStream<Buffer> fetch(long amount) {
+    pending.fetch(amount);
+    return this;
+  }
+
+  @Override
+  public synchronized ClientMultipartFormUpload resume() {
+    pending.fetch(Long.MAX_VALUE);
+    return this;
+  }
+
+  @Override
+  public synchronized ClientMultipartFormUpload endHandler(Handler<Void> handler) {
+    endHandler = handler;
+    return this;
+  }
+
+  @Override
+  public Future<Void> pipeTo(WriteStream<Buffer> dst) {
+    return pipe().to(dst);
+  }
+
+  @Override
+  public Pipe<Buffer> pipe() {
+    Pipe<Buffer> pipe = ReadStream.super.pipe();
+    return new Pipe<>() {
+      @Override
+      public Pipe<Buffer> endOnFailure(boolean end) {
+        pipe.endOnFailure(end);
+        return this;
+      }
+      @Override
+      public Pipe<Buffer> endOnSuccess(boolean end) {
+        pipe.endOnSuccess(end);
+        return this;
+      }
+      @Override
+      public Pipe<Buffer> endOnComplete(boolean end) {
+        pipe.endOnComplete(end);
+        return this;
+      }
+      @Override
+      public Future<Void> to(WriteStream<Buffer> dst) {
+        Future<Void> f = pipe.to(dst);
+        pump();
+        return f;
+      }
+      @Override
+      public void close() {
+        pipe.close();
+      }
+    };
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -171,6 +171,11 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
+  public Future<HttpClientResponse> send(ClientForm form) {
+    throw new IllegalStateException();
+  }
+
+  @Override
   public Future<HttpClientResponse> connect() {
     throw new IllegalStateException();
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -4448,6 +4448,7 @@ public abstract class HttpTest extends HttpTestBase {
       public HttpClientRequest redirectHandler(@Nullable Function<HttpClientResponse, Future<HttpClientRequest>> handler) { throw new UnsupportedOperationException(); }
       public HttpClientRequest earlyHintsHandler(@Nullable Handler<MultiMap> handler) { throw new UnsupportedOperationException(); }
       public Future<Void> sendHead() { throw new UnsupportedOperationException(); }
+      public Future<HttpClientResponse> send(ClientForm form) { throw new UnsupportedOperationException(); }
       public Future<HttpClientResponse> connect() { throw new UnsupportedOperationException(); }
       public Future<Void> end(String chunk) { throw new UnsupportedOperationException(); }
       public Future<Void> end(String chunk, String enc) { throw new UnsupportedOperationException(); }

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/HttpClientFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/HttpClientFileUploadTest.java
@@ -1,0 +1,372 @@
+package io.vertx.tests.http.fileupload;
+
+import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
+import io.vertx.test.core.TestUtils;
+import io.vertx.test.http.HttpTestBase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+public class HttpClientFileUploadTest extends HttpTestBase {
+
+  @Rule
+  public TemporaryFolder testFolder = new TemporaryFolder();
+
+  @Test
+  public void testFormUrlEncoded() throws Exception {
+    server.requestHandler(req -> {
+      req.setExpectMultipart(true);
+      req.endHandler(v -> {
+        assertEquals("param1_value", req.getFormAttribute("param1"));
+        req.response().end();
+      });
+    });
+    startServer(testAddress);
+    MultiMap form = MultiMap.caseInsensitiveMultiMap();
+    form.add("param1", "param1_value");
+    client.request(new RequestOptions(requestOptions).setMethod(HttpMethod.POST))
+      .compose(req -> req
+        .send(ClientForm.form(form))
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::body))
+      .await();
+  }
+
+  @Test
+  public void testFormUrlEncodedWithCharset() throws Exception {
+    String str = "ø";
+    String expected = URLDecoder.decode(URLEncoder.encode(str, StandardCharsets.ISO_8859_1.name()), StandardCharsets.UTF_8.name());
+    server.requestHandler(req -> {
+      req.setExpectMultipart(true);
+      req.endHandler(v -> {
+        String val = req.getFormAttribute("param1");
+        assertEquals(expected, val);
+        req.response().end();
+      });
+    });
+    startServer();
+    MultiMap form = MultiMap.caseInsensitiveMultiMap();
+    form.add("param1", str);
+    client.request(new RequestOptions(requestOptions).setMethod(HttpMethod.POST))
+      .compose(req -> req
+        .send(ClientForm.form(form).charset(StandardCharsets.ISO_8859_1))
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::body))
+      .await();
+  }
+
+  @Test
+  public void testFormUrlEncodedUnescaped() throws Exception {
+    server.requestHandler(req -> {
+      req.setExpectMultipart(true);
+      req.bodyHandler(body -> {
+        assertEquals("grant_type=client_credentials&resource=https%3A%2F%2Fmanagement.core.windows.net%2F", body.toString());
+        req.response().end();
+      });
+    });
+    startServer();
+    MultiMap form = MultiMap.caseInsensitiveMultiMap();
+    form
+      .set("grant_type", "client_credentials")
+      .set("resource", "https://management.core.windows.net/");
+    client.request(new RequestOptions(requestOptions).setMethod(HttpMethod.POST))
+      .compose(req -> req
+        .send(ClientForm.form(form))
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::body))
+      .await();
+  }
+
+  @Test
+  public void testFormUrlEncodedMultipleHeaders() throws Exception {
+    server.requestHandler(req -> {
+      req.setExpectMultipart(true);
+      req.endHandler(v -> {
+        assertEquals(Arrays.asList("1", "2"), req.headers().getAll("bla"));
+        req.response().end();
+      });
+    });
+    startServer();
+    MultiMap form = MultiMap.caseInsensitiveMultiMap();
+    client.request(new RequestOptions(requestOptions).putHeader("bla", Arrays.asList("1", "2")).setMethod(HttpMethod.POST))
+      .compose(req -> req
+        .send(ClientForm.form(form))
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::body))
+      .await();
+  }
+
+  @Test
+  public void testFormMultipart() throws Exception {
+    server.requestHandler(req -> {
+      assertTrue(req.getHeader(HttpHeaders.CONTENT_TYPE).startsWith("multipart/form-data"));
+      req.setExpectMultipart(true);
+      req.endHandler(v -> {
+        assertEquals("param1_value", req.getFormAttribute("param1"));
+        req.response().end();
+      });
+    });
+    startServer();
+    MultiMap form = MultiMap.caseInsensitiveMultiMap();
+    form.add("param1", "param1_value");
+    client.request(new RequestOptions(requestOptions).putHeader("content-type", "multipart/form-data").setMethod(HttpMethod.POST))
+      .compose(req -> req
+        .send(ClientForm.form(form))
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::body))
+      .await();
+  }
+
+  @Test
+  public void testFormMultipartWithCharset() throws Exception {
+    server.requestHandler(req -> {
+      req.body().onComplete(onSuccess(body -> {
+        assertTrue(body.toString().contains("content-type: text/plain; charset=ISO-8859-1"));
+        req.response().end();
+      }));
+    });
+    startServer();
+    MultiMap form = MultiMap.caseInsensitiveMultiMap();
+    form.add("param1", "param1_value");
+    client.request(new RequestOptions(requestOptions).putHeader("content-type", "multipart/form-data").setMethod(HttpMethod.POST))
+      .compose(req -> req
+        .send(ClientForm.form(form).charset(StandardCharsets.ISO_8859_1))
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::body))
+      .await();
+  }
+
+  @Test
+  public void testFileUploadFormMultipart32B() throws Exception {
+    testFileUploadFormMultipart(32, false);
+  }
+
+  @Test
+  public void testFileUploadFormMultipart32K() throws Exception {
+    testFileUploadFormMultipart(32 * 1024, false);
+  }
+
+  @Test
+  public void testFileUploadFormMultipart32M() throws Exception {
+    testFileUploadFormMultipart(32 * 1024 * 1024, false);
+  }
+
+  @Test
+  public void testMemoryFileUploadFormMultipart() throws Exception {
+    testFileUploadFormMultipart(32 * 1024, true);
+  }
+
+  private void testFileUploadFormMultipart(int size, boolean memory) throws Exception {
+    Buffer content = Buffer.buffer(TestUtils.randomAlphaString(size));
+    Upload upload;
+    if (memory) {
+      upload = Upload.memoryUpload("test", "test.txt", content);
+    } else {
+      upload = Upload.fileUpload("test", "test.txt", content);
+    }
+    ClientMultipartForm form = ClientMultipartForm.multipartForm()
+      .attribute("toolkit", "vert.x")
+      .attribute("runtime", "jvm");
+    testFileUploadFormMultipart(form, Collections.singletonList(upload), (req, uploads) -> {
+      assertEquals("vert.x", req.getFormAttribute("toolkit"));
+      assertEquals("jvm", req.getFormAttribute("runtime"));
+      assertEquals(1, uploads.size());
+      assertEquals("test", uploads.get(0).name);
+      assertEquals("test.txt", uploads.get(0).filename);
+      assertEquals(content, uploads.get(0).data);
+    });
+  }
+
+  @Test
+  public void testFileUploadsFormMultipart() throws Exception {
+    Buffer content1 = Buffer.buffer(TestUtils.randomAlphaString(16));
+    Buffer content2 = Buffer.buffer(TestUtils.randomAlphaString(16));
+    List<Upload> toUpload = Arrays.asList(
+      Upload.fileUpload("test1", "test1.txt", content1),
+      Upload.fileUpload("test2", "test2.txt", content2)
+    );
+    ClientMultipartForm form = ClientMultipartForm.multipartForm();
+    testFileUploadFormMultipart(form, toUpload, (req, uploads) -> {
+      assertEquals(2, uploads.size());
+      assertEquals("test1", uploads.get(0).name);
+      assertEquals("test1.txt", uploads.get(0).filename);
+      assertEquals("UTF-8", uploads.get(0).charset);
+      assertEquals(content1, uploads.get(0).data);
+      assertEquals("test2", uploads.get(1).name);
+      assertEquals("test2.txt", uploads.get(1).filename);
+      assertEquals("UTF-8", uploads.get(1).charset);
+      assertEquals(content2, uploads.get(1).data);
+    });
+  }
+
+    @Test
+    public void testFileUploadsFormMultipartWithCharset() throws Exception {
+      Buffer content = Buffer.buffer(TestUtils.randomAlphaString(16));
+      List<Upload> toUpload = Collections.singletonList(Upload.fileUpload("test1", "test1.txt", content));
+      ClientMultipartForm form = ClientMultipartForm.multipartForm().charset(StandardCharsets.ISO_8859_1);
+      testFileUploadFormMultipart(form, toUpload, (req, uploads) -> {
+        assertEquals(1, uploads.size());
+        assertEquals("test1", uploads.get(0).name);
+        assertEquals("test1.txt", uploads.get(0).filename);
+        assertEquals("ISO-8859-1", uploads.get(0).charset);
+      });
+    }
+
+    @Test
+    public void testFileUploadsSameNameFormMultipart() throws Exception {
+      Buffer content1 = Buffer.buffer(TestUtils.randomAlphaString(16));
+      Buffer content2 = Buffer.buffer(TestUtils.randomAlphaString(16));
+      List<Upload> toUpload = Arrays.asList(
+        Upload.fileUpload("test", "test1.txt", content1),
+        Upload.fileUpload("test", "test2.txt", content2)
+      );
+      ClientMultipartForm form = ClientMultipartForm.multipartForm();
+      testFileUploadFormMultipart(form, toUpload, (req, uploads) -> {
+        assertEquals(2, uploads.size());
+        assertEquals("test", uploads.get(0).name);
+        assertEquals("test1.txt", uploads.get(0).filename);
+        assertEquals(content1, uploads.get(0).data);
+        assertEquals("test", uploads.get(1).name);
+        assertEquals("test2.txt", uploads.get(1).filename);
+        assertEquals(content2, uploads.get(1).data);
+      });
+    }
+
+  @Test
+  public void testFileUploadsSameNameFormMultipartDisableMultipartMixed() throws Exception {
+    Buffer content1 = Buffer.buffer(TestUtils.randomAlphaString(16));
+    Buffer content2 = Buffer.buffer(TestUtils.randomAlphaString(16));
+    List<Upload> toUpload = Arrays.asList(
+      Upload.fileUpload("test", "test1.txt", content1),
+      Upload.fileUpload("test", "test2.txt", content2)
+    );
+    ClientMultipartForm form = ClientMultipartForm.multipartForm().mixed(false);
+    testFileUploadFormMultipart(form, toUpload, (req, uploads) -> {
+      assertEquals(2, uploads.size());
+      assertEquals("test", uploads.get(0).name);
+      assertEquals("test1.txt", uploads.get(0).filename);
+      assertEquals(content1, uploads.get(0).data);
+      assertEquals("test", uploads.get(1).name);
+      assertEquals("test2.txt", uploads.get(1).filename);
+      assertEquals(content2, uploads.get(1).data);
+    });
+  }
+
+  private void testFileUploadFormMultipart(
+    ClientMultipartForm form,
+    List<Upload> toUpload,
+    BiConsumer<HttpServerRequest,
+      List<Upload>> checker) throws Exception {
+    File[] testFiles = new File[toUpload.size()];
+    for (int i = 0;i < testFiles.length;i++) {
+      Upload upload = toUpload.get(i);
+      if (upload.file) {
+        String name = upload.filename;
+        testFiles[i] = testFolder.newFile(name);
+        vertx.fileSystem().writeFileBlocking(testFiles[i].getPath(), upload.data);
+        form.textFileUpload(toUpload.get(i).name, toUpload.get(i).filename, "text/plain", testFiles[i].getPath());
+      } else {
+        form.textFileUpload(toUpload.get(i).name, toUpload.get(i).filename, "text/plain", upload.data);
+      }
+    }
+
+    server.requestHandler(req -> {
+      req.setExpectMultipart(true);
+      List<Upload> uploads = new ArrayList<>();
+      req.uploadHandler(upload -> {
+        Buffer fileBuffer = Buffer.buffer();
+        assertEquals("text/plain", upload.contentType());
+        upload.handler(fileBuffer::appendBuffer);
+        upload.endHandler(v -> {
+          uploads.add(new Upload(upload.name(), upload.filename(), true, upload.charset(), fileBuffer));
+        });
+      });
+      req.endHandler(v -> {
+        checker.accept(req, uploads);
+        req.response().end();
+      });
+    });
+    startServer();
+
+    client.request(new RequestOptions(requestOptions).setMethod(HttpMethod.POST))
+      .compose(req -> req
+        .send(form)
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::body))
+      .await();
+  }
+
+  static class Upload {
+    final String name;
+    final String filename;
+    final String charset;
+    final Buffer data;
+    final boolean file;
+    private Upload(String name, String filename, boolean file, String charset, Buffer data) {
+      this.name = name;
+      this.filename = filename;
+      this.charset = charset;
+      this.data = data;
+      this.file = file;
+    }
+    static Upload fileUpload(String name, String filename, Buffer data) {
+      return new Upload(name, filename, true, null, data);
+    }
+    static Upload memoryUpload(String name, String filename, Buffer data) {
+      return new Upload(name, filename, false, null, data);
+    }
+  }
+
+  @Test
+  public void testMultipartFormMultipleHeaders() throws Exception {
+    server.requestHandler(req -> {
+      req.setExpectMultipart(true);
+      req.endHandler(v -> {
+        assertEquals(Arrays.asList("1", "2"), req.headers().getAll("bla"));
+        req.response().end();
+      });
+    });
+    startServer();
+    client.request(new RequestOptions(requestOptions).putHeader("bla", Arrays.asList("1", "2")).setMethod(HttpMethod.POST))
+      .compose(req -> req
+        .send(ClientMultipartForm.multipartForm())
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::body))
+      .await();
+  }
+
+  @Test
+  public void testFileUploadWhenFileDoesNotExist() throws Exception {
+    server.requestHandler(req -> {
+      fail();
+    });
+    startServer();
+    try {
+      client.request(new RequestOptions(requestOptions).putHeader("bla", Arrays.asList("1", "2")).setMethod(HttpMethod.POST))
+        .compose(req -> req
+          .send(ClientMultipartForm
+            .multipartForm()
+            .textFileUpload("file", "nonexistentFilename", "nonexistentPathname", "text/plain"))
+          .expecting(HttpResponseExpectation.SC_OK)
+          .compose(HttpClientResponse::body))
+        .await();
+    } catch (Exception err) {
+      assertEquals(err.getClass(), HttpPostRequestEncoder.ErrorDataEncoderException.class);
+      assertEquals(err.getCause().getClass(), FileNotFoundException.class);
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

HTTP client form submission has been available for ages in Vert.x Web Client exclusively. Since there is no good reason for that, this has been implemented in HTTP client as well.

Changes:

HTTP client form submission implementation.
