### PR TITLE
Remove usage of jackson type reference where it is not needed

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -13,7 +13,6 @@ package io.vertx.core.json.jackson;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.SegmentedStringWriter;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.util.BufferRecycler;
 import com.fasterxml.jackson.core.util.ByteArrayBuilder;
 import io.netty.buffer.ByteBufInputStream;
@@ -30,8 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
@@ -67,26 +64,14 @@ public class JacksonCodec implements JsonCodec {
     return fromParser(createParser(json), clazz);
   }
 
-  public <T> T fromString(String str, TypeReference<T> typeRef) throws DecodeException {
-    return fromString(str, classTypeOf(typeRef));
-  }
-
   @Override
   public <T> T fromBuffer(Buffer json, Class<T> clazz) throws DecodeException {
     return fromParser(createParser(json), clazz);
   }
 
-  public <T> T fromBuffer(Buffer buf, TypeReference<T> typeRef) throws DecodeException {
-    return fromBuffer(buf, classTypeOf(typeRef));
-  }
-
   @Override
   public <T> T fromValue(Object json, Class<T> toValueType) {
     throw new DecodeException("Mapping " + toValueType.getName() + "  is not available without Jackson Databind on the classpath");
-  }
-
-  public <T> T fromValue(Object json, TypeReference<T> type) {
-    throw new DecodeException("Mapping " + type.getType().getTypeName() + " is not available without Jackson Databind on the classpath");
   }
 
   @Override
@@ -378,17 +363,6 @@ public class JacksonCodec implements JsonCodec {
     }
   }
 
-  private static <T> Class<T> classTypeOf(TypeReference<T> typeRef) {
-    Type type = typeRef.getType();
-    if (type instanceof Class) {
-      return (Class<T>) type;
-    } else if (type instanceof ParameterizedType) {
-      return (Class<T>) ((ParameterizedType)type).getRawType();
-    } else {
-      throw new DecodeException();
-    }
-  }
-
   private static <T> T cast(Object o, Class<T> clazz) {
     if (o instanceof Map) {
       if (!clazz.isAssignableFrom(Map.class)) {
@@ -448,29 +422,5 @@ public class JacksonCodec implements JsonCodec {
       }
       return clazz.cast(o);
     }
-  }
-
-  /**
-   * Decode a given JSON string to a POJO of the given type.
-   * @param str the JSON string.
-   * @param type the type to map to.
-   * @param <T> the generic type.
-   * @return an instance of T
-   * @throws DecodeException when there is a parsing or invalid mapping.
-   */
-  public static <T> T decodeValue(String str, TypeReference<T> type) throws DecodeException {
-    return JacksonFactory.CODEC.fromString(str, type);
-  }
-
-  /**
-   * Decode a given JSON buffer to a POJO of the given class type.
-   * @param buf the JSON buffer.
-   * @param type the type to map to.
-   * @param <T> the generic type.
-   * @return an instance of T
-   * @throws DecodeException when there is a parsing or invalid mapping.
-   */
-  public static <T> T decodeValue(Buffer buf, TypeReference<T> type) throws DecodeException {
-    return JacksonFactory.CODEC.fromBuffer(buf, type);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/parsetools/JsonEvent.java
+++ b/vertx-core/src/main/java/io/vertx/core/parsetools/JsonEvent.java
@@ -11,10 +11,8 @@
 
 package io.vertx.core.parsetools;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -22,7 +20,7 @@ import io.vertx.core.json.JsonObject;
 import java.time.Instant;
 
 /**
- * A JSON event emited by the {@link JsonParser}.
+ * A JSON event emitted by the {@link JsonParser}.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -155,14 +153,5 @@ public interface JsonEvent {
    * @return the decoded value
    */
   <T> T mapTo(Class<T> type);
-
-  /**
-   * Decodes and returns the current value as the specified {@code type}.
-   *
-   * @param type the type to decode the value to
-   * @return the decoded value
-   */
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  <T> T mapTo(TypeReference<T> type);
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/parsetools/impl/JsonEventImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/parsetools/impl/JsonEventImpl.java
@@ -102,15 +102,6 @@ public class JsonEventImpl implements JsonEvent {
   }
 
   @Override
-  public <T> T mapTo(TypeReference<T> type) {
-    try {
-      return JacksonFactory.CODEC.fromValue(value, type);
-    } catch (Exception e) {
-      throw new DecodeException(e.getMessage(), e);
-    }
-  }
-
-  @Override
   public Integer integerValue() {
     if (value != null) {
       Number number = (Number) value;

--- a/vertx-core/src/test/java/io/vertx/tests/json/JacksonDatabindTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/json/JacksonDatabindTest.java
@@ -23,7 +23,6 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.jackson.DatabindCodec;
-import io.vertx.core.json.jackson.JacksonCodec;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
@@ -57,13 +56,15 @@ public class JacksonDatabindTest extends VertxTestBase {
     String json = Json.encode(Collections.singletonList(original));
     List<Pojo> correct;
 
-    correct = JacksonCodec.decodeValue(json, new TypeReference<List<Pojo>>() {
+    DatabindCodec databindCodec = new DatabindCodec();
+
+    correct = databindCodec.fromString(json, new TypeReference<List<Pojo>>() {
     });
     assertTrue(((List) correct).get(0) instanceof Pojo);
     assertEquals(original.value, correct.get(0).value);
 
     // same must apply if instead of string we use a buffer
-    correct = JacksonCodec.decodeValue(Buffer.buffer(json, "UTF8"), new TypeReference<List<Pojo>>() {
+    correct = databindCodec.fromBuffer(Buffer.buffer(json, "UTF8"), new TypeReference<List<Pojo>>() {
     });
     assertTrue(((List) correct).get(0) instanceof Pojo);
     assertEquals(original.value, correct.get(0).value);

--- a/vertx-core/src/test/java/io/vertx/tests/parsetools/JsonParserTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/parsetools/JsonParserTest.java
@@ -11,7 +11,6 @@
 
 package io.vertx.tests.parsetools;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
@@ -603,16 +602,6 @@ public class JsonParserTest {
   }
 
     @Test
-    public void testObjectMappingWithTypeReference() {
-      JsonParser parser = JsonParser.newParser();
-      List<Object> values = new ArrayList<>();
-      parser.objectValueMode();
-      parser.handler(event ->   values.add(event.mapTo(new TypeReference<TheObject>() {})));
-      parser.handle(new JsonObject().put("f", "the-value").toBuffer());
-      assertEquals(Collections.singletonList(new TheObject("the-value")), values);
-    }
-
-    @Test
     public void testArrayMapping() {
       JsonParser parser = JsonParser.newParser();
       List<Object> values = new ArrayList<>();
@@ -641,17 +630,6 @@ public class JsonParserTest {
       }
       assertEquals(Collections.emptyList(), values);
       assertEquals(1, errors.size());
-    }
-
-    @Test
-    public void testArrayMappingWithTypeReference() {
-      JsonParser parser = JsonParser.newParser();
-      List<Object> values = new ArrayList<>();
-      parser.arrayValueMode();
-      parser.handler(event -> values.add(event.mapTo(new TypeReference<LinkedList<Long>>() {})));
-      parser.handle(new JsonArray().add(0).add(1).add(2).toBuffer());
-      assertEquals(Collections.singletonList(Arrays.asList(0L, 1L, 2L)), values);
-      assertEquals(LinkedList.class, values.get(0).getClass());
     }
 
   public static class TheObject {


### PR DESCRIPTION
 Remove usage of Jackson `TypeReference`.
    
Motivation:
    
Jackson's `TypeReference` is only supported by the `DatabindCodec`. A few methods declaring `TypeReference` are still available on `JacksonCodec` and `JsonEvent`, such methods should be removed because the lead to incomplete usage of `JacksonCodec` and will simply not work at all with potential other implementations of the JSON spi.
    
Changes:
    
Remove methods declaring `TypeReference` and update tests accordingly.
