### PR TITLE
HTTP/1 client connection unsolicited messages should be treated as invalid

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -61,6 +61,11 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
   }
 
   @Override
+  public HttpClientConnection invalidMessageHandler(Handler<Object> handler) {
+    return this;
+  }
+
+  @Override
   public Http2ClientConnection concurrencyChangeHandler(Handler<Long> handler) {
     concurrencyChangeHandler = handler;
     return this;

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -60,6 +60,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
   private Handler<Throwable> exceptionHandler;
   private Handler<Buffer> pingHandler;
   private Handler<Void> evictionHandler;
+  private Handler<Object> invalidMessageHandler;
   private Handler<Long> concurrencyChangeHandler;
   private Handler<Http2Settings> remoteSettingsHandler;
 
@@ -868,6 +869,15 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
       evictionHandler = handler;
     }
     current.evictionHandler(handler);
+    return this;
+  }
+
+  @Override
+  public HttpClientConnection invalidMessageHandler(Handler<Object> handler) {
+    if (current instanceof Http1xClientConnection) {
+      invalidMessageHandler = handler;
+    }
+    current.invalidMessageHandler(handler);
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -44,6 +44,14 @@ public interface HttpClientConnection extends HttpConnection {
   HttpClientConnection evictionHandler(Handler<Void> handler);
 
   /**
+   * Set a {@code handler} called when the connection receives invalid messages.
+   *
+   * @param handler the handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  HttpClientConnection invalidMessageHandler(Handler<Object> handler);
+
+  /**
    * Set a {@code handler} called when the connection concurrency changes.
    * The handler is called with the new concurrency.
    *


### PR DESCRIPTION
Motivation:

The current implementation of HTTP/1 client connection fails the connection when it receives unsolicited messages and does not release them. Such messages should be properly released to avoid leaking referenced counted messages.

Changes:

Update the HTTP/1 client connection to handle unsolicited messages as invalid, since invalid messages are released by the invalid message handler.
