### PR TITLE
VertxConnection enhancements

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxHandler.java
@@ -140,7 +140,7 @@ public final class VertxHandler<C extends VertxConnection> extends ChannelDuplex
 
   @Override
   public void channelReadComplete(ChannelHandlerContext ctx) {
-    conn.endReadAndFlush();
+    conn.readComplete();
   }
 
   @Override


### PR DESCRIPTION
Motivation:

1. the implementation of `VertxConnection` performs un-necessary flushes when a resume operation happens during a outbound drain that will flush the connection
2. resuming the connection while during a read in progress should be a no-op and handled by the `channelRead`/`channelReadComplete` operations
