### PR TITLE
Http1xServerRequest should eagerly create the inbound queue for threading models other than event-loop

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerConnectionInitializer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerConnectionInitializer.java
@@ -20,6 +20,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.vertx.core.Handler;
+import io.vertx.core.ThreadingModel;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
@@ -41,6 +42,7 @@ import java.util.function.Supplier;
 class HttpServerConnectionInitializer {
 
   private final ContextInternal context;
+  private final ThreadingModel threadingModel;
   private final Supplier<ContextInternal> streamContextSupplier;
   private final VertxInternal vertx;
   private final HttpServerImpl server;
@@ -56,6 +58,7 @@ class HttpServerConnectionInitializer {
   private final Function<String, String> encodingDetector;
 
   HttpServerConnectionInitializer(ContextInternal context,
+                                  ThreadingModel threadingModel,
                                   Supplier<ContextInternal> streamContextSupplier,
                                   HttpServerImpl server,
                                   VertxInternal vertx,
@@ -77,6 +80,7 @@ class HttpServerConnectionInitializer {
     }
 
     this.context = context;
+    this.threadingModel = threadingModel;
     this.streamContextSupplier = streamContextSupplier;
     this.server = server;
     this.vertx = vertx;
@@ -250,6 +254,7 @@ class HttpServerConnectionInitializer {
     HttpServerMetrics metrics = (HttpServerMetrics) server.getMetrics();
     VertxHandler<Http1xServerConnection> handler = VertxHandler.create(chctx -> {
       Http1xServerConnection conn = new Http1xServerConnection(
+        threadingModel,
         streamContextSupplier,
         sslContextManager,
         options,

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -211,6 +211,7 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
         exceptionHandler);
       HttpServerConnectionInitializer initializer = new HttpServerConnectionInitializer(
         listenContext,
+        context.threadingModel(),
         streamContextSupplier,
         this,
         vertx,

--- a/vertx-core/src/test/java/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
+++ b/vertx-core/src/test/java/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
@@ -227,6 +227,7 @@ public class HttpServerHandlerBenchmark extends BenchmarkBase {
     };
     VertxHandler<Http1xServerConnection> handler = VertxHandler.create(chctx -> {
       Http1xServerConnection conn = new Http1xServerConnection(
+        ThreadingModel.EVENT_LOOP,
         () -> context,
               null,
         options,

--- a/vertx-core/src/test/java/io/vertx/tests/benchmark/Http1xServerConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/benchmark/Http1xServerConnectionTest.java
@@ -14,6 +14,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.vertx.core.Handler;
+import io.vertx.core.ThreadingModel;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
@@ -57,6 +58,7 @@ public class Http1xServerConnectionTest extends VertxTestBase {
 
     VertxHandler<Http1xServerConnection> handler = VertxHandler.create(chctx -> {
       Http1xServerConnection conn = new Http1xServerConnection(
+        ThreadingModel.EVENT_LOOP,
         () -> context,
         null,
         new HttpServerOptions(),


### PR DESCRIPTION
Motivation:

50adff0f881bd1dcdb00881a2f29428ffc3233d7 introduced a regression that creates a race situation when the threading model is not event-loop: when the handler pause request, the end event has already been processed and the request end handling event will be lost.

Changes:

Servers bound with a non event-loop threading model must always create the queue to channel event execution in the worker in order to avoid a race situation.
