### PR TITLE
Async JSON parser should handle large integer (literaly speaking) number representations

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/parsetools/impl/JsonParserImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/parsetools/impl/JsonParserImpl.java
@@ -239,7 +239,12 @@ public class JsonParserImpl implements JsonParser {
         }
         case VALUE_NUMBER_INT: {
           try {
-            event = new JsonEventImpl(token, JsonEventType.VALUE, field, parser.getLongValue());
+            Number number = parser.getNumberValue();
+            if (number instanceof Integer) {
+              // Backward compat
+              number = (long) (int) number;
+            }
+            event = new JsonEventImpl(token, JsonEventType.VALUE, field, number);
           } catch (IOException e) {
             handle(e);
             continue;


### PR DESCRIPTION
Motivation:

Large number representations are not handled by the async JSON parser, leading to a decoder exception since the async parser tries to obtain a long number from the Jackson parser. The parser should be able to handle this case using a big integer.

Changes:

Obtain a java number from the Jackson parser instead of a Long.

Result:

When a large integer number is parsed, the async parser parses the value succesfully and the json event value will be a big integer.
