### PR TITLE
Decouple OutboundMessageQueue from EventLoop

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/VertxHttp2Stream.java
@@ -80,7 +80,7 @@ abstract class VertxHttp2Stream<C extends Http2ConnectionBase> {
     this.priority = HttpUtils.DEFAULT_STREAM_PRIORITY;
     this.isConnect = false;
     this.writable = true;
-    this.outboundQueue = new OutboundMessageQueue<>(conn.context().nettyEventLoop()) {
+    this.outboundQueue = new OutboundMessageQueue<>(conn.context().executor()) {
       // TODO implement stop drain to optimize flushes ?
       @Override
       public boolean test(MessageWrite msg) {

--- a/vertx-core/src/test/java/io/vertx/tests/concurrent/OutboundMessageQueueTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/concurrent/OutboundMessageQueueTest.java
@@ -12,6 +12,7 @@ package io.vertx.tests.concurrent;
 
 import io.netty.channel.EventLoop;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.EventExecutor;
 import io.vertx.core.internal.concurrent.OutboundMessageQueue;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
@@ -31,14 +32,14 @@ public class OutboundMessageQueueTest extends VertxTestBase {
 
   private List<Integer> output = Collections.synchronizedList(new ArrayList<>());
   private OutboundMessageQueue<Integer> queue;
-  private EventLoop eventLoop;
+  private EventExecutor eventLoop;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
     disableThreadChecks();
     output = Collections.synchronizedList(new ArrayList<>());
-    eventLoop = ((ContextInternal)vertx.getOrCreateContext()).nettyEventLoop();
+    eventLoop = ((ContextInternal)vertx.getOrCreateContext()).executor();
   }
 
   @Test


### PR DESCRIPTION
Motivation:

In order to reuse `OutboundMessageQueue` elsewhere than in vertx-core, this queue should use an `EventExecutor` instead of an `EventLoop`.

Changes:

Now `OutboundMessageQueue` uses an `EventExecutor` instead of an vEventLoop`
