### PR TITLE
Fix reentrant close in InboundMessageHandler

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/LocalEventBusTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/LocalEventBusTest.java
@@ -1459,4 +1459,27 @@ public class LocalEventBusTest extends EventBusTestBase {
     });
     await();
   }
+
+  @Test
+  public void testUnregisterInHandler() {
+    waitFor(2);
+    MessageConsumerImpl<Object> consumer = (MessageConsumerImpl<Object>) vertx.eventBus().consumer(ADDRESS1);
+    consumer.discardHandler(msg -> {
+      assertEquals("msg-2", msg.body());
+      complete();
+    });
+    consumer.handler(msg -> {
+      consumer.unregister();
+      vertx.runOnContext(v -> {
+        complete();
+      });
+    });
+    consumer.pause();
+    vertx.eventBus().send(ADDRESS1, "msg-1");
+    vertx.eventBus().send(ADDRESS1, "msg-2");
+    vertx.runOnContext(v -> {
+      consumer.resume();
+    });
+    await();
+  }
 }


### PR DESCRIPTION
Motivation:

The `InboundMessageHandler` clears message channel upon consumer side close, this operation should be delated when called from a consumer drain as it corrupts the message channel state. This happens in the new event-bus message consumer when consumer is unregistered when handling an event-bus message.

Changes:

When `InboundMessageHandler` consumer is closed when handling a message, the release message is delayed until the drain operation is finished to avoid corrupting the structure.
