### PR TITLE
Expose the deployment manager internal API

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -14,7 +14,7 @@ package io.vertx.core.impl;
 import io.netty.channel.EventLoop;
 import io.vertx.core.*;
 import io.vertx.core.Future;
-import io.vertx.core.impl.deployment.Deployment;
+import io.vertx.core.internal.deployment.Deployment;
 import io.vertx.core.internal.WorkerPool;
 import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.internal.EventExecutor;
@@ -64,7 +64,7 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
     super(locals);
     JsonObject config = null;
     if (deployment != null) {
-      config = Deployment.unwrap(deployment).options().getConfig();
+      config = deployment.deployment().options().getConfig();
     }
     if (config == null) {
       config = new JsonObject();

--- a/vertx-core/src/main/java/io/vertx/core/impl/deployment/DefaultDeployment.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/deployment/DefaultDeployment.java
@@ -14,9 +14,10 @@ import io.netty.channel.EventLoop;
 import io.vertx.core.*;
 import io.vertx.core.impl.ContextBuilderImpl;
 import io.vertx.core.impl.VertxImpl;
-import io.vertx.core.internal.WorkerPool;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.WorkerPool;
+import io.vertx.core.internal.deployment.Deployment;
 import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.internal.logging.Logger;
 
@@ -25,18 +26,14 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
-public class Deployment {
+public class DefaultDeployment implements Deployment {
 
-  public static Deployment unwrap(DeploymentContext ctx) {
-    return ((DefaultDeploymentManager.DeploymentContextImpl)ctx).deployment();
-  }
-
-  public static Deployment deployment(VertxImpl vertx,
-                                      Logger log,
-                                      DeploymentOptions options,
-                                      Function<Deployable, String> identifierProvider,
-                                      ClassLoader tccl,
-                                      Callable<? extends Deployable> supplier) throws Exception {
+  public static DefaultDeployment deployment(VertxImpl vertx,
+                                             Logger log,
+                                             DeploymentOptions options,
+                                             Function<Deployable, String> identifierProvider,
+                                             ClassLoader tccl,
+                                             Callable<? extends Deployable> supplier) throws Exception {
     int numberOfInstances = options.getInstances();
     Set<Deployable> deployables = Collections.newSetFromMap(new IdentityHashMap<>());
     for (int i = 0; i < numberOfInstances;i++) {
@@ -69,7 +66,7 @@ public class Deployment {
       }
     }
     ArrayList<Deployable> list = new ArrayList<>(deployables);
-    return new Deployment(vertx, options, log, list, identifierProvider.apply(list.get(0)), mode, workerPool, tccl);
+    return new DefaultDeployment(vertx, options, log, list, identifierProvider.apply(list.get(0)), mode, workerPool, tccl);
   }
 
   private final VertxImpl vertx;
@@ -82,14 +79,14 @@ public class Deployment {
   private final List<Instance> instances = new CopyOnWriteArrayList<>();
   private final ClassLoader tccl;
 
-  public Deployment(VertxImpl vertx,
-                    DeploymentOptions options,
-                    Logger log,
-                    List<Deployable> deployables,
-                    String identifier,
-                    ThreadingModel threading,
-                    WorkerPool workerPool,
-                    ClassLoader tccl) {
+  public DefaultDeployment(VertxImpl vertx,
+                           DeploymentOptions options,
+                           Logger log,
+                           List<Deployable> deployables,
+                           String identifier,
+                           ThreadingModel threading,
+                           WorkerPool workerPool,
+                           ClassLoader tccl) {
     this.vertx = vertx;
     this.log = log;
     this.options = options;
@@ -117,7 +114,7 @@ public class Deployment {
   }
 
   public DeploymentOptions options() {
-    return options;
+    return new DeploymentOptions(options);
   }
 
   public String identifier() {

--- a/vertx-core/src/main/java/io/vertx/core/impl/deployment/DefaultDeploymentManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/deployment/DefaultDeploymentManager.java
@@ -14,7 +14,9 @@ package io.vertx.core.impl.deployment;
 import io.vertx.core.*;
 import io.vertx.core.impl.VertxImpl;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.deployment.Deployment;
 import io.vertx.core.internal.deployment.DeploymentContext;
+import io.vertx.core.internal.deployment.DeploymentManager;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 

--- a/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
@@ -15,7 +15,7 @@ import io.netty.channel.EventLoop;
 import io.vertx.core.*;
 import io.vertx.core.Future;
 import io.vertx.core.impl.*;
-import io.vertx.core.impl.deployment.Deployment;
+import io.vertx.core.internal.deployment.Deployment;
 import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.impl.future.FailedFuture;
 import io.vertx.core.impl.future.PromiseImpl;
@@ -435,7 +435,7 @@ public interface ContextInternal extends Context {
     if (deployment == null) {
       return 0;
     }
-    return Deployment.unwrap(deployment).options().getInstances();
+    return deployment.deployment().options().getInstances();
   }
 
   CloseFuture closeFuture();

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxInternal.java
@@ -15,6 +15,7 @@ package io.vertx.core.internal;
 import io.netty.channel.EventLoopGroup;
 import io.vertx.core.*;
 import io.vertx.core.impl.*;
+import io.vertx.core.internal.deployment.DeploymentManager;
 import io.vertx.core.internal.resolver.NameResolver;
 import io.vertx.core.internal.threadchecker.BlockedThreadChecker;
 import io.vertx.core.net.NetServerOptions;
@@ -181,10 +182,18 @@ public interface VertxInternal extends Vertx {
     return context.executeBlockingInternal(blockingCodeHandler);
   }
 
+  /**
+   * @return the cluster manager
+   */
   ClusterManager clusterManager();
 
   /**
-   * @return the default name resolver
+   * @return the deployment manager
+   */
+  DeploymentManager deploymentManager();
+
+  /**
+   * @return the name resolver
    */
   NameResolver nameResolver();
 

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxWrapper.java
@@ -19,6 +19,7 @@ import io.vertx.core.dns.DnsClientOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.*;
+import io.vertx.core.internal.deployment.DeploymentManager;
 import io.vertx.core.internal.resolver.NameResolver;
 import io.vertx.core.internal.threadchecker.BlockedThreadChecker;
 import io.vertx.core.net.NetClient;
@@ -307,6 +308,11 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public ClusterManager clusterManager() {
     return delegate.clusterManager();
+  }
+
+  @Override
+  public DeploymentManager deploymentManager() {
+    return delegate.deploymentManager();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/internal/deployment/Deployment.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/deployment/Deployment.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.internal.deployment;
+
+import io.vertx.core.*;
+
+import java.util.*;
+
+public interface Deployment {
+
+  /**
+   * @return the set of context of this deployment
+   */
+  Set<Context> contexts();
+
+  /**
+   * @return the set of deployable of this deployment
+   */
+  Set<Deployable> instances();
+
+  /**
+   * @return a copy of the deployment options
+   */
+  DeploymentOptions options();
+
+  /**
+   * @return the deployable identifier, e.g. java:MyVerticle
+   */
+  String identifier();
+
+  /**
+   * Deploy this deployment in its context
+   * @param context the context
+   * @return a future of the completion
+   */
+  Future<?> deploy(DeploymentContext context);
+
+  /**
+   * Undeploy this deployment
+   *
+   * @return a future of the completion
+   */
+  Future<?> undeploy();
+
+  /**
+   * Deployment cleanup.
+   *
+   * @return a future of the completion
+   */
+  Future<?> cleanup();
+
+}

--- a/vertx-core/src/main/java/io/vertx/core/internal/deployment/DeploymentContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/deployment/DeploymentContext.java
@@ -52,4 +52,6 @@ public interface DeploymentContext {
    */
   String id();
 
+  Deployment deployment();
+
 }

--- a/vertx-core/src/main/java/io/vertx/core/internal/deployment/DeploymentManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/deployment/DeploymentManager.java
@@ -9,11 +9,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
-package io.vertx.core.impl.deployment;
+package io.vertx.core.internal.deployment;
 
 import io.vertx.core.*;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.deployment.DeploymentContext;
 
 import java.util.*;
 

--- a/vertx-core/src/test/java/io/vertx/tests/deployment/DeploymentTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/deployment/DeploymentTest.java
@@ -13,11 +13,9 @@ package io.vertx.tests.deployment;
 
 import io.netty.channel.EventLoop;
 import io.vertx.core.*;
-import io.vertx.core.impl.VertxImpl;
-import io.vertx.core.impl.deployment.Deployment;
+import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.deployment.DeploymentContext;
-import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
@@ -537,8 +535,8 @@ public class DeploymentTest extends VertxTestBase {
     awaitLatch(deployLatch);
     assertWaitUntil(() -> deployCount.get() == numInstances);
     assertEquals(1, vertx.deploymentIDs().size());
-    DeploymentContext deployment = ((VertxImpl) vertx).deploymentManager().deployment(vertx.deploymentIDs().iterator().next());
-    Set<Deployable> verticles = Deployment.unwrap(deployment).instances();
+    DeploymentContext deployment = ((VertxInternal) vertx).deploymentManager().deployment(vertx.deploymentIDs().iterator().next());
+    Set<Deployable> verticles = deployment.deployment().instances();
     assertEquals(numInstances, verticles.size());
     CountDownLatch undeployLatch = new CountDownLatch(1);
     assertEquals(numInstances, deployCount.get());
@@ -1068,7 +1066,7 @@ public class DeploymentTest extends VertxTestBase {
     assertWaitUntil(() -> messageCount.get() == 3);
     assertEquals(9, totalReportedInstances.get());
     assertWaitUntil(() -> vertx.deploymentIDs().size() == 1);
-    DeploymentContext deployment = ((VertxImpl) vertx).deploymentManager().deployment(vertx.deploymentIDs().iterator().next());
+    DeploymentContext deployment = ((VertxInternal) vertx).deploymentManager().deployment(vertx.deploymentIDs().iterator().next());
     awaitFuture(vertx.undeploy(deployment.id()));
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/ha/ComplexHATest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/ha/ComplexHATest.java
@@ -16,9 +16,8 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.impl.VertxImpl;
-import io.vertx.core.impl.deployment.Deployment;
-import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.test.core.Repeat;
@@ -169,7 +168,7 @@ public class ComplexHATest extends VertxTestBase {
 
   protected Set<DeploymentContext> takeDeploymentSnapshot(int pos) {
     Set<DeploymentContext> snapshot = ConcurrentHashMap.newKeySet();
-    VertxImpl v = (VertxImpl)vertices[pos];
+    VertxInternal v = (VertxInternal)vertices[pos];
     for (String depID: v.deploymentIDs()) {
       snapshot.add(v.deploymentManager().deployment(depID));
     }
@@ -232,7 +231,7 @@ public class ComplexHATest extends VertxTestBase {
     for (DeploymentContext prev: prevSet) {
       boolean contains = false;
       for (DeploymentContext curr: currSet) {
-        if (Deployment.unwrap(curr).identifier().equals(Deployment.unwrap(prev).identifier()) && Deployment.unwrap(curr).options().toJson().equals(Deployment.unwrap(prev).options().toJson())) {
+        if (curr.deployment().identifier().equals(prev.deployment().identifier()) && curr.deployment().options().toJson().equals(prev.deployment().options().toJson())) {
           contains = true;
           break;
         }

--- a/vertx-core/src/test/java/io/vertx/tests/ha/HATest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/ha/HATest.java
@@ -15,9 +15,9 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.impl.VertxImpl;
-import io.vertx.core.impl.deployment.Deployment;
-import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.deployment.Deployment;
+import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.test.core.VertxTestBase;
@@ -268,7 +268,7 @@ public class HATest extends VertxTestBase {
 
     assertTrue(vertx1.deploymentIDs().size() == 1);
     String depID = vertx1.deploymentIDs().iterator().next();
-    assertTrue(Deployment.unwrap(((VertxImpl) vertx1).deploymentManager().deployment(depID)).identifier().equals("java:" + HAVerticle1.class.getName()));
+    assertTrue(((VertxInternal) vertx1).deploymentManager().deployment(depID).deployment().identifier().equals("java:" + HAVerticle1.class.getName()));
   }
 
   @Test
@@ -296,7 +296,7 @@ public class HATest extends VertxTestBase {
 
     assertTrue(vertx1.deploymentIDs().size() == 1);
     String depID = vertx1.deploymentIDs().iterator().next();
-    assertTrue(Deployment.unwrap(((VertxImpl) vertx1).deploymentManager().deployment(depID)).identifier().equals("java:" + HAVerticle1.class.getName()));
+    assertTrue(((VertxInternal) vertx1).deploymentManager().deployment(depID).deployment().identifier().equals("java:" + HAVerticle1.class.getName()));
   }
 
   @Test
@@ -392,7 +392,7 @@ public class HATest extends VertxTestBase {
     VertxImpl vi = (VertxImpl) vertices[pos];
     for (String deploymentID: vi.deploymentIDs()) {
       DeploymentContext dep = vi.deploymentManager().deployment(deploymentID);
-      if (verticleName.equals(Deployment.unwrap(dep).identifier()) && options.toJson().equals(Deployment.unwrap(dep).options().toJson())) {
+      if (verticleName.equals(dep.deployment().identifier()) && options.toJson().equals(dep.deployment().options().toJson())) {
         return;
       }
     }


### PR DESCRIPTION
Motivation:

The deployment manager API is currently an implementation, this API is used by Vert.x Shell to extract deployment information.

Changes:

Expose the deployment manager API.

Implementation cleanups.
