### PR TITLE
Rename concurrent message channel to message queue

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
@@ -15,7 +15,7 @@ import io.vertx.core.*;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.concurrent.InboundMessageChannel;
+import io.vertx.core.internal.concurrent.InboundMessageQueue;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.streams.ReadStream;
@@ -31,7 +31,7 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
   private Handler<Void> endHandler;
   private Handler<Message<T>> discardHandler;
   private final int maxBufferedMessages;
-  private final InboundMessageChannel<Message<T>> pending;
+  private final InboundMessageQueue<Message<T>> pending;
   private Promise<Void> result;
   private boolean registered;
   private boolean full;
@@ -41,7 +41,7 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
     this.localOnly = localOnly;
     this.result = context.promise();
     this.maxBufferedMessages = maxBufferedMessages;
-    this.pending = new InboundMessageChannel<>(context.executor(), context.executor(), maxBufferedMessages, maxBufferedMessages) {
+    this.pending = new InboundMessageQueue<>(context.executor(), context.executor(), maxBufferedMessages, maxBufferedMessages) {
       @Override
       protected void handleResume() {
         full = false;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/ClientMultipartFormUpload.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/ClientMultipartFormUpload.java
@@ -20,7 +20,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.buffer.BufferInternal;
-import io.vertx.core.internal.concurrent.InboundMessageChannel;
+import io.vertx.core.internal.concurrent.InboundMessageQueue;
 import io.vertx.core.internal.http.HttpHeadersInternal;
 import io.vertx.core.streams.Pipe;
 import io.vertx.core.streams.ReadStream;
@@ -46,7 +46,7 @@ public class ClientMultipartFormUpload implements ReadStream<Buffer> {
   private Handler<Throwable> exceptionHandler;
   private Handler<Buffer> dataHandler;
   private Handler<Void> endHandler;
-  private final InboundMessageChannel<Object> pending;
+  private final InboundMessageQueue<Object> pending;
   private boolean writable;
   private boolean ended;
   private final ContextInternal context;
@@ -57,7 +57,7 @@ public class ClientMultipartFormUpload implements ReadStream<Buffer> {
                                    HttpPostRequestEncoder.EncoderMode encoderMode) throws Exception {
     this.context = context;
     this.writable = true;
-    this.pending = new InboundMessageChannel<>(context.executor(), context.executor()) {
+    this.pending = new InboundMessageQueue<>(context.executor(), context.executor()) {
       @Override
       protected void handleResume() {
         writable = true;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -40,7 +40,7 @@ import io.vertx.core.http.*;
 import io.vertx.core.http.impl.headers.HeadersAdaptor;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
-import io.vertx.core.internal.concurrent.InboundMessageChannel;
+import io.vertx.core.internal.concurrent.InboundMessageQueue;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.*;
@@ -415,7 +415,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
   private static class StreamImpl extends Stream implements HttpClientStream {
 
     private final Http1xClientConnection conn;
-    private final InboundMessageChannel<Object> queue;
+    private final InboundMessageQueue<Object> queue;
     private boolean closed;
     private Handler<HttpResponseHead> headHandler;
     private Handler<Buffer> chunkHandler;
@@ -431,7 +431,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
       super(context, promise, id);
 
       this.conn = conn;
-      this.queue = new InboundMessageChannel<>(conn.context.eventLoop(), context.executor()) {
+      this.queue = new InboundMessageQueue<>(conn.context.eventLoop(), context.executor()) {
         @Override
         protected void handleResume() {
           conn.doResume();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -32,7 +32,7 @@ import io.vertx.core.internal.http.HttpServerRequestInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.internal.concurrent.InboundMessageChannel;
+import io.vertx.core.internal.concurrent.InboundMessageQueue;
 import io.vertx.core.net.impl.HostAndPortImpl;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 import io.vertx.core.spi.tracing.SpanKind;
@@ -86,13 +86,13 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   private HttpPostRequestDecoder decoder;
   private boolean ended;
   private long bytesRead;
-  private final InboundMessageChannel<Object> queue;
+  private final InboundMessageQueue<Object> queue;
 
   Http1xServerRequest(Http1xServerConnection conn, HttpRequest request, ContextInternal context) {
     this.conn = conn;
     this.context = context;
     this.request = request;
-    this.queue = new InboundMessageChannel<>(context.eventLoop(), context.executor()) {
+    this.queue = new InboundMessageQueue<>(context.eventLoop(), context.executor()) {
       @Override
       protected void handleMessage(Object elt) {
         if (elt == InboundBuffer.END_SENTINEL) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -27,8 +27,8 @@ import io.vertx.core.http.StreamPriority;
 import io.vertx.core.http.impl.headers.Http2HeadersAdaptor;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
-import io.vertx.core.internal.concurrent.InboundMessageChannel;
-import io.vertx.core.internal.concurrent.OutboundMessageChannel;
+import io.vertx.core.internal.concurrent.InboundMessageQueue;
+import io.vertx.core.internal.concurrent.OutboundMessageQueue;
 import io.vertx.core.net.impl.MessageWrite;
 
 /**
@@ -38,8 +38,8 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
 
   private static final MultiMap EMPTY = new Http2HeadersAdaptor(EmptyHttp2Headers.INSTANCE);
 
-  private final OutboundMessageChannel<MessageWrite> outboundQueue;
-  private final InboundMessageChannel<Object> inboundQueue;
+  private final OutboundMessageQueue<MessageWrite> outboundQueue;
+  private final InboundMessageQueue<Object> inboundQueue;
   protected final C conn;
   protected final VertxInternal vertx;
   protected final ContextInternal context;
@@ -58,7 +58,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
     this.conn = conn;
     this.vertx = conn.vertx();
     this.context = context;
-    this.inboundQueue = new InboundMessageChannel<>(conn.context().eventLoop(), context.executor()) {
+    this.inboundQueue = new InboundMessageQueue<>(conn.context().eventLoop(), context.executor()) {
       @Override
       protected void handleMessage(Object item) {
         if (item instanceof MultiMap) {
@@ -80,7 +80,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
     this.priority = HttpUtils.DEFAULT_STREAM_PRIORITY;
     this.isConnect = false;
     this.writable = true;
-    this.outboundQueue = new OutboundMessageChannel<>(conn.context().nettyEventLoop()) {
+    this.outboundQueue = new OutboundMessageQueue<>(conn.context().nettyEventLoop()) {
       // TODO implement stop drain to optimize flushes ?
       @Override
       public boolean test(MessageWrite msg) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -33,10 +33,9 @@ import io.vertx.core.http.*;
 import io.vertx.core.http.impl.ws.WebSocketFrameImpl;
 import io.vertx.core.http.impl.ws.WebSocketFrameInternal;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.http.WebSocketInternal;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.internal.concurrent.InboundMessageChannel;
+import io.vertx.core.internal.concurrent.InboundMessageQueue;
 import io.vertx.core.net.impl.VertxConnection;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -63,7 +62,7 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
   private final VertxConnection conn;
   private ChannelHandlerContext chctx;
   protected final ContextInternal context;
-  private final InboundMessageChannel<WebSocketFrameInternal> pending;
+  private final InboundMessageQueue<WebSocketFrameInternal> pending;
   private MessageConsumer binaryHandlerRegistration;
   private MessageConsumer textHandlerRegistration;
   private String subProtocol;
@@ -100,7 +99,7 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
     this.context = context;
     this.maxWebSocketFrameSize = maxWebSocketFrameSize;
     this.maxWebSocketMessageSize = maxWebSocketMessageSize;
-    this.pending = new InboundMessageChannel<>(context.eventLoop(), context.executor()) {
+    this.pending = new InboundMessageQueue<>(context.eventLoop(), context.executor()) {
       @Override
       protected void handleResume() {
         conn.doResume();

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -31,7 +31,7 @@ import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.impl.HttpUtils;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
-import io.vertx.core.internal.concurrent.InboundMessageChannel;
+import io.vertx.core.internal.concurrent.InboundMessageQueue;
 import io.vertx.core.internal.tls.SslContextManager;
 import io.vertx.core.internal.net.SslChannelProvider;
 import io.vertx.core.internal.net.SslHandshakeCompletionHandler;
@@ -56,7 +56,7 @@ public class NetSocketImpl extends VertxConnection implements NetSocketInternal 
   private final SSLOptions sslOptions;
   private final SocketAddress remoteAddress;
   private final TCPMetrics metrics;
-  private final InboundMessageChannel<Object> pending;
+  private final InboundMessageQueue<Object> pending;
   private final String negotiatedApplicationLayerProtocol;
   private Handler<Void> endHandler;
   private volatile Handler<Void> drainHandler;
@@ -90,7 +90,7 @@ public class NetSocketImpl extends VertxConnection implements NetSocketInternal 
     this.metrics = metrics;
     this.messageHandler = new DataMessageHandler();
     this.negotiatedApplicationLayerProtocol = negotiatedApplicationLayerProtocol;
-    this.pending = new InboundMessageChannel<>(context.eventLoop(), context.executor()) {
+    this.pending = new InboundMessageQueue<>(context.eventLoop(), context.executor()) {
       @Override
       protected void handleResume() {
         NetSocketImpl.this.doResume();

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -24,7 +24,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.concurrent.OutboundMessageChannel;
+import io.vertx.core.internal.concurrent.OutboundMessageQueue;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 
@@ -57,7 +57,7 @@ public class VertxConnection extends ConnectionBase {
   private static final int MAX_REGION_SIZE = 1024 * 1024;
 
   public final VoidChannelPromise voidPromise;
-  private final OutboundMessageChannel<MessageWrite> messageQueue;
+  private final OutboundMessageQueue<MessageWrite> outboundMessageQueue;
   private Handler<Void> shutdownHandler;
 
   // State accessed exclusively from the event loop thread
@@ -74,7 +74,7 @@ public class VertxConnection extends ConnectionBase {
   public VertxConnection(ContextInternal context, ChannelHandlerContext chctx) {
     super(context, chctx);
     this.channelWritable = chctx.channel().isWritable();
-    this.messageQueue = new InternalMessageChannel(chctx.channel().eventLoop());
+    this.outboundMessageQueue = new InternalMessageChannel(chctx.channel().eventLoop());
     this.voidPromise = new VoidChannelPromise(chctx.channel(), false);
     this.autoRead = true;
   }
@@ -194,7 +194,7 @@ public class VertxConnection extends ConnectionBase {
       shutdownTimeout = null;
       timeout.cancel(false);
     }
-    messageQueue.close();
+    outboundMessageQueue.close();
     super.handleClosed();
   }
 
@@ -210,7 +210,7 @@ public class VertxConnection extends ConnectionBase {
   void channelWritabilityChanged() {
     channelWritable = chctx.channel().isWritable();
     if (channelWritable) {
-      messageQueue.tryDrain();
+      outboundMessageQueue.tryDrain();
     }
   }
 
@@ -401,7 +401,7 @@ public class VertxConnection extends ConnectionBase {
   }
 
   public final boolean writeToChannel(MessageWrite msg) {
-    return messageQueue.write(msg);
+    return outboundMessageQueue.write(msg);
   }
 
   /**
@@ -433,7 +433,7 @@ public class VertxConnection extends ConnectionBase {
    * @return the write queue writability status
    */
   public boolean writeQueueFull() {
-    return !messageQueue.isWritable();
+    return !outboundMessageQueue.isWritable();
   }
 
   /**
@@ -487,9 +487,9 @@ public class VertxConnection extends ConnectionBase {
   }
 
   /**
-   * Version of {@link OutboundMessageChannel} accessing internal connection base state.
+   * Version of {@link OutboundMessageQueue} accessing internal connection base state.
    */
-  private class InternalMessageChannel extends OutboundMessageChannel<MessageWrite> implements Predicate<MessageWrite> {
+  private class InternalMessageChannel extends OutboundMessageQueue<MessageWrite> implements Predicate<MessageWrite> {
 
     public InternalMessageChannel(EventLoop eventLoop) {
       super(eventLoop);

--- a/vertx-core/src/test/java/io/vertx/tests/concurrent/InboundMessageQueueSingleThreadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/concurrent/InboundMessageQueueSingleThreadTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntConsumer;
 
-public class InboundMessageChannelSingleThreadTest extends InboundMessageChannelTest {
+public class InboundMessageQueueSingleThreadTest extends InboundMessageQueueTest {
 
   @Override
   protected Context createContext(VertxInternal vertx) {

--- a/vertx-core/src/test/java/io/vertx/tests/concurrent/InboundMessageQueueSpScTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/concurrent/InboundMessageQueueSpScTest.java
@@ -13,7 +13,7 @@ package io.vertx.tests.concurrent;
 import io.vertx.core.Context;
 import io.vertx.core.internal.VertxInternal;
 
-public class InboundMessageChannelSpScTest extends InboundMessageChannelTest {
+public class InboundMessageQueueSpScTest extends InboundMessageQueueTest {
 
   @Override
   protected Context createContext(VertxInternal vertx) {

--- a/vertx-core/src/test/java/io/vertx/tests/concurrent/InboundMessageQueueTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/concurrent/InboundMessageQueueTest.java
@@ -15,7 +15,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
-import io.vertx.core.internal.concurrent.InboundMessageChannel;
+import io.vertx.core.internal.concurrent.InboundMessageQueue;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntConsumer;
 
-public abstract class InboundMessageChannelTest extends VertxTestBase {
+public abstract class InboundMessageQueueTest extends VertxTestBase {
 
   private volatile Thread producerThread;
   private volatile Thread consumerThread;
@@ -35,10 +35,10 @@ public abstract class InboundMessageChannelTest extends VertxTestBase {
   TestChannel queue;
   final AtomicInteger sequence = new AtomicInteger();
 
-  InboundMessageChannelTest() {
+  InboundMessageQueueTest() {
   }
 
-  class TestChannel extends InboundMessageChannel<Integer> {
+  class TestChannel extends InboundMessageQueue<Integer> {
 
     final IntConsumer consumer;
     private Handler<Void> drainHandler;

--- a/vertx-core/src/test/java/io/vertx/tests/concurrent/InboundReadQueueTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/concurrent/InboundReadQueueTest.java
@@ -1,52 +1,52 @@
 package io.vertx.tests.concurrent;
 
-import io.vertx.core.streams.impl.MessageChannel;
+import io.vertx.core.streams.impl.MessagePassingQueue;
 import io.vertx.test.core.AsyncTestBase;
 import org.junit.Test;
 
 import java.util.LinkedList;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.vertx.core.streams.impl.MessageChannel.drainResult;
+import static io.vertx.core.streams.impl.MessagePassingQueue.drainResult;
 
 public class InboundReadQueueTest extends AsyncTestBase {
 
-  final MessageChannel.Factory factory = MessageChannel.SPSC;
+  final MessagePassingQueue.Factory factory = MessagePassingQueue.SPSC;
 
   @Test
   public void testAdd() {
-    MessageChannel<Integer> queue = factory.create(elt -> false);
-    assertEquals(MessageChannel.DRAIN_REQUIRED_MASK, queue.add(0));
+    MessagePassingQueue<Integer> queue = factory.create(elt -> false);
+    assertEquals(MessagePassingQueue.DRAIN_REQUIRED_MASK, queue.add(0));
     for (int i = 1;i < 15;i++) {
       assertEquals(0L, queue.add(i));
     }
-    assertEquals(MessageChannel.UNWRITABLE_MASK, queue.add(17));
+    assertEquals(MessagePassingQueue.UNWRITABLE_MASK, queue.add(17));
   }
 
   @Test
   public void testDrainSingle() {
-    MessageChannel<Integer> queue = factory.create(elt -> true);
-    assertEquals(MessageChannel.DRAIN_REQUIRED_MASK, queue.add(0));
-    assertEquals(MessageChannel.drainResult(0, 0, false), queue.drain(17));
+    MessagePassingQueue<Integer> queue = factory.create(elt -> true);
+    assertEquals(MessagePassingQueue.DRAIN_REQUIRED_MASK, queue.add(0));
+    assertEquals(MessagePassingQueue.drainResult(0, 0, false), queue.drain(17));
   }
 
   @Test
   public void testFoo() {
-    MessageChannel<Integer> queue = factory.create(elt -> false);
-    assertEquals(MessageChannel.DRAIN_REQUIRED_MASK, queue.add(0));
+    MessagePassingQueue<Integer> queue = factory.create(elt -> false);
+    assertEquals(MessagePassingQueue.DRAIN_REQUIRED_MASK, queue.add(0));
     assertEquals(drainResult(0, 1, false), queue.drain());
   }
 
   @Test
   public void testDrainFully() {
     LinkedList<Integer> consumed = new LinkedList<>();
-    MessageChannel<Integer> queue = factory.create(elt -> {
+    MessagePassingQueue<Integer> queue = factory.create(elt -> {
       consumed.add(elt);
       return true;
     });
-    assertEquals(MessageChannel.DRAIN_REQUIRED_MASK, queue.add(0));
+    assertEquals(MessagePassingQueue.DRAIN_REQUIRED_MASK, queue.add(0));
     int idx = 1;
-    while ((queue.add(idx++) & MessageChannel.UNWRITABLE_MASK) == 0) {
+    while ((queue.add(idx++) & MessagePassingQueue.UNWRITABLE_MASK) == 0) {
       //
     }
     assertEquals(16, idx);
@@ -59,24 +59,24 @@ public class InboundReadQueueTest extends AsyncTestBase {
 
   @Test
   public void testDrainRefuseSingleElement() {
-    MessageChannel<Integer> queue = factory.create(elt -> false);
-    assertEquals(MessageChannel.DRAIN_REQUIRED_MASK, queue.add(0));
+    MessagePassingQueue<Integer> queue = factory.create(elt -> false);
+    assertEquals(MessagePassingQueue.DRAIN_REQUIRED_MASK, queue.add(0));
     assertEquals(drainResult(0, 1, false), queue.drain());
   }
 
   @Test
   public void testConsumeDrain() {
     AtomicInteger demand = new AtomicInteger(0);
-    MessageChannel<Integer> queue = factory.create(elt -> {
+    MessagePassingQueue<Integer> queue = factory.create(elt -> {
       if (demand.get() > 0) {
         demand.decrementAndGet();
         return true;
       }
       return false;
     });
-    assertEquals(MessageChannel.DRAIN_REQUIRED_MASK, queue.add(0));
+    assertEquals(MessagePassingQueue.DRAIN_REQUIRED_MASK, queue.add(0));
     int idx = 1;
-    while ((queue.add(idx++) & MessageChannel.UNWRITABLE_MASK) == 0) {
+    while ((queue.add(idx++) & MessagePassingQueue.UNWRITABLE_MASK) == 0) {
       //
     }
     assertEquals(16, idx);
@@ -91,9 +91,9 @@ public class InboundReadQueueTest extends AsyncTestBase {
   @Test
   public void testPartialDrain() {
     AtomicInteger demand = new AtomicInteger(0);
-    MessageChannel<Integer> queue = factory.create(elt -> true);
+    MessagePassingQueue<Integer> queue = factory.create(elt -> true);
     int idx = 0;
-    while ((queue.add(idx++) & MessageChannel.UNWRITABLE_MASK) == 0) {
+    while ((queue.add(idx++) & MessagePassingQueue.UNWRITABLE_MASK) == 0) {
       //
     }
     assertEquals(16, idx);
@@ -105,7 +105,7 @@ public class InboundReadQueueTest extends AsyncTestBase {
   @Test
   public void testUnwritableCount() {
     AtomicInteger demand = new AtomicInteger();
-    MessageChannel<Integer> queue = factory.create(elt-> {
+    MessagePassingQueue<Integer> queue = factory.create(elt-> {
       if (demand.get() > 0) {
         demand.decrementAndGet();
         return true;
@@ -115,17 +115,17 @@ public class InboundReadQueueTest extends AsyncTestBase {
     });
     int count = 0;
     while (true) {
-      if ((queue.add(count++) & MessageChannel.UNWRITABLE_MASK) != 0) {
+      if ((queue.add(count++) & MessagePassingQueue.UNWRITABLE_MASK) != 0) {
         break;
       }
     }
     demand.set(1);
     assertEquals(drainResult(0, 15, false), queue.drain() & 0xFFFF);
-    assertFlagsSet(queue.add(count++), MessageChannel.UNWRITABLE_MASK);
+    assertFlagsSet(queue.add(count++), MessagePassingQueue.UNWRITABLE_MASK);
     demand.set(count - 1);
     int flags = queue.drain();
-    assertFlagsSet(flags, MessageChannel.WRITABLE_MASK);
-    assertEquals(0, MessageChannel.numberOfPendingElements(flags));
+    assertFlagsSet(flags, MessagePassingQueue.WRITABLE_MASK);
+    assertEquals(0, MessagePassingQueue.numberOfPendingElements(flags));
   }
 
   private void assertFlagsSet(int flags, int... masks) {

--- a/vertx-core/src/test/java/io/vertx/tests/concurrent/OutboundMessageQueueTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/concurrent/OutboundMessageQueueTest.java
@@ -12,9 +12,8 @@ package io.vertx.tests.concurrent;
 
 import io.netty.channel.EventLoop;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.concurrent.OutboundMessageChannel;
+import io.vertx.core.internal.concurrent.OutboundMessageQueue;
 import io.vertx.test.core.VertxTestBase;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -28,10 +27,10 @@ import java.util.stream.IntStream;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class OutboundMessageChannelTest extends VertxTestBase {
+public class OutboundMessageQueueTest extends VertxTestBase {
 
   private List<Integer> output = Collections.synchronizedList(new ArrayList<>());
-  private OutboundMessageChannel<Integer> queue;
+  private OutboundMessageQueue<Integer> queue;
   private EventLoop eventLoop;
 
   @Override
@@ -44,7 +43,7 @@ public class OutboundMessageChannelTest extends VertxTestBase {
 
   @Test
   public void testReentrantWriteAccept() {
-    queue = new OutboundMessageChannel<>(eventLoop) {
+    queue = new OutboundMessageQueue<>(eventLoop) {
       int reentrant = 0;
       @Override
       public boolean test(Integer msg) {
@@ -70,7 +69,7 @@ public class OutboundMessageChannelTest extends VertxTestBase {
 
   @Test
   public void testReentrantWriteReject() {
-    queue = new OutboundMessageChannel<>(eventLoop) {
+    queue = new OutboundMessageQueue<>(eventLoop) {
       int reentrant = 0;
       @Override
       public boolean test(Integer msg) {
@@ -96,7 +95,7 @@ public class OutboundMessageChannelTest extends VertxTestBase {
 
   @Test
   public void testReentrantOverflowThenDrain1() {
-    queue = new OutboundMessageChannel<>(eventLoop) {
+    queue = new OutboundMessageQueue<>(eventLoop) {
       int reentrant = 0;
       int draining = 0;
       int drained = 0;
@@ -147,7 +146,7 @@ public class OutboundMessageChannelTest extends VertxTestBase {
 
   @Test
   public void testReentrantOverflowThenDrain2() {
-    queue = new OutboundMessageChannel<>(eventLoop) {
+    queue = new OutboundMessageQueue<>(eventLoop) {
       int reentrant = 0;
       int draining = 0;
       int drained = 0;
@@ -208,7 +207,7 @@ public class OutboundMessageChannelTest extends VertxTestBase {
   @Test
   public void testReentrantTryDrain() {
     AtomicBoolean overflow = new AtomicBoolean();
-    queue = new OutboundMessageChannel<>(eventLoop) {
+    queue = new OutboundMessageQueue<>(eventLoop) {
       int draining;
       @Override
       protected void startDraining() {
@@ -244,7 +243,7 @@ public class OutboundMessageChannelTest extends VertxTestBase {
     AtomicBoolean paused = new AtomicBoolean();
     AtomicInteger count = new AtomicInteger();
     AtomicInteger test = new AtomicInteger();
-    queue = new OutboundMessageChannel<>(eventLoop) {
+    queue = new OutboundMessageQueue<>(eventLoop) {
       @Override
       protected void handleDrained() {
         int msg = count.getAndIncrement();
@@ -270,7 +269,7 @@ public class OutboundMessageChannelTest extends VertxTestBase {
 
   @Test
   public void testReentrantClose() {
-    queue = new OutboundMessageChannel<>(eventLoop) {
+    queue = new OutboundMessageQueue<>(eventLoop) {
       @Override
       public boolean test(Integer msg) {
         if (msg == 0) {
@@ -299,7 +298,7 @@ public class OutboundMessageChannelTest extends VertxTestBase {
   @Test
   public void testCloseWhileDrainScheduled() {
     AtomicInteger drains = new AtomicInteger();
-    queue = new OutboundMessageChannel<>(eventLoop) {
+    queue = new OutboundMessageQueue<>(eventLoop) {
       @Override
       public boolean test(Integer msg) {
         return false;


### PR DESCRIPTION
Motivation:

Channel name implies bidirectionality, in our case this is one way so queue is better naming.
