### PR TITLE
Avoid swallowing a TimeoutException on Future#await

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/future/FutureAwaitTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/future/FutureAwaitTest.java
@@ -83,4 +83,14 @@ public class FutureAwaitTest extends VertxTestBase {
       assertSame(msg, expected.getMessage());
     }
   }
+
+  @Test
+  public void testAwaitThrowsTimeoutException() {
+    TimeoutException failure = new TimeoutException();
+    try {
+      Future.failedFuture(failure).await();
+      fail();
+    } catch (Exception expected) {
+    }
+  }
 }


### PR DESCRIPTION
Motivation:

`Future#await` delegates to its overload with a specifiable timeout and catches the timeout exception that should not occur. That does not take in account the fact that the future itself could throw such exception and swallows it.

Changes:

Rewrite the code to avoid delegation and fix the bug.
