### PR TITLE
Internal api cleanup

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
@@ -14,11 +14,15 @@ package io.vertx.core.dns;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.impl.HostnameResolver;
+import io.vertx.core.internal.resolver.NameResolver;
 import io.vertx.core.json.JsonObject;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
+import static io.vertx.core.impl.Utils.isLinux;
+import static io.vertx.core.internal.resolver.NameResolver.parseLinux;
 
 /**
  * Configuration options for Vert.x hostname resolver. The resolver uses the local <i>hosts</i> file and performs
@@ -29,6 +33,17 @@ import java.util.List;
 @DataObject
 @JsonGen(publicConverter = false)
 public class AddressResolverOptions {
+
+  static {
+    if (isLinux()) {
+      NameResolver.ResolverOptions options = parseLinux(new File("/etc/resolv.conf"));
+      DEFAULT_NDOTS = options.effectiveNdots();
+      DEFAULT_ROTATE_SERVERS = options.isRotate();
+    } else {
+      DEFAULT_NDOTS = 1;
+      DEFAULT_ROTATE_SERVERS = false;
+    }
+  }
 
   /**
    * The default list of DNS servers = null (uses system name server's list like resolve.conf otherwise Google Public DNS)
@@ -83,15 +98,15 @@ public class AddressResolverOptions {
   /**
    * The default ndots value = loads the value from the OS on Linux otherwise use the value 1
    */
-  public static final int DEFAULT_NDOTS = HostnameResolver.DEFAULT_NDOTS_RESOLV_OPTION;
+  public static final int DEFAULT_NDOTS;
 
   /**
    * The default servers rotate value = loads the value from the OS on Linux otherwise use the value false
    */
-  public static final boolean DEFAULT_ROTATE_SERVERS = HostnameResolver.DEFAULT_ROTATE_RESOLV_OPTION;
+  public static final boolean DEFAULT_ROTATE_SERVERS;
 
   /**
-   * The default round robin inet address = false
+   * The default round-robin inet address = false
    */
   public static final boolean DEFAULT_ROUND_ROBIN_INET_ADDRESS = false;
 

--- a/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsAddressResolverProvider.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsAddressResolverProvider.java
@@ -19,7 +19,6 @@ import io.netty.util.NetUtil;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.dns.AddressResolverOptions;
-import io.vertx.core.impl.HostnameResolver;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.spi.dns.AddressResolverProvider;
@@ -122,7 +121,7 @@ public class DnsAddressResolverProvider implements AddressResolverProvider, Host
       builder.searchDomains(options.getSearchDomains());
       int ndots = options.getNdots();
       if (ndots == -1) {
-        ndots = HostnameResolver.DEFAULT_NDOTS_RESOLV_OPTION;
+        ndots = AddressResolverOptions.DEFAULT_NDOTS;
       }
       builder.ndots(ndots);
     }
