### PR TITLE
HTTP/2 client queued writes should fail when stream creation fails

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -603,7 +603,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
         createStream(request, headers);
       } catch (Http2Exception ex) {
         promise.fail(ex);
-        handleException(ex);
+        onException(ex);
         return;
       }
       if (buf != null) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -15,6 +15,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.EmptyHttp2Headers;
+import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.util.concurrent.FutureListener;
@@ -253,6 +254,12 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
       }
       return;
     }
+    if (failure != null) {
+      if (promise != null) {
+        promise.fail(failure);
+      }
+      return;
+    }
     if (end) {
       endWritten();
     }
@@ -282,6 +289,10 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
   void doWriteData(ByteBuf buf, boolean end, Promise<Void> promise) {
     if (reset != -1L) {
       promise.fail("Stream reset");
+      return;
+    }
+    if (failure != null) {
+      promise.fail(failure);
       return;
     }
     ByteBuf chunk;


### PR DESCRIPTION
Motivation:

HTTP/2 client queues writes when the stream has an asynchronous boundary. When the stream creation fails, the failure should be recorded so that queued writes can be guarded against the failure.

Changes:

Record stream creation failure, when a delayed writes observes the failure, the write operation should be failed and not proceed further.
