### PR TITLE
Provide a coherent implementation of hashCode for JsonObject/JsonArray with respect to equals.

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -12,6 +12,7 @@
 package io.vertx.core.json;
 
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.shareddata.ClusterSerializable;
 import io.vertx.core.shareddata.Shareable;
 
@@ -20,7 +21,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static io.vertx.core.json.JsonObject.compareObjects;
+import static io.vertx.core.json.impl.JsonUtil.compare;
 import static io.vertx.core.json.impl.JsonUtil.*;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
@@ -661,24 +662,29 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
   @Override
   public boolean equals(Object o) {
     // null check
-    if (o == null)
+    if (o == null) {
       return false;
+    }
     // self check
-    if (this == o)
+    if (this == o) {
       return true;
+    }
     // type check and cast
-    if (getClass() != o.getClass())
+    if (getClass() != o.getClass()) {
       return false;
+    }
 
     JsonArray other = (JsonArray) o;
     // size check
-    if (this.size() != other.size())
+    int size = this.size();
+    if (size != other.size()) {
       return false;
+    }
     // value comparison
-    for (int i = 0; i < this.size(); i++) {
+    for (int i = 0; i < size; i++) {
       Object thisValue = this.getValue(i);
       Object otherValue = other.getValue(i);
-      if (thisValue != otherValue && !compareObjects(thisValue, otherValue)) {
+      if (thisValue != otherValue && !compare(thisValue, otherValue)) {
         return false;
       }
     }
@@ -688,7 +694,11 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable, Shareab
 
   @Override
   public int hashCode() {
-    return list.hashCode();
+    int h = 0;
+    for (Object value : this) {
+      h += JsonUtil.hashCode(value);
+    }
+    return h;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -11,6 +11,7 @@
 package io.vertx.core.json;
 
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.core.shareddata.ClusterSerializable;
 import io.vertx.core.shareddata.Shareable;
 
@@ -1162,19 +1163,23 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   @Override
   public boolean equals(Object o) {
     // null check
-    if (o == null)
+    if (o == null) {
       return false;
+    }
     // self check
-    if (this == o)
+    if (this == o) {
       return true;
+    }
     // type check and cast
-    if (getClass() != o.getClass())
+    if (getClass() != o.getClass()) {
       return false;
+    }
 
     JsonObject other = (JsonObject) o;
     // size check
-    if (this.size() != other.size())
+    if (this.size() != other.size()) {
       return false;
+    }
     // value comparison
     for (String key : map.keySet()) {
       if (!other.containsKey(key)) {
@@ -1183,7 +1188,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
 
       Object thisValue = this.getValue(key);
       Object otherValue = other.getValue(key);
-      if (thisValue != otherValue && !compareObjects(thisValue, otherValue)) {
+      if (thisValue != otherValue && !compare(thisValue, otherValue)) {
         return false;
       }
     }
@@ -1191,55 +1196,15 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
     return true;
   }
 
-  static boolean compareObjects(Object o1, Object o2) {
-    if (o1 instanceof Number && o2 instanceof Number) {
-      if (o1.getClass() == o2.getClass()) {
-        return o1.equals(o2);
-      } else {
-        // meaning that the numbers are different types
-        Number n1 = (Number) o1;
-        Number n2 = (Number) o2;
-        return compareNumbers(n1, n2);
-      }
-    } else if (o1 instanceof CharSequence && o2 instanceof CharSequence && o1.getClass() != o2.getClass()) {
-      return Objects.equals(o1.toString(), o2.toString());
-    } else {
-      return Objects.equals(o1, o2);
-    }
-  }
-
-  private static boolean compareNumbers(Number n1, Number n2) {
-    if (isDecimalNumber(n1) && isDecimalNumber(n2)) {
-      // compare as floating point double
-      return n1.doubleValue() == n2.doubleValue();
-    } else if (isWholeNumber(n1) && isWholeNumber(n2)) {
-      // compare as integer long
-      return n1.longValue() == n2.longValue();
-    } else if (isWholeNumber(n1) && isDecimalNumber(n2) ||
-      isDecimalNumber(n1) && isWholeNumber(n2)) {
-      // if its either integer or long and the other is float or double or vice versa,
-      // compare as floating point double
-      return n1.doubleValue() == n2.doubleValue();
-    } else {
-      if (isWholeNumber(n1)) {
-        return n1.longValue() == n2.longValue();
-      } else  {
-        return n1.doubleValue() == n2.doubleValue();
-      }
-    }
-  }
-
-  private static boolean isWholeNumber(Number thisValue) {
-    return thisValue instanceof Integer || thisValue instanceof Long;
-  }
-
-  private static boolean isDecimalNumber(Number thisValue) {
-    return thisValue instanceof Float || thisValue instanceof Double;
-  }
-
   @Override
   public int hashCode() {
-    return map.hashCode();
+    int h = 0;
+    for (Map.Entry<String, ?> entry : this) {
+      Object key = entry.getKey();
+      Object value = entry.getValue();
+      h += (key.hashCode() ^ JsonUtil.hashCode(value));
+    }
+    return h;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/json/impl/JsonUtil.java
+++ b/src/main/java/io/vertx/core/json/impl/JsonUtil.java
@@ -16,10 +16,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.Shareable;
 
 import java.time.Instant;
-import java.util.Base64;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -127,5 +124,61 @@ public final class JsonUtil {
   public static <T> Stream<T> asStream(Iterator<T> sourceIterator) {
     Iterable<T> iterable = () -> sourceIterator;
     return StreamSupport.stream(iterable.spliterator(), false);
+  }
+
+  public static int hashCode(Object value) {
+    if (value == null) {
+      return 0;
+    } else if (value instanceof Number) {
+      return Double.hashCode(((Number) value).doubleValue());
+    } else {
+      return value.hashCode();
+    }
+  }
+
+  public static boolean compare(Object o1, Object o2) {
+    if (o1 instanceof Number && o2 instanceof Number) {
+      if (o1.getClass() == o2.getClass()) {
+        return o1.equals(o2);
+      } else {
+        // meaning that the numbers are different types
+        Number n1 = (Number) o1;
+        Number n2 = (Number) o2;
+        return compareNumbers(n1, n2);
+      }
+    } else if (o1 instanceof CharSequence && o2 instanceof CharSequence && o1.getClass() != o2.getClass()) {
+      return Objects.equals(o1.toString(), o2.toString());
+    } else {
+      return Objects.equals(o1, o2);
+    }
+  }
+
+  private static boolean compareNumbers(Number n1, Number n2) {
+    if (isDecimalNumber(n1) && isDecimalNumber(n2)) {
+      // compare as floating point double
+      return n1.doubleValue() == n2.doubleValue();
+    } else if (isWholeNumber(n1) && isWholeNumber(n2)) {
+      // compare as integer long
+      return n1.longValue() == n2.longValue();
+    } else if (isWholeNumber(n1) && isDecimalNumber(n2) ||
+      isDecimalNumber(n1) && isWholeNumber(n2)) {
+      // if its either integer or long and the other is float or double or vice versa,
+      // compare as floating point double
+      return n1.doubleValue() == n2.doubleValue();
+    } else {
+      if (isWholeNumber(n1)) {
+        return n1.longValue() == n2.longValue();
+      } else  {
+        return n1.doubleValue() == n2.doubleValue();
+      }
+    }
+  }
+
+  private static boolean isWholeNumber(Number thisValue) {
+    return thisValue instanceof Integer || thisValue instanceof Long;
+  }
+
+  private static boolean isDecimalNumber(Number thisValue) {
+    return thisValue instanceof Float || thisValue instanceof Double;
   }
 }

--- a/src/test/java/io/vertx/core/json/JsonObjectTest.java
+++ b/src/test/java/io/vertx/core/json/JsonObjectTest.java
@@ -1548,22 +1548,22 @@ public class JsonObjectTest {
 
   @Test
   public void testNumberEquality() {
-    assertNumberEquals(4, 4);
-    assertNumberEquals(4, (long)4);
-    assertNumberEquals(4, 4f);
-    assertNumberEquals(4, 4D);
-    assertNumberEquals((long)4, (long)4);
-    assertNumberEquals((long)4, 4f);
-    assertNumberEquals((long)4, 4D);
-    assertNumberEquals(4f, 4f);
-    assertNumberEquals(4f, 4D);
-    assertNumberEquals(4D, 4D);
-    assertNumberEquals(4.1D, 4.1D);
-    assertNumberEquals(4.1f, 4.1f);
+    assertNumberEqualsAndHashCode(4, 4);
+    assertNumberEqualsAndHashCode(4, (long)4);
+    assertNumberEqualsAndHashCode(4, 4f);
+    assertNumberEqualsAndHashCode(4, 4D);
+    assertNumberEqualsAndHashCode((long)4, (long)4);
+    assertNumberEqualsAndHashCode((long)4, 4f);
+    assertNumberEqualsAndHashCode((long)4, 4D);
+    assertNumberEqualsAndHashCode(4f, 4f);
+    assertNumberEqualsAndHashCode(4f, 4D);
+    assertNumberEqualsAndHashCode(4D, 4D);
+    assertNumberEqualsAndHashCode(4.1D, 4.1D);
+    assertNumberEqualsAndHashCode(4.1f, 4.1f);
     assertNumberNotEquals(4.1f, 4.1D);
-    assertNumberEquals(4.5D, 4.5D);
-    assertNumberEquals(4.5f, 4.5f);
-    assertNumberEquals(4.5f, 4.5D);
+    assertNumberEqualsAndHashCode(4.5D, 4.5D);
+    assertNumberEqualsAndHashCode(4.5f, 4.5f);
+    assertNumberEqualsAndHashCode(4.5f, 4.5D);
     assertNumberNotEquals(4, 5);
     assertNumberNotEquals(4, (long)5);
     assertNumberNotEquals(4, 5D);
@@ -1574,34 +1574,39 @@ public class JsonObjectTest {
     assertNumberNotEquals(4f, 5f);
     assertNumberNotEquals(4f, 5D);
     assertNumberNotEquals(4D, 5D);
-    assertNumberEquals(2f, 2);
-    assertNumberEquals(2D, 2);
+    assertNumberEqualsAndHashCode(2f, 2);
+    assertNumberEqualsAndHashCode(2D, 2);
     assertNumberNotEquals(2.3D, 2);
     assertNumberNotEquals(2.3f, 2);
-    assertNumberEquals(2, new BigDecimal(2));
-    assertNumberEquals(new BigDecimal(2), 2);
-    assertNumberEquals(2D, new BigDecimal(2));
-    assertNumberEquals(new BigDecimal(2), 2D);
-    assertNumberEquals(2, BigInteger.valueOf(2));
-    assertNumberEquals(BigInteger.valueOf(2), 2);
-    assertNumberEquals(2D, BigInteger.valueOf(2));
-    assertNumberEquals(BigInteger.valueOf(2), 2D);
-    assertNumberEquals(BigInteger.valueOf(2), new BigDecimal(2));
-    assertNumberEquals(new BigDecimal(2), BigInteger.valueOf(2));
+    assertNumberEqualsAndHashCode(2, new BigDecimal(2));
+    assertNumberEqualsAndHashCode(new BigDecimal(2), 2);
+    assertNumberEqualsAndHashCode(2D, new BigDecimal(2));
+    assertNumberEqualsAndHashCode(new BigDecimal(2), 2D);
+    assertNumberEqualsAndHashCode(2, BigInteger.valueOf(2));
+    assertNumberEqualsAndHashCode(BigInteger.valueOf(2), 2);
+    assertNumberEqualsAndHashCode(2D, BigInteger.valueOf(2));
+    assertNumberEqualsAndHashCode(BigInteger.valueOf(2), 2D);
+    assertNumberEqualsAndHashCode(BigInteger.valueOf(2), new BigDecimal(2));
+    assertNumberEqualsAndHashCode(new BigDecimal(2), BigInteger.valueOf(2));
   }
 
-  private void assertNumberEquals(Number value1, Number value2) {
-    JsonObject o1 = new JsonObject().put("key", value1);
-    JsonObject o2 = new JsonObject().put("key", value2);
+  private void assertNumberEqualsAndHashCode(Number value1, Number value2) {
+    assertNumberEqualsAndHashCode(value1, value2, n -> new JsonObject().put("key", n));
+    assertNumberEqualsAndHashCode(value1, value2, n -> new JsonObject().put("key", Collections.singletonMap("key", n)));
+    assertNumberEqualsAndHashCode(value1, value2, n -> new JsonArray().add(n));
+    assertNumberEqualsAndHashCode(value1, value2, n -> new JsonArray().add(Collections.singletonList(n)));
+  }
+
+  private void assertNumberEqualsAndHashCode(Number value1, Number value2, Function<Number, Object> f) {
+    Object o1 = f.apply(value1);
+    Object o2 = f.apply(value2);
     if (!o1.equals(o2)) {
       fail("Was expecting " + value1.getClass().getSimpleName() + ":" + value1 + " == " +
-          value2.getClass().getSimpleName() + ":" + value2);
+        value2.getClass().getSimpleName() + ":" + value2);
     }
-    JsonArray a1 = new JsonArray().add(value1);
-    JsonArray a2 = new JsonArray().add(value2);
-    if (!a1.equals(a2)) {
-      fail("Was expecting " + value1.getClass().getSimpleName() + ":" + value1 + " == " +
-          value2.getClass().getSimpleName() + ":" + value2);
+    if (o1.hashCode() != o2.hashCode()) {
+      fail("Was expecting " + value1.getClass().getSimpleName() + ":" + value1 + " and " +
+        value2.getClass().getSimpleName() + ":" + value2);
     }
   }
 
@@ -1905,7 +1910,7 @@ public class JsonObjectTest {
       1234567890123456789L,
       Short.MAX_VALUE
     }) {
-      assertNumberEquals(n, numbers.getNumber("missingKey", n));
+      assertNumberEqualsAndHashCode(n, numbers.getNumber("missingKey", n));
     }
   }
 


### PR DESCRIPTION
Motivation:

`JsonArray`/`JsonObject` hashCode implementations rely on the wrapped data structure hashCode implementation and on the generic Object `hashCode` function.

1. The hash value might differ from data structure implementations.

2. Number coercion is performed in equals which allows case were we do have equality (after coercion) but hash differs (e.g. 4L and 4D)

Changes:

`JsonObject`/`JsonArray` implement `hashCode` methods.

Number's `hashCode` is computed against the `hashCode` of their double value.