### PR TITLE
Correctly report the response end during Http1xServerResponse lifecycle

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/AssembledFullHttpRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/AssembledFullHttpRequest.java
@@ -12,6 +12,7 @@
 package io.vertx.core.http.impl;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpContent;
@@ -29,16 +30,12 @@ import io.netty.handler.codec.http.LastHttpContent;
  */
 class AssembledFullHttpRequest extends AssembledHttpRequest implements FullHttpRequest {
 
-  public AssembledFullHttpRequest(HttpRequest request, LastHttpContent content) {
-    super(request, content);
-  }
-
   public AssembledFullHttpRequest(HttpRequest request) {
-    super(request, LastHttpContent.EMPTY_LAST_CONTENT);
+    super(request, LastHttpContent.EMPTY_LAST_CONTENT, true);
   }
 
   public AssembledFullHttpRequest(HttpRequest request, ByteBuf buf) {
-    super(request, toLastContent(buf));
+    super(request, toLastContent(buf), true);
   }
 
   private static LastHttpContent toLastContent(ByteBuf buf) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/AssembledFullHttpResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/AssembledFullHttpResponse.java
@@ -24,9 +24,26 @@ class AssembledFullHttpResponse extends AssembledHttpResponse implements FullHtt
 
   private HttpHeaders trailingHeaders;
 
-  public AssembledFullHttpResponse(boolean head, HttpVersion version, HttpResponseStatus status, HttpHeaders headers, ByteBuf buf, HttpHeaders trailingHeaders) {
-    super(head, version, status, headers, buf);
-    this.trailingHeaders = trailingHeaders;
+  public AssembledFullHttpResponse(
+    boolean head,
+    HttpVersion version,
+    HttpResponseStatus status,
+    ByteBuf buf,
+    HttpHeaders headers,
+    HttpHeaders trailers) {
+    this(head, version, status, buf, headers, trailers, true);
+  }
+
+  public AssembledFullHttpResponse(
+    boolean head,
+    HttpVersion version,
+    HttpResponseStatus status,
+    ByteBuf buf,
+    HttpHeaders headers,
+    HttpHeaders trailers,
+    boolean ended) {
+    super(head, version, status, headers, buf, ended);
+    this.trailingHeaders = trailers;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/AssembledHttpContent.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/AssembledHttpContent.java
@@ -12,12 +12,9 @@
 package io.vertx.core.http.impl;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufHolder;
-import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.DecoderResult;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
 
 /**
@@ -26,26 +23,15 @@ import io.netty.handler.codec.http.LastHttpContent;
  *
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-class AssembledLastHttpContent extends AssembledHttpObject implements LastHttpContent {
+class AssembledHttpContent extends AssembledHttpObject implements HttpContent {
 
-  private final HttpHeaders trailingHeaders;
   private DecoderResult result;
-  private ByteBuf content;
+  private final ByteBuf content;
 
-  AssembledLastHttpContent(ByteBuf content, HttpHeaders trailingHeaders) {
-    this(content, trailingHeaders, DecoderResult.SUCCESS);
-  }
-
-  AssembledLastHttpContent(ByteBuf content, HttpHeaders trailingHeaders, DecoderResult result) {
-    super(true);
-    this.trailingHeaders = trailingHeaders;
-    this.result = result;
+  AssembledHttpContent(ByteBuf content) {
+    super(false);
+    this.result = DecoderResult.SUCCESS;
     this.content = content;
-  }
-
-  @Override
-  public HttpHeaders trailingHeaders() {
-    return trailingHeaders;
   }
 
   @Override
@@ -54,13 +40,13 @@ class AssembledLastHttpContent extends AssembledHttpObject implements LastHttpCo
   }
 
   @Override
-  public LastHttpContent retain(int increment) {
+  public HttpContent retain(int increment) {
     content.retain(increment);
     return this;
   }
 
   @Override
-  public LastHttpContent retain() {
+  public HttpContent retain() {
     content.retain();
     return this;
   }
@@ -116,13 +102,13 @@ class AssembledLastHttpContent extends AssembledHttpObject implements LastHttpCo
   }
 
   @Override
-  public AssembledLastHttpContent touch() {
+  public AssembledHttpContent touch() {
     content.touch();
     return this;
   }
 
   @Override
-  public AssembledLastHttpContent touch(Object hint) {
+  public AssembledHttpContent touch(Object hint) {
     content.touch(hint);
     return this;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/AssembledHttpObject.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/AssembledHttpObject.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+public class AssembledHttpObject {
+
+  private final boolean ended;
+
+  public AssembledHttpObject(boolean ended) {
+    this.ended = ended;
+  }
+
+  public final boolean isEnded() {
+    return ended;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/AssembledHttpRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/AssembledHttpRequest.java
@@ -12,6 +12,7 @@
 package io.vertx.core.http.impl;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.UnsupportedMessageTypeException;
 import io.netty.handler.codec.http.*;
@@ -23,15 +24,17 @@ import io.netty.handler.codec.http.*;
  *
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-class AssembledHttpRequest implements HttpContent, HttpRequest {
+class AssembledHttpRequest extends AssembledHttpObject implements HttpContent, HttpRequest {
+
   private final HttpRequest request;
   protected final HttpContent content;
 
   AssembledHttpRequest(HttpRequest request, ByteBuf buf) {
-    this(request, new DefaultHttpContent(buf));
+    this(request, new DefaultHttpContent(buf), false);
   }
 
-  AssembledHttpRequest(HttpRequest request, HttpContent content) {
+  AssembledHttpRequest(HttpRequest request, HttpContent content, boolean ended) {
+    super(ended);
     this.request = request;
     this.content = content;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/AssembledHttpResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/AssembledHttpResponse.java
@@ -13,6 +13,8 @@ package io.vertx.core.http.impl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.*;
 
@@ -23,7 +25,7 @@ import io.netty.handler.codec.http.*;
  *
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-class AssembledHttpResponse implements io.netty.handler.codec.http.HttpResponse, HttpContent {
+class AssembledHttpResponse extends AssembledHttpObject implements io.netty.handler.codec.http.HttpResponse, HttpContent {
 
   private boolean head;
   private HttpResponseStatus status;
@@ -33,10 +35,15 @@ class AssembledHttpResponse implements io.netty.handler.codec.http.HttpResponse,
   private DecoderResult result = DecoderResult.SUCCESS;
 
   AssembledHttpResponse(boolean head, HttpVersion version, HttpResponseStatus status, HttpHeaders headers) {
-    this(head, version, status, headers, Unpooled.EMPTY_BUFFER);
+    this(head, version, status, headers, Unpooled.EMPTY_BUFFER, false);
   }
 
   AssembledHttpResponse(boolean head, HttpVersion version, HttpResponseStatus status, HttpHeaders headers, ByteBuf content) {
+    this(head, version, status, headers, content, false);
+  }
+
+  AssembledHttpResponse(boolean head, HttpVersion version, HttpResponseStatus status, HttpHeaders headers, ByteBuf content, boolean ended) {
+    super(ended);
     this.head = head;
     this.status = status;
     this.version = version;

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -404,6 +404,7 @@ public class VertxConnection extends ConnectionBase {
     });
   }
 
+  // Write to channel boolean return for now is not used so avoids reading a volatile
   public final boolean writeToChannel(MessageWrite msg) {
     return outboundMessageQueue.write(msg);
   }


### PR DESCRIPTION
Motivation:

We incorrectly send incorrect pre response messages (like continue) that makes `Http1xServerResponse` state invalid.

Changes:

Emit messages that correctly reports when a response ends.
