### PR TITLE
ReadStream can be adapted to a Java blocking stream

### DIFF
--- a/vertx-core/src/main/asciidoc/virtualthreads.adoc
+++ b/vertx-core/src/main/asciidoc/virtualthreads.adoc
@@ -6,7 +6,7 @@ You still write the traditional Vert.x code processing events, but you have the 
 
 === Introduction
 
-The non-blocking nature of Vert.x leads to asynchronous APIs. 
+The non-blocking nature of Vert.x leads to asynchronous APIs.
 Asynchronous APIs can take various forms including callback style, promises and reactive extensions.
 
 In some cases, programming using asynchronous APIs can be more challenging than using a direct synchronous style, in particular if you have several operations that you want to do sequentially.
@@ -55,6 +55,13 @@ or on a JDK `CompletionStage`
 [source,java]
 ----
 {@link examples.VirtualThreadExamples#awaitingFutures2}
+----
+
+You can also transform a Vert.x `ReadStream` to a Java blocking stream:
+
+[source,java]
+----
+{@link examples.VirtualThreadExamples#blockingStream}
 ----
 
 ==== Field visibility

--- a/vertx-core/src/main/java/examples/VirtualThreadExamples.java
+++ b/vertx-core/src/main/java/examples/VirtualThreadExamples.java
@@ -16,6 +16,7 @@ import io.vertx.core.http.*;
 import io.vertx.docgen.Source;
 
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
 
 @Source
 public class VirtualThreadExamples {
@@ -91,6 +92,18 @@ public class VirtualThreadExamples {
 
   public void awaitingFutures2(HttpClientResponse response, CompletionStage<Buffer> completionStage) {
     Buffer body = Future.fromCompletionStage(completionStage).await();
+  }
+
+  public void blockingStream(HttpServer server) {
+    server.requestHandler(request -> {
+      Stream<Buffer> blockingStream = request.blockingStream();
+      HttpServerResponse response = request.response();
+      response.setChunked(true);
+      blockingStream
+        .map(buff -> "" + buff.length())
+        .forEach(size -> response.write(size));
+      response.end();
+    });
   }
 
   private Future<String> getRemoteString() {

--- a/vertx-core/src/main/java/io/vertx/core/internal/streams/ReadStreamIterator.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/streams/ReadStreamIterator.java
@@ -116,7 +116,7 @@ public class ReadStreamIterator<E> implements Iterator<E>, Handler<E> {
           return true;
         }
         if (ended != null) {
-          return false;
+          return ended != END_SENTINEL;
         }
         awaitProgress();
       }

--- a/vertx-core/src/main/java/io/vertx/core/streams/ReadStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/streams/ReadStream.java
@@ -19,9 +19,15 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.PromiseInternal;
+import io.vertx.core.internal.streams.ReadStreamIterator;
 import io.vertx.core.streams.impl.PipeImpl;
 
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Represents a stream of items that can be read from.
@@ -133,6 +139,18 @@ public interface ReadStream<T> extends StreamBase {
     });
     exceptionHandler(promise::tryFail);
     return promise.future();
+  }
+
+  /**
+   * Adapt this {@code ReadStream} to a blocking sequential {@code Stream}, the return stream usage is restricted to
+   * non vertx threads or vertx virtual threads.
+   *
+   * @return a blocking stream
+   */
+  @GenIgnore
+  default Stream<T> blockingStream() {
+    Iterator<T> iterator = ReadStreamIterator.iterator(this);
+    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
   }
 
   /**


### PR DESCRIPTION
Motivation:

The Vert.x virtual stream programming model provides async/await to interact with asynchronous futures, yet the stream approach has been left naked.

Changes:

A new `ReadStream` blockingStream default method is added to convert a `ReadStream` to a `java.util.stream.Stream`.

This blocking stream can be used from a Vert.x virtual thread or a non Vert.x thread.

When used from a Vert.x virtual thread, each blocking interaction with the stream suspends the virtual thread and release the context ownership to let other tasks process tasks, allowing the context execution to happen and handle pending context tasks.