### PR TITLE
Make sure ContextBuilder defaults to EL threading model

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -11,17 +11,20 @@
 
 package io.vertx.core.eventbus.impl.clustered;
 
-import io.vertx.core.*;
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBusOptions;
 import io.vertx.core.eventbus.MessageCodec;
 import io.vertx.core.eventbus.impl.*;
+import io.vertx.core.impl.utils.ConcurrentCyclicSequence;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
-import io.vertx.core.impl.utils.ConcurrentCyclicSequence;
 import io.vertx.core.internal.net.NetSocketInternal;
 import io.vertx.core.net.*;
 import io.vertx.core.net.impl.NetClientBuilder;
@@ -77,7 +80,6 @@ public final class ClusteredEventBus extends EventBusImpl {
     this.clusterManager = clusterManager;
     this.nodeSelector = nodeSelector;
     this.context = vertx.contextBuilder()
-      .withThreadingModel(ThreadingModel.EVENT_LOOP)
       .withClassLoader(Thread.currentThread().getContextClassLoader())
       .withCloseFuture(new CloseFuture())
       .build();

--- a/vertx-core/src/main/java/io/vertx/core/impl/ContextBuilderImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ContextBuilderImpl.java
@@ -12,11 +12,15 @@ package io.vertx.core.impl;
 
 import io.netty.channel.EventLoop;
 import io.vertx.core.ThreadingModel;
-import io.vertx.core.internal.WorkerPool;
-import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextBuilder;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.WorkerPool;
+import io.vertx.core.internal.deployment.DeploymentContext;
+
+import java.util.Objects;
+
+import static io.vertx.core.ThreadingModel.EVENT_LOOP;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -31,30 +35,36 @@ public class ContextBuilderImpl implements ContextBuilder {
   private WorkerPool workerPool;
   private DeploymentContext deploymentContext;
 
-  public ContextBuilderImpl(VertxImpl vertx) {
-    this.vertx = vertx;
+  ContextBuilderImpl(VertxImpl vertx) {
+    this.vertx = Objects.requireNonNull(vertx);
+    this.threadingModel = EVENT_LOOP;
   }
 
+  @Override
   public ContextBuilderImpl withThreadingModel(ThreadingModel threadingModel) {
-    this.threadingModel = threadingModel;
+    this.threadingModel = Objects.requireNonNull(threadingModel);
     return this;
   }
 
+  @Override
   public ContextBuilderImpl withEventLoop(EventLoop eventLoop) {
     this.eventLoop = eventLoop;
     return this;
   }
 
+  @Override
   public ContextBuilderImpl withClassLoader(ClassLoader classLoader) {
     this.classLoader = classLoader;
     return this;
   }
 
+  @Override
   public ContextBuilderImpl withCloseFuture(CloseFuture closeFuture) {
     this.closeFuture = closeFuture;
     return this;
   }
 
+  @Override
   public ContextBuilderImpl withWorkerPool(WorkerPool workerPool) {
     this.workerPool = workerPool;
     return this;
@@ -65,6 +75,7 @@ public class ContextBuilderImpl implements ContextBuilder {
     return this;
   }
 
+  @Override
   public ContextInternal build() {
     EventLoop eventLoop = this.eventLoop;
     if (eventLoop == null) {

--- a/vertx-core/src/main/java/io/vertx/core/impl/deployment/DefaultDeployment.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/deployment/DefaultDeployment.java
@@ -124,57 +124,45 @@ public class DefaultDeployment implements Deployment {
   public Future<?> deploy(DeploymentContext deployment) {
     EventLoop workerLoop = null;
     List<Future<?>> futures = new ArrayList<>();
-    for (Deployable verticle: deployables) {
+    for (Deployable verticle : deployables) {
       CloseFuture closeFuture = new CloseFuture(log);
+      ContextBuilderImpl contextBuilder = ((ContextBuilderImpl) vertx.contextBuilder())
+        .withDeploymentContext(deployment)
+        .withCloseFuture(closeFuture)
+        .withClassLoader(tccl);
       ContextInternal context;
       switch (threading) {
         case WORKER:
           if (workerLoop == null) {
-            context = ((ContextBuilderImpl)vertx.contextBuilder())
+            context = contextBuilder
               .withThreadingModel(ThreadingModel.WORKER)
-              .withDeploymentContext(deployment)
-              .withCloseFuture(closeFuture)
               .withWorkerPool(workerPool)
-              .withClassLoader(tccl)
               .build();
             workerLoop = context.nettyEventLoop();
           } else {
-            context = ((ContextBuilderImpl)vertx.contextBuilder())
+            context = contextBuilder
               .withThreadingModel(ThreadingModel.WORKER)
               .withEventLoop(workerLoop)
-              .withDeploymentContext(deployment)
-              .withCloseFuture(closeFuture)
               .withWorkerPool(workerPool)
-              .withClassLoader(tccl)
               .build();
           }
           break;
         case VIRTUAL_THREAD:
           if (workerLoop == null) {
-            context = ((ContextBuilderImpl)vertx.contextBuilder())
+            context = contextBuilder
               .withThreadingModel(ThreadingModel.VIRTUAL_THREAD)
-              .withDeploymentContext(deployment)
-              .withCloseFuture(closeFuture)
-              .withClassLoader(tccl)
               .build();
             workerLoop = context.nettyEventLoop();
           } else {
-            context = ((ContextBuilderImpl)vertx.contextBuilder())
+            context = contextBuilder
               .withThreadingModel(ThreadingModel.VIRTUAL_THREAD)
               .withEventLoop(workerLoop)
-              .withDeploymentContext(deployment)
-              .withCloseFuture(closeFuture)
-              .withClassLoader(tccl)
               .build();
           }
           break;
         default:
-          context = ((ContextBuilderImpl)vertx.contextBuilder())
-            .withThreadingModel(ThreadingModel.EVENT_LOOP)
-            .withDeploymentContext(deployment)
-            .withCloseFuture(closeFuture)
+          context = contextBuilder
             .withWorkerPool(workerPool)
-            .withClassLoader(tccl)
             .build();
           break;
       }

--- a/vertx-core/src/main/java/io/vertx/core/internal/pool/ConnectionPool.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/pool/ConnectionPool.java
@@ -13,7 +13,6 @@ package io.vertx.core.internal.pool;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.ThreadingModel;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 
@@ -34,7 +33,6 @@ public interface ConnectionPool<C> {
   Function<ContextInternal, ContextInternal> EVENT_LOOP_CONTEXT_PROVIDER = ctx -> {
     VertxInternal vertx = ctx.owner();
     return vertx.contextBuilder()
-      .withThreadingModel(ThreadingModel.EVENT_LOOP)
       .withEventLoop(ctx.nettyEventLoop())
       .withWorkerPool(vertx.workerPool())
       .build();

--- a/vertx-core/src/test/java/io/vertx/tests/benchmark/Http1xServerConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/benchmark/Http1xServerConnectionTest.java
@@ -14,7 +14,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.vertx.core.Handler;
-import io.vertx.core.ThreadingModel;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
@@ -51,7 +50,6 @@ public class Http1xServerConnectionTest extends VertxTestBase {
 
     ContextInternal context = vertx
       .contextBuilder()
-      .withThreadingModel(ThreadingModel.EVENT_LOOP)
       .withEventLoop(vertxChannel.eventLoop())
       .withClassLoader(Thread.currentThread().getContextClassLoader())
       .build();

--- a/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
@@ -14,7 +14,8 @@ package io.vertx.tests.context;
 import io.netty.channel.EventLoop;
 import io.vertx.core.*;
 import io.vertx.core.Future;
-import io.vertx.core.impl.*;
+import io.vertx.core.impl.VertxImpl;
+import io.vertx.core.impl.VertxThread;
 import io.vertx.core.internal.*;
 import io.vertx.core.spi.context.storage.AccessMode;
 import io.vertx.core.spi.context.storage.ContextLocal;
@@ -1005,13 +1006,11 @@ public class ContextTest extends VertxTestBase {
     VertxImpl impl = (VertxImpl) vertx;
     ContextInternal ctx1 = impl
       .contextBuilder()
-      .withThreadingModel(ThreadingModel.EVENT_LOOP)
       .withEventLoop(impl.eventLoopGroup().next())
       .withClassLoader(tccl1)
       .build();
     ContextInternal ctx2 = impl
       .contextBuilder()
-      .withThreadingModel(ThreadingModel.EVENT_LOOP)
       .withEventLoop(impl.eventLoopGroup().next())
       .withClassLoader(tccl2)
       .build();

--- a/vertx-core/src/test/java/io/vertx/tests/net/ConnectionBaseTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/ConnectionBaseTest.java
@@ -17,15 +17,14 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.ThreadingModel;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.buffer.BufferInternal;
+import io.vertx.core.internal.net.NetSocketInternal;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetSocket;
-import io.vertx.core.internal.net.NetSocketInternal;
 import io.vertx.core.net.impl.VertxConnection;
 import io.vertx.core.net.impl.VertxHandler;
 import io.vertx.core.transport.Transport;
@@ -602,7 +601,6 @@ public class ConnectionBaseTest extends VertxTestBase {
     return new EmbeddedChannel(VertxHandler.create(chctx -> {
       ContextInternal ctx = ((VertxInternal)vertx)
         .contextBuilder()
-        .withThreadingModel(ThreadingModel.EVENT_LOOP)
         .withEventLoop(chctx.channel().eventLoop())
         .build();
       return connectionFactory.apply(ctx, chctx);
@@ -614,7 +612,6 @@ public class ConnectionBaseTest extends VertxTestBase {
     public TestConnection(ChannelHandlerContext chctx) {
       super(((VertxInternal)ConnectionBaseTest.this.vertx)
         .contextBuilder()
-        .withThreadingModel(ThreadingModel.EVENT_LOOP)
         .withEventLoop((EventLoop) chctx.executor())
         .build(), chctx);
     }

--- a/vertx-core/src/test/java/io/vertx/tests/pool/ConnectionPoolTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/pool/ConnectionPoolTest.java
@@ -12,7 +12,6 @@ package io.vertx.tests.pool;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.ThreadingModel;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.ConnectionPoolTooBusyException;
 import io.vertx.core.impl.ContextImpl;
@@ -978,7 +977,6 @@ public class ConnectionPoolTest extends VertxTestBase {
     CountDownLatch latch3 = new CountDownLatch(1);
     ContextInternal context2 = vertx
       .contextBuilder()
-      .withThreadingModel(ThreadingModel.EVENT_LOOP)
       .withEventLoop(context1.nettyEventLoop())
       .withWorkerPool(context1.workerPool())
       .withClassLoader(context1.classLoader())


### PR DESCRIPTION
The Javadoc implies that it is the default, but the implementation leaves it to null, forcing callers to set the EL model everywhere.

With this change, EL threading model is the default and invoking the withThreadingModel method with a null parameter is forbidden.