### PR TITLE
make sure after resume we just deliver one message at one moment

### DIFF
--- a/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/LocalEventBusTest.java
@@ -1401,7 +1401,6 @@ public class LocalEventBusTest extends EventBusTestBase {
       eb.send(ADDRESS1, "val1");
       Context ctx = Vertx.currentContext();
       ctx.runOnContext(v -> {
-        consumer.resume();
         ((MessageConsumerImpl<?>) consumer).discardHandler(discarded -> {
           assertEquals("val1", discarded.body());
           testComplete();


### PR DESCRIPTION
Motivation:

I had a [change](https://github.com/eclipse-vertx/vert.x/pull/5457) recently in 4.5.13 (not a lucky number)
After upgrading to this version we have noticed after resume we do receive more than one message at one moment.
First I extended the test to reproduce the case... and after that I done the prod code change.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