@@ -130,7 +129,7 @@ public class DnsAddressResolverProvider implements AddressResolverProvider, Host
     this.dnsNameResolverBuilder = builder;
     this.resolverGroup = new DnsAddressResolverGroup(builder) {
       @Override
-      protected io.netty.resolver.AddressResolver<InetSocketAddress> newAddressResolver(EventLoop eventLoop, NameResolver<InetAddress> resolver) throws Exception {
+      protected io.netty.resolver.AddressResolver<InetSocketAddress> newAddressResolver(EventLoop eventLoop, io.netty.resolver.NameResolver<InetAddress> resolver) throws Exception {
         io.netty.resolver.AddressResolver<InetSocketAddress> addressResolver;
         if (options.isRoundRobinInetAddress()) {
           addressResolver = new RoundRobinInetAddressResolver(eventLoop, resolver).asAddressResolver();
@@ -230,7 +229,7 @@ public class DnsAddressResolverProvider implements AddressResolverProvider, Host
   private void refreshHostsFile() {
     HostsFileEntries entries;
     if (hostsPath != null) {
-      File file = vertx.resolveFile(hostsPath).getAbsoluteFile();
+      File file = vertx.fileResolver().resolve(hostsPath).getAbsoluteFile();
       try {
         if (!file.exists() || !file.isFile()) {
           throw new IOException();

--- a/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
@@ -55,8 +55,12 @@ public class DnsClientImpl implements DnsClient {
       throw new IllegalArgumentException("Cannot resolve the host to a valid ip address");
     }
 
+    DnsAddressResolverProvider provider = DnsAddressResolverProvider.create(vertx, vertx.nameResolver().options()
+      .setServers(Collections.singletonList(dnsServer.getHostString() + ":" + dnsServer.getPort()))
+      .setOptResourceEnabled(false));
+
     this.options = new DnsClientOptions(options);
-    this.provider = vertx.dnsAddressResolverProvider(dnsServer);
+    this.provider = provider;
     this.vertx = vertx;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -55,7 +55,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   protected volatile boolean started;
 
   public EventBusImpl(VertxInternal vertx) {
-    VertxMetrics metrics = vertx.metricsSPI();
+    VertxMetrics metrics = vertx.metrics();
     this.vertx = vertx;
     this.metrics = metrics != null ? metrics.createEventBusMetrics() : null;
   }

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -76,7 +76,11 @@ public final class ClusteredEventBus extends EventBusImpl {
     this.options = options.getEventBusOptions();
     this.clusterManager = clusterManager;
     this.nodeSelector = nodeSelector;
-    this.context = vertx.createEventLoopContext(null, new CloseFuture(), null, Thread.currentThread().getContextClassLoader());
+    this.context = vertx.contextBuilder()
+      .withThreadingModel(ThreadingModel.EVENT_LOOP)
+      .withClassLoader(Thread.currentThread().getContextClassLoader())
+      .withCloseFuture(new CloseFuture())
+      .build();
     this.client = client;
   }
 
@@ -98,7 +102,7 @@ public final class ClusteredEventBus extends EventBusImpl {
 
   /**
    * Pick a default address for clustered event bus when none was provided by either the user or the cluster manager.
-   * 
+   *
    * This is used by Vert.x launcher.
    */
   public static String defaultAddress() {
@@ -127,7 +131,7 @@ public final class ClusteredEventBus extends EventBusImpl {
 
   private NetClient createNetClient(VertxInternal vertx, NetClientOptions clientOptions) {
     NetClientBuilder builder = new NetClientBuilder(vertx, clientOptions);
-    VertxMetrics metricsSPI = vertx.metricsSPI();
+    VertxMetrics metricsSPI = vertx.metrics();
     if (metricsSPI != null) {
       builder.metrics(metricsSPI.createNetClientMetrics(clientOptions));
     }

--- a/vertx-core/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -93,9 +93,9 @@ public class AsyncFileImpl implements AsyncFile {
     try {
       if (options.getPerms() != null) {
         FileAttribute<?> attrs = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(options.getPerms()));
-        ch = AsynchronousFileChannel.open(file, opts, vertx.getWorkerPool().executor(), attrs);
+        ch = AsynchronousFileChannel.open(file, opts, vertx.workerPool().executor(), attrs);
       } else {
-        ch = AsynchronousFileChannel.open(file, opts, vertx.getWorkerPool().executor());
+        ch = AsynchronousFileChannel.open(file, opts, vertx.workerPool().executor());
       }
       if (options.isAppend()) writePos = ch.size();
     } catch (IOException e) {

--- a/vertx-core/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
@@ -96,7 +96,7 @@ public class FileResolverImpl implements FileResolver {
     }
   }
 
-  public File resolveFile(String fileName) {
+  public File resolve(String fileName) {
     int idx = fileName.length() - 1;
     if (idx >= 0 && fileName.charAt(idx) == '/') {
       fileName = fileName.substring(0, idx);

--- a/vertx-core/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
@@ -442,8 +442,8 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<Void>() {
       public Void perform() {
         try {
-          Path source = vertx.resolveFile(from).toPath();
-          Path target = vertx.resolveFile(to).toPath();
+          Path source = resolveFile(from).toPath();
+          Path target = resolveFile(to).toPath();
           Files.copy(source, target, copyOptions);
         } catch (IOException e) {
           throw new FileSystemException(getFileCopyErrorMessage(from, to), e);
@@ -459,8 +459,8 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<Void>() {
       public Void perform() {
         try {
-          Path source = vertx.resolveFile(from).toPath();
-          Path target = vertx.resolveFile(to).toPath();
+          Path source = resolveFile(from).toPath();
+          Path target = resolveFile(to).toPath();
           if (recursive) {
             Files.walkFileTree(source, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
               new SimpleFileVisitor<Path>() {
@@ -504,8 +504,8 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<Void>() {
       public Void perform() {
         try {
-          Path source = vertx.resolveFile(from).toPath();
-          Path target = vertx.resolveFile(to).toPath();
+          Path source = resolveFile(from).toPath();
+          Path target = resolveFile(to).toPath();
           Files.move(source, target, copyOptions);
         } catch (IOException e) {
           throw new FileSystemException(getFileMoveErrorMessage(from, to), e);
@@ -520,7 +520,7 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<Void>() {
       public Void perform() {
         try {
-          String path = vertx.resolveFile(p).getAbsolutePath();
+          String path = resolveFile(p).getAbsolutePath();
           if (len < 0) {
             throw new FileSystemException("Cannot truncate file to size < 0");
           }
@@ -549,7 +549,7 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<Void>() {
       public Void perform() {
         try {
-          Path target = vertx.resolveFile(path).toPath();
+          Path target = resolveFile(path).toPath();
           if (dirPermissions != null) {
             Files.walkFileTree(target, new SimpleFileVisitor<Path>() {
               public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
@@ -582,7 +582,7 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<Void>() {
       public Void perform() {
         try {
-          Path target = vertx.resolveFile(path).toPath();
+          Path target = resolveFile(path).toPath();
           UserPrincipalLookupService service = target.getFileSystem().getUserPrincipalLookupService();
           UserPrincipal userPrincipal = user == null ? null : service.lookupPrincipalByName(user);
           GroupPrincipal groupPrincipal = group == null ? null : service.lookupPrincipalByGroupName(group);
@@ -620,7 +620,7 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<FileProps>() {
       public FileProps perform() {
         try {
-          Path target = vertx.resolveFile(path).toPath();
+          Path target = resolveFile(path).toPath();
           BasicFileAttributes attrs;
           if (followLinks) {
             attrs = Files.readAttributes(target, BasicFileAttributes.class);
@@ -649,8 +649,8 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<Void>() {
       public Void perform() {
         try {
-          Path source = vertx.resolveFile(link).toPath();
-          Path target = vertx.resolveFile(existing).toPath();
+          Path source = resolveFile(link).toPath();
+          Path target = resolveFile(existing).toPath();
           if (symbolic) {
             Files.createSymbolicLink(source, target);
           } else {
@@ -676,7 +676,7 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<String>() {
       public String perform() {
         try {
-          Path source = vertx.resolveFile(link).toPath();
+          Path source = resolveFile(link).toPath();
           return Files.readSymbolicLink(source).toString();
         } catch (IOException e) {
           throw new FileSystemException(getFileAccessErrorMessage("read", link), e);
@@ -694,7 +694,7 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<Void>() {
       public Void perform() {
         try {
-          Path source = vertx.resolveFile(path).toPath();
+          Path source = resolveFile(path).toPath();
           delete(source, recursive);
         } catch (IOException e) {
           throw new FileSystemException(getFileAccessErrorMessage("delete", path), e);
@@ -743,7 +743,7 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<Void>() {
       public Void perform() {
         try {
-          Path source = vertx.resolveFile(path).toPath();
+          Path source = resolveFile(path).toPath();
           if (createParents) {
             if (attrs != null) {
               Files.createDirectories(source, attrs);
@@ -772,7 +772,7 @@ public class FileSystemImpl implements FileSystem {
         try {
           Path tmpDir;
           if (parentDir != null) {
-            Path dir = vertx.resolveFile(parentDir).toPath();
+            Path dir = resolveFile(parentDir).toPath();
             if (attrs != null) {
               tmpDir = Files.createTempDirectory(dir, prefix, attrs);
             } else {
@@ -800,7 +800,7 @@ public class FileSystemImpl implements FileSystem {
         try {
           Path tmpFile;
           if (parentDir != null) {
-            Path dir = vertx.resolveFile(parentDir).toPath();
+            Path dir = resolveFile(parentDir).toPath();
             if (attrs != null) {
               tmpFile = Files.createTempFile(dir, prefix, suffix, attrs);
             } else {
@@ -833,7 +833,7 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<List<String>>() {
       public List<String> perform() {
         try {
-          File file = vertx.resolveFile(p);
+          File file = resolveFile(p);
           if (!file.exists()) {
             throw new FileSystemException("Cannot read directory " + file + ". Does not exist");
           }
@@ -874,7 +874,7 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<Buffer>() {
       public Buffer perform() {
         try {
-          Path target = vertx.resolveFile(path).toPath();
+          Path target = resolveFile(path).toPath();
           byte[] bytes = Files.readAllBytes(target);
           return Buffer.buffer(bytes);
         } catch (IOException e) {
@@ -890,7 +890,7 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<Void>() {
       public Void perform() {
         try {
-          Path target = vertx.resolveFile(path).toPath();
+          Path target = resolveFile(path).toPath();
           Files.write(target, data.getBytes());
           return null;
         } catch (IOException e) {
@@ -905,7 +905,7 @@ public class FileSystemImpl implements FileSystem {
     Objects.requireNonNull(options);
     return new BlockingAction<AsyncFile>() {
       public AsyncFile perform() {
-        String path = vertx.resolveFile(p).getAbsolutePath();
+        String path = resolveFile(p).getAbsolutePath();
         return doOpen(path, options, context);
       }
     };
@@ -925,7 +925,7 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<Void>() {
       public Void perform() {
         try {
-          Path target = vertx.resolveFile(p).toPath();
+          Path target = resolveFile(p).toPath();
           if (attrs != null) {
             Files.createFile(target, attrs);
           } else {
@@ -943,7 +943,7 @@ public class FileSystemImpl implements FileSystem {
     Objects.requireNonNull(path);
     return new BlockingAction<Boolean>() {
       public Boolean perform() {
-        File file = vertx.resolveFile(path);
+        File file = resolveFile(path);
         return file.exists();
       }
     };
@@ -954,7 +954,7 @@ public class FileSystemImpl implements FileSystem {
     return new BlockingAction<FileSystemProps>() {
       public FileSystemProps perform() {
         try {
-          Path target = vertx.resolveFile(path).toPath();
+          Path target = resolveFile(path).toPath();
           FileStore fs = Files.getFileStore(target);
           return new FileSystemPropsImpl(fs.name(), fs.getTotalSpace(), fs.getUnallocatedSpace(), fs.getUsableSpace());
         } catch (IOException e) {
@@ -962,6 +962,10 @@ public class FileSystemImpl implements FileSystem {
         }
       }
     };
+  }
+
+  private File resolveFile(String from) {
+    return vertx.fileResolver().resolve(from);
   }
 
   protected abstract class BlockingAction<T> implements Callable<T> {

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientBuilder.java
@@ -79,8 +79,8 @@ public interface HttpClientBuilder {
    *
    * @param resolver the address resolver
    */
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  HttpClientBuilder withAddressResolver(AddressResolver resolver);
+  @GenIgnore
+  HttpClientBuilder withAddressResolver(AddressResolver<?> resolver);
 
   /**
    * Configure the client to use a load balancer.

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -426,7 +426,7 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
       if (headWritten) {
         throw new IllegalStateException("Head already written");
       }
-      File file = vertx.resolveFile(filename);
+      File file = vertx.fileResolver().resolve(filename);
       RandomAccessFile raf;
       try {
         raf = new RandomAccessFile(file, "r");

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -63,7 +63,7 @@ public class HttpClientBase implements MetricsProvider, Closeable {
     }
     this.alpnVersions = alpnVersions.stream().map(HttpVersion::alpnName).collect(Collectors.toUnmodifiableList());
     this.vertx = vertx;
-    this.metrics = vertx.metricsSPI() != null ? vertx.metricsSPI().createHttpClientMetrics(options) : null;
+    this.metrics = vertx.metrics() != null ? vertx.metrics().createHttpClientMetrics(options) : null;
     this.options = new HttpClientOptions(options);
     this.closeSequence = new CloseSequence(this::doClose, this::doShutdown);
     this.proxyFilter = options.getNonProxyHosts() != null ? ProxyFilter.nonProxyHosts(options.getNonProxyHosts()) : ProxyFilter.DEFAULT_PROXY_FILTER;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -76,7 +76,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
     AddressResolver<?> _addressResolver = addressResolver;
     if (_loadBalancer != null) {
       if (_addressResolver == null) {
-        _addressResolver = vertx.hostnameResolver();
+        _addressResolver = vertx.nameResolver();
       }
     } else {
       if (_addressResolver != null) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -23,7 +23,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
   private PoolOptions poolOptions;
   private Handler<HttpConnection> connectHandler;
   private Function<HttpClientResponse, Future<RequestOptions>> redirectHandler;
-  private AddressResolver addressResolver;
+  private AddressResolver<?> addressResolver;
   private LoadBalancer loadBalancer = null;
 
   public HttpClientBuilderInternal(VertxInternal vertx) {
@@ -55,7 +55,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
   }
 
   @Override
-  public HttpClientBuilder withAddressResolver(AddressResolver resolver) {
+  public HttpClientBuilder withAddressResolver(AddressResolver<?> resolver) {
     this.addressResolver = resolver;
     return this;
   }
@@ -73,7 +73,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
 
   private EndpointResolver endpointResolver(HttpClientOptions co) {
     LoadBalancer _loadBalancer = loadBalancer;
-    AddressResolver _addressResolver = addressResolver;
+    AddressResolver<?> _addressResolver = addressResolver;
     if (_loadBalancer != null) {
       if (_addressResolver == null) {
         _addressResolver = vertx.hostnameResolver();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -125,7 +125,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     return (key) -> {
       int maxPoolSize = Math.max(poolOptions.getHttp1MaxSize(), poolOptions.getHttp2MaxSize());
       ClientMetrics clientMetrics = HttpClientImpl.this.metrics != null ? HttpClientImpl.this.metrics.createEndpointMetrics(key.server, maxPoolSize) : null;
-      PoolMetrics poolMetrics = HttpClientImpl.this.metrics != null ? vertx.metricsSPI().createPoolMetrics("http", key.server.toString(), maxPoolSize) : null;
+      PoolMetrics poolMetrics = HttpClientImpl.this.metrics != null ? vertx.metrics().createPoolMetrics("http", key.server.toString(), maxPoolSize) : null;
       ProxyOptions proxyOptions = key.proxyOptions;
       if (proxyOptions != null && !key.ssl && proxyOptions.getType() == ProxyType.HTTP) {
         SocketAddress server = SocketAddress.inetSocketAddress(proxyOptions.getPort(), proxyOptions.getHost());

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -187,7 +187,9 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
     if (context.isEventLoopContext()) {
       listenContext = context;
     } else {
-      listenContext = vertx.createEventLoopContext(context.nettyEventLoop(), context.workerPool(), context.classLoader());
+      listenContext = context.toBuilder()
+        .withThreadingModel(ThreadingModel.EVENT_LOOP)
+        .build();
     }
     NetServerInternal server = vertx.createNetServer(tcpOptions);
     Handler<Throwable> h = exceptionHandler;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -876,7 +876,7 @@ public final class HttpUtils {
 
   static Future<AsyncFile> resolveFile(ContextInternal context, String filename, long offset, long length) {
     VertxInternal vertx = context.owner();
-    File file_ = vertx.resolveFile(filename);
+    File file_ = vertx.fileResolver().resolve(filename);
     if (!file_.exists()) {
       return context.failedFuture(new FileNotFoundException());
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/SharedHttpClientConnectionGroup.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/SharedHttpClientConnectionGroup.java
@@ -10,10 +10,7 @@
  */
 package io.vertx.core.http.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.internal.ContextInternal;
@@ -192,7 +189,7 @@ class SharedHttpClientConnectionGroup extends ManagedResource implements PoolCon
   private Future<Lease<HttpClientConnectionInternal>> requestConnection2(ContextInternal ctx, long timeout) {
     PromiseInternal<Lease<HttpClientConnectionInternal>> promise = ctx.promise();
     // ctx.workerPool() -> not sure we want that in a pool
-    ContextInternal connCtx = vertx.createEventLoopContext(ctx.nettyEventLoop(), ctx.workerPool(), ctx.classLoader());
+    ContextInternal connCtx = ctx.toBuilder().withThreadingModel(ThreadingModel.EVENT_LOOP).build();
     Request request = new Request(connCtx, client.options().getProtocolVersion(), timeout, promise);
     request.acquire();
     return promise.future();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
@@ -69,7 +69,7 @@ public class WebSocketClientImpl extends HttpClientBase implements WebSocketClie
     Function<EndpointKey, WebSocketGroup> provider = (key_) -> {
       int maxPoolSize = options.getMaxConnections();
       ClientMetrics clientMetrics = WebSocketClientImpl.this.metrics != null ? WebSocketClientImpl.this.metrics.createEndpointMetrics(key_.server, maxPoolSize) : null;
-      PoolMetrics queueMetrics = WebSocketClientImpl.this.metrics != null ? vertx.metricsSPI().createPoolMetrics("ws", key_.server.toString(), maxPoolSize) : null;
+      PoolMetrics queueMetrics = WebSocketClientImpl.this.metrics != null ? vertx.metrics().createPoolMetrics("ws", key_.server.toString(), maxPoolSize) : null;
       HttpChannelConnector connector = new HttpChannelConnector(WebSocketClientImpl.this, netClient, sslOptions, key_.proxyOptions, clientMetrics, HttpVersion.HTTP_1_1, key_.ssl, false, key_.authority, key_.server, false);
       return new WebSocketGroup(null, queueMetrics, options, maxPoolSize, connector);
     };

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketGroup.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketGroup.java
@@ -77,7 +77,7 @@ class WebSocketGroup extends ManagedResource {
     if (ctx.isEventLoopContext()) {
       eventLoopContext = ctx;
     } else {
-      eventLoopContext = ctx.owner().createEventLoopContext(ctx.nettyEventLoop(), ctx.workerPool(), ctx.classLoader());
+      eventLoopContext = ctx.toBuilder().withThreadingModel(ThreadingModel.EVENT_LOOP).build();
     }
     Future<HttpClientConnectionInternal> fut = connector.httpConnect(eventLoopContext);
     fut.onComplete(ar -> {

--- a/vertx-core/src/main/java/io/vertx/core/impl/ContextBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ContextBase.java
@@ -11,8 +11,7 @@
 package io.vertx.core.impl;
 
 import io.vertx.core.Handler;
-import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.EventExecutor;
+import io.vertx.core.internal.*;
 import io.vertx.core.spi.context.storage.AccessMode;
 import io.vertx.core.spi.context.storage.ContextLocal;
 
@@ -32,12 +31,12 @@ abstract class ContextBase implements ContextInternal {
   }
 
   public ContextInternal beginDispatch() {
-    VertxImpl vertx = (VertxImpl) owner();
+    VertxImpl vertx = owner();
     return vertx.beginDispatch(this);
   }
 
   public void endDispatch(ContextInternal previous) {
-    VertxImpl vertx = (VertxImpl) owner();
+    VertxImpl vertx = owner();
     vertx.endDispatch(previous);
   }
 
@@ -115,4 +114,18 @@ abstract class ContextBase implements ContextInternal {
       executor().execute(() -> task.handle(argument));
     }
   }
+
+  @Override
+  public abstract VertxImpl owner();
+
+  @Override
+  public ContextBuilder toBuilder() {
+      return new ContextBuilderImpl(owner())
+        .withCloseFuture(closeFuture())
+        .withEventLoop(nettyEventLoop())
+        .withThreadingModel(threadingModel())
+        .withDeploymentContext(deployment())
+        .withWorkerPool(workerPool())
+        .withClassLoader(classLoader());
+    }
 }

--- a/vertx-core/src/main/java/io/vertx/core/impl/ContextBuilderImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ContextBuilderImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl;
+
+import io.netty.channel.EventLoop;
+import io.vertx.core.ThreadingModel;
+import io.vertx.core.internal.WorkerPool;
+import io.vertx.core.internal.deployment.DeploymentContext;
+import io.vertx.core.internal.CloseFuture;
+import io.vertx.core.internal.ContextBuilder;
+import io.vertx.core.internal.ContextInternal;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class ContextBuilderImpl implements ContextBuilder {
+
+  private final VertxImpl vertx;
+  private ThreadingModel threadingModel;
+  private EventLoop eventLoop;
+  private ClassLoader classLoader;
+  private CloseFuture closeFuture;
+  private WorkerPool workerPool;
+  private DeploymentContext deploymentContext;
+
+  public ContextBuilderImpl(VertxImpl vertx) {
+    this.vertx = vertx;
+  }
+
+  public ContextBuilderImpl withThreadingModel(ThreadingModel threadingModel) {
+    this.threadingModel = threadingModel;
+    return this;
+  }
+
+  public ContextBuilderImpl withEventLoop(EventLoop eventLoop) {
+    this.eventLoop = eventLoop;
+    return this;
+  }
+
+  public ContextBuilderImpl withClassLoader(ClassLoader classLoader) {
+    this.classLoader = classLoader;
+    return this;
+  }
+
+  public ContextBuilderImpl withCloseFuture(CloseFuture closeFuture) {
+    this.closeFuture = closeFuture;
+    return this;
+  }
+
+  public ContextBuilderImpl withWorkerPool(WorkerPool workerPool) {
+    this.workerPool = workerPool;
+    return this;
+  }
+
+  public ContextBuilderImpl withDeploymentContext(DeploymentContext deploymentContext) {
+    this.deploymentContext = deploymentContext;
+    return this;
+  }
+
+  public ContextInternal build() {
+    EventLoop eventLoop = this.eventLoop;
+    if (eventLoop == null) {
+      eventLoop = vertx.nettyEventLoopGroup().next();
+    }
+    CloseFuture closeFuture = this.closeFuture;
+    if (closeFuture == null) {
+      closeFuture = vertx.closeFuture();
+    }
+    ClassLoader classLoader = this.classLoader;
+    if (classLoader == null) {
+      classLoader = Thread.currentThread().getContextClassLoader();
+    }
+    return vertx.createContext(threadingModel, eventLoop, closeFuture, workerPool, deploymentContext, classLoader);
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -14,13 +14,14 @@ package io.vertx.core.impl;
 import io.netty.channel.EventLoop;
 import io.vertx.core.*;
 import io.vertx.core.Future;
-import io.vertx.core.impl.deployment.DeploymentContext;
+import io.vertx.core.impl.deployment.Deployment;
+import io.vertx.core.internal.WorkerPool;
+import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.internal.EventExecutor;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tracing.VertxTracer;
 
@@ -63,7 +64,7 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
     super(locals);
     JsonObject config = null;
     if (deployment != null) {
-      config = deployment.deployment().options().getConfig();
+      config = Deployment.unwrap(deployment).options().getConfig();
     }
     if (config == null) {
       config = new JsonObject();
@@ -119,7 +120,7 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
 
   @Override
   public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
-    return workerPool.executeBlocking(this, blockingCodeHandler, ordered ? executeBlockingTasks : null);
+    return ExecuteBlocking.executeBlocking(workerPool, this, blockingCodeHandler, ordered ? executeBlockingTasks : null);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -15,11 +15,11 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.ThreadingModel;
-import io.vertx.core.impl.deployment.DeploymentContext;
+import io.vertx.core.internal.WorkerPool;
+import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.EventExecutor;
-import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tracing.VertxTracer;
 
@@ -101,7 +101,7 @@ final class DuplicatedContext extends ContextBase implements ContextInternal {
   }
 
   @Override
-  public VertxInternal owner() {
+  public VertxImpl owner() {
     return delegate.owner();
   }
 
@@ -127,7 +127,7 @@ final class DuplicatedContext extends ContextBase implements ContextInternal {
 
   @Override
   public <T> Future<T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
-    return delegate.workerPool.executeBlocking(this, blockingCodeHandler, ordered ? delegate.executeBlockingTasks : null);
+    return ExecuteBlocking.executeBlocking(delegate.workerPool, this, blockingCodeHandler, ordered ? delegate.executeBlockingTasks : null);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/HostnameResolver.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/HostnameResolver.java
@@ -41,7 +41,7 @@ import static io.vertx.core.impl.Utils.isLinux;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class HostnameResolver implements AddressResolver {
+public class HostnameResolver implements AddressResolver<SocketAddress> {
 
   private static final Logger log = LoggerFactory.getLogger(HostnameResolver.class);
 
@@ -77,7 +77,7 @@ public class HostnameResolver implements AddressResolver {
   }
 
   @Override
-  public EndpointResolver<?, ?, ?, ?> endpointResolver(Vertx vertx) {
+  public EndpointResolver<SocketAddress, ?, ?, ?> endpointResolver(Vertx vertx) {
     return new Impl();
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
@@ -13,11 +13,11 @@ package io.vertx.core.impl;
 import io.netty.channel.EventLoop;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.*;
-import io.vertx.core.impl.deployment.DeploymentContext;
+import io.vertx.core.internal.WorkerPool;
+import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.EventExecutor;
-import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tracing.VertxTracer;
 
@@ -52,12 +52,12 @@ import java.util.concurrent.ConcurrentMap;
  */
 public final class ShadowContext extends ContextBase {
 
-  final VertxInternal owner;
+  final VertxImpl owner;
   final ContextBase delegate;
   private final EventLoopExecutor eventLoop;
   final TaskQueue orderedTasks;
 
-  ShadowContext(VertxInternal owner, EventLoopExecutor eventLoop, ContextInternal delegate) {
+  ShadowContext(VertxImpl owner, EventLoopExecutor eventLoop, ContextInternal delegate) {
     super(((ContextBase)delegate).locals);
     this.owner = owner;
     this.eventLoop = eventLoop;
@@ -90,7 +90,7 @@ public final class ShadowContext extends ContextBase {
   }
 
   @Override
-  public VertxInternal owner() {
+  public VertxImpl owner() {
     return owner;
   }
 
@@ -112,7 +112,7 @@ public final class ShadowContext extends ContextBase {
 
   @Override
   public WorkerPool workerPool() {
-    return owner.getWorkerPool();
+    return owner.workerPool();
   }
 
   @Override
@@ -151,7 +151,7 @@ public final class ShadowContext extends ContextBase {
 
   @Override
   public <T> Future<@Nullable T> executeBlocking(Callable<T> blockingCodeHandler, boolean ordered) {
-    return owner.getWorkerPool().executeBlocking(this, blockingCodeHandler, ordered ? orderedTasks : null);
+    return ExecuteBlocking.executeBlocking(owner.workerPool(), this, blockingCodeHandler, ordered ? orderedTasks : null);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -13,7 +13,6 @@ package io.vertx.core.impl;
 
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
-import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.internal.ThreadExecutorMap;
@@ -35,11 +34,12 @@ import io.vertx.core.http.*;
 import io.vertx.core.http.impl.*;
 import io.vertx.core.impl.deployment.DefaultDeploymentManager;
 import io.vertx.core.impl.deployment.Deployment;
-import io.vertx.core.impl.deployment.DeploymentContext;
+import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.impl.deployment.DeploymentManager;
 import io.vertx.core.impl.verticle.VerticleManager;
 import io.vertx.core.internal.*;
 import io.vertx.core.internal.net.NetClientInternal;
+import io.vertx.core.internal.resolver.NameResolver;
 import io.vertx.core.internal.threadchecker.BlockedThreadChecker;
 import io.vertx.core.net.*;
 import io.vertx.core.net.impl.*;
@@ -64,13 +64,11 @@ import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.eventbus.impl.clustered.NodeSelector;
 import io.vertx.core.spi.tracing.VertxTracer;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.Cleaner;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -157,7 +155,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   private final EventLoopGroup acceptorEventLoopGroup;
   private final ExecutorService virtualThreadExecutor;
   private final BlockedThreadChecker checker;
-  private final HostnameResolver hostnameResolver;
+  private final NameResolver nameResolver;
   private final AddressResolverOptions addressResolverOptions;
   private final EventBusInternal eventBus;
   private volatile HAManager haManager;
@@ -231,7 +229,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     this.transportUnavailabilityCause = transportUnavailabilityCause;
     this.fileResolver = fileResolver;
     this.addressResolverOptions = options.getAddressResolverOptions();
-    this.hostnameResolver = new HostnameResolver(this, options.getAddressResolverOptions());
+    this.nameResolver = new NameResolver(this, options.getAddressResolverOptions());
     this.tracer = tracer == VertxTracer.NOOP ? null : tracer;
     this.clusterManager = clusterManager;
     this.nodeSelector = nodeSelector;
@@ -328,12 +326,10 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     return Utils.isWindows() ? new WindowsFileSystem(this) : new FileSystemImpl(this);
   }
 
-  @Override
   public long maxEventLoopExecTime() {
     return maxEventLoopExecTime;
   }
 
-  @Override
   public TimeUnit maxEventLoopExecTimeUnit() {
     return maxEventLoopExecTimeUnit;
   }
@@ -355,7 +351,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   public NetClient createNetClient(NetClientOptions options) {
     CloseFuture fut = resolveCloseFuture();
     NetClientBuilder builder = new NetClientBuilder(this, options);
-    builder.metrics(metricsSPI() != null ? metricsSPI().createNetClientMetrics(options) : null);
+    builder.metrics(metrics() != null ? metrics().createNetClientMetrics(options) : null);
     NetClientInternal netClient = builder.build();
     fut.add(netClient);
     return new CleanableNetClient(netClient, cleaner);
@@ -445,20 +441,19 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   // The background pool is used for making blocking calls to legacy synchronous APIs
-  public WorkerPool getWorkerPool() {
+  public WorkerPool workerPool() {
     return workerPool;
   }
 
-  @Override
-  public WorkerPool getInternalWorkerPool() {
+  public WorkerPool internalWorkerPool() {
     return internalWorkerPool;
   }
 
-  public EventLoopGroup getEventLoopGroup() {
+  public EventLoopGroup eventLoopGroup() {
     return eventLoopGroup;
   }
 
-  public EventLoopGroup getAcceptorEventLoopGroup() {
+  public EventLoopGroup acceptorEventLoopGroup() {
     return acceptorEventLoopGroup;
   }
 
@@ -483,13 +478,25 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     return ctx;
   }
 
+  /**
+   * @return event loop context
+   */
+  private ContextInternal createContext(
+    ThreadingModel threadingModel, DeploymentContext deployment, CloseFuture closeFuture, WorkerPool workerPool, ClassLoader tccl) {
+    return createContext(threadingModel, nettyEventLoopGroup().next(), closeFuture, workerPool, deployment, tccl);
+  }
+
+  private ContextInternal createContext(ThreadingModel threadingModel, EventLoop eventLoop, WorkerPool workerPool, ClassLoader tccl) {
+    return createContext(threadingModel, eventLoop, closeFuture(), workerPool, null, tccl);
+  }
+
   private ContextInternal createContext(Thread thread) {
     if (thread instanceof VertxThread && ((VertxThread) thread).owner == this) {
       if (((VertxThread)thread).isWorker()) {
-        return createWorkerContext(eventLoopGroup.next(), workerPool, null);
+        return createContext(ThreadingModel.WORKER, eventLoopGroup.next(), workerPool, null);
       } else {
         io.netty.util.concurrent.EventExecutor eventLoop = ThreadExecutorMap.currentExecutor();
-        return createEventLoopContext((EventLoop) eventLoop, workerPool, null);
+        return createContext(ThreadingModel.EVENT_LOOP, (EventLoop) eventLoop, workerPool, null);
       }
     } else {
       ContextInternal ctx;
@@ -522,7 +529,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       if (eventExecutor != null) {
         ctx = createContext(ThreadingModel.OTHER, eventLoopExecutor, eventExecutor, workerPool, closeFuture, null, Thread.currentThread().getContextClassLoader());
       } else {
-        ctx = createEventLoopContext(eventLoop, workerPool, Thread.currentThread().getContextClassLoader());
+        ctx = createContext(ThreadingModel.EVENT_LOOP, eventLoop, workerPool, Thread.currentThread().getContextClassLoader());
       }
       return ctx;
     }
@@ -572,6 +579,11 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     } else {
       return new Object[contextLocals.length];
     }
+  }
+
+  @Override
+  public ContextBuilder contextBuilder() {
+    return new ContextBuilderImpl(this);
   }
 
   public ContextImpl createContext(ThreadingModel threadingModel,
@@ -712,7 +724,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     }
   }
 
-  public ClusterManager getClusterManager() {
+  public ClusterManager clusterManager() {
     return clusterManager;
   }
 
@@ -751,7 +763,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       }, false));
     }
     fut = fut
-      .transform(ar -> hostnameResolver.close())
+      .transform(ar -> nameResolver.close())
       .transform(ar -> Future.future(h -> eventBus.close((Promise) h)))
       .transform(ar -> closeClusterManager())
       .transform(ar -> {
@@ -812,7 +824,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
         return currentContext.failedFuture(e);
       }
       return deploymentManager.deploy(currentContext.deployment(), currentContext, deployment).
-        map(DeploymentContext::deploymentID);
+        map(DeploymentContext::id);
     }
   }
 
@@ -823,7 +835,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       haManager().deployVerticle(name, options, promise);
       return promise.future();
     } else {
-      return verticleManager.deployVerticle(name, options).map(DeploymentContext::deploymentID);
+      return verticleManager.deployVerticle(name, options).map(DeploymentContext::id);
     }
   }
 
@@ -847,7 +859,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     return deploymentManager
       .deployments()
       .stream()
-      .map(DeploymentContext::deploymentID)
+      .map(DeploymentContext::id)
       .collect(Collectors.toSet());
   }
 
@@ -876,19 +888,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     return eventLoopGroup;
   }
 
-  // For testing
-  public void simulateKill() {
-    if (haManager() != null) {
-      haManager().simulateKill();
-    }
-  }
-
-  @Override
-  public DeploymentContext getDeployment(String deploymentID) {
-    return deploymentManager.getDeployment(deploymentID);
-  }
-
-  @Override
   public synchronized void failoverCompleteHandler(FailoverCompleteHandler failoverCompleteHandler) {
     if (haManager() != null) {
       haManager().setFailoverCompleteHandler(failoverCompleteHandler);
@@ -896,48 +895,13 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   @Override
-  public boolean isKilled() {
-    return haManager().isKilled();
-  }
-
-  @Override
-  public void failDuringFailover(boolean fail) {
-    if (haManager() != null) {
-      haManager().failDuringFailover(fail);
-    }
-  }
-
-  @Override
-  public VertxMetrics metricsSPI() {
+  public VertxMetrics metrics() {
     return metrics;
   }
 
   @Override
-  public File resolveFile(String fileName) {
-    return fileResolver.resolveFile(fileName);
-  }
-
-  @Override
-  public Future<InetAddress> resolveAddress(String hostname) {
-    return hostnameResolver.resolveHostname(hostname);
-  }
-
-  @Override
-  public HostnameResolver hostnameResolver() {
-    return hostnameResolver;
-  }
-
-  @Override
-  public DnsAddressResolverProvider dnsAddressResolverProvider(InetSocketAddress addr) {
-    AddressResolverOptions options = new AddressResolverOptions(addressResolverOptions);
-    options.setServers(Collections.singletonList(addr.getHostString() + ":" + addr.getPort()));
-    options.setOptResourceEnabled(false);
-    return DnsAddressResolverProvider.create(this, options);
-  }
-
-  @Override
-  public AddressResolverGroup<InetSocketAddress> nettyAddressResolverGroup() {
-    return hostnameResolver.nettyAddressResolverGroup();
+  public NameResolver nameResolver() {
+    return nameResolver;
   }
 
   @Override
@@ -1005,6 +969,10 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   public HAManager haManager() {
     return haManager;
+  }
+
+  public DeploymentManager deploymentManager() {
+    return deploymentManager;
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
@@ -10,9 +10,9 @@
  */
 package io.vertx.core.impl;
 
-import io.vertx.core.ThreadingModel;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.EventExecutor;
+import io.vertx.core.internal.WorkerPool;
 import io.vertx.core.spi.metrics.PoolMetrics;
 
 import java.util.concurrent.CountDownLatch;

--- a/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
@@ -15,6 +15,8 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.*;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.WorkerExecutorInternal;
+import io.vertx.core.internal.WorkerPool;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.metrics.PoolMetrics;
@@ -54,7 +56,7 @@ class WorkerExecutorImpl implements MetricsProvider, WorkerExecutorInternal {
   }
 
   @Override
-  public WorkerPool getPool() {
+  public WorkerPool pool() {
     return pool;
   }
 
@@ -72,7 +74,7 @@ class WorkerExecutorImpl implements MetricsProvider, WorkerExecutorInternal {
     } else {
       orderedTasks = null;
     }
-    return pool.executeBlocking(context, blockingCodeHandler, orderedTasks);
+    return ExecuteBlocking.executeBlocking(pool, context, blockingCodeHandler, orderedTasks);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/WorkerTask.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/WorkerTask.java
@@ -21,13 +21,13 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-abstract class WorkerTask extends AtomicInteger implements Runnable {
+public abstract class WorkerTask extends AtomicInteger implements Runnable {
 
   private final PoolMetrics metrics;
   private final Object queueMetric;
   private Runnable onComplete;
 
-  WorkerTask(PoolMetrics metrics, Object queueMetric) {
+  public WorkerTask(PoolMetrics metrics, Object queueMetric) {
     this.metrics = metrics;
     this.queueMetric = queueMetric;
   }
@@ -72,7 +72,7 @@ abstract class WorkerTask extends AtomicInteger implements Runnable {
   /**
    * Reject the task.
    */
-  void reject() {
+  public void reject() {
   }
 
   protected abstract void execute();

--- a/vertx-core/src/main/java/io/vertx/core/impl/deployment/DefaultDeploymentManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/deployment/DefaultDeploymentManager.java
@@ -14,6 +14,7 @@ package io.vertx.core.impl.deployment;
 import io.vertx.core.*;
 import io.vertx.core.impl.VertxImpl;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 
@@ -60,7 +61,7 @@ public class DefaultDeploymentManager implements DeploymentManager {
     return new HashSet<>(deployments.values());
   }
 
-  public DeploymentContext getDeployment(String deploymentID) {
+  public DeploymentContext deployment(String deploymentID) {
     return deployments.get(deploymentID);
   }
 
@@ -145,7 +146,7 @@ public class DefaultDeploymentManager implements DeploymentManager {
     return result.future();
   }
 
-  private class DeploymentContextImpl implements DeploymentContext {
+  class DeploymentContextImpl implements DeploymentContext {
 
     private static final int ST_DEPLOYED = 0, ST_UNDEPLOYING = 1, ST_UNDEPLOYED = 2;
 
@@ -241,7 +242,6 @@ public class DefaultDeploymentManager implements DeploymentManager {
       return children.remove(deployment);
     }
 
-    @Override
     public Deployment deployment() {
       return deployment;
     }
@@ -252,7 +252,7 @@ public class DefaultDeploymentManager implements DeploymentManager {
     }
 
     @Override
-    public String deploymentID() {
+    public String id() {
       return deploymentID;
     }
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/deployment/DeploymentManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/deployment/DeploymentManager.java
@@ -13,6 +13,7 @@ package io.vertx.core.impl.deployment;
 
 import io.vertx.core.*;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.deployment.DeploymentContext;
 
 import java.util.*;
 
@@ -29,7 +30,7 @@ public interface DeploymentManager {
 
   Collection<DeploymentContext> deployments();
 
-  DeploymentContext getDeployment(String deploymentID);
+  DeploymentContext deployment(String deploymentID);
 
   Future<Void> undeployAll();
 

--- a/vertx-core/src/main/java/io/vertx/core/impl/verticle/VerticleManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/verticle/VerticleManager.java
@@ -14,7 +14,7 @@ import io.vertx.core.*;
 import io.vertx.core.impl.deployment.Deployment;
 import io.vertx.core.impl.ServiceHelper;
 import io.vertx.core.impl.*;
-import io.vertx.core.impl.deployment.DeploymentContext;
+import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.impl.deployment.DeploymentManager;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;

--- a/vertx-core/src/main/java/io/vertx/core/internal/ContextBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/ContextBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.internal;
+
+import io.netty.channel.EventLoop;
+import io.vertx.core.ThreadingModel;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface ContextBuilder {
+
+  /**
+   * Override the {@link ThreadingModel#EVENT_LOOP} with the given {@code threadingModel}.
+   *
+   * @param threadingModel the override
+   * @return this fluent object
+   */
+  ContextBuilder withThreadingModel(ThreadingModel threadingModel);
+
+  /**
+   * Set the {@code eventLoop} to use, when none is specified an event-loop will be assigned
+   * from the Vert.x event-loop group.
+   *
+   * @return this fluent object
+   */
+  ContextBuilder withEventLoop(EventLoop eventLoop);
+
+  /**
+   * Set the {@code classLoader} to use, when none is specified the default thread context class loader
+   * is used.
+   *
+   * @return this fluent object
+   */
+  ContextBuilder withClassLoader(ClassLoader classLoader);
+
+  /**
+   * Set the {@code closeFuture} to use, when none is specified the Vert.x close future is used.
+   *
+   * @return this fluent object
+   */
+  ContextBuilder withCloseFuture(CloseFuture closeFuture);
+
+  /**
+   * Set the {@code workerPool} to use, when none is specified, the default worker pool is assigned.
+   *
+   * @return this fluent object
+   */
+  ContextBuilder withWorkerPool(WorkerPool workerPool);
+
+  /**
+   * @return a context using the resources specified in this builder
+   */
+  ContextInternal build();
+
+}

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxWrapper.java
@@ -10,20 +10,16 @@
  */
 package io.vertx.core.internal;
 
-import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
-import io.netty.resolver.AddressResolverGroup;
 import io.vertx.core.*;
 import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.dns.DnsClient;
 import io.vertx.core.dns.DnsClientOptions;
-import io.vertx.core.dns.impl.DnsAddressResolverProvider;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.*;
-import io.vertx.core.impl.*;
-import io.vertx.core.impl.deployment.DeploymentContext;
+import io.vertx.core.internal.resolver.NameResolver;
 import io.vertx.core.internal.threadchecker.BlockedThreadChecker;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
@@ -39,10 +35,7 @@ import io.vertx.core.spi.file.FileResolver;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
 
-import java.io.File;
 import java.lang.ref.Cleaner;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -114,11 +107,6 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public EventBus eventBus() {
     return delegate.eventBus();
-  }
-
-  @Override
-  public DnsAddressResolverProvider dnsAddressResolverProvider(InetSocketAddress addr) {
-    return delegate.dnsAddressResolverProvider(addr);
   }
 
   @Override
@@ -232,13 +220,8 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public long maxEventLoopExecTime() {
-    return delegate.maxEventLoopExecTime();
-  }
-
-  @Override
-  public TimeUnit maxEventLoopExecTimeUnit() {
-    return delegate.maxEventLoopExecTimeUnit();
+  public ContextBuilder contextBuilder() {
+    return delegate.contextBuilder();
   }
 
   @Override
@@ -247,23 +230,23 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public EventLoopGroup getEventLoopGroup() {
-    return delegate.getEventLoopGroup();
+  public EventLoopGroup eventLoopGroup() {
+    return delegate.eventLoopGroup();
   }
 
   @Override
-  public EventLoopGroup getAcceptorEventLoopGroup() {
-    return delegate.getAcceptorEventLoopGroup();
+  public EventLoopGroup acceptorEventLoopGroup() {
+    return delegate.acceptorEventLoopGroup();
   }
 
   @Override
-  public WorkerPool getWorkerPool() {
-    return delegate.getWorkerPool();
+  public WorkerPool workerPool() {
+    return delegate.workerPool();
   }
 
   @Override
-  public WorkerPool getInternalWorkerPool() {
-    return delegate.getInternalWorkerPool();
+  public WorkerPool internalWorkerPool() {
+    return delegate.internalWorkerPool();
   }
 
   @Override
@@ -272,8 +255,8 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public VertxMetrics metricsSPI() {
-    return delegate.metricsSPI();
+  public VertxMetrics metrics() {
+    return delegate.metrics();
   }
 
   @Override
@@ -289,11 +272,6 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public ContextInternal getContext() {
     return delegate.getContext();
-  }
-
-  @Override
-  public ContextInternal createContext(ThreadingModel threadingModel, EventLoop eventLoop, CloseFuture closeFuture, WorkerPool workerPool, DeploymentContext deployment, ClassLoader tccl) {
-    return delegate.createContext(threadingModel, eventLoop, closeFuture, workerPool, deployment, tccl);
   }
 
   @Override
@@ -327,63 +305,18 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public void simulateKill() {
-    delegate.simulateKill();
+  public ClusterManager clusterManager() {
+    return delegate.clusterManager();
   }
 
   @Override
-  public DeploymentContext getDeployment(String deploymentID) {
-    return delegate.getDeployment(deploymentID);
-  }
-
-  @Override
-  public void failoverCompleteHandler(FailoverCompleteHandler failoverCompleteHandler) {
-    delegate.failoverCompleteHandler(failoverCompleteHandler);
-  }
-
-  @Override
-  public boolean isKilled() {
-    return delegate.isKilled();
-  }
-
-  @Override
-  public void failDuringFailover(boolean fail) {
-    delegate.failDuringFailover(fail);
-  }
-
-  @Override
-  public File resolveFile(String fileName) {
-    return delegate.resolveFile(fileName);
-  }
-
-  @Override
-  public ClusterManager getClusterManager() {
-    return delegate.getClusterManager();
-  }
-
-  @Override
-  public HAManager haManager() {
-    return delegate.haManager();
-  }
-
-  @Override
-  public Future<InetAddress> resolveAddress(String hostname) {
-    return delegate.resolveAddress(hostname);
-  }
-
-  @Override
-  public HostnameResolver hostnameResolver() {
-    return delegate.hostnameResolver();
+  public NameResolver nameResolver() {
+    return delegate.nameResolver();
   }
 
   @Override
   public FileResolver fileResolver() {
     return delegate.fileResolver();
-  }
-
-  @Override
-  public AddressResolverGroup<InetSocketAddress> nettyAddressResolverGroup() {
-    return delegate.nettyAddressResolverGroup();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/internal/WorkerExecutorInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/WorkerExecutorInternal.java
@@ -8,9 +8,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.core.impl;
+package io.vertx.core.internal;
 
-import io.vertx.core.Closeable;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
 
@@ -18,7 +17,11 @@ import io.vertx.core.WorkerExecutor;
  * @author Thomas Segismont
  */
 public interface WorkerExecutorInternal extends WorkerExecutor {
+
   Vertx vertx();
 
-  WorkerPool getPool();
+  /**
+   * @return the worker pool
+   */
+  WorkerPool pool();
 }

--- a/vertx-core/src/main/java/io/vertx/core/internal/WorkerPool.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/WorkerPool.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.internal;
+
+import io.vertx.core.spi.metrics.PoolMetrics;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Executor service + metrics.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class WorkerPool {
+
+  private final ExecutorService executor;
+  private final PoolMetrics metrics;
+
+  public WorkerPool(ExecutorService executor, PoolMetrics metrics) {
+    this.executor = executor;
+    this.metrics = metrics;
+  }
+
+  /**
+   * @return the bare executor
+   */
+  public ExecutorService executor() {
+    return executor;
+  }
+
+  /**
+   * @return the metrics
+   */
+  public PoolMetrics metrics() {
+    return metrics;
+  }
+
+  /**
+   * Close the pool
+   */
+  public void close() {
+    if (metrics != null) {
+      metrics.close();
+    }
+    executor.shutdownNow();
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/internal/deployment/DeploymentContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/deployment/DeploymentContext.java
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
-package io.vertx.core.impl.deployment;
+package io.vertx.core.internal.deployment;
 
 import io.vertx.core.Future;
 import io.vertx.core.internal.ContextInternal;
@@ -50,11 +50,6 @@ public interface DeploymentContext {
   /**
    * @return the deployment ID
    */
-  String deploymentID();
-
-  /**
-   * @return what is actually deployed
-   */
-  Deployment deployment();
+  String id();
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/internal/net/SslChannelProvider.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/net/SslChannelProvider.java
@@ -21,7 +21,6 @@ import io.vertx.core.internal.tls.SslContextProvider;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 
-import java.net.InetSocketAddress;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
@@ -39,7 +38,7 @@ public class SslChannelProvider {
   public SslChannelProvider(VertxInternal vertx,
                             SslContextProvider sslContextProvider,
                             boolean sni) {
-    this.workerPool = vertx.getInternalWorkerPool().executor();
+    this.workerPool = vertx.internalWorkerPool().executor();
     this.sni = sni;
     this.sslContextProvider = sslContextProvider;
   }

--- a/vertx-core/src/main/java/io/vertx/core/internal/pool/ConnectionPool.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/pool/ConnectionPool.java
@@ -13,6 +13,7 @@ package io.vertx.core.internal.pool;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.ThreadingModel;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 
@@ -32,7 +33,11 @@ public interface ConnectionPool<C> {
    */
   Function<ContextInternal, ContextInternal> EVENT_LOOP_CONTEXT_PROVIDER = ctx -> {
     VertxInternal vertx = ctx.owner();
-    return vertx.createEventLoopContext(ctx.nettyEventLoop(), vertx.getWorkerPool(), null);
+    return vertx.contextBuilder()
+      .withThreadingModel(ThreadingModel.EVENT_LOOP)
+      .withEventLoop(ctx.nettyEventLoop())
+      .withWorkerPool(vertx.workerPool())
+      .build();
   };
 
   static <C> ConnectionPool<C> pool(PoolConnector<C> connector, int[] maxSizes) {

--- a/vertx-core/src/main/java/io/vertx/core/internal/resolver/NameResolver.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/resolver/NameResolver.java
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
-package io.vertx.core.impl;
+package io.vertx.core.internal.resolver;
 
 import io.netty.channel.EventLoop;
 import io.netty.resolver.AddressResolverGroup;
@@ -34,46 +34,39 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static io.vertx.core.impl.Utils.isLinux;
-
 /**
- * Resolves host names, using DNS and /etc/hosts config based on {@link AddressResolverOptions}
+ * Resolves host names, using DNS and {@code /etc/hosts config} based on {@link AddressResolverOptions}
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class HostnameResolver implements AddressResolver<SocketAddress> {
+public class NameResolver implements AddressResolver<SocketAddress> {
 
-  private static final Logger log = LoggerFactory.getLogger(HostnameResolver.class);
+  private static final Logger log = LoggerFactory.getLogger(NameResolver.class);
 
   private static final String NDOTS_LABEL = "ndots:";
   private static final String ROTATE_LABEL = "rotate";
   private static final String OPTIONS_ROW_LABEL = "options";
-  public static final int DEFAULT_NDOTS_RESOLV_OPTION;
-  public static final boolean DEFAULT_ROTATE_RESOLV_OPTION;
-
 
   private static final int DEFAULT_NDOTS = 1;
   private static final boolean DEFAULT_ROTATE = false;
 
-  static {
-    if (isLinux()) {
-      ResolverOptions options = parseLinux(new File("/etc/resolv.conf"));
-      DEFAULT_NDOTS_RESOLV_OPTION = options.effectiveNdots();
-      DEFAULT_ROTATE_RESOLV_OPTION = options.isRotate();
-    } else {
-      DEFAULT_NDOTS_RESOLV_OPTION = DEFAULT_NDOTS;
-      DEFAULT_ROTATE_RESOLV_OPTION = DEFAULT_ROTATE;
-    }
-  }
-
+  private final AddressResolverOptions options;
   private final Vertx vertx;
   private final AddressResolverGroup<InetSocketAddress> resolverGroup;
   private final AddressResolverProvider provider;
 
-  public HostnameResolver(Vertx vertx, AddressResolverOptions options) {
+  public NameResolver(Vertx vertx, AddressResolverOptions options) {
+    this.options = options;
     this.provider = AddressResolverProvider.factory(vertx, options);
     this.resolverGroup = provider.resolver(options);
     this.vertx = vertx;
+  }
+
+  /**
+   * @return the options
+   */
+  public AddressResolverOptions options() {
+    return new AddressResolverOptions(options);
   }
 
   @Override
@@ -81,37 +74,43 @@ public class HostnameResolver implements AddressResolver<SocketAddress> {
     return new Impl();
   }
 
-  public Future<InetAddress> resolveHostname(String hostname) {
+  /**
+   * Resolve an address (e.g. {@code vertx.io} into the first found A (IPv4) or AAAA (IPv6) record.
+   *
+   * @param hostname the hostname to resolve
+   * @return a future notified with the result
+   */
+  public Future<InetAddress> resolve(String hostname) {
     ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
-    io.netty.util.concurrent.Future<InetSocketAddress> fut = resolveHostname(context.nettyEventLoop(), hostname);
+    io.netty.util.concurrent.Future<InetSocketAddress> fut = resolve(context.nettyEventLoop(), hostname);
     PromiseInternal<InetSocketAddress> promise = context.promise();
     fut.addListener(promise);
     return promise.map(InetSocketAddress::getAddress);
   }
 
-  public io.netty.util.concurrent.Future<InetSocketAddress> resolveHostname(EventLoop eventLoop, String hostname) {
-    io.netty.resolver.AddressResolver<InetSocketAddress> resolver = getResolver(eventLoop);
+  public io.netty.util.concurrent.Future<InetSocketAddress> resolve(EventLoop eventLoop, String hostname) {
+    io.netty.resolver.AddressResolver<InetSocketAddress> resolver = resolver(eventLoop);
     return resolver.resolve(InetSocketAddress.createUnresolved(hostname, 0));
   }
 
-  public void resolveHostnameAll(String hostname, Handler<AsyncResult<List<InetSocketAddress>>> resultHandler) {
+  public void resolveAll(String hostname, Handler<AsyncResult<List<InetSocketAddress>>> resultHandler) {
     ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
-    io.netty.util.concurrent.Future<List<InetSocketAddress>> fut = resolveHostnameAll(context.nettyEventLoop(), hostname);
+    io.netty.util.concurrent.Future<List<InetSocketAddress>> fut = resolveAll(context.nettyEventLoop(), hostname);
     PromiseInternal<List<InetSocketAddress>> promise = context.promise();
     fut.addListener(promise);
     promise.future().onComplete(resultHandler);
   }
 
-  public io.netty.util.concurrent.Future<List<InetSocketAddress>> resolveHostnameAll(EventLoop eventLoop, String hostname) {
-    io.netty.resolver.AddressResolver<InetSocketAddress> resolver = getResolver(eventLoop);
+  public io.netty.util.concurrent.Future<List<InetSocketAddress>> resolveAll(EventLoop eventLoop, String hostname) {
+    io.netty.resolver.AddressResolver<InetSocketAddress> resolver = resolver(eventLoop);
     return resolver.resolveAll(InetSocketAddress.createUnresolved(hostname, 0));
   }
 
-  public io.netty.resolver.AddressResolver<InetSocketAddress> getResolver(EventLoop eventLoop){
+  private io.netty.resolver.AddressResolver<InetSocketAddress> resolver(EventLoop eventLoop){
     return resolverGroup.getResolver(eventLoop);
   }
 
-  AddressResolverGroup<InetSocketAddress> nettyAddressResolverGroup() {
+  public AddressResolverGroup<InetSocketAddress> nettyAddressResolverGroup() {
     return resolverGroup;
   }
 
@@ -194,7 +193,7 @@ public class HostnameResolver implements AddressResolver<SocketAddress> {
     @Override
     public Future<L> resolve(SocketAddress address, EndpointBuilder<L, SocketAddress> builder) {
       Promise<L> promise = Promise.promise();
-      resolveHostnameAll(address.host(), ar -> {
+      resolveAll(address.host(), ar -> {
         EndpointBuilder<L, SocketAddress> builder2 = builder;
         if (ar.succeeded()) {
           for (InetSocketAddress addr : ar.result()) {

--- a/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextManager.java
@@ -220,7 +220,7 @@ public class SslContextManager {
       if (sslOptions.getCrlPaths() != null) {
         tmp.addAll(sslOptions.getCrlPaths()
           .stream()
-          .map(path -> ctx.owner().resolveFile(path).getAbsolutePath())
+          .map(path -> ctx.owner().fileResolver().resolve(path).getAbsolutePath())
           .map(ctx.owner().fileSystem()::readFileBlocking)
           .collect(Collectors.toList()));
       }

--- a/vertx-core/src/main/java/io/vertx/core/net/AddressResolver.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/AddressResolver.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
  * A provider for address resolver.
  */
 @Unstable
-public interface AddressResolver {
+public interface AddressResolver<A extends Address> {
 
   /**
    * A simple synchronous resolver for demo and testing purposes.
@@ -40,7 +40,7 @@ public interface AddressResolver {
    * @param mapping the mapping function
    * @return an address resolver
    */
-  static AddressResolver mappingResolver(Function<Address, List<SocketAddress>> mapping) {
+  static <A extends Address> AddressResolver<A> mappingResolver(Function<A, List<SocketAddress>> mapping) {
     return vertx -> new MappingResolver<>(mapping);
   }
 
@@ -50,6 +50,6 @@ public interface AddressResolver {
    * @param vertx the vertx instance
    * @return the resolver
    */
-  EndpointResolver<?, ?, ?, ?> endpointResolver(Vertx vertx);
+  EndpointResolver<A, ?, ?, ?> endpointResolver(Vertx vertx);
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/PemKeyCertOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/PemKeyCertOptions.java
@@ -420,12 +420,12 @@ public class PemKeyCertOptions implements KeyCertOptions {
     if (helper == null) {
       List<Buffer> keys = new ArrayList<>();
       for (String keyPath : keyPaths) {
-        keys.add(vertx.fileSystem().readFileBlocking(((VertxInternal)vertx).resolveFile(keyPath).getAbsolutePath()));
+        keys.add(vertx.fileSystem().readFileBlocking(((VertxInternal)vertx).fileResolver().resolve(keyPath).getAbsolutePath()));
       }
       keys.addAll(keyValues);
       List<Buffer> certs = new ArrayList<>();
       for (String certPath : certPaths) {
-        certs.add(vertx.fileSystem().readFileBlocking(((VertxInternal)vertx).resolveFile(certPath).getAbsolutePath()));
+        certs.add(vertx.fileSystem().readFileBlocking(((VertxInternal)vertx).fileResolver().resolve(certPath).getAbsolutePath()));
       }
       certs.addAll(certValues);
       helper = new KeyStoreHelper(KeyStoreHelper.loadKeyCert(keys, certs), KeyStoreHelper.DUMMY_PASSWORD, null);

--- a/vertx-core/src/main/java/io/vertx/core/net/PemTrustOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/PemTrustOptions.java
@@ -205,7 +205,7 @@ public class PemTrustOptions implements TrustOptions, Cloneable {
     if (helper == null) {
       Stream<Buffer> certValues = certPaths.
         stream().
-        map(path -> ((VertxInternal)vertx).resolveFile(path).getAbsolutePath()).
+        map(path -> ((VertxInternal)vertx).fileResolver().resolve(path).getAbsolutePath()).
         map(vertx.fileSystem()::readFileBlocking);
       certValues = Stream.concat(certValues, this.certValues.stream());
       helper = new KeyStoreHelper(KeyStoreHelper.loadCA(certValues), null, null);

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
@@ -146,7 +146,7 @@ public final class ChannelProvider {
 
   private void handleConnect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, ClientSSLOptions sslOptions, Promise<Channel> channelHandler) {
     VertxInternal vertx = context.owner();
-    bootstrap.resolver(vertx.nettyAddressResolverGroup());
+    bootstrap.resolver(vertx.nameResolver().nettyAddressResolverGroup());
     bootstrap.handler(new ChannelInitializer<Channel>() {
       @Override
       protected void initChannel(Channel ch) {
@@ -191,7 +191,7 @@ public final class ChannelProvider {
     final String proxyPassword = proxyOptions.getPassword();
     final ProxyType proxyType = proxyOptions.getType();
 
-    vertx.resolveAddress(proxyHost).onComplete(dnsRes -> {
+    vertx.nameResolver().resolve(proxyHost).onComplete(dnsRes -> {
       if (dnsRes.succeeded()) {
         InetAddress address = dnsRes.result();
         InetSocketAddress proxyAddr = new InetSocketAddress(address, proxyPort);

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/MappingLookup.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/MappingLookup.java
@@ -7,16 +7,16 @@ import io.vertx.core.spi.endpoint.EndpointBuilder;
 import java.util.Collections;
 import java.util.List;
 
-class MappingLookup<B> {
+class MappingLookup<A extends Address, B> {
 
   private static final List INITIAL = Collections.singletonList(new Object());
 
-  final Address address;
+  final A address;
   final EndpointBuilder<B, SocketAddress> builder;
   List<SocketAddress> endpoints;
   B list;
 
-  MappingLookup(Address name, EndpointBuilder<B, SocketAddress> builder) {
+  MappingLookup(A name, EndpointBuilder<B, SocketAddress> builder) {
     this.endpoints = INITIAL;
     this.address = name;
     this.builder = builder;

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/MappingResolver.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/MappingResolver.java
@@ -20,17 +20,17 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
-public class MappingResolver<B> implements EndpointResolver<Address, SocketAddress, MappingLookup<B>, B> {
+public class MappingResolver<A extends Address, B> implements EndpointResolver<A, SocketAddress, MappingLookup<A, B>, B> {
 
-  private final Function<Address, List<SocketAddress>> serviceMap;
+  private final Function<A, List<SocketAddress>> serviceMap;
 
-  public MappingResolver(Function<Address, List<SocketAddress>> serviceMap) {
+  public MappingResolver(Function<A, List<SocketAddress>> serviceMap) {
     this.serviceMap = Objects.requireNonNull(serviceMap);
   }
 
   @Override
-  public Address tryCast(Address address) {
-    return address;
+  public A tryCast(Address address) {
+    return (A) address;
   }
 
   @Override
@@ -39,12 +39,12 @@ public class MappingResolver<B> implements EndpointResolver<Address, SocketAddre
   }
 
   @Override
-  public Future<MappingLookup<B>> resolve(Address address, EndpointBuilder<B, SocketAddress> builder) {
+  public Future<MappingLookup<A, B>> resolve(A address, EndpointBuilder<B, SocketAddress> builder) {
     return Future.succeededFuture(new MappingLookup<>(address, builder));
   }
 
   @Override
-  public B endpoint(MappingLookup<B> state) {
+  public B endpoint(MappingLookup<A, B> state) {
     List<SocketAddress> endpoints = serviceMap.apply(state.address);
     synchronized (state) {
       if (!Objects.equals(state.endpoints, endpoints)) {
@@ -62,12 +62,12 @@ public class MappingResolver<B> implements EndpointResolver<Address, SocketAddre
   }
 
   @Override
-  public boolean isValid(MappingLookup<B> state) {
+  public boolean isValid(MappingLookup<A, B> state) {
     return true;
   }
 
   @Override
-  public void dispose(MappingLookup<B> data) {
+  public void dispose(MappingLookup<A, B> data) {
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -76,7 +76,7 @@ class NetClientImpl implements NetClientInternal {
     CloseSequence closeSequence1 = new CloseSequence(this::doClose, this::doGrace, this::doShutdown);
 
     this.vertx = vertx;
-    this.channelGroup = new DefaultChannelGroup(vertx.getAcceptorEventLoopGroup().next(), true);
+    this.channelGroup = new DefaultChannelGroup(vertx.acceptorEventLoopGroup().next(), true);
     this.options = new NetClientOptions(options);
     this.sslContextManager = new SslContextManager(SslContextManager.resolveEngineOptions(options.getSslEngineOptions(), options.isUseAlpn()));
     this.metrics = metrics;

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -248,7 +248,7 @@ public class NetSocketImpl extends VertxConnection implements NetSocketInternal 
   @Override
   public Future<Void> sendFile(String filename, long offset, long length) {
     PromiseInternal<Void> promise = context.promise();
-    File file = vertx.resolveFile(filename);
+    File file = vertx.fileResolver().resolve(filename);
     RandomAccessFile raf;
     try {
       raf = new RandomAccessFile(file, "r");

--- a/vertx-core/src/main/java/io/vertx/core/spi/file/FileResolver.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/file/FileResolver.java
@@ -52,7 +52,7 @@ public interface FileResolver extends Closeable {
    * @param fileName the name to resolve
    * @return a file resolved
    */
-  File resolveFile(String fileName);
+  File resolve(String fileName);
 
   /**
    * Close this file resolver, this is a blocking operation.

--- a/vertx-core/src/main/java/module-info.java
+++ b/vertx-core/src/main/java/module-info.java
@@ -93,6 +93,8 @@ module io.vertx.core {
   exports io.vertx.core.internal.concurrent;
   exports io.vertx.core.internal.resource;
   exports io.vertx.core.internal.streams;
+  exports io.vertx.core.internal.deployment;
+  exports io.vertx.core.internal.resolver;
 
   // Testing
 

--- a/vertx-core/src/test/java/io/vertx/benchmarks/BenchmarkContext.java
+++ b/vertx-core/src/test/java/io/vertx/benchmarks/BenchmarkContext.java
@@ -38,10 +38,10 @@ public class BenchmarkContext {
     return new ContextImpl(
       impl,
       new Object[0],
-      new EventLoopExecutor(impl.getEventLoopGroup().next()),
+      new EventLoopExecutor(impl.eventLoopGroup().next()),
       ThreadingModel.WORKER,
       EXECUTOR,
-      impl.getWorkerPool(),
+      impl.workerPool(),
       null,
       null,
       Thread.currentThread().getContextClassLoader()

--- a/vertx-core/src/test/java/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
+++ b/vertx-core/src/test/java/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
@@ -33,10 +33,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
@@ -214,7 +211,11 @@ public class HttpServerHandlerBenchmark extends BenchmarkBase {
         new VertxHttpResponseEncoder());
     vertxChannel.config().setAllocator(new Alloc());
 
-    ContextInternal context = vertx.createEventLoopContext(vertxChannel.eventLoop(), null, Thread.currentThread().getContextClassLoader());
+    ContextInternal context = vertx.contextBuilder()
+      .withThreadingModel(ThreadingModel.EVENT_LOOP)
+      .withEventLoop(vertxChannel.eventLoop())
+      .withClassLoader(Thread.currentThread().getContextClassLoader())
+      .build();
     Handler<HttpServerRequest> app = request -> {
       HttpServerResponse response = request.response();
       MultiMap headers = response.headers();

--- a/vertx-core/src/test/java/io/vertx/it/file/CustomFileResolver.java
+++ b/vertx-core/src/test/java/io/vertx/it/file/CustomFileResolver.java
@@ -25,7 +25,7 @@ public class CustomFileResolver implements FileResolver {
   }
 
   @Override
-  public File resolveFile(String fileName) {
+  public File resolve(String fileName) {
     return new File(fileName);
   }
 }

--- a/vertx-core/src/test/java/io/vertx/it/metrics/ServiceLoaderTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/metrics/ServiceLoaderTest.java
@@ -37,7 +37,7 @@ public class ServiceLoaderTest {
     MetricsOptions metricsOptions = new MetricsOptions().setEnabled(enabled);
     VertxOptions options = new VertxOptions().setMetricsOptions(metricsOptions);
     Vertx vertx = Vertx.vertx(options);
-    VertxMetrics metrics = ((VertxInternal) vertx).metricsSPI();
+    VertxMetrics metrics = ((VertxInternal) vertx).metrics();
     if (enabled) {
       assertNotNull(metrics);
       assertTrue(metrics instanceof FakeVertxMetrics);
@@ -55,6 +55,6 @@ public class ServiceLoaderTest {
       .with(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)))
       .withMetrics(options -> metrics);
     Vertx vertx = builder.build();
-    assertSame(metrics, ((VertxInternal) vertx).metricsSPI());
+    assertSame(metrics, ((VertxInternal) vertx).metrics());
   }
 }

--- a/vertx-core/src/test/java/io/vertx/it/netty/NettyCompatTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/netty/NettyCompatTest.java
@@ -27,7 +27,7 @@ public class NettyCompatTest extends VertxTestBase {
   @Test
   public void testAddressResolver() {
     VertxInternal vertx = (VertxInternal) super.vertx;
-    vertx.resolveAddress("localhost").onComplete(onSuccess(v -> testComplete()));
+    vertx.nameResolver().resolve("localhost").onComplete(onSuccess(v -> testComplete()));
     await();
   }
 

--- a/vertx-core/src/test/java/io/vertx/test/fakeresolver/FakeEndpointResolver.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakeresolver/FakeEndpointResolver.java
@@ -18,7 +18,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-public class FakeEndpointResolver<B> implements AddressResolver, EndpointResolver<FakeAddress, FakeEndpoint, FakeState<B>, B> {
+public class FakeEndpointResolver<B> implements AddressResolver<FakeAddress>, EndpointResolver<FakeAddress, FakeEndpoint, FakeState<B>, B> {
 
   public static class Endpoint {
     final List<SocketAddress> addresses;
@@ -72,7 +72,7 @@ public class FakeEndpointResolver<B> implements AddressResolver, EndpointResolve
   }
 
   @Override
-  public EndpointResolver<?, ?, ?, ?> endpointResolver(Vertx vertx) {
+  public EndpointResolver<FakeAddress, ?, ?, ?> endpointResolver(Vertx vertx) {
     return this;
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/benchmark/Http1xServerConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/benchmark/Http1xServerConnectionTest.java
@@ -14,6 +14,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.vertx.core.Handler;
+import io.vertx.core.ThreadingModel;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
@@ -48,7 +49,12 @@ public class Http1xServerConnectionTest extends VertxTestBase {
       new VertxHttpResponseEncoder());
     vertxChannel.config().setAllocator(new io.vertx.benchmarks.HttpServerHandlerBenchmark.Alloc());
 
-    ContextInternal context = vertx.createEventLoopContext(vertxChannel.eventLoop(), null, Thread.currentThread().getContextClassLoader());
+    ContextInternal context = vertx
+      .contextBuilder()
+      .withThreadingModel(ThreadingModel.EVENT_LOOP)
+      .withEventLoop(vertxChannel.eventLoop())
+      .withClassLoader(Thread.currentThread().getContextClassLoader())
+      .build();
 
 
     VertxHandler<Http1xServerConnection> handler = VertxHandler.create(chctx -> {

--- a/vertx-core/src/test/java/io/vertx/tests/context/ContextTaskTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ContextTaskTest.java
@@ -11,11 +11,13 @@
 package io.vertx.tests.context;
 
 import io.vertx.core.Handler;
+import io.vertx.core.ThreadingModel;
 import io.vertx.core.Vertx;
+import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.impl.VertxThread;
-import io.vertx.core.impl.WorkerPool;
+import io.vertx.core.internal.WorkerPool;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
@@ -63,7 +65,12 @@ public class ContextTaskTest extends VertxTestBase {
   }
 
   private ContextInternal createWorkerContext() {
-    return ((VertxInternal) vertx).createWorkerContext(null, null, new WorkerPool(workerExecutor, null), Thread.currentThread().getContextClassLoader());
+    return ((VertxInternal) vertx).contextBuilder()
+      .withThreadingModel(ThreadingModel.WORKER)
+      .withCloseFuture(new CloseFuture())
+      .withWorkerPool(new WorkerPool(workerExecutor, null))
+      .withClassLoader(Thread.currentThread().getContextClassLoader())
+      .build();
   }
 
   // SCHEDULE + DISPATCH

--- a/vertx-core/src/test/java/io/vertx/tests/context/ShadowContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ShadowContextTest.java
@@ -1,14 +1,12 @@
 package io.vertx.tests.context;
 
 import io.netty.channel.EventLoop;
-import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.http.*;
 import io.vertx.core.impl.LocalSeq;
 import io.vertx.core.impl.ShadowContext;
-import io.vertx.core.impl.VertxThread;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.NetClient;
@@ -494,7 +492,7 @@ public class ShadowContextTest extends AsyncTestBase {
 
   @Test
   public void testGetOrCreateContextFromUnassociatedWorkerThread() {
-    Executor executor = actualVertx.getWorkerPool().executor();
+    Executor executor = actualVertx.workerPool().executor();
     testGetOrCreateContextFromUnassociatedThread(executor);
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/deployment/DeploymentTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/deployment/DeploymentTest.java
@@ -13,9 +13,10 @@ package io.vertx.tests.deployment;
 
 import io.netty.channel.EventLoop;
 import io.vertx.core.*;
+import io.vertx.core.impl.VertxImpl;
 import io.vertx.core.impl.deployment.Deployment;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.impl.deployment.DeploymentContext;
+import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.test.core.TestUtils;
@@ -536,12 +537,12 @@ public class DeploymentTest extends VertxTestBase {
     awaitLatch(deployLatch);
     assertWaitUntil(() -> deployCount.get() == numInstances);
     assertEquals(1, vertx.deploymentIDs().size());
-    DeploymentContext deployment = ((VertxInternal) vertx).getDeployment(vertx.deploymentIDs().iterator().next());
-    Set<Deployable> verticles = ((Deployment)deployment.deployment()).instances();
+    DeploymentContext deployment = ((VertxImpl) vertx).deploymentManager().deployment(vertx.deploymentIDs().iterator().next());
+    Set<Deployable> verticles = Deployment.unwrap(deployment).instances();
     assertEquals(numInstances, verticles.size());
     CountDownLatch undeployLatch = new CountDownLatch(1);
     assertEquals(numInstances, deployCount.get());
-    vertx.undeploy(deployment.deploymentID()).onComplete(onSuccess(v -> {
+    vertx.undeploy(deployment.id()).onComplete(onSuccess(v -> {
       assertEquals(1, undeployHandlerCount.incrementAndGet());
       undeployLatch.countDown();
     }));
@@ -1067,8 +1068,8 @@ public class DeploymentTest extends VertxTestBase {
     assertWaitUntil(() -> messageCount.get() == 3);
     assertEquals(9, totalReportedInstances.get());
     assertWaitUntil(() -> vertx.deploymentIDs().size() == 1);
-    DeploymentContext deployment = ((VertxInternal) vertx).getDeployment(vertx.deploymentIDs().iterator().next());
-    awaitFuture(vertx.undeploy(deployment.deploymentID()));
+    DeploymentContext deployment = ((VertxImpl) vertx).deploymentManager().deployment(vertx.deploymentIDs().iterator().next());
+    awaitFuture(vertx.undeploy(deployment.id()));
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/endpoint/DnsResolverTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/endpoint/DnsResolverTest.java
@@ -70,7 +70,7 @@ public class DnsResolverTest extends VertxTestBase {
       return set;
     });
     super.setUp();
-    resolver = (EndpointResolver) ((VertxInternal)vertx).hostnameResolver().endpointResolver(vertx);
+    resolver = (EndpointResolver) ((VertxInternal)vertx).nameResolver().endpointResolver(vertx);
   }
 
   public void tearDown() throws Exception {

--- a/vertx-core/src/test/java/io/vertx/tests/endpoint/MappingResolverTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/endpoint/MappingResolverTest.java
@@ -20,6 +20,7 @@ import io.vertx.core.net.endpoint.ServerEndpoint;
 import io.vertx.core.net.endpoint.LoadBalancer;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakeresolver.FakeAddress;
+import org.apache.commons.math3.analysis.function.Add;
 import org.junit.Test;
 
 import java.util.*;
@@ -34,7 +35,7 @@ public class MappingResolverTest extends VertxTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    AddressResolver ar = AddressResolver.mappingResolver(addr -> {
+    AddressResolver<?> ar = AddressResolver.mappingResolver(addr -> {
       Function<Address, List<SocketAddress>> m = mapping;
       return m != null ? m.apply(addr) : null;
     });

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTest.java
@@ -18,7 +18,6 @@ import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.spi.VertxMetricsFactory;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.metrics.TCPMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
@@ -259,7 +258,7 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
     testSubsRemoved(latch -> {
       VertxInternal vi = (VertxInternal) vertices[1];
       Promise<Void> promise = vi.getOrCreateContext().promise();
-      vi.getClusterManager().leave(promise);
+      vi.clusterManager().leave(promise);
       promise.future().onComplete(onSuccess(v -> {
         latch.countDown();
       }));
@@ -682,7 +681,7 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
   public void testPreserveMessageOrderingOnContext() {
     int num = 256;
     startNodes(2);
-    ClusterManager clusterManager = ((VertxInternal) vertices[0]).getClusterManager();
+    ClusterManager clusterManager = ((VertxInternal) vertices[0]).clusterManager();
     if (clusterManager instanceof FakeClusterManager) {
       // Other CM will exhibit latency for this one we must fake it
       FakeClusterManager fakeClusterManager = (FakeClusterManager) clusterManager;

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/FaultToleranceTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/FaultToleranceTest.java
@@ -104,7 +104,7 @@ public abstract class FaultToleranceTest extends VertxTestBase {
   }
 
   protected void afterNodesKilled() throws Exception {
-    ClusterManager clusterManager = vertx.getClusterManager();
+    ClusterManager clusterManager = vertx.clusterManager();
     assertEqualsEventually("Remaining members", Integer.valueOf(2), () -> clusterManager.getNodes().size());
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/NodeInfoTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/NodeInfoTest.java
@@ -32,7 +32,7 @@ public class NodeInfoTest extends VertxTestBase {
   @Test
   public void testFailedFutureForUnknownNode() {
     startNodes(2);
-    ClusterManager clusterManager = ((VertxInternal) vertices[0]).getClusterManager();
+    ClusterManager clusterManager = ((VertxInternal) vertices[0]).clusterManager();
     // Create unknown node identifier
     String unknown = String.join("", clusterManager.getNodes());
     // Needed as callback might be done from non Vert.x thread

--- a/vertx-core/src/test/java/io/vertx/tests/file/FileResolverTestBase.java
+++ b/vertx-core/src/test/java/io/vertx/tests/file/FileResolverTestBase.java
@@ -67,15 +67,19 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     resolver = new FileResolverImpl();
   }
 
-  protected ClassLoader resourcesLoader(File baseDir) throws Exception {
-    return Thread.currentThread().getContextClassLoader();
-  }
-
   @Override
   protected void tearDown() throws Exception {
     Thread.currentThread().setContextClassLoader(testCL);
     resolver.close();
     super.tearDown();
+  }
+
+  protected ClassLoader resourcesLoader(File baseDir) throws Exception {
+    return Thread.currentThread().getContextClassLoader();
+  }
+
+  private static File resolveFile(VertxInternal vertx, String na) {
+    return vertx.fileResolver().resolve(na);
   }
 
   @Test
@@ -91,21 +95,21 @@ public abstract class FileResolverTestBase extends VertxTestBase {
 
   @Test
   public void testResolveNotExistFile() {
-    File file = resolver.resolveFile("doesnotexist.txt");
+    File file = resolver.resolve("doesnotexist.txt");
     assertFalse(file.exists());
     assertEquals("doesnotexist.txt", file.getPath());
   }
 
   @Test
   public void testResolveNotExistDirectory() {
-    File file = resolver.resolveFile("somedir");
+    File file = resolver.resolve("somedir");
     assertFalse(file.exists());
     assertEquals("somedir", file.getPath());
   }
 
   @Test
   public void testResolveNotExistFileInDirectory() {
-    File file = resolver.resolveFile("somedir/doesnotexist.txt");
+    File file = resolver.resolve("somedir/doesnotexist.txt");
     assertFalse(file.exists());
     assertEquals("somedir" + File.separator + "doesnotexist.txt", file.getPath());
   }
@@ -113,7 +117,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   @Test
   public void testResolveFileFromClasspath() throws Exception {
     for (int i = 0; i < 2; i++) {
-      File file = resolver.resolveFile("afile.html");
+      File file = resolver.resolve("afile.html");
       assertTrue(file.exists());
       assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertFalse(file.isDirectory());
@@ -126,7 +130,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     VertxInternal vertx = (VertxInternal) Vertx.vertx(new VertxOptions().setFileSystemOptions(new FileSystemOptions().setFileCachingEnabled(true)));
     try {
       for (int i = 0; i < 2; i++) {
-        File file = vertx.resolveFile("afile.html");
+        File file = resolveFile(vertx, "afile.html");
         assertTrue(file.exists());
         assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
         assertFalse(file.isDirectory());
@@ -140,7 +144,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   @Test
   public void testResolveFileWithSpacesFromClasspath() throws Exception {
     for (int i = 0; i < 2; i++) {
-      File file = resolver.resolveFile("afile with spaces.html");
+      File file = resolver.resolve("afile with spaces.html");
       assertTrue(file.exists());
       assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertFalse(file.isDirectory());
@@ -152,7 +156,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   public void testResolveFileWithSpaceAtEndFromClasspath() {
     Assume.assumeFalse(Utils.isWindows());
     for (int i = 0; i < 2; i++) {
-      File file = resolver.resolveFile("afilewithspaceatend ");
+      File file = resolver.resolve("afilewithspaceatend ");
       assertTrue(file.exists());
       assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertFalse(file.isDirectory());
@@ -164,7 +168,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   public void testCacheDirIsPosix0700() throws Exception {
     Assume.assumeFalse(Utils.isWindows());
 
-    File file = resolver.resolveFile("afile with spaces.html");
+    File file = resolver.resolve("afile with spaces.html");
     assertTrue(file.exists());
     assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
     File parent = file.getParentFile(); // this should be the cache directory
@@ -176,7 +180,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   @Test
   public void testResolveDirectoryFromClasspath() throws Exception {
     for (int i = 0; i < 2; i++) {
-      File file = resolver.resolveFile("webroot");
+      File file = resolver.resolve("webroot");
       assertTrue(file.exists());
       assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertTrue(file.isDirectory());
@@ -186,7 +190,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   @Test
   public void testResolveFileInDirectoryFromClasspath() throws Exception {
     for (int i = 0; i < 2; i++) {
-      File file = resolver.resolveFile("webroot/somefile.html");
+      File file = resolver.resolve("webroot/somefile.html");
       assertTrue(file.exists());
       assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertFalse(file.isDirectory());
@@ -197,7 +201,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   @Test
   public void testResolveSubDirectoryFromClasspath() throws Exception {
     for (int i = 0; i < 2; i++) {
-      File file = resolver.resolveFile("webroot/subdir");
+      File file = resolver.resolve("webroot/subdir");
       assertTrue(file.exists());
       assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertTrue(file.isDirectory());
@@ -207,7 +211,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   @Test
   public void testResolveFileInSubDirectoryFromClasspath() throws Exception {
     for (int i = 0; i < 2; i++) {
-      File file = resolver.resolveFile("webroot/subdir/subfile.html");
+      File file = resolver.resolve("webroot/subdir/subfile.html");
       assertTrue(file.exists());
       assertTrue(file.getPath().startsWith(cacheBaseDir + "-"));
       assertFalse(file.isDirectory());
@@ -217,7 +221,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
 
   @Test
   public void testRecursivelyUnpack() throws Exception {
-    File file = resolver.resolveFile("webroot/subdir");
+    File file = resolver.resolve("webroot/subdir");
     assertTrue(file.exists());
     File sub = new File(file, "subfile.html");
     assertTrue(sub.exists());
@@ -226,7 +230,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
 
   @Test
   public void testRecursivelyUnpack2() throws Exception {
-    File file = resolver.resolveFile("webroot/subdir");
+    File file = resolver.resolve("webroot/subdir");
     assertTrue(file.exists());
     File sub = new File(new File(file, "subdir2"), "subfile2.html");
     assertTrue(sub.exists());
@@ -236,7 +240,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   @Test
   public void testDeleteCacheDir() throws Exception {
     FileResolver resolver2 = new FileResolverImpl();
-    File file = resolver2.resolveFile("webroot/somefile.html");
+    File file = resolver2.resolve("webroot/somefile.html");
     assertTrue(file.exists());
     File cacheDir = file.getParentFile().getParentFile();
     assertTrue(cacheDir.exists());
@@ -247,7 +251,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   @Test
   public void testCacheDirDeletedOnVertxClose() {
     VertxInternal vertx2 = (VertxInternal) vertx();
-    File file = vertx2.resolveFile("webroot/somefile.html");
+    File file = resolveFile(vertx2, "webroot/somefile.html");
     assertTrue(file.exists());
     File cacheDir = file.getParentFile().getParentFile();
     assertTrue(cacheDir.exists());
@@ -315,7 +319,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
       Runnable runnable = () -> {
         try {
           start.await();
-          File file = resolver.resolveFile("temp");
+          File file = resolver.resolve("temp");
           byte[] data = Files.readAllBytes(file.toPath());
           Assert.assertArrayEquals(content, data);
         } catch (Exception e) {
@@ -360,10 +364,10 @@ public abstract class FileResolverTestBase extends VertxTestBase {
           return super.getResource(name);
         }
       });
-      File f = vertx.resolveFile("foo");
+      File f = resolveFile(vertx, "foo");
       assertEquals("foo", new String(Files.readAllBytes(f.toPath())));
       Files.write(tmp.toPath(), "bar".getBytes());
-      f = vertx.resolveFile("foo");
+      f = resolveFile(vertx, "foo");
       if (enabled) {
         assertEquals("foo", new String(Files.readAllBytes(f.toPath())));
       } else {
@@ -382,14 +386,14 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   @Test
   public void testResolveAfterCloseThrowsISE() throws Exception {
     FileResolver resolver2 = new FileResolverImpl();
-    File file = resolver2.resolveFile("webroot/somefile.html");
+    File file = resolver2.resolve("webroot/somefile.html");
     assertTrue(file.exists());
     File cacheDir = file.getParentFile().getParentFile();
     assertTrue(cacheDir.exists());
     resolver2.close();
     assertFalse(cacheDir.exists());
     try {
-      resolver2.resolveFile("webroot/somefile.html");
+      resolver2.resolve("webroot/somefile.html");
       fail("Should fail");
     } catch (IllegalStateException e) {
       // OK
@@ -398,14 +402,14 @@ public abstract class FileResolverTestBase extends VertxTestBase {
 
   @Test
   public void testResolveRelativeFileInDirectoryFromClasspath() {
-    File somefile = resolver.resolveFile("a/a.txt");
+    File somefile = resolver.resolve("a/a.txt");
     assertTrue(somefile.exists());
     assertTrue(somefile.getPath().startsWith(cacheBaseDir + "-"));
     assertFalse(somefile.isDirectory());
     // resolve a relative file
     File someotherfile = new File(new File(somefile.getParentFile().getParentFile(), "b"), "b.txt");
     assertFalse(someotherfile.exists()); // is hasn't been extracted yet
-    someotherfile = resolver.resolveFile(someotherfile.getAbsolutePath());
+    someotherfile = resolver.resolve(someotherfile.getAbsolutePath());
     assertTrue(someotherfile.exists()); // is should be rebased and extracted now
     assertTrue(someotherfile.getPath().startsWith(cacheBaseDir + "-"));
     assertFalse(someotherfile.isDirectory());
@@ -413,13 +417,13 @@ public abstract class FileResolverTestBase extends VertxTestBase {
 
   @Test
   public void testDoNotResolveAbsoluteFileInDirectoryFromClasspath() {
-    File somefile = resolver.resolveFile("/a/a.txt");
+    File somefile = resolver.resolve("/a/a.txt");
     assertFalse(somefile.exists());
   }
 
   @Test
   public void testResolveCacheDir() {
-    File somefile = resolver.resolveFile("");
+    File somefile = resolver.resolve("");
     assertTrue(somefile.exists());
     assertTrue(somefile.getPath().startsWith(cacheBaseDir + "-"));
     assertTrue(somefile.isDirectory());
@@ -442,7 +446,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   @Test
   public void testBugEndWithSlash() {
     FileResolver resolver = ((VertxInternal) vertx).fileResolver();
-    File f = resolver.resolveFile("tree/");
+    File f = resolver.resolve("tree/");
     assertNotNull(f);
     assertTrue(f.isDirectory());
     assertEquals("tree", f.getName());

--- a/vertx-core/src/test/java/io/vertx/tests/file/FileSystemFileResolverTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/file/FileSystemFileResolverTest.java
@@ -32,7 +32,7 @@ public class FileSystemFileResolverTest extends FileResolverTestBase {
 
   @Test
   public void testResolvePlusSignsOnName() {
-    File file = resolver.resolveFile("this+that");
+    File file = resolver.resolve("this+that");
     assertFalse(file.exists());
     assertEquals("this+that", file.getPath());
   }
@@ -60,7 +60,7 @@ public class FileSystemFileResolverTest extends FileResolverTestBase {
       };
       thread.setContextClassLoader(next);
       try {
-        File file = resolver.resolveFile(s);
+        File file = resolver.resolve(s);
         assertNotNull(file);
       } finally {
         thread.setContextClassLoader(prev);
@@ -90,7 +90,7 @@ public class FileSystemFileResolverTest extends FileResolverTestBase {
     };
     thread.setContextClassLoader(next);
     try {
-      File file = resolver.resolveFile("a/a.txt");
+      File file = resolver.resolve("a/a.txt");
       String content = Files.readString(file.toPath());
       assertEquals("the_content", content);
     } finally {

--- a/vertx-core/src/test/java/io/vertx/tests/file/JarFileResolverWithOddClassLoaderTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/file/JarFileResolverWithOddClassLoaderTest.java
@@ -23,7 +23,7 @@ public class JarFileResolverWithOddClassLoaderTest {
     try (FileResolver resolver = new FileResolverImpl()) {
       Thread.currentThread().setContextClassLoader(cl);
       String fileName = "META-INF/resources/_static/wc-chatbot/0.1.2/LICENSE";
-      File resolved = resolver.resolveFile(fileName);
+      File resolved = resolver.resolve(fileName);
       Assertions.assertThat(resolved).exists();
     } finally {
       Thread.currentThread().setContextClassLoader(orig);

--- a/vertx-core/src/test/java/io/vertx/tests/file/URLBundleFileResolverTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/file/URLBundleFileResolverTest.java
@@ -28,12 +28,12 @@ public class URLBundleFileResolverTest extends JarFileResolverTest {
   public void testResolveURLBundle() {
     String fileName = "java/lang/Object.class";
     assertFalse(resolver.getFileCache().getFile(fileName).exists());
-    File file = resolver.resolveFile(fileName);
+    File file = resolver.resolve(fileName);
     assertTrue(file.exists());
     // cache.getFile should return the cached file.
     assertTrue(resolver.getFileCache().getFile(fileName).exists());
     // resolve again
-    file = resolver.resolveFile(fileName);
+    file = resolver.resolve(fileName);
     assertTrue(file.exists());
     assertTrue(resolver.getFileCache().getFile(fileName).exists());
   }

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsOptionsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsOptionsTest.java
@@ -68,7 +68,7 @@ public class MetricsOptionsTest extends VertxTestBase {
   public void testMetricsEnabledWithoutConfig() {
     vertx.close();
     vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
-    VertxMetrics metrics = ((VertxInternal) vertx).metricsSPI();
+    VertxMetrics metrics = ((VertxInternal) vertx).metrics();
     assertNull(metrics);
   }
 
@@ -82,6 +82,6 @@ public class MetricsOptionsTest extends VertxTestBase {
       .with(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)))
       .withMetrics(new SimpleVertxMetricsFactory<>(metrics))
       .build();
-    assertSame(metrics, ((VertxInternal) vertx).metricsSPI());
+    assertSame(metrics, ((VertxInternal) vertx).metrics());
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/net/ConnectionBaseTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/ConnectionBaseTest.java
@@ -17,6 +17,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.ThreadingModel;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.internal.ContextInternal;
@@ -599,7 +600,11 @@ public class ConnectionBaseTest extends VertxTestBase {
 
   private <C extends VertxConnection> EmbeddedChannel channel(BiFunction<ContextInternal, ChannelHandlerContext, C> connectionFactory) {
     return new EmbeddedChannel(VertxHandler.create(chctx -> {
-      ContextInternal ctx = ((VertxInternal)vertx).createEventLoopContext(chctx.channel().eventLoop(), null, null);
+      ContextInternal ctx = ((VertxInternal)vertx)
+        .contextBuilder()
+        .withThreadingModel(ThreadingModel.EVENT_LOOP)
+        .withEventLoop(chctx.channel().eventLoop())
+        .build();
       return connectionFactory.apply(ctx, chctx);
     }));
   }
@@ -608,7 +613,10 @@ public class ConnectionBaseTest extends VertxTestBase {
     Handler<Message> handler;
     public TestConnection(ChannelHandlerContext chctx) {
       super(((VertxInternal)ConnectionBaseTest.this.vertx)
-        .createEventLoopContext((EventLoop) chctx.executor(), null, null), chctx);
+        .contextBuilder()
+        .withThreadingModel(ThreadingModel.EVENT_LOOP)
+        .withEventLoop((EventLoop) chctx.executor())
+        .build(), chctx);
     }
     @Override
     protected void handleMessage(Object msg) {

--- a/vertx-core/src/test/java/io/vertx/tests/pool/ConnectionPoolTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/pool/ConnectionPoolTest.java
@@ -12,8 +12,10 @@ package io.vertx.tests.pool;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.ThreadingModel;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.ConnectionPoolTooBusyException;
+import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.pool.*;
@@ -949,7 +951,7 @@ public class ConnectionPoolTest extends VertxTestBase {
 
   @Test
   public void testDefaultSelector() throws Exception {
-    ContextInternal context1 = vertx.createEventLoopContext();
+    ContextImpl context1 = (ContextImpl) vertx.createEventLoopContext();
     ConnectionManager mgr = new ConnectionManager();
     ConnectionPool<Connection> pool = ConnectionPool.pool(mgr, new int[] { 10 }, 10);
     CountDownLatch latch1 = new CountDownLatch(1);
@@ -974,7 +976,13 @@ public class ConnectionPoolTest extends VertxTestBase {
       }));
     awaitLatch(latch2);
     CountDownLatch latch3 = new CountDownLatch(1);
-    ContextInternal context2 = vertx.createEventLoopContext(context1.nettyEventLoop(), context1.workerPool(), context1.classLoader());
+    ContextInternal context2 = vertx
+      .contextBuilder()
+      .withThreadingModel(ThreadingModel.EVENT_LOOP)
+      .withEventLoop(context1.nettyEventLoop())
+      .withWorkerPool(context1.workerPool())
+      .withClassLoader(context1.classLoader())
+      .build();
     pool
       .acquire(context2, 0)
       .onComplete(onSuccess(lease -> {

--- a/vertx-core/src/test/java/io/vertx/tests/shareddata/ClusteredAsynchronousLockTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/shareddata/ClusteredAsynchronousLockTest.java
@@ -108,7 +108,7 @@ public class ClusteredAsynchronousLockTest extends AsynchronousLockTest {
     testLockReleased(latch -> {
       VertxInternal vi = (VertxInternal) vertices[0];
       Promise<Void> promise = vi.getOrCreateContext().promise();
-      vi.getClusterManager().leave(promise);
+      vi.clusterManager().leave(promise);
       promise.future().onComplete(onSuccess(v -> {
         latch.countDown();
       }));

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxBootstrapTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxBootstrapTest.java
@@ -73,7 +73,7 @@ public class VertxBootstrapTest {
     });
     Vertx vertx = fut.get(10, TimeUnit.SECONDS);
     assertNotNull(vertx);
-    assertNotNull(((VertxInternal)vertx).getClusterManager());
+    assertNotNull(((VertxInternal)vertx).clusterManager());
   }
 
   @Test
@@ -85,7 +85,7 @@ public class VertxBootstrapTest {
       factory.metricsFactory(options -> metrics);
       factory.init();
       Vertx vertx = factory.vertx();
-      assertSame(metrics, ((VertxInternal)vertx).metricsSPI());
+      assertSame(metrics, ((VertxInternal)vertx).metrics());
     });
   }
 
@@ -149,7 +149,7 @@ public class VertxBootstrapTest {
       });
     });
     Vertx vertx = res.get(10, TimeUnit.SECONDS);
-    assertSame(clusterManager, ((VertxInternal)vertx).getClusterManager());
+    assertSame(clusterManager, ((VertxInternal)vertx).clusterManager());
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxBuilderTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxBuilderTest.java
@@ -30,6 +30,6 @@ public class VertxBuilderTest  extends AsyncTestBase {
   public void testMetricsFactoryDoesNotRequireOptions() {
     FakeVertxMetrics metrics = new FakeVertxMetrics();
     Vertx vertx = Vertx.builder().withMetrics(options -> metrics).build();
-    assertEquals(metrics, ((VertxInternal)vertx).metricsSPI());
+    assertEquals(metrics, ((VertxInternal)vertx).metrics());
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/wrapper/VertxWrapperImpl.java
+++ b/vertx-core/src/test/java/io/vertx/tests/wrapper/VertxWrapperImpl.java
@@ -13,4 +13,5 @@ public class VertxWrapperImpl extends VertxWrapper {
   protected VertxWrapperImpl(VertxInternal delegate) {
     super(delegate);
   }
+
 }

--- a/vertx-core/src/test/java/module-info.java
+++ b/vertx-core/src/test/java/module-info.java
@@ -38,8 +38,9 @@ open module io.vertx.core.tests {
   requires static io.netty.codec.haproxy;
   requires io.netty.codec.http2;
   requires io.netty.resolver.dns;
+    requires commons.math3;
 
-  provides VerticleFactory with ClasspathVerticleFactory, io.vertx.tests.vertx.AccessEventBusFromInitVerticleFactory;
+    provides VerticleFactory with ClasspathVerticleFactory, io.vertx.tests.vertx.AccessEventBusFromInitVerticleFactory;
 
   // Cluster manager implementations overrides them (TCK)
   exports io.vertx.tests.ha;


### PR DESCRIPTION
- reduces the amount of methods on `VertxInternal`/`ContextInternal`
- introduce context builder to avoid the proliferation of context creational methods
- move the impl API used by `VertxInternal`/`ContextInternal` to internal package
- rename `HostnameResolver` -> `NameResolver`
-  `AddressResolver` now declares a type parameter bound to `Address` for more clarity

