### PR TITLE
Remove FileSystem recursive deletion that uses a recursive parameter

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/file/FileSystem.java
+++ b/vertx-core/src/main/java/io/vertx/core/file/FileSystem.java
@@ -298,16 +298,15 @@ public interface FileSystem {
    * deleted recursively.
    *
    * @param path  path to the file
-   * @param recursive  delete recursively?
    * @return a future notified on completion
    */
-  Future<Void> deleteRecursive(String path, boolean recursive);
+  Future<Void> deleteRecursive(String path);
 
   /**
-   * Blocking version of {@link #deleteRecursive(String, boolean)}
+   * Blocking version of {@link #deleteRecursive(String)}
    */
   @Fluent
-  FileSystem deleteRecursiveBlocking(String path, boolean recursive) ;
+  FileSystem deleteRecursiveBlocking(String path) ;
 
   /**
    * Create the directory represented by {@code path}, asynchronously.

--- a/vertx-core/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
@@ -220,12 +220,12 @@ public class FileSystemImpl implements FileSystem {
   }
 
   @Override
-  public Future<Void> deleteRecursive(String path, boolean recursive) {
-    return deleteInternal(path, recursive).run();
+  public Future<Void> deleteRecursive(String path) {
+    return deleteInternal(path, true).run();
   }
 
-  public FileSystem deleteRecursiveBlocking(String path, boolean recursive) {
-    deleteInternal(path, recursive).perform();
+  public FileSystem deleteRecursiveBlocking(String path) {
+    deleteInternal(path, true).perform();
     return this;
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/file/FileSystemTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/file/FileSystemTest.java
@@ -116,8 +116,8 @@ public class FileSystemTest extends VertxTestBase {
     assertNullPointerException(() -> vertx.fileSystem().readSymlinkBlocking(null));
     assertNullPointerException(() -> vertx.fileSystem().delete(null));
     assertNullPointerException(() -> vertx.fileSystem().deleteBlocking(null));
-    assertNullPointerException(() -> vertx.fileSystem().deleteRecursive(null, true));
-    assertNullPointerException(() -> vertx.fileSystem().deleteRecursiveBlocking(null, true));
+    assertNullPointerException(() -> vertx.fileSystem().deleteRecursive(null));
+    assertNullPointerException(() -> vertx.fileSystem().deleteRecursiveBlocking(null));
     assertNullPointerException(() -> vertx.fileSystem().mkdir(null));
     assertNullPointerException(() -> vertx.fileSystem().mkdirBlocking(null));
     assertNullPointerException(() -> vertx.fileSystem().mkdir(null, "ignored"));
@@ -827,7 +827,7 @@ public class FileSystemTest extends VertxTestBase {
   private void testDelete(String fileName, boolean recursive, boolean shouldPass,
                           Handler<Void> afterOK) {
     if (recursive) {
-      vertx.fileSystem().deleteRecursive(testDir + pathSep + fileName, recursive).onComplete(createHandler(shouldPass, afterOK));
+      vertx.fileSystem().deleteRecursive(testDir + pathSep + fileName).onComplete(createHandler(shouldPass, afterOK));
     } else {
       vertx.fileSystem().delete(testDir + pathSep + fileName).onComplete(createHandler(shouldPass, afterOK));
     }


### PR DESCRIPTION
Instead deleteRecursive or delete should be used
