### PR TITLE
Enable IoUring again in CI

### DIFF
--- a/.github/workflows/ci-5.x.yml
+++ b/.github/workflows/ci-5.x.yml
@@ -18,9 +18,9 @@ jobs:
           - os: ubuntu-latest
             jdk: 11
             profile: '-PNativeEpoll'
-#          - os: ubuntu-latest
-#            jdk: 11
-#            profile: '-PNativeIoUring'
+          - os: ubuntu-latest
+            jdk: 11
+            profile: '-PNativeIoUring'
           - os: ubuntu-latest
             jdk: 11
             profile: '-PNativeEpoll+DomainSockets'


### PR DESCRIPTION
IoUring CI was disabled due to a regression in Netty, this enable it again since 4.2.0.CR4 has been released with a fix