### PR TITLE
Async JSON parser should handle large integer (literaly speaking) number representations

### DIFF
--- a/src/main/java/io/vertx/core/parsetools/impl/JsonParserImpl.java
+++ b/src/main/java/io/vertx/core/parsetools/impl/JsonParserImpl.java
@@ -239,7 +239,12 @@ public class JsonParserImpl implements JsonParser {
         }
         case VALUE_NUMBER_INT: {
           try {
-            event = new JsonEventImpl(token, JsonEventType.VALUE, field, parser.getLongValue());
+            Number number = parser.getNumberValue();
+            if (number instanceof Integer) {
+              // Backward compat
+              number = (long) (int) number;
+            }
+            event = new JsonEventImpl(token, JsonEventType.VALUE, field, number);
           } catch (IOException e) {
             handle(e);
             continue;

--- a/src/test/java/io/vertx/core/parsetools/JsonParserTest.java
+++ b/src/test/java/io/vertx/core/parsetools/JsonParserTest.java
@@ -20,6 +20,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.test.core.TestUtils;
 import org.junit.Test;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.*;
@@ -149,19 +151,6 @@ public class JsonParserTest {
     assertEquals(Collections.emptyList(), objects);
     assertEquals(Collections.emptyList(), errors);
     assertEquals(1, endCount.get());
-  }
-
-  @Test
-  public void parseNumberFormatException() {
-    Buffer data = Buffer.buffer(Long.MAX_VALUE + "0");
-    try {
-      JsonParser.newParser().handler(val -> {}).write(data).end();
-      fail();
-    } catch (DecodeException expected) {
-    }
-    List<Throwable> errors = new ArrayList<>();
-    JsonParser.newParser().exceptionHandler(errors::add).handler(val -> {}).write(data).end();
-    assertEquals(1, errors.size());
   }
 
   @Test
@@ -341,8 +330,8 @@ public class JsonParserTest {
       assertFalse(event.isString());
       assertEquals(567, (long)event.integerValue());
       assertEquals(567L, (long)event.longValue());
-      assertEquals(567f, (float)event.floatValue(), 0.01f);
-      assertEquals(567d, (double)event.doubleValue(), 0.01d);
+      assertEquals(567f, event.floatValue(), 0.01f);
+      assertEquals(567d, event.doubleValue(), 0.01d);
       assertThrowCCE(event,
         JsonEvent::stringValue,
         JsonEvent::booleanValue,
@@ -367,6 +356,32 @@ public class JsonParserTest {
       assertEquals(567L, (long)event.longValue());
       assertEquals(567.45f, (float)event.floatValue(), 0.01f);
       assertEquals(567.45d, (double)event.doubleValue(), 0.01d);
+      assertThrowCCE(event,
+        JsonEvent::stringValue,
+        JsonEvent::booleanValue,
+        JsonEvent::binaryValue,
+        JsonEvent::instantValue,
+        JsonEvent::objectValue,
+        JsonEvent::arrayValue);
+    });
+  }
+
+  @Test
+  public void testBigInteger() {
+    String expected = "18446744073709551615";
+    testValue(expected, event -> {
+      BigInteger big = new BigInteger(expected);
+      assertEquals(big, event.value());
+      assertFalse(event.isArray());
+      assertFalse(event.isObject());
+      assertTrue(event.isNumber());
+      assertFalse(event.isNull());
+      assertFalse(event.isBoolean());
+      assertFalse(event.isString());
+      assertEquals(big.intValue(), (int)event.integerValue());
+      assertEquals(big.longValue(), (long)event.longValue());
+      assertEquals(big.floatValue(), event.floatValue(), 0.01f);
+      assertEquals(big.doubleValue(), event.doubleValue(), 0.01d);
       assertThrowCCE(event,
         JsonEvent::stringValue,
         JsonEvent::booleanValue,


### PR DESCRIPTION
Motivation:

Large number representations are not handled by the async JSON parser, leading to a decoder exception since the async parser tries to obtain a long number from the Jackson parser. The parser should be able to handle this case using a big integer.

Changes:

Obtain a java number from the Jackson parser instead of a Long.

Result:

When a large integer number is parsed, the async parser parses the value succesfully and the json event value will be a big integer.