### PR TITLE
Revert "Use simple parser instead of regex for parsing resolv.conf (#5439)"

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/HostnameResolver.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/HostnameResolver.java
@@ -45,25 +45,35 @@ public class HostnameResolver implements AddressResolver {
 
   private static final Logger log = LoggerFactory.getLogger(HostnameResolver.class);
 
-  private static final String NDOTS_LABEL = "ndots:";
-  private static final String ROTATE_LABEL = "rotate";
-  private static final String OPTIONS_ROW_LABEL = "options";
+  private static Pattern resolvOption(String regex) {
+    return Pattern.compile("^[ \\t\\f]*options[^\n]+" + regex + "(?=$|\\s)", Pattern.MULTILINE);
+  }
+
+  private static final Pattern NDOTS_OPTIONS_PATTERN = resolvOption("ndots:[ \\t\\f]*(\\d)+");
+  private static final Pattern ROTATE_OPTIONS_PATTERN = resolvOption("rotate");
   public static final int DEFAULT_NDOTS_RESOLV_OPTION;
   public static final boolean DEFAULT_ROTATE_RESOLV_OPTION;
 
-
-  private static final int DEFAULT_NDOTS = 1;
-  private static final boolean DEFAULT_ROTATE = false;
-
   static {
+    int ndots = 1;
+    boolean rotate = false;
     if (isLinux()) {
-      ResolverOptions options = parseLinux(new File("/etc/resolv.conf"));
-      DEFAULT_NDOTS_RESOLV_OPTION = options.effectiveNdots();
-      DEFAULT_ROTATE_RESOLV_OPTION = options.isRotate();
-    } else {
-      DEFAULT_NDOTS_RESOLV_OPTION = DEFAULT_NDOTS;
-      DEFAULT_ROTATE_RESOLV_OPTION = DEFAULT_ROTATE;
+      File f = new File("/etc/resolv.conf");
+      try {
+        if (f.exists() && f.isFile()) {
+          String conf = Files.readString(f.toPath());
+          int ndotsOption = parseNdotsOptionFromResolvConf(conf);
+          if (ndotsOption != -1) {
+            ndots = ndotsOption;
+          }
+          rotate = parseRotateOptionFromResolvConf(conf);
+        }
+      } catch (Throwable t) {
+        log.debug("Failed to load options from /etc/resolv/.conf", t);
+      }
     }
+    DEFAULT_NDOTS_RESOLV_OPTION = ndots;
+    DEFAULT_ROTATE_RESOLV_OPTION = rotate;
   }
 
   private final Vertx vertx;
@@ -119,65 +129,18 @@ public class HostnameResolver implements AddressResolver {
     return provider.close();
   }
 
-  // visible for testing
-  public static ResolverOptions parseLinux(File f) {
-    try {
-      if (f.exists() && f.isFile()) {
-        return parseLinux(new String(Files.readAllBytes(f.toPath())));
-      }
-    } catch (Throwable t) {
-      log.debug("Failed to load options from /etc/resolv.conf", t);
-    }
-    return new ResolverOptions(DEFAULT_NDOTS, DEFAULT_ROTATE);
-  }
-
-  // exists mainly to facilitate testing
-  public static ResolverOptions parseLinux(String input) {
+  public static int parseNdotsOptionFromResolvConf(String s) {
     int ndots = -1;
-    boolean rotate = false;
-    try {
-      int optionsIndex = input.indexOf(OPTIONS_ROW_LABEL);
-      if (optionsIndex != -1) {
-        boolean isProperOptionsLabel = false;
-        if (optionsIndex == 0) {
-          isProperOptionsLabel = true;
-        } else if (Character.isWhitespace(input.charAt(optionsIndex - 1))) {
-            isProperOptionsLabel = true;
-        }
-        if (isProperOptionsLabel) {
-          String afterOptions = input.substring(optionsIndex + OPTIONS_ROW_LABEL.length());
-          int rotateIndex = afterOptions.indexOf(ROTATE_LABEL);
-          if (rotateIndex != -1) {
-            if (!containsNewLine(afterOptions.substring(0, rotateIndex))) {
-              rotate = true;
-            }
-          }
-          int ndotsIndex = afterOptions.indexOf(NDOTS_LABEL);
-          if (ndotsIndex != -1) {
-            if (!containsNewLine(afterOptions.substring(0, ndotsIndex))) {
-              Matcher matcher = Holder.NDOTS_PATTERN.matcher(afterOptions.substring(ndotsIndex));
-              while (matcher.find()) {
-                ndots = Integer.parseInt(matcher.group(1));
-              }
-            }
-          }
-        }
-      }
-    } catch (NumberFormatException e) {
-      log.debug("Failed to load options from /etc/resolv.conf", e);
+    Matcher matcher = NDOTS_OPTIONS_PATTERN.matcher(s);
+    while (matcher.find()) {
+      ndots = Integer.parseInt(matcher.group(1));
     }
-    return new ResolverOptions(ndots, rotate);
+    return ndots;
   }
 
-  //TODO: this can easily be parallelized if necessary
-  private static boolean containsNewLine(String input) {
-    for (int i = 0; i < input.length(); i++) {
-      char c = input.charAt(i);
-      if (c == '\n') {
-        return true;
-      }
-    }
-    return false;
+  public static boolean parseRotateOptionFromResolvConf(String s) {
+    Matcher matcher = ROTATE_OPTIONS_PATTERN.matcher(s);
+    return matcher.find();
   }
 
   class Impl<L> implements EndpointResolver<SocketAddress, SocketAddress, L, L> {
@@ -226,33 +189,5 @@ public class HostnameResolver implements AddressResolver {
     @Override
     public void close() {
     }
-  }
-
-  public static class ResolverOptions {
-    private final int ndots;
-    private final boolean rotate;
-
-    public ResolverOptions(int ndots, boolean rotate) {
-      this.ndots = ndots;
-      this.rotate = rotate;
-    }
-
-    public int ndots() {
-      return ndots;
-    }
-
-    public int effectiveNdots() {
-      return ndots != -1 ? ndots : 1;
-    }
-
-    public boolean isRotate() {
-      return rotate;
-    }
-  }
-
-  // used in order to avoid initialization of the pattern when it's not really needed
-  private static class Holder {
-
-    private static final Pattern NDOTS_PATTERN = Pattern.compile("ndots:[ \\t\\f]*(\\d)+(?=$|\\s)");
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/dns/HostnameResolutionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/dns/HostnameResolutionTest.java
@@ -35,6 +35,7 @@ import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakedns.FakeDNSServer;
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -768,40 +769,40 @@ public class HostnameResolutionTest extends VertxTestBase {
 
   @Test
   public void testParseResolvConf() {
-    assertEquals(-1, HostnameResolver.parseLinux("options").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("options ndots: 4").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("\noptions ndots: 4").ndots());
-    assertEquals(-1, HostnameResolver.parseLinux("boptions ndots: 4").ndots());
-    assertEquals(4, HostnameResolver.parseLinux(" options ndots: 4").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("\toptions ndots: 4").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("\foptions ndots: 4").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("\n options ndots: 4").ndots());
+    assertEquals(-1, HostnameResolver.parseNdotsOptionFromResolvConf("options"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots: 4"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("\noptions ndots: 4"));
+    assertEquals(-1, HostnameResolver.parseNdotsOptionFromResolvConf("boptions ndots: 4"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf(" options ndots: 4"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("\toptions ndots: 4"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("\foptions ndots: 4"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("\n options ndots: 4"));
 
-    assertEquals(4, HostnameResolver.parseLinux("options\tndots: 4").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("options\fndots: 4").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("options  ndots: 4").ndots());
-    assertEquals(-1, HostnameResolver.parseLinux("options\nndots: 4").ndots());
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options\tndots: 4"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options\fndots: 4"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options  ndots: 4"));
+    assertEquals(-1, HostnameResolver.parseNdotsOptionFromResolvConf("options\nndots: 4"));
 
-    assertEquals(4, HostnameResolver.parseLinux("options ndots:4").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("options ndots:\t4").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("options ndots:  4").ndots());
-    assertEquals(-1, HostnameResolver.parseLinux("options ndots:\n4").ndots());
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots:4"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots:\t4"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots:  4"));
+    assertEquals(-1, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots:\n4"));
 
-    assertEquals(4, HostnameResolver.parseLinux("options ndots:4 ").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("options ndots:4\t").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("options ndots:4\f").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("options ndots:4\n").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("options ndots:4\r").ndots());
-    assertEquals(-1, HostnameResolver.parseLinux("options ndots:4_").ndots());
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots:4 "));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots:4\t"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots:4\f"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots:4\n"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots:4\r"));
+    assertEquals(-1, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots:4_"));
 
-    assertEquals(2, HostnameResolver.parseLinux("options ndots:4\noptions ndots:2").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("options ndots:4 debug").ndots());
-    assertEquals(4, HostnameResolver.parseLinux("options debug ndots:4").ndots());
+    assertEquals(2, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots:4\noptions ndots:2"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options ndots:4 debug"));
+    assertEquals(4, HostnameResolver.parseNdotsOptionFromResolvConf("options debug ndots:4"));
 
-    assertEquals(false, HostnameResolver.parseLinux("options").isRotate());
-    assertEquals(true, HostnameResolver.parseLinux("options rotate").isRotate());
-    assertEquals(true, HostnameResolver.parseLinux("options rotate\n").isRotate());
-    assertEquals(false, HostnameResolver.parseLinux("options\nrotate").isRotate());
+    assertEquals(false, HostnameResolver.parseRotateOptionFromResolvConf("options"));
+    assertEquals(true, HostnameResolver.parseRotateOptionFromResolvConf("options rotate"));
+    assertEquals(true, HostnameResolver.parseRotateOptionFromResolvConf("options rotate\n"));
+    assertEquals(false, HostnameResolver.parseRotateOptionFromResolvConf("options\nrotate"));
   }
 
   @Test


### PR DESCRIPTION
Testing without this fix.