### PR TITLE
Clustered event-bus inbound/outbound connection separation of concerns.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/InboundConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/InboundConnection.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.eventbus.impl.clustered;
+
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.impl.CodecManager;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.parsetools.RecordParser;
+import io.vertx.core.spi.metrics.EventBusMetrics;
+
+/**
+ * Process event-bus server connections, this connection reads messages, the only data
+ * it writes are pong replies.
+ */
+final class InboundConnection implements Handler<Buffer> {
+
+  private static final Buffer PONG = Buffer.buffer(new byte[]{(byte) 1});
+
+  private final ClusteredEventBus clusteredEventBus;
+  private final NetSocket socket;
+  private final RecordParser parser;
+  private int size = -1;
+  private Handler<ClusteredMessage<?, ?>> handler;
+
+  public InboundConnection(ClusteredEventBus clusteredEventBus, NetSocket socket) {
+    this.clusteredEventBus = clusteredEventBus;
+
+    RecordParser parser = RecordParser.newFixed(4);
+    parser.setOutput(this::decodeMessage);
+
+    this.socket = socket;
+    this.parser = parser;
+  }
+
+  @Override
+  public void handle(Buffer data) {
+    parser.handle(data);
+  }
+
+  InboundConnection handler(Handler<ClusteredMessage<?, ?>> messageHandler) {
+    handler = messageHandler;
+    return this;
+  }
+
+  private void decodeMessage(Buffer buff) {
+    if (size == -1) {
+      size = buff.getInt(0);
+      parser.fixedSizeMode(size);
+    } else {
+      ClusteredMessage<?, ?> received = new ClusteredMessage<>(clusteredEventBus);
+      received.readFromWire(buff, clusteredEventBus.codecManager());
+      parser.fixedSizeMode(4);
+      size = -1;
+      if (received.hasFailure()) {
+        received.internalError();
+      } else if (received.codec() == CodecManager.PING_MESSAGE_CODEC) {
+        // Just send back pong directly on connection
+        socket.write(PONG);
+      } else {
+        EventBusMetrics<?> metrics = clusteredEventBus.metrics();
+        if (metrics != null) {
+          metrics.messageRead(received.address(), buff.length());
+        }
+        handler.handle(received);
+      }
+    }
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/OutboundConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/OutboundConnection.java
@@ -11,6 +11,8 @@
 
 package io.vertx.core.eventbus.impl.clustered;
 
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBusOptions;
@@ -20,63 +22,49 @@ import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.NetSocket;
-import io.vertx.core.net.impl.ConnectionBase;
-import io.vertx.core.spi.cluster.NodeInfo;
 import io.vertx.core.spi.metrics.EventBusMetrics;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
 
 /**
+ * Connects the event-bus to another event-bus server, this connection write messages, the only data
+ * it receives are pong replies.
+ *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-class ConnectionHolder {
+final class OutboundConnection implements Handler<Buffer> {
 
-  private static final Logger log = LoggerFactory.getLogger(ConnectionHolder.class);
+  private static final Logger log = LoggerFactory.getLogger(OutboundConnection.class);
 
   private static final String PING_ADDRESS = "__vertx_ping";
 
   private final ClusteredEventBus eventBus;
   private final String remoteNodeId;
   private final VertxInternal vertx;
-  private final EventBusMetrics metrics;
+  private final EventBusMetrics<?> metrics;
 
   private Queue<MessageWrite> pendingWrites;
   private NetSocket socket;
   private boolean connected;
-  private long timeoutID = -1;
+  private long pingReplyTimeoutID = -1;
   private long pingTimeoutID = -1;
 
-  ConnectionHolder(ClusteredEventBus eventBus, String remoteNodeId) {
+  OutboundConnection(ClusteredEventBus eventBus, String remoteNodeId) {
     this.eventBus = eventBus;
     this.remoteNodeId = remoteNodeId;
     this.vertx = eventBus.vertx();
     this.metrics = eventBus.getMetrics();
   }
 
-  void connect() {
-    Promise<NodeInfo> promise = Promise.promise();
-    eventBus.vertx().getClusterManager().getNodeInfo(remoteNodeId, promise);
-    promise.future()
-      .flatMap(info -> eventBus.client().connect(info.port(), info.host()))
-      .onComplete(ar -> {
-        if (ar.succeeded()) {
-          connected(ar.result());
-        } else {
-          log.warn("Connecting to server " + remoteNodeId + " failed", ar.cause());
-          close(ar.cause());
-        }
-      });
+  String remoteNodeId() {
+    return remoteNodeId;
   }
 
-  // TODO optimise this (contention on monitor)
   synchronized void writeMessage(MessageImpl<?, ?> message, Promise<Void> writePromise) {
     if (connected) {
-      Buffer data = ((ClusteredMessage) message).encodeToWire();
-      if (metrics != null) {
-        metrics.messageWritten(message.address(), data.length());
-      }
-      socket.write(data).onComplete(writePromise);
+      writeMessage(message)
+        .onComplete(writePromise);
     } else {
       if (pendingWrites == null) {
         if (log.isDebugEnabled()) {
@@ -88,13 +76,16 @@ class ConnectionHolder {
     }
   }
 
-  void close() {
-    close(ConnectionBase.CLOSED_EXCEPTION);
+  @Override
+  public void handle(Buffer event) {
+    // Got a pong back
+    vertx.cancelTimer(pingReplyTimeoutID);
+    schedulePing();
   }
 
-  private void close(Throwable cause) {
-    if (timeoutID != -1) {
-      vertx.cancelTimer(timeoutID);
+  void handleClose(Throwable cause) {
+    if (pingReplyTimeoutID != -1) {
+      vertx.cancelTimer(pingReplyTimeoutID);
     }
     if (pingTimeoutID != -1) {
       vertx.cancelTimer(pingTimeoutID);
@@ -107,43 +98,32 @@ class ConnectionHolder {
         }
       }
     }
-    // The holder can be null or different if the target server is restarted with same nodeInfo
-    // before the cleanup for the previous one has been processed
-    if (eventBus.connections().remove(remoteNodeId, this)) {
-      if (log.isDebugEnabled()) {
-        log.debug("Cluster connection closed for server " + remoteNodeId);
-      }
-    }
   }
 
   private void schedulePing() {
     EventBusOptions options = eventBus.options();
     pingTimeoutID = vertx.setTimer(options.getClusterPingInterval(), id1 -> {
       // If we don't get a pong back in time we close the connection
-      timeoutID = vertx.setTimer(options.getClusterPingReplyInterval(), id2 -> {
+      pingReplyTimeoutID = vertx.setTimer(options.getClusterPingReplyInterval(), id2 -> {
         // Didn't get pong in time - consider connection dead
         log.warn("No pong from server " + remoteNodeId + " - will consider it dead");
-        close();
+        socket.close();
       });
-      ClusteredMessage pingMessage =
-        new ClusteredMessage<>(remoteNodeId, PING_ADDRESS, null, null, new PingMessageCodec(), true, eventBus);
-      Buffer data = pingMessage.encodeToWire();
-      socket.write(data);
+      ClusteredMessage<?, ?> pingMessage = new ClusteredMessage<>(
+        remoteNodeId,
+        PING_ADDRESS,
+        null,
+        null,
+        new PingMessageCodec(),
+        true,
+        eventBus);
+      writeMessage(pingMessage);
     });
   }
 
-  private synchronized void connected(NetSocket socket) {
+  synchronized void connected(NetSocket socket) {
     this.socket = socket;
-    connected = true;
-    socket.exceptionHandler(err -> {
-      close(err);
-    });
-    socket.closeHandler(v -> close());
-    socket.handler(data -> {
-      // Got a pong back
-      vertx.cancelTimer(timeoutID);
-      schedulePing();
-    });
+    this.connected = true;
     // Start a pinger
     schedulePing();
     if (pendingWrites != null) {
@@ -151,14 +131,19 @@ class ConnectionHolder {
         log.debug("Draining the queue for server " + remoteNodeId);
       }
       for (MessageWrite ctx : pendingWrites) {
-        Buffer data = ((ClusteredMessage<?, ?>)ctx.message).encodeToWire();
-        if (metrics != null) {
-          metrics.messageWritten(ctx.message.address(), data.length());
-        }
-        socket.write(data).onComplete(ctx.writePromise);
+        writeMessage(ctx.message)
+          .onComplete(ctx.writePromise);
       }
     }
     pendingWrites = null;
+  }
+
+  private Future<Void> writeMessage(MessageImpl<?, ?> message) {
+    Buffer data = ((ClusteredMessage<?, ?>)message).encodeToWire();
+    if (metrics != null) {
+      metrics.messageWritten(message.address(), data.length());
+    }
+    return socket.write(data);
   }
 
   private static class MessageWrite {


### PR DESCRIPTION
Changes:

Introduce proper `OutboundConnection` (previously `ConnectionHolder`) and handle socket wiring concerns outside of this class. Move the connection cleanup (removing from map and pending message write notifications) to be consistently triggered by the socket close handler.

Introduce proper `InboundConnection` (previously a lambda) and handle socket wiring concerns outside of this class which only cares about decoding clustered messages and relaying them to the event-bus local delivery.

Close the TCP server when the event bus is closed.
