### PR TITLE
Handle correctly future await from an execute blocking on a virtual thread

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
@@ -35,7 +35,8 @@ public class WorkerExecutor implements EventExecutor {
       throw new IllegalStateException(msg);
     }
     ContextInternal ctx = VertxImpl.currentContext(thread);
-    if (ctx != null && ctx.threadingModel() == ThreadingModel.VIRTUAL_THREAD) {
+    if (ctx != null && ctx.inThread()) {
+      // It can only be a Vert.x virtual thread
       return (io.vertx.core.impl.WorkerExecutor) ctx.executor();
     } else {
       return null;

--- a/vertx-core/src/test/java/io/vertx/tests/virtualthread/VirtualThreadContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/virtualthread/VirtualThreadContextTest.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.tests.virtualthread;
 
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -389,6 +390,32 @@ public class VirtualThreadContextTest extends VertxTestBase {
     ctx.runOnContext(v -> {
       testComplete();
     });
+    await();
+  }
+
+  @Test
+  public void testAwaitFromVirtualThreadExecuteBlocking() {
+    Assume.assumeTrue(isVirtualThreadAvailable());
+    Context ctx = vertx.createVirtualThreadContext();
+    ctx.executeBlocking(() -> {
+      vertx.timer(20).await();
+      return "done";
+    }).onComplete(onSuccess(res -> {
+      assertEquals("done", res);
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
+  public void testAwaitFromWorkerExecuteBlocking() {
+    Context ctx = vertx.getOrCreateContext();
+    ctx.executeBlocking(() -> {
+      vertx.timer(20).await();
+      return "done";
+    }).onComplete(onFailure(res -> {
+      testComplete();
+    }));
     await();
   }
 }


### PR DESCRIPTION
Motivation:

`Future#await` ensures that we use a virtual thread context to obtain an execute to suspend the virtual thread, however this check also includes execute blocking tasks.

Changes:

When obtaining the worker executor to suspend the current task, ensure that we are on the context thread, so execute blocking tasks are not included.
