### PR TITLE
Use an implementation of ChannelPromise that delegates to a Vert.x promise

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -29,7 +29,6 @@ import io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageD
 import io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
@@ -235,7 +234,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
   private static boolean isZstdAvailable() {
     return Zstd.isAvailable();
   }
-  private void beginRequest(Stream stream, HttpRequestHead request, boolean chunked, ByteBuf buf, boolean end, boolean connect, PromiseInternal<Void> promise) {
+  private void beginRequest(Stream stream, HttpRequestHead request, boolean chunked, ByteBuf buf, boolean end, boolean connect, Promise<Void> promise) {
     request.id = stream.id;
     request.remoteAddress = remoteAddress();
     stream.bytesWritten += buf != null ? buf.readableBytes() : 0L;
@@ -262,18 +261,16 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
     }
   }
 
-  private void writeBuffer(Stream s, ByteBuf buff, boolean end, FutureListener<Void> listener) {
+  private void writeBufferToChannel(Stream s, ByteBuf buff, boolean end, Promise<Void> listener) {
     s.bytesWritten += buff != null ? buff.readableBytes() : 0L;
     Object msg;
     if (isConnect) {
       msg = buff != null ? buff : Unpooled.EMPTY_BUFFER;
       if (end) {
-        write(msg, false, channelFuture()
-          .addListener(listener)
-          .addListener(v -> closeInternal())
-        );
+        write(msg, false, listener)
+          .addListener(v -> closeInternal());
       } else {
-        write(msg, false, voidPromise);
+        write(msg, false);
       }
     } else {
       if (end) {
@@ -333,7 +330,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
     return false;
   }
 
-  private void writeHead(Stream stream, HttpRequestHead request, boolean chunked, ByteBuf buf, boolean end, boolean connect, PromiseInternal<Void> listener) {
+  private void writeHead(Stream stream, HttpRequestHead request, boolean chunked, ByteBuf buf, boolean end, boolean connect, Promise<Void> listener) {
     writeToChannel(new MessageWrite() {
       @Override
       public void write() {
@@ -351,7 +348,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
     });
   }
 
-  private void writeBuffer(Stream stream, ByteBuf buff, boolean end, PromiseInternal<Void> listener) {
+  private void writeBuffer(Stream stream, ByteBuf buff, boolean end, Promise<Void> listener) {
     writeToChannel(new MessageWrite() {
       @Override
       public void write() {
@@ -359,7 +356,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
           listener.fail("Stream reset");
           return;
         }
-        writeBuffer(stream, buff, end, (FutureListener<Void>)listener);
+        writeBufferToChannel(stream, buff, end, listener);
       }
 
       @Override
@@ -558,7 +555,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
     @Override
     public Future<Void> writeBuffer(ByteBuf buff, boolean end) {
       if (buff != null || end) {
-        PromiseInternal<Void> listener = context.promise();
+        Promise<Void> listener = context.promise();
         conn.writeBuffer(this, buff, end, listener);
         return listener.future();
       } else {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerConnection.java
@@ -198,11 +198,11 @@ public class Http1xServerConnection extends Http1xConnection implements HttpServ
     }
   }
 
-  void write(HttpObject msg, PromiseInternal<Void> promise) {
+  void write(HttpObject msg, Promise<Void> promise) {
     writeToChannel(new MessageWrite() {
       @Override
       public void write() {
-        Http1xServerConnection.this.write(msg, false, promise == null ? voidPromise : wrap(promise));
+        Http1xServerConnection.this.write(msg, false, promise);
         if (msg instanceof LastHttpContent) {
           responseComplete();
         }
@@ -236,7 +236,7 @@ public class Http1xServerConnection extends Http1xConnection implements HttpServ
           }
         }
       } else {
-        ChannelPromise channelFuture = channelFuture();
+        ChannelPromise channelFuture = newChannelPromise();
         writeToChannel(Unpooled.EMPTY_BUFFER, channelFuture);
         channelFuture.addListener(fut -> fail(result.cause()));
       }
@@ -426,13 +426,13 @@ public class Http1xServerConnection extends Http1xConnection implements HttpServ
     chctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE), promise);
   }
 
-  void write103EarlyHints(HttpHeaders headers, PromiseInternal<Void> promise) {
+  void write103EarlyHints(HttpHeaders headers, Promise<Void> promise) {
     chctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1,
       HttpResponseStatus.EARLY_HINTS,
       Unpooled.buffer(0),
       headers,
       EmptyHttpHeaders.INSTANCE
-    )).addListener(promise);
+    ), newChannelPromise(promise));
   }
 
   protected void handleClosed() {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -23,6 +23,7 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.eventbus.EventBus;
@@ -305,7 +306,7 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
       if (isClosed()) {
         return context.failedFuture("WebSocket is closed");
       }
-      PromiseInternal<Void> promise = context.promise();
+      Promise<Void> promise = context.promise();
       conn.writeToChannel(encodeFrame((WebSocketFrameImpl) frame), promise);
       return promise.future();
     }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -425,8 +425,12 @@ public abstract class ConnectionBase {
     }
   }
 
-  public ChannelPromise channelFuture() {
+  public ChannelPromise newChannelPromise() {
     return chctx.newPromise();
+  }
+
+  public ChannelPromise newChannelPromise(Promise<Void> promise) {
+    return new DelegatingChannelPromise(promise, channel());
   }
 
   public String remoteName() {

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/DelegatingChannelPromise.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/DelegatingChannelPromise.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net.impl;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPromise;
+import io.netty.util.concurrent.AbstractFuture;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.vertx.core.Promise;
+import io.vertx.core.impl.future.FutureBase;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+class DelegatingChannelPromise extends AbstractFuture<Void> implements ChannelPromise {
+
+  private ChannelPromise bridge;
+  private final Channel channel;
+  private final Promise<Void> promise;
+
+  DelegatingChannelPromise(Promise<Void> promise, Channel channel) {
+    this.channel = Objects.requireNonNull(channel);
+    this.promise = Objects.requireNonNull(promise);
+  }
+
+  @Override
+  public Channel channel() {
+    return channel;
+  }
+
+  @Override
+  public ChannelPromise setSuccess(Void result) {
+    return setSuccess();
+  }
+
+  @Override
+  public ChannelPromise setSuccess() {
+    promise.succeed();
+    return this;
+  }
+
+  @Override
+  public boolean trySuccess() {
+    return promise.tryComplete();
+  }
+
+  @Override
+  public ChannelPromise setFailure(Throwable cause) {
+    promise.tryFail(cause);
+    return this;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public ChannelPromise addListener(GenericFutureListener<? extends Future<? super Void>> listener) {
+    bridge().addListeners(listener);
+    return this;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public ChannelPromise addListeners(GenericFutureListener<? extends Future<? super Void>>... listeners) {
+    bridge().addListeners(listeners);
+    return this;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public ChannelPromise removeListener(GenericFutureListener<? extends Future<? super Void>> listener) {
+    bridge().removeListeners(listener);
+    return this;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public ChannelPromise removeListeners(GenericFutureListener<? extends Future<? super Void>>... listeners) {
+    bridge().removeListeners(listeners);
+    return this;
+  }
+
+  @Override
+  public ChannelPromise sync() throws InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ChannelPromise syncUninterruptibly() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ChannelPromise await() throws InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ChannelPromise awaitUninterruptibly() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ChannelPromise unvoid() {
+    return this;
+  }
+
+  @Override
+  public boolean isVoid() {
+    return false;
+  }
+
+  @Override
+  public boolean trySuccess(Void result) {
+    return promise.tryComplete();
+  }
+
+  @Override
+  public boolean tryFailure(Throwable cause) {
+    return promise.tryFail(cause);
+  }
+
+  @Override
+  public boolean setUncancellable() {
+    return true;
+  }
+
+  @Override
+  public boolean isSuccess() {
+    return promise.future().succeeded();
+  }
+
+  @Override
+  public boolean isCancellable() {
+    return false;
+  }
+
+  @Override
+  public Throwable cause() {
+    return promise.future().cause();
+  }
+
+  @Override
+  public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean await(long timeoutMillis) throws InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean awaitUninterruptibly(long timeout, TimeUnit unit) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean awaitUninterruptibly(long timeoutMillis) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Void getNow() {
+    return null;
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    return false;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return false;
+  }
+
+  @Override
+  public boolean isDone() {
+    return promise.future().isComplete();
+  }
+
+  private ChannelPromise bridge() {
+    ChannelPromise p;
+    // Could use double-checked locking ?
+    synchronized (this) {
+      p = bridge;
+      if (p == null) {
+        ChannelPromise pr = channel.newPromise();
+        p = pr;
+        ((FutureBase<?>)promise.future())
+          .addListener((result, failure) -> {
+          if (failure == null) {
+            pr.setSuccess();
+          } else {
+            pr.setFailure(failure);
+          }
+        });
+        bridge = p;
+      }
+    }
+    return p;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -22,6 +22,7 @@ import io.netty.util.ReferenceCounted;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.eventbus.Message;
@@ -142,7 +143,7 @@ public class NetSocketImpl extends VertxConnection implements NetSocketInternal 
 
   @Override
   public Future<Void> writeMessage(Object message) {
-    PromiseInternal<Void> promise = context.promise();
+    Promise<Void> promise = context.promise();
     writeToChannel(message, promise);
     return promise.future();
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -322,8 +322,17 @@ public class VertxConnection extends ConnectionBase {
   /**
    * Like {@link #write(Object, boolean, ChannelPromise)}.
    */
-  public void write(Object msg, boolean forceFlush, FutureListener<Void> promise) {
-    write(msg, forceFlush, wrap(promise));
+  public final ChannelPromise write(Object msg, boolean forceFlush, Promise<Void> promise) {
+    ChannelPromise channelPromise = promise == null ? voidPromise : newChannelPromise(promise);
+    write(msg, forceFlush, channelPromise);
+    return channelPromise;
+  }
+
+  /**
+   * Like {@link #write(Object, boolean, ChannelPromise)}.
+   */
+  public final ChannelPromise write(Object msg, boolean forceFlush) {
+    return write(msg, forceFlush, voidPromise);
   }
 
   /**
@@ -335,7 +344,7 @@ public class VertxConnection extends ConnectionBase {
    * @param forceFlush flush when {@code true} or there is no read in progress
    * @param promise the promise receiving the completion event
    */
-  public void write(Object msg, boolean forceFlush, ChannelPromise promise) {
+  public final ChannelPromise write(Object msg, boolean forceFlush, ChannelPromise promise) {
     assert chctx.executor().inEventLoop();
     if (METRICS_ENABLED) {
       reportsBytesWritten(msg);
@@ -347,6 +356,7 @@ public class VertxConnection extends ConnectionBase {
     } else {
       chctx.write(msg, promise);
     }
+    return promise;
   }
 
   /**
@@ -368,8 +378,8 @@ public class VertxConnection extends ConnectionBase {
     return writeToChannel(obj, voidPromise);
   }
 
-  public final boolean writeToChannel(Object msg, FutureListener<Void> listener) {
-    return writeToChannel(msg, listener == null ? voidPromise : wrap(listener));
+  public final boolean writeToChannel(Object msg, Promise<Void> listener) {
+    return writeToChannel(msg, listener == null ? voidPromise : newChannelPromise(listener));
   }
 
   public final boolean writeToChannel(Object msg, ChannelPromise promise) {

--- a/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
@@ -17,6 +17,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
@@ -45,7 +46,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
-public class ConnectionBaseTest extends VertxTestBase {
+public class VertxConnectionTest extends VertxTestBase {
 
   private NetClient client;
   private NetServer server;
@@ -226,9 +227,8 @@ public class ConnectionBaseTest extends VertxTestBase {
       while (conn.writeToChannel(chunk.getByteBuf())) {
         num++;
       }
-      conn.writeToChannel(Unpooled.EMPTY_BUFFER, future -> {
-        ctx.emit(v -> testComplete());
-      });
+      Future.<Void>future(future -> conn.writeToChannel(Unpooled.EMPTY_BUFFER, future))
+        .onComplete(onSuccess(v1 -> ctx.emit(v2 -> testComplete())));
       drain.complete(null);
     };
     client.connect(1234, "localhost")
@@ -423,7 +423,6 @@ public class ConnectionBaseTest extends VertxTestBase {
   @Test
   public void testReentrantRead() throws Exception {
     connectHandler = conn -> {
-      VertxConnection vertxConn = (VertxConnection) conn;
       ChannelHandlerContext ctx = conn.channelHandlerContext();
       ChannelPipeline pipeline = ctx.pipeline();
       AtomicInteger reentrant = new AtomicInteger();
@@ -500,6 +499,32 @@ public class ConnectionBaseTest extends VertxTestBase {
     so.write("ping");
     awaitLatch(latch);
     so.resume();
+    await();
+  }
+
+  @Test
+  public void testChannelPromisePiggiesBackOnEventLoop() throws Exception {
+    waitFor(2);
+    disableThreadChecks();
+    connectHandler = conn -> {
+      Promise<Void> promise = Promise.promise();
+      ChannelPromise channelPromise = ((VertxConnection) conn).write(Unpooled.copiedBuffer("outbound-1", StandardCharsets.UTF_8), false, promise);
+      Future<Void> future = promise.future();
+      future.onComplete(onSuccess(v -> {
+        new Thread(() -> {
+          Thread curr = Thread.currentThread();
+          future.onComplete(ar -> {
+            assertSame(curr, Thread.currentThread());
+            complete();
+          });
+          channelPromise.addListener((ChannelFutureListener) f -> {
+            assertTrue(channelPromise.channel().eventLoop().inEventLoop());
+            complete();
+          });
+        }).start();
+      }));
+    };
+    awaitFuture(client.connect(1234, "localhost"));
     await();
   }
 
@@ -644,7 +669,7 @@ public class ConnectionBaseTest extends VertxTestBase {
   private class TestConnection extends VertxConnection {
     Handler<Message> handler;
     public TestConnection(ChannelHandlerContext chctx) {
-      super(((VertxInternal)ConnectionBaseTest.this.vertx)
+      super(((VertxInternal) VertxConnectionTest.this.vertx)
         .contextBuilder()
         .withEventLoop((EventLoop) chctx.executor())
         .build(), chctx);
@@ -767,7 +792,7 @@ public class ConnectionBaseTest extends VertxTestBase {
     pipeline.fireChannelRead(factory.next());
     assertEquals(0, count.get());
     Object expected = new Object();
-    connection.write(expected, false, ch.newPromise());
+    connection.write(expected, false);
     connection.resume();
     assertEquals(0, count.get());
     assertTrue(ch.hasPendingTasks());


### PR DESCRIPTION
Motivation:

Channel write promise returned by Vert.x are a mirror of Netty channel promise through a `FutureListener`. We can instead use a custom `ChannelPromise` implementation wrapping a Vert.x promise.

Changes:

Add an implementation of `ChannelPromise` delegating to a Vert.x future, the promise lazily creates an actual `ChannelPromise` if dispatch to a listener is required such as the idle state handler.
