### PR TITLE
Promote context local to API

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/Context.java
+++ b/vertx-core/src/main/java/io/vertx/core/Context.java
@@ -17,10 +17,13 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.impl.VertxThread;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.context.storage.AccessMode;
+import io.vertx.core.spi.context.storage.ContextLocal;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 /**
  * The execution context of a {@link io.vertx.core.Handler} execution.
@@ -246,4 +249,100 @@ public interface Context {
   @Nullable
   Handler<Throwable> exceptionHandler();
 
+  /**
+   * Get local data associated with {@code key} using the concurrent access mode.
+   *
+   * @param key  the key of the data
+   * @param <T>  the type of the data
+   * @return the local data
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default <T> T getLocal(ContextLocal<T> key) {
+    return getLocal(key, AccessMode.CONCURRENT);
+  }
+
+  /**
+   * <p>Get local data associated with {@code key} using the concurrent access mode.</p>
+   *
+   * <p>When it does not exist the {@code initialValueSupplier} is called to obtain the initial value.</p>
+   *
+   * <p> The {@code initialValueSupplier} might be called multiple times when multiple threads call this method concurrently.
+   *
+   * @param key  the key of the data
+   * @param initialValueSupplier the supplier of the initial value optionally called
+   * @param <T>  the type of the data
+   * @return the local data
+   */
+  @GenIgnore
+  default <T> T getLocal(ContextLocal<T> key, Supplier<? extends T> initialValueSupplier) {
+    return getLocal(key, AccessMode.CONCURRENT, initialValueSupplier);
+  }
+
+  /**
+   * <p>Associate local data with {@code key} using the concurrent access mode.</p>
+   *
+   * @param key  the key of the data
+   * @param value  the data
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default <T> void putLocal(ContextLocal<T> key, T value) {
+    putLocal(key, AccessMode.CONCURRENT, value);
+  }
+
+  /**
+   * <p>Remove local data associated with {@code key} using the concurrent access mode.</p>
+   *
+   * @param key  the key to be removed
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default <T> void removeLocal(ContextLocal<T> key) {
+    putLocal(key, null);
+  }
+
+  /**
+   * <p>Get local data associated with {@code key} using the specified access mode.</p>
+   *
+   * @param key  the key of the data
+   * @param accessMode the access mode
+   * @param <T>  the type of the data
+   * @return the local data
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  <T> T getLocal(ContextLocal<T> key, AccessMode accessMode);
+
+  /**
+   * <p>Get local data associated with {@code key} using the specified access mode.</p>
+   *
+   * <p>When it does not exist the {@code initialValueSupplier} is called to obtain the initial value.</p>
+   *
+   * <p> The {@code initialValueSupplier} might be called multiple times when multiple threads call this method concurrently.
+   *
+   * @param key  the key of the data
+   * @param initialValueSupplier the supplier of the initial value optionally called
+   * @param <T>  the type of the data
+   * @return the local data
+   */
+  @GenIgnore
+  <T> T getLocal(ContextLocal<T> key, AccessMode accessMode, Supplier<? extends T> initialValueSupplier);
+
+  /**
+   * <p>Associate local data with {@code key} using the specified access mode.</p>
+   *
+   * @param key  the key of the data
+   * @param accessMode the access mode
+   * @param value  the data
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  <T> void putLocal(ContextLocal<T> key, AccessMode accessMode, T value);
+
+  /**
+   * <p>Remove local data associated with {@code key} using the specified access mode.</p>
+   *
+   * @param key  the key to be removed
+   * @param accessMode the access mode
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default <T> void removeLocal(ContextLocal<T> key, AccessMode accessMode) {
+    putLocal(key, accessMode, null);
+  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
@@ -313,58 +313,6 @@ public interface ContextInternal extends Context {
   }
 
   /**
-   * Get some local data from the context.
-   *
-   * @param key  the key of the data
-   * @param <T>  the type of the data
-   * @return the local data
-   */
-  default <T> T getLocal(ContextLocal<T> key) {
-    return getLocal(key, AccessMode.CONCURRENT);
-  }
-
-  /**
-   * Get some local data from the context.
-   *
-   * @param key  the key of the data
-   * @param <T>  the type of the data
-   * @return the local data
-   */
-  <T> T getLocal(ContextLocal<T> key, AccessMode accessMode);
-
-  /**
-   * Get some local data from the context, when it does not exist the {@code initialValueSupplier} is called to obtain
-   * the initial value.
-   *
-   * <p> The {@code initialValueSupplier} might be called multiple times when multiple threads call this method concurrently.
-   *
-   * @param key  the key of the data
-   * @param initialValueSupplier the supplier of the initial value optionally called
-   * @param <T>  the type of the data
-   * @return the local data
-   */
-  <T> T getLocal(ContextLocal<T> key, AccessMode accessMode, Supplier<? extends T> initialValueSupplier);
-
-  /**
-   * Put some local data in the context.
-   * <p>
-   * This can be used to share data between different handlers that share a context
-   *
-   * @param key  the key of the data
-   * @param value  the data
-   */
-  <T> void putLocal(ContextLocal<T> key, AccessMode accessMode, T value);
-
-  /**
-   * Remove some local data from the context.
-   *
-   * @param key  the key to remove
-   */
-  default <T> void removeLocal(ContextLocal<T> key, AccessMode accessMode) {
-    putLocal(key, accessMode, null);
-  }
-
-  /**
    * @deprecated instead use {@link #getLocal(ContextLocal, AccessMode)}
    */
   @Deprecated(forRemoval = true)

--- a/vertx-core/src/main/java/io/vertx/core/spi/context/storage/ContextLocal.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/context/storage/ContextLocal.java
@@ -18,13 +18,40 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * A local storage for arbitrary data attached to a duplicated {@link Context}.
+ * <p>A local storage for arbitrary data attached to a {@link Context}.</p>
  *
  * <p>Local storage should be registered before creating a {@link io.vertx.core.Vertx} instance, once registered a
  * local storage cannot be unregistered.
  *
  * <p>It is recommended to initialize local storage as static fields of a {@link io.vertx.core.spi.VertxServiceProvider},
  * since providers are discovered before the capture of known local storages.
+ *
+ * <pre>{@code
+ * public class CustomLocal implements VertxServiceProvider {
+ *   public static final ContextLocal<CustomLocal> KEY = ContextLocal.registerLocal(CustomLocal.class);
+ *   ...
+ * }
+ * }</pre>
+ *
+ * <p>Such provider must then be declared as a <a href="https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html">Java service provider</a>
+ * in {@code META/INF/services/io.vertx.core.spi.VertxServiceProvider} and optionally in a {@code module-info.java}.</p>
+ *
+ * <p>Context local can be used from a Vert.x {@link Context} with the following methods.</p>
+ *
+ * <ul>
+ *   <li>{@link Context#getLocal(ContextLocal)}</li>
+ *   <li>{@link Context#getLocal(ContextLocal, Supplier)}</li>
+ *   <li>{@link Context#putLocal(ContextLocal, Object)}</li>
+ *   <li>{@link Context#removeLocal(ContextLocal)}</li>
+ *   <li>{@link Context#getLocal(ContextLocal, AccessMode)}</li>
+ *   <li>{@link Context#getLocal(ContextLocal, AccessMode, Supplier)}</li>
+ *   <li>{@link Context#putLocal(ContextLocal, AccessMode, Object)}</li>
+ *   <li>{@link Context#removeLocal(ContextLocal, AccessMode)}</li>
+ * </ul>
+ *
+ * <pre>{@code
+ * context.putLocal(CustomLocal.KEY, new CustomLocal(...));
+ * }</pre>
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */


### PR DESCRIPTION
Motivation:

Context local data is a feature we should support for users even though it is a more advanced feature.

Changes:

Move API to `io.vertx.core.Context`, improve Javadoc and add missing API methods.
