### PR TITLE
Support max lifetime on HTTP Client pool

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/PoolOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/PoolOptions.java
@@ -15,6 +15,8 @@ import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.impl.Arguments;
 import io.vertx.core.json.JsonObject;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Options configuring a {@link HttpClient} pool.
  *
@@ -40,6 +42,16 @@ public class PoolOptions {
   public static final int DEFAULT_MAX_WAIT_QUEUE_SIZE = -1;
 
   /**
+   * Default maximum pooled connection lifetime = 0 (no maximum)
+   */
+  public static final int DEFAULT_MAXIMUM_LIFETIME = 0;
+
+  /**
+   * Default maximum pooled connection lifetime unit = seconds
+   */
+  public static final TimeUnit DEFAULT_MAXIMUM_LIFETIME_TIME_UNIT = TimeUnit.SECONDS;
+
+  /**
    * Default pool cleaner period = 1000 ms (1 second)
    */
   public static final int DEFAULT_POOL_CLEANER_PERIOD = 1000;
@@ -51,6 +63,8 @@ public class PoolOptions {
 
   private int http1MaxSize;
   private int http2MaxSize;
+  private int maxLifetime;
+  private TimeUnit maxLifetimeUnit;
   private int cleanerPeriod;
   private int eventLoopSize;
   private int maxWaitQueueSize;
@@ -61,6 +75,8 @@ public class PoolOptions {
   public PoolOptions() {
     http1MaxSize = DEFAULT_MAX_POOL_SIZE;
     http2MaxSize = DEFAULT_HTTP2_MAX_POOL_SIZE;
+    maxLifetime = DEFAULT_MAXIMUM_LIFETIME;
+    maxLifetimeUnit = DEFAULT_MAXIMUM_LIFETIME_TIME_UNIT;
     cleanerPeriod = DEFAULT_POOL_CLEANER_PERIOD;
     eventLoopSize = DEFAULT_POOL_EVENT_LOOP_SIZE;
     maxWaitQueueSize = DEFAULT_MAX_WAIT_QUEUE_SIZE;
@@ -74,6 +90,8 @@ public class PoolOptions {
   public PoolOptions(PoolOptions other) {
     this.http1MaxSize = other.http1MaxSize;
     this.http2MaxSize = other.http2MaxSize;
+    maxLifetime = other.maxLifetime;
+    maxLifetimeUnit = other.maxLifetimeUnit;
     this.cleanerPeriod = other.cleanerPeriod;
     this.eventLoopSize = other.eventLoopSize;
     this.maxWaitQueueSize = other.maxWaitQueueSize;
@@ -131,6 +149,45 @@ public class PoolOptions {
       throw new IllegalArgumentException("http2MaxPoolSize must be > 0");
     }
     this.http2MaxSize = max;
+    return this;
+  }
+
+  /**
+   * @return the pooled connection max lifetime unit
+   */
+  public TimeUnit getMaxLifetimeUnit() {
+    return maxLifetimeUnit;
+  }
+
+  /**
+   * Establish a max lifetime unit for pooled connections.
+   *
+   * @param maxLifetimeUnit pooled connection max lifetime unit
+   * @return a reference to this, so the API can be used fluently
+   */
+  public PoolOptions setMaxLifetimeUnit(TimeUnit maxLifetimeUnit) {
+    this.maxLifetimeUnit = maxLifetimeUnit;
+    return this;
+  }
+
+  /**
+   * @return pooled connection max lifetime
+   */
+  public int getMaxLifetime() {
+    return maxLifetime;
+  }
+
+  /**
+   * Establish a max lifetime for pooled connections, a value of zero disables the maximum lifetime.
+   *
+   * @param maxLifetime the pool connection max lifetime
+   * @return a reference to this, so the API can be used fluently
+   */
+  public PoolOptions setMaxLifetime(int maxLifetime) {
+    if (maxLifetime < 0) {
+      throw new IllegalArgumentException("maxLifetime must be >= 0");
+    }
+    this.maxLifetime = maxLifetime;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -18,10 +18,10 @@ import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.compression.Brotli;
 import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.compression.Zstd;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.*;
-import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.websocketx.*;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandshaker;
 import io.netty.handler.codec.http.websocketx.extensions.compression.DeflateFrameClientExtensionHandshaker;
@@ -32,19 +32,21 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.WebSocketVersion;
-import io.vertx.core.internal.buffer.BufferInternal;
+import io.vertx.core.http.*;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
-import io.vertx.core.http.*;
+import io.vertx.core.http.WebSocketVersion;
 import io.vertx.core.http.impl.headers.HeadersAdaptor;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
+import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.internal.concurrent.InboundMessageQueue;
+import io.vertx.core.internal.net.NetSocketInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.net.impl.*;
-import io.vertx.core.internal.net.NetSocketInternal;
+import io.vertx.core.net.impl.MessageWrite;
+import io.vertx.core.net.impl.NetSocketImpl;
+import io.vertx.core.net.impl.VertxHandler;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
 import io.vertx.core.spi.tracing.SpanKind;
@@ -75,6 +77,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
   public final ClientMetrics metrics;
   private final HttpVersion version;
   private final boolean pooled;
+  private final long lifetimeEvictionTimestamp;
 
   private final Deque<Stream> requests = new ArrayDeque<>();
   private final Deque<Stream> responses = new ArrayDeque<>();
@@ -100,7 +103,8 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
                          HostAndPort authority,
                          ContextInternal context,
                          ClientMetrics metrics,
-                         boolean pooled) {
+                         boolean pooled,
+                         long maxLifetime) {
     super(context, chctx);
     this.client = client;
     this.options = client.options();
@@ -109,6 +113,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
     this.authority = authority;
     this.metrics = metrics;
     this.version = version;
+    this.lifetimeEvictionTimestamp = maxLifetime > 0 ? System.currentTimeMillis() + maxLifetime : Long.MAX_VALUE;
     this.keepAliveTimeout = options.getKeepAliveTimeout();
     this.expirationTimestamp = expirationTimestampOf(keepAliveTimeout);
     this.pooled = pooled;
@@ -1261,7 +1266,8 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
 
   @Override
   public boolean isValid() {
-    return expirationTimestamp == 0 || System.currentTimeMillis() <= expirationTimestamp;
+    long now = System.currentTimeMillis();
+    return now <= expirationTimestamp && now <= lifetimeEvictionTimestamp;
   }
 
   /**
@@ -1271,6 +1277,6 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
    * @return the expiration timestamp
    */
   private static long expirationTimestampOf(long timeout) {
-    return timeout == 0 ? 0L : System.currentTimeMillis() + timeout * 1000;
+    return timeout > 0 ? System.currentTimeMillis() + timeout * 1000 : Long.MAX_VALUE;
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -12,7 +12,6 @@ package io.vertx.core.http.impl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
@@ -21,7 +20,10 @@ import io.netty.handler.codec.http.*;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
 import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.*;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.http.HttpVersion;
@@ -53,6 +55,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
 
   private HttpClientBase client;
   private HttpClientConnectionInternal current;
+  private final long maxLifetime;
   private boolean upgradeProcessed;
 
   private Handler<Void> closeHandler;
@@ -65,9 +68,10 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
   private Handler<Long> concurrencyChangeHandler;
   private Handler<Http2Settings> remoteSettingsHandler;
 
-  Http2UpgradeClientConnection(HttpClientBase client, Http1xClientConnection connection) {
+  Http2UpgradeClientConnection(HttpClientBase client, Http1xClientConnection connection, long maxLifetime) {
     this.client = client;
     this.current = connection;
+    this.maxLifetime = maxLifetime;
   }
 
   public HttpClientConnectionInternal unwrap() {
@@ -277,6 +281,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
     private final Http1xClientConnection upgradingConnection;
     private final HttpClientStream upgradingStream;
     private final Http2UpgradeClientConnection upgradedConnection;
+    private final long maxLifetime;
     private HttpClientStream upgradedStream;
     private Handler<HttpResponseHead> headHandler;
     private Handler<Buffer> chunkHandler;
@@ -290,10 +295,11 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
     private Handler<HttpFrame> unknownFrameHandler;
     private Handler<Void> closeHandler;
 
-    UpgradingStream(HttpClientStream stream, Http2UpgradeClientConnection upgradedConnection, Http1xClientConnection upgradingConnection) {
+    UpgradingStream(HttpClientStream stream, Http2UpgradeClientConnection upgradedConnection, Http1xClientConnection upgradingConnection, long maxLifetime) {
       this.upgradedConnection = upgradedConnection;
       this.upgradingConnection = upgradingConnection;
       this.upgradingStream = stream;
+      this.maxLifetime = maxLifetime;
     }
 
     @Override
@@ -354,7 +360,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
         public void upgradeTo(ChannelHandlerContext ctx, FullHttpResponse upgradeResponse) throws Exception {
 
           // Now we need to upgrade this to an HTTP2
-          VertxHttp2ConnectionHandler<Http2ClientConnection> handler = Http2ClientConnection.createHttp2ConnectionHandler(upgradedConnection.client, upgradingConnection.metrics, upgradingConnection.context(), true, upgradedConnection.current.metric(), upgradedConnection.current.authority(), upgradingConnection.pooled());
+          VertxHttp2ConnectionHandler<Http2ClientConnection> handler = Http2ClientConnection.createHttp2ConnectionHandler(upgradedConnection.client, upgradingConnection.metrics, upgradingConnection.context(), true, upgradedConnection.current.metric(), upgradedConnection.current.authority(), upgradingConnection.pooled(), maxLifetime);
           upgradingConnection.channel().pipeline().addLast(handler);
           handler.connectFuture().addListener(future -> {
             if (!future.isSuccess()) {
@@ -782,7 +788,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
     if (current instanceof Http1xClientConnection && !upgradeProcessed) {
       return current
         .createStream(context)
-        .map(stream -> new UpgradingStream(stream, this, (Http1xClientConnection) current));
+        .map(stream -> new UpgradingStream(stream, this, (Http1xClientConnection) current, maxLifetime));
     } else {
       return current
         .createStream(context)

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -15,29 +15,31 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
+import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.http.HttpClientInternal;
+import io.vertx.core.internal.net.endpoint.EndpointResolverInternal;
 import io.vertx.core.internal.pool.ConnectionPool;
 import io.vertx.core.internal.pool.Lease;
-import io.vertx.core.net.endpoint.Endpoint;
-import io.vertx.core.net.endpoint.impl.EndpointResolverImpl;
-import io.vertx.core.http.*;
-import io.vertx.core.net.*;
-import io.vertx.core.internal.net.endpoint.EndpointResolverInternal;
-import io.vertx.core.net.endpoint.ServerInteraction;
 import io.vertx.core.internal.resource.ResourceManager;
+import io.vertx.core.net.*;
+import io.vertx.core.net.endpoint.Endpoint;
+import io.vertx.core.net.endpoint.EndpointResolver;
+import io.vertx.core.net.endpoint.ServerInteraction;
+import io.vertx.core.net.endpoint.impl.EndpointResolverImpl;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
-import io.vertx.core.net.endpoint.EndpointResolver;
 import io.vertx.core.spi.metrics.PoolMetrics;
 
 import java.lang.ref.WeakReference;
-import java.util.*;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -54,6 +56,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   private long timerID;
   private volatile Handler<HttpConnection> connectionHandler;
   private final Function<ContextInternal, ContextInternal> contextProvider;
+  private final long maxLifetime;
 
   public HttpClientImpl(VertxInternal vertx,
                         EndpointResolver endpointResolver,
@@ -64,11 +67,12 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     this.endpointResolver = (EndpointResolverImpl) endpointResolver;
     this.poolOptions = poolOptions;
     httpCM = new ResourceManager<>();
-    if (poolOptions.getCleanerPeriod() > 0 && (options.getKeepAliveTimeout() > 0L || options.getHttp2KeepAliveTimeout() > 0L)) {
+    if (poolCheckerIsNeeded(options, poolOptions)) {
       PoolChecker checker = new PoolChecker(this);
       ContextInternal timerContext = vertx.createEventLoopContext();
       timerID = timerContext.setTimer(poolOptions.getCleanerPeriod(), checker);
     }
+    this.maxLifetime = MILLISECONDS.convert(poolOptions.getMaxLifetime(), poolOptions.getMaxLifetimeUnit());
     int eventLoopSize = poolOptions.getEventLoopSize();
     if (eventLoopSize > 0) {
       ContextInternal[] eventLoops = new ContextInternal[eventLoopSize];
@@ -83,6 +87,10 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     } else {
       contextProvider = ConnectionPool.EVENT_LOOP_CONTEXT_PROVIDER;
     }
+  }
+
+  private static boolean poolCheckerIsNeeded(HttpClientOptions options, PoolOptions poolOptions) {
+    return poolOptions.getCleanerPeriod() > 0 && (options.getKeepAliveTimeout() > 0L || options.getHttp2KeepAliveTimeout() > 0L || poolOptions.getMaxLifetime() > 0L);
   }
 
   Function<ContextInternal, ContextInternal> contextProvider() {
@@ -132,7 +140,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
         key = new EndpointKey(key.ssl, key.sslOptions, proxyOptions, server, key.authority);
         proxyOptions = null;
       }
-      HttpChannelConnector connector = new HttpChannelConnector(HttpClientImpl.this, netClient, key.sslOptions, proxyOptions, clientMetrics, options.getProtocolVersion(), key.ssl, options.isUseAlpn(), key.authority, key.server, true);
+      HttpChannelConnector connector = new HttpChannelConnector(HttpClientImpl.this, netClient, key.sslOptions, proxyOptions, clientMetrics, options.getProtocolVersion(), key.ssl, options.isUseAlpn(), key.authority, key.server, true, maxLifetime);
       return new SharedHttpClientConnectionGroup(
         vertx,
         HttpClientImpl.this,
@@ -235,7 +243,8 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
       useAlpn,
       authority,
       server,
-      false);
+      false,
+      0);
     return (Future) connector.httpConnect(vertx.getOrCreateContext()).map(conn -> new UnpooledHttpClientConnection(conn).init());
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
@@ -15,13 +15,13 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.PromiseInternal;
+import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.resource.ResourceManager;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.internal.resource.ResourceManager;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.PoolMetrics;
 
@@ -70,7 +70,7 @@ public class WebSocketClientImpl extends HttpClientBase implements WebSocketClie
       int maxPoolSize = options.getMaxConnections();
       ClientMetrics clientMetrics = WebSocketClientImpl.this.metrics != null ? WebSocketClientImpl.this.metrics.createEndpointMetrics(key_.server, maxPoolSize) : null;
       PoolMetrics queueMetrics = WebSocketClientImpl.this.metrics != null ? vertx.metrics().createPoolMetrics("ws", key_.server.toString(), maxPoolSize) : null;
-      HttpChannelConnector connector = new HttpChannelConnector(WebSocketClientImpl.this, netClient, sslOptions, key_.proxyOptions, clientMetrics, HttpVersion.HTTP_1_1, key_.ssl, false, key_.authority, key_.server, false);
+      HttpChannelConnector connector = new HttpChannelConnector(WebSocketClientImpl.this, netClient, sslOptions, key_.proxyOptions, clientMetrics, HttpVersion.HTTP_1_1, key_.ssl, false, key_.authority, key_.server, false, 0);
       return new WebSocketGroup(null, queueMetrics, options, maxPoolSize, connector);
     };
     webSocketCM

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -18,8 +18,8 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.Future;
 import io.vertx.core.*;
+import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.http.*;
@@ -5201,6 +5201,45 @@ public abstract class HttpTest extends HttpTestBase {
       }))));
     await();
   }
+
+  @Test
+  public void testMaxLifetime() throws Exception {
+    waitFor(2);
+
+    int poolCleanerPeriod = 100;
+    int maxLifetime = 3000;
+    server
+      .connectionHandler(conn -> {
+        long now = System.currentTimeMillis();
+        conn.closeHandler(v -> {
+          long lifetime = System.currentTimeMillis() - now;
+          int delta = 500;
+          int lowerBound = maxLifetime - poolCleanerPeriod - delta;
+          assertTrue("Was expecting connection to be closed in more than " + lowerBound + ": " + lifetime, lifetime >= lowerBound);
+          int upperBound = maxLifetime + poolCleanerPeriod + delta;
+          assertTrue("Was expecting connection to be closed in less than " + upperBound + ": " + lifetime, lifetime <= upperBound);
+          complete();
+        });
+      })
+      .requestHandler(req -> {
+        req.response().end();
+      });
+    startServer(testAddress);
+
+    client.close();
+    PoolOptions poolOptions = new PoolOptions()
+      .setCleanerPeriod(poolCleanerPeriod)
+      .setMaxLifetime(maxLifetime)
+      .setMaxLifetimeUnit(TimeUnit.MILLISECONDS);
+    client = vertx.createHttpClient(createBaseClientOptions(), poolOptions);
+
+    // Create a connection that remains in the pool
+    client.request(requestOptions)
+      .compose(req -> req.send().compose(resp -> resp.body().<Void>mapEmpty()))
+      .onComplete(onSuccess(v -> complete()));
+    await();
+  }
+
 
   @Test
   public void testHttpConnect() {


### PR DESCRIPTION
Closes #5360

It would help in some cases:

- make sure a connection does not live longer than authorized by some firewall
- give an opportunity to the client to find new backend replicas started after the pool reached its maximum size