### PR TITLE
Vert.x Jackson json factory read constraint configuration should be overridable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,6 +565,25 @@
             </configuration>
           </execution>
           <execution>
+            <id>jackson-config-override</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>io/vertx/it/json/JacksonConfigOverrideTest.java</include>
+              </includes>
+              <systemProperties>
+                <vertx.jackson.defaultReadMaxNestingDepth>100</vertx.jackson.defaultReadMaxNestingDepth>
+                <vertx.jackson.defaultReadMaxDocumentLength>100</vertx.jackson.defaultReadMaxDocumentLength>
+                <vertx.jackson.defaultReadMaxNumberLength>100</vertx.jackson.defaultReadMaxNumberLength>
+                <vertx.jackson.defaultReadMaxStringLength>100</vertx.jackson.defaultReadMaxStringLength>
+                <vertx.jackson.defaultReadMaxNameLength>100</vertx.jackson.defaultReadMaxNameLength>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
             <id>no-jackson</id>
             <goals>
               <goal>integration-test</goal>

--- a/src/main/asciidoc/override/json.adoc
+++ b/src/main/asciidoc/override/json.adoc
@@ -127,3 +127,21 @@ When you are unsure of the string validity then you should use instead `{@link i
 ----
 {@link docoverride.json.Examples#example5}
 ----
+
+=== Jackson configuration
+
+==== Read constraint configuration
+
+Since Jackson 2.15, upper bound constraints have been added to limit the bytes cumulated when parsing a JSON input.
+
+You can override the default configuration of the underlying parsers used by Vert.x with the following system properties:
+
+- `vertx.jackson.defaultReadMaxNestingDepth`: Maximum Nesting depth
+- `vertx.jackson.defaultReadMaxDocumentLength`: Maximum Document length
+- `vertx.jackson.defaultReadMaxNumberLength`: Maximum Number value length
+- `vertx.jackson.defaultReadMaxStringLength`: Maximum String value length
+- `vertx.jackson.defaultReadMaxNameLength`: Maximum Property name length
+- `vertx.jackson.defaultMaxTokenCount`: Maximum Token count
+
+You can refer to https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/latest/index.html[this] for more information.
+

--- a/src/test/java/io/vertx/core/json/JacksonTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonTest.java
@@ -14,8 +14,11 @@ package io.vertx.core.json;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.jackson.JacksonCodec;
 import io.vertx.test.core.VertxTestBase;
+import org.junit.Assert;
 import org.junit.Test;
 
+import static com.fasterxml.jackson.core.StreamReadConstraints.*;
+import static io.vertx.test.core.TestUtils.repeat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -69,4 +72,64 @@ public class JacksonTest extends VertxTestBase {
     codec.toBuffer(new RuntimeException("Unsupported"));
   }
 
+  @Test
+  public void testDefaultConstraints() {
+    testReadConstraints(
+      DEFAULT_MAX_DEPTH,
+      DEFAULT_MAX_NUM_LEN,
+      DEFAULT_MAX_STRING_LEN,
+      DEFAULT_MAX_NAME_LEN);
+  }
+
+  public static void testReadConstraints(int defaultMaxDepth,
+                                         int maxNumberLength,
+                                         int defaultMaxStringLength,
+                                         int defaultMaxNameLength) {
+    testMaxNestingDepth(defaultMaxDepth);
+    try {
+      testMaxNestingDepth(defaultMaxDepth + 1);
+      Assert.fail();
+    } catch (DecodeException expected) {
+    }
+    testMaxNumberLength(maxNumberLength);
+    try {
+      testMaxNumberLength(maxNumberLength + 1);
+      Assert.fail();
+    } catch (DecodeException expected) {
+    }
+
+    testMaxStringLength(defaultMaxStringLength);
+    try {
+      testMaxStringLength(defaultMaxStringLength + 1);
+      Assert.fail();
+    } catch (DecodeException expected) {
+    }
+
+    testMaxNameLength(defaultMaxNameLength);
+    try {
+      testMaxNameLength(defaultMaxNameLength + 1);
+      Assert.fail();
+    } catch (DecodeException expected) {
+    }
+  }
+
+  private static JsonArray testMaxNestingDepth(int depth) {
+    String json = repeat("[", depth) + repeat("]", depth);
+    return new JsonArray(json);
+  }
+
+  private static JsonObject testMaxNumberLength(int len) {
+    String json = "{\"number\":" + repeat("1", len) + "}";
+    return new JsonObject(json);
+  }
+
+  private static JsonObject testMaxStringLength(int len) {
+    String json = "{\"string\":\"" + repeat("a", len) + "\"}";
+    return new JsonObject(json);
+  }
+
+  private static JsonObject testMaxNameLength(int len) {
+    String json = "{\"" + repeat("a", len) + "\":3}";
+    return new JsonObject(json);
+  }
 }

--- a/src/test/java/io/vertx/test/core/TestUtils.java
+++ b/src/test/java/io/vertx/test/core/TestUtils.java
@@ -566,4 +566,11 @@ public class TestUtils {
     }
   }
 
+  public static String repeat(String s, int times) {
+    StringBuilder sb = new StringBuilder(s.length() * times);
+    for (int i = 0;i < times;i++) {
+      sb.append(s);
+    }
+    return sb.toString();
+  }
 }


### PR DESCRIPTION
Motivation:

Read constraints were added since Jackson 2.15 to provide upper bounds for input such as the maximum number of a name. These constraints can be configured per json factory, Vert.x static json factory should provide configurability for it.

Changes:

Add system properties that configure the Vert.x static Jackson json factory.
