### PR TITLE
HTTP/1 client connection unsolicited messages should be treated as invalid

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -66,10 +66,7 @@ import static io.vertx.core.http.HttpHeaders.*;
  */
 public class Http1xClientConnection extends Http1xConnection implements HttpClientConnectionInternal {
 
-  private static final Handler<Object> INVALID_MSG_HANDLER = msg -> {
-    ReferenceCountUtil.release(msg);
-    throw new IllegalStateException("Invalid object " + msg);
-  };
+  private static final Handler<Object> INVALID_MSG_HANDLER = ReferenceCountUtil::release;
 
   private final HttpClientBase client;
   private final HttpClientOptions options;
@@ -126,6 +123,12 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
   @Override
   public HttpClientConnectionInternal evictionHandler(Handler<Void> handler) {
     evictionHandler = handler;
+    return this;
+  }
+
+  @Override
+  public HttpClientConnectionInternal invalidMessageHandler(Handler<Object> handler) {
+    invalidMessageHandler = handler;
     return this;
   }
 
@@ -758,6 +761,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
       pendingFrames.add(frame);
     } else {
       invalidMessageHandler.handle(msg);
+      fail(new VertxException("Received an invalid message: " + msg.getClass().getName()));
     }
   }
 
@@ -767,7 +771,8 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
       stream = responses.peekFirst();
     }
     if (stream == null) {
-      fail(new VertxException("Received HTTP message with no request in progress"));
+      invalidMessageHandler.handle(obj);
+      fail(new VertxException("Received an HTTP message with no request in progress: " + obj.getClass().getName()));
     } else if (obj instanceof io.netty.handler.codec.http.HttpResponse) {
       io.netty.handler.codec.http.HttpResponse response = (io.netty.handler.codec.http.HttpResponse) obj;
       HttpVersion version;
@@ -849,9 +854,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
     // removing this codec might fire pending buffers in the HTTP decoder
     // this happens when the channel reads the HTTP response and the following data in a single buffer
     Handler<Object> prev = invalidMessageHandler;
-    invalidMessageHandler = msg -> {
-      ReferenceCountUtil.release(msg);
-    };
+    invalidMessageHandler = INVALID_MSG_HANDLER;
     try {
       pipeline.remove("codec");
     } finally {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -78,6 +78,11 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
   }
 
   @Override
+  public HttpClientConnectionInternal invalidMessageHandler(Handler<Object> handler) {
+    return this;
+  }
+
+  @Override
   public Http2ClientConnection concurrencyChangeHandler(Handler<Long> handler) {
     concurrencyChangeHandler = handler;
     return this;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -61,6 +61,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
   private Handler<Throwable> exceptionHandler;
   private Handler<Buffer> pingHandler;
   private Handler<Void> evictionHandler;
+  private Handler<Object> invalidMessageHandler;
   private Handler<Long> concurrencyChangeHandler;
   private Handler<Http2Settings> remoteSettingsHandler;
 
@@ -858,6 +859,15 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
       evictionHandler = handler;
     }
     current.evictionHandler(handler);
+    return this;
+  }
+
+  @Override
+  public HttpClientConnectionInternal invalidMessageHandler(Handler<Object> handler) {
+    if (current instanceof Http1xClientConnection) {
+      invalidMessageHandler = handler;
+    }
+    current.invalidMessageHandler(handler);
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientConnectionInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientConnectionInternal.java
@@ -55,6 +55,14 @@ public interface HttpClientConnectionInternal extends HttpConnection {
   HttpClientConnectionInternal evictionHandler(Handler<Void> handler);
 
   /**
+   * Set a {@code handler} called when the connection receives invalid messages.
+   *
+   * @param handler the handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  HttpClientConnectionInternal invalidMessageHandler(Handler<Object> handler);
+
+  /**
    * Set a {@code handler} called when the connection concurrency changes.
    * The handler is called with the new concurrency.
    *

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -5811,4 +5811,36 @@ public class Http1xTest extends HttpTest {
     expected.add("server-3");
     assertEquals(expected, responses);
   }
+
+
+  @Test
+  public void testUnsolicitedMessagesAreTreatedAsInvalid() throws Exception {
+    NetServer server = vertx
+      .createNetServer()
+      .connectHandler(so -> {
+        so.write("HTTP/1.1 200 OK\r\n" +
+          "Content-Type: text/plain\r\n" +
+          "Content-Length: 11\r\n" +
+          "\r\n" +
+          "Hello World");
+      });
+    server.listen(testAddress).await();
+
+    HttpClientAgent client = vertx.httpClientBuilder().withConnectHandler(conn -> {
+      List<Object> invalidMessages = new ArrayList<>();
+      ((HttpClientConnectionInternal) conn).invalidMessageHandler(invalidMessages::add);
+      conn.exceptionHandler(err -> {
+      });
+      conn.closeHandler(v -> {
+        assertEquals(2, invalidMessages.size());
+        assertTrue(invalidMessages.get(0) instanceof io.netty.handler.codec.http.HttpResponse);
+        assertTrue(invalidMessages.get(1) instanceof io.netty.handler.codec.http.LastHttpContent);
+        testComplete();
+      });
+    }).build();
+
+    client.request(requestOptions);
+
+    await();
+  }
 }


### PR DESCRIPTION
Motivation:

The current implementation of HTTP/1 client connection fails the connection when it receives unsolicited messages and does not release them. Such messages should be properly released to avoid leaking referenced counted messages.

Changes:

Update the HTTP/1 client connection to handle unsolicited messages as invalid, since invalid messages are released by the invalid message handler.
