### PR TITLE
Handle correctly future await from an execute blocking on a virtual thread

### DIFF
--- a/src/main/java/io/vertx/core/impl/WorkerExecutor.java
+++ b/src/main/java/io/vertx/core/impl/WorkerExecutor.java
@@ -36,7 +36,8 @@ public class WorkerExecutor implements EventExecutor {
       throw new IllegalStateException(msg);
     }
     ContextInternal ctx = VertxImpl.currentContext(thread);
-    if (ctx != null && ctx.threadingModel() == ThreadingModel.VIRTUAL_THREAD) {
+    if (ctx != null && ctx.inThread()) {
+      // It can only be a Vert.x virtual thread
       return (io.vertx.core.impl.WorkerExecutor) ctx.executor();
     } else {
       return null;

--- a/src/test/java/io/vertx/core/FutureAwaitTest.java
+++ b/src/test/java/io/vertx/core/FutureAwaitTest.java
@@ -1,0 +1,57 @@
+package io.vertx.core;
+
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class FutureAwaitTest extends VertxTestBase {
+
+  @Test
+  public void testAwaitFromEventLoopThread() {
+    Promise<String> promise = Promise.promise();
+    Future<String> future = promise.future();
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    ctx.nettyEventLoop().execute(() -> {
+      try {
+        Future.await(future);
+      } catch (IllegalStateException expected) {
+        testComplete();
+      }
+    });
+    await();
+  }
+
+  @Test
+  public void testAwaitFromNonVertxThread() {
+    Promise<String> promise = Promise.promise();
+    Future<String> future = promise.future();
+    Thread current = Thread.currentThread();
+    new Thread(() -> {
+      while (current.getState() != Thread.State.WAITING) {
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException ignore) {
+        }
+      }
+      promise.complete("the-result");
+    }).start();
+    String res = Future.await(future);
+    assertEquals("the-result", res);
+  }
+
+  @Test
+  public void testAwaitWithTimeout() {
+    Promise<String> promise = Promise.promise();
+    Future<String> future = promise.future();
+    long now = System.currentTimeMillis();
+    try {
+      Future.await(future, 100, TimeUnit.MILLISECONDS);
+      fail();
+    } catch (TimeoutException expected) {
+    }
+    assertTrue((System.currentTimeMillis() - now) >= 100);
+  }
+}

--- a/src/test/java/io/vertx/core/FutureTest.java
+++ b/src/test/java/io/vertx/core/FutureTest.java
@@ -1822,15 +1822,6 @@ public class FutureTest extends FutureTestBase {
   }
 
   @Test
-  public void testAwaitFromPlainThread() {
-    try {
-      Future.await(Promise.promise().future());
-      fail();
-    } catch (IllegalStateException e) {
-    }
-  }
-
-  @Test
   public void contextFutureTimeoutFires() {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
     Promise<String> promise = ctx.promise();

--- a/src/test/java/io/vertx/core/VirtualThreadContextTest.java
+++ b/src/test/java/io/vertx/core/VirtualThreadContextTest.java
@@ -387,4 +387,30 @@ public class VirtualThreadContextTest extends VertxTestBase {
     });
     await();
   }
+
+  @Test
+  public void testAwaitFromVirtualThreadExecuteBlocking() {
+    Assume.assumeTrue(isVirtualThreadAvailable());
+    Context ctx = vertx.createVirtualThreadContext();
+    ctx.executeBlocking(() -> {
+      Future.await(vertx.timer(20));
+      return "done";
+    }).onComplete(onSuccess(res -> {
+      assertEquals("done", res);
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
+  public void testAwaitFromWorkerExecuteBlocking() {
+    Context ctx = vertx.getOrCreateContext();
+    ctx.executeBlocking(() -> {
+      Future.await(vertx.timer(20));
+      return "done";
+    }).onComplete(onFailure(res -> {
+      testComplete();
+    }));
+    await();
+  }
 }


### PR DESCRIPTION
Motivation:

`Future#await` ensures that we use a virtual thread context to obtain an execute to suspend the virtual thread, however this check also includes execute blocking tasks.

Changes:

When obtaining the worker executor to suspend the current task, ensure that we are on the context thread, so execute blocking tasks are not included.
