### PR TITLE
Mitigate usage of NoStackTraceThrowable

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/dns/DnsException.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/DnsException.java
@@ -11,8 +11,7 @@
 
 package io.vertx.core.dns;
 
-import io.vertx.core.impl.NoStackTraceThrowable;
-import java.util.Objects;
+import io.vertx.core.VertxException;
 
 /**
  * Exception which is used to notify the {@link io.vertx.core.AsyncResult}
@@ -20,14 +19,14 @@ import java.util.Objects;
  *
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-public final class DnsException extends NoStackTraceThrowable {
+public final class DnsException extends VertxException {
 
   private static final String ERROR_MESSAGE_PREFIX = "DNS query error occurred: ";
-  private DnsResponseCode code;
+
+  private final DnsResponseCode code;
 
   public DnsException(DnsResponseCode code) {
-    super(ERROR_MESSAGE_PREFIX + code);
-    Objects.requireNonNull(code, "code");
+    super(ERROR_MESSAGE_PREFIX + code, true);
     this.code = code;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/impl/NoStackTraceException.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/NoStackTraceException.java
@@ -15,7 +15,7 @@ import io.vertx.core.VertxException;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
- * @deprecated instead use {@link io.vertx.core.VertxException}
+ * @deprecated for removal in Vert.x 6, instead catch {@link io.vertx.core.VertxException}
  */
 @Deprecated(forRemoval = true)
 public class NoStackTraceException extends VertxException {

--- a/vertx-core/src/main/java/io/vertx/core/impl/NoStackTraceThrowable.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/NoStackTraceThrowable.java
@@ -11,17 +11,19 @@
 
 package io.vertx.core.impl;
 
+import io.vertx.core.VertxException;
+
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
- * @deprecated instead use {@link io.vertx.core.VertxException}
+ * @deprecated for removal in Vert.x 6, instead catch {@link io.vertx.core.VertxException}
  */
 @Deprecated(forRemoval = true)
-public class NoStackTraceThrowable extends Throwable {
+public class NoStackTraceThrowable extends VertxException {
 
   /**
    * @deprecated instead use {@link io.vertx.core.VertxException#noStackTrace(String)}
    */
   public NoStackTraceThrowable(String message) {
-    super(message, null, false, false);
+    super(message, null, true);
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/future/FutureAwaitTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/future/FutureAwaitTest.java
@@ -14,6 +14,7 @@ package io.vertx.tests.future;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
@@ -69,5 +70,17 @@ public class FutureAwaitTest extends VertxTestBase {
     } catch (TimeoutException expected) {
     }
     assertTrue((System.currentTimeMillis() - now) >= 100);
+  }
+
+  @Test
+  public void testAwaitNoStackTraceFailure() {
+    String msg = TestUtils.randomAlphaString(10);
+    Future<String> future = Future.failedFuture(msg);
+    try {
+      future.await();
+      fail();
+    } catch (Exception expected) {
+      assertSame(msg, expected.getMessage());
+    }
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/virtualthread/VirtualThreadContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/virtualthread/VirtualThreadContextTest.java
@@ -10,7 +10,6 @@
  */
 package io.vertx.tests.virtualthread;
 
-import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -266,7 +265,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
         Future<Void> fut = promise.future();
         fut.await();
         fail();
-      } catch (Throwable e) {
+      } catch (Exception e) {
         if (e instanceof InterruptedException) {
           interrupted.set(true);
         }

--- a/vertx-core/src/test/java/io/vertx/tests/worker/ExecuteBlockingTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/worker/ExecuteBlockingTest.java
@@ -12,7 +12,7 @@
 package io.vertx.tests.worker;
 
 import io.vertx.core.Context;
-import io.vertx.core.impl.NoStackTraceException;
+import io.vertx.core.VertxException;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
@@ -49,7 +49,7 @@ public class ExecuteBlockingTest extends VertxTestBase {
         Thread.sleep(1000);
       } catch (Exception ignore) {
       }
-      throw new NoStackTraceException("failed!");
+      throw VertxException.noStackTrace("failed!");
     }).onComplete(onFailure(t -> {
       assertEquals("failed!", t.getMessage());
       testComplete();


### PR DESCRIPTION
Motivation:

`NoStackTraceThrowable` currently extends `Throwable` and has been moved to the implementation package not exported in `module-info`.

There are several concerns we need to solve:

1. Virtual threads and Kotlin coroutines need to catch a throwable which is not a recommended practice, e.g. an `Exception` catch declaration let the `NoStackTraceThrowable` go through.
2. Users relying on `NoStackTraceThrowable` developing a modular application have to catch `Throwable` instead since the type is not exported.

We should provide a transitory path to remove `NoStackTraceThrowable` in Vert.x 6.

Changes:

`NoStackTraceThrowable` extends `VertxException` instead of `Throwable`.

Users catching `NoStackTraceThrowable` (which is deprecated) can instead catch `VertxException` and achieve the same effect.

