### PR TITLE
Vert.x Jackson json factory read constraint configuration should be overridable

### DIFF
--- a/vertx-core/pom.xml
+++ b/vertx-core/pom.xml
@@ -403,6 +403,26 @@
             </configuration>
           </execution>
           <execution>
+            <id>jackson-config-override</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>io/vertx/it/json/JacksonConfigOverrideTest.java</include>
+              </includes>
+              <systemProperties>
+                <vertx.jackson.defaultReadMaxNestingDepth>100</vertx.jackson.defaultReadMaxNestingDepth>
+                <vertx.jackson.defaultReadMaxDocumentLength>100</vertx.jackson.defaultReadMaxDocumentLength>
+                <vertx.jackson.defaultReadMaxNumberLength>100</vertx.jackson.defaultReadMaxNumberLength>
+                <vertx.jackson.defaultReadMaxStringLength>100</vertx.jackson.defaultReadMaxStringLength>
+                <vertx.jackson.defaultReadMaxNameLength>100</vertx.jackson.defaultReadMaxNameLength>
+                <vertx.jackson.defaultReadMaxTokenCount>100</vertx.jackson.defaultReadMaxTokenCount>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
             <id>no-jackson</id>
             <goals>
               <goal>integration-test</goal>

--- a/vertx-core/src/main/asciidoc/json.adoc
+++ b/vertx-core/src/main/asciidoc/json.adoc
@@ -127,3 +127,21 @@ When you are unsure of the string validity then you should use instead `{@link i
 ----
 {@link examples.JsonExamples#example5}
 ----
+
+=== Jackson configuration
+
+==== Read constraint configuration
+
+Since Jackson 2.15, upper bound constraints have been added to limit the bytes cumulated when parsing a JSON input.
+
+You can override the default configuration of the underlying parsers used by Vert.x with the following system properties:
+
+- `vertx.jackson.defaultReadMaxNestingDepth`: Maximum Nesting depth
+- `vertx.jackson.defaultReadMaxDocumentLength`: Maximum Document length
+- `vertx.jackson.defaultReadMaxNumberLength`: Maximum Number value length
+- `vertx.jackson.defaultReadMaxStringLength`: Maximum String value length
+- `vertx.jackson.defaultReadMaxNameLength`: Maximum Property name length
+- `vertx.jackson.defaultMaxTokenCount`: Maximum Token count
+
+You can refer to https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/latest/index.html[this] for more information.
+

--- a/vertx-core/src/main/java/io/vertx/core/impl/SysProps.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/SysProps.java
@@ -13,6 +13,8 @@ package io.vertx.core.impl;
 import io.vertx.core.internal.http.HttpHeadersInternal;
 
 import java.io.File;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 /**
  * Vert.x known system properties.
@@ -86,6 +88,13 @@ public enum SysProps {
    */
   LOGGER_DELEGATE_FACTORY_CLASS_NAME("vertx.logger-delegate-factory-class-name"),
 
+  JACKSON_DEFAULT_READ_MAX_NESTING_DEPTH("vertx.jackson.defaultReadMaxNestingDepth"),
+  JACKSON_DEFAULT_READ_MAX_DOC_LEN("vertx.jackson.defaultReadMaxDocumentLength"),
+  JACKSON_DEFAULT_READ_MAX_NUM_LEN("vertx.jackson.defaultReadMaxNumberLength"),
+  JACKSON_DEFAULT_READ_MAX_STRING_LEN("vertx.jackson.defaultReadMaxStringLength"),
+  JACKSON_DEFAULT_READ_MAX_NAME_LEN("vertx.jackson.defaultReadMaxNameLength"),
+  JACKSON_DEFAULT_READ_MAX_TOKEN_COUNT("vertx.jackson.defaultMaxTokenCount"),
+
   ;
 
   public final String name;
@@ -96,6 +105,22 @@ public enum SysProps {
 
   public String get() {
     return System.getProperty(name);
+  }
+
+  public OptionalLong getAsLong() throws NumberFormatException {
+    String s = get();
+    if (s != null) {
+      return OptionalLong.of(Long.parseLong(s));
+    }
+    return OptionalLong.empty();
+  }
+
+  public OptionalInt getAsInt() throws NumberFormatException {
+    String s = get();
+    if (s != null) {
+      return OptionalInt.of(Integer.parseInt(s));
+    }
+    return OptionalInt.empty();
   }
 
   public boolean getBoolean() {

--- a/vertx-core/src/test/java/io/vertx/it/json/JacksonConfigOverrideTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/json/JacksonConfigOverrideTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.it.json;
+
+import io.vertx.test.core.VertxTestBase;
+import io.vertx.tests.json.JacksonTest;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class JacksonConfigOverrideTest extends VertxTestBase {
+
+  @Test
+  public void testReadConstraints() {
+    JacksonTest.testReadConstraints(100,  100, 100, 100);
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/tests/json/JacksonTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/json/JacksonTest.java
@@ -11,12 +11,16 @@
 
 package io.vertx.tests.json;
 
-import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.EncodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.jackson.JacksonCodec;
 import io.vertx.test.core.VertxTestBase;
+import org.junit.Assert;
 import org.junit.Test;
 
+import static com.fasterxml.jackson.core.StreamReadConstraints.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -70,4 +74,64 @@ public class JacksonTest extends VertxTestBase {
     codec.toBuffer(new RuntimeException("Unsupported"));
   }
 
+  @Test
+  public void testDefaultConstraints() {
+    testReadConstraints(
+      DEFAULT_MAX_DEPTH,
+      DEFAULT_MAX_NUM_LEN,
+      DEFAULT_MAX_STRING_LEN,
+      DEFAULT_MAX_NAME_LEN);
+  }
+
+  public static void testReadConstraints(int defaultMaxDepth,
+                                         int maxNumberLength,
+                                         int defaultMaxStringLength,
+                                         int defaultMaxNameLength) {
+    testMaxNestingDepth(defaultMaxDepth);
+    try {
+      testMaxNestingDepth(defaultMaxDepth + 1);
+      Assert.fail();
+    } catch (DecodeException expected) {
+    }
+    testMaxNumberLength(maxNumberLength);
+    try {
+      testMaxNumberLength(maxNumberLength + 1);
+      Assert.fail();
+    } catch (DecodeException expected) {
+    }
+
+    testMaxStringLength(defaultMaxStringLength);
+    try {
+      testMaxStringLength(defaultMaxStringLength + 1);
+      Assert.fail();
+    } catch (DecodeException expected) {
+    }
+
+    testMaxNameLength(defaultMaxNameLength);
+    try {
+      testMaxNameLength(defaultMaxNameLength + 1);
+      Assert.fail();
+    } catch (DecodeException expected) {
+    }
+  }
+
+  private static JsonArray testMaxNestingDepth(int depth) {
+    String json = "[".repeat(depth) + "]".repeat(depth);
+    return new JsonArray(json);
+  }
+
+  private static JsonObject testMaxNumberLength(int len) {
+    String json = "{\"number\":" + "1".repeat(len) + "}";
+    return new JsonObject(json);
+  }
+
+  private static JsonObject testMaxStringLength(int len) {
+    String json = "{\"string\":\"" + "a".repeat(len) + "\"}";
+    return new JsonObject(json);
+  }
+
+  private static JsonObject testMaxNameLength(int len) {
+    String json = "{\"" + "a".repeat(len) + "\":3}";
+    return new JsonObject(json);
+  }
 }


### PR DESCRIPTION
Motivation:

Read constraints were added since Jackson 2.15 to provide upper bounds for input such as the maximum number of a name. These constraints can be configured per json factory, Vert.x static json factory should provide configurability for it.

Changes:

Add system properties that configure the Vert.x static Jackson json factory.
