### PR TITLE
Introduce an option for HTTP/2 upgrade max content length

### DIFF
--- a/vertx-core/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -29,6 +29,11 @@ public class HttpClientOptionsConverter {
             obj.setHttp2KeepAliveTimeout(((Number)member.getValue()).intValue());
           }
           break;
+        case "http2UpgradeMaxContentLength":
+          if (member.getValue() instanceof Number) {
+            obj.setHttp2UpgradeMaxContentLength(((Number)member.getValue()).intValue());
+          }
+          break;
         case "keepAlive":
           if (member.getValue() instanceof Boolean) {
             obj.setKeepAlive((Boolean)member.getValue());
@@ -156,6 +161,7 @@ public class HttpClientOptionsConverter {
     json.put("http2MultiplexingLimit", obj.getHttp2MultiplexingLimit());
     json.put("http2ConnectionWindowSize", obj.getHttp2ConnectionWindowSize());
     json.put("http2KeepAliveTimeout", obj.getHttp2KeepAliveTimeout());
+    json.put("http2UpgradeMaxContentLength", obj.getHttp2UpgradeMaxContentLength());
     json.put("keepAlive", obj.isKeepAlive());
     json.put("keepAliveTimeout", obj.getKeepAliveTimeout());
     json.put("pipelining", obj.isPipelining());

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -122,6 +122,11 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public static final boolean DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE_WITH_PREFLIGHT_REQUEST = false;
 
+  /**
+   * Default maximum length of the aggregated content in bytes
+   */
+  public static final int DEFAULT_HTTP2_UPGRADE_MAX_CONTENT_LENGTH = 65536;
+
   /*
    * Default max redirect = 16
    */
@@ -160,6 +165,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   private int http2MultiplexingLimit;
   private int http2ConnectionWindowSize;
   private int http2KeepAliveTimeout;
+  private int http2UpgradeMaxContentLength;
 
   private boolean decompressionSupported;
   private String defaultHost;
@@ -214,6 +220,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.http2MultiplexingLimit = other.http2MultiplexingLimit;
     this.http2ConnectionWindowSize = other.http2ConnectionWindowSize;
     this.http2KeepAliveTimeout = other.getHttp2KeepAliveTimeout();
+    this.http2UpgradeMaxContentLength = other.getHttp2UpgradeMaxContentLength();
     this.decompressionSupported = other.decompressionSupported;
     this.defaultHost = other.defaultHost;
     this.defaultPort = other.defaultPort;
@@ -264,6 +271,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     http2MultiplexingLimit = DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
     http2ConnectionWindowSize = DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE;
     http2KeepAliveTimeout = DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT;
+    http2UpgradeMaxContentLength = DEFAULT_HTTP2_UPGRADE_MAX_CONTENT_LENGTH;
     decompressionSupported = DEFAULT_DECOMPRESSION_SUPPORTED;
     defaultHost = DEFAULT_DEFAULT_HOST;
     defaultPort = DEFAULT_DEFAULT_PORT;
@@ -527,6 +535,27 @@ public class HttpClientOptions extends ClientOptionsBase {
       throw new IllegalArgumentException("HTTP/2 keepAliveTimeout must be >= 0");
     }
     this.http2KeepAliveTimeout = keepAliveTimeout;
+    return this;
+  }
+
+  /**
+   * @return the HTTP/2 upgrade maximum length of the aggregated content in bytes
+   */
+  public int getHttp2UpgradeMaxContentLength() {
+    return http2UpgradeMaxContentLength;
+  }
+
+  /**
+   * Set the HTTP/2 upgrade maximum length of the aggregated content in bytes.
+   * This is only taken into account when {@link HttpClientOptions#http2ClearTextUpgradeWithPreflightRequest} is set to {@code false} (which is the default).
+   * When {@link HttpClientOptions#http2ClearTextUpgradeWithPreflightRequest} is {@code true}, then the client makes a preflight OPTIONS request
+   * and the upgrade will not send a body, voiding the requirements.
+   *
+   * @param http2UpgradeMaxContentLength the length, in bytes
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientOptions setHttp2UpgradeMaxContentLength(int http2UpgradeMaxContentLength) {
+    this.http2UpgradeMaxContentLength = http2UpgradeMaxContentLength;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -431,7 +431,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnectionInterna
           handler.clientUpgrade(ctx);
         }
       };
-      HttpClientUpgradeHandler upgradeHandler = new HttpClientUpgradeHandler(httpCodec, upgradeCodec, 65536) {
+      HttpClientUpgradeHandler upgradeHandler = new HttpClientUpgradeHandler(httpCodec, upgradeCodec, upgradedConnection.client.options().getHttp2UpgradeMaxContentLength()) {
 
         private long bufferedSize = 0;
         private Deque<Object> buffered = new ArrayDeque<>();

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -180,6 +180,13 @@ public class Http1xTest extends HttpTest {
     assertEquals(options, options.setHttp2ConnectionWindowSize(-1));
     assertEquals(-1, options.getHttp2ConnectionWindowSize());
 
+    assertEquals(HttpClientOptions.DEFAULT_HTTP2_UPGRADE_MAX_CONTENT_LENGTH, options.getHttp2UpgradeMaxContentLength());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setHttp2UpgradeMaxContentLength(rand));
+    assertEquals(rand, options.getHttp2UpgradeMaxContentLength());
+    assertEquals(options, options.setHttp2UpgradeMaxContentLength(-1));
+    assertEquals(-1, options.getHttp2UpgradeMaxContentLength());
+
     assertEquals(60000, options.getConnectTimeout());
     rand = TestUtils.randomPositiveInt();
     assertEquals(options, options.setConnectTimeout(rand));
@@ -428,6 +435,7 @@ public class Http1xTest extends HttpTest {
     int http2MaxPoolSize = TestUtils.randomPositiveInt();
     int http2MultiplexingLimit = TestUtils.randomPositiveInt();
     int http2ConnectionWindowSize = TestUtils.randomPositiveInt();
+    int http2UpgradeMaxContentLength = TestUtils.randomPositiveInt();
     boolean decompressionSupported = rand.nextBoolean();
     HttpVersion protocolVersion = HttpVersion.HTTP_1_0;
     int maxChunkSize = TestUtils.randomPositiveInt();
@@ -480,6 +488,7 @@ public class Http1xTest extends HttpTest {
     options.setDecoderInitialBufferSize(decoderInitialBufferSize);
     options.setKeepAliveTimeout(keepAliveTimeout);
     options.setHttp2KeepAliveTimeout(http2KeepAliveTimeout);
+    options.setHttp2UpgradeMaxContentLength(http2UpgradeMaxContentLength);
     HttpClientOptions copy = new HttpClientOptions(options);
     checkCopyHttpClientOptions(options, copy);
     HttpClientOptions copy2 = new HttpClientOptions(options.toJson());
@@ -516,6 +525,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(def.getPipeliningLimit(), json.getPipeliningLimit());
     assertEquals(def.getHttp2MultiplexingLimit(), json.getHttp2MultiplexingLimit());
     assertEquals(def.getHttp2ConnectionWindowSize(), json.getHttp2ConnectionWindowSize());
+    assertEquals(def.getHttp2UpgradeMaxContentLength(), json.getHttp2UpgradeMaxContentLength());
     assertEquals(def.isVerifyHost(), json.isVerifyHost());
     assertEquals(def.isDecompressionSupported(), json.isDecompressionSupported());
     assertEquals(def.isTrustAll(), json.isTrustAll());
@@ -575,6 +585,7 @@ public class Http1xTest extends HttpTest {
     int http2MaxPoolSize = TestUtils.randomPositiveInt();
     int http2MultiplexingLimit = TestUtils.randomPositiveInt();
     int http2ConnectionWindowSize = TestUtils.randomPositiveInt();
+    int http2UpgradeMaxContentLength = TestUtils.randomPositiveInt();
     boolean decompressionSupported = rand.nextBoolean();
     HttpVersion protocolVersion = HttpVersion.HTTP_1_1;
     int maxChunkSize = TestUtils.randomPositiveInt();
@@ -616,6 +627,7 @@ public class Http1xTest extends HttpTest {
       .put("http2MaxPoolSize", http2MaxPoolSize)
       .put("http2MultiplexingLimit", http2MultiplexingLimit)
       .put("http2ConnectionWindowSize", http2ConnectionWindowSize)
+      .put("http2UpgradeMaxContentLength", http2UpgradeMaxContentLength)
       .put("decompressionSupported", decompressionSupported)
       .put("protocolVersion", protocolVersion.name())
       .put("maxChunkSize", maxChunkSize)
@@ -667,6 +679,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(pipeliningLimit, options.getPipeliningLimit());
     assertEquals(http2MultiplexingLimit, options.getHttp2MultiplexingLimit());
     assertEquals(http2ConnectionWindowSize, options.getHttp2ConnectionWindowSize());
+    assertEquals(http2UpgradeMaxContentLength, options.getHttp2UpgradeMaxContentLength());
     assertEquals(decompressionSupported, options.isDecompressionSupported());
     assertEquals(protocolVersion, options.getProtocolVersion());
     assertEquals(maxChunkSize, options.getMaxChunkSize());


### PR DESCRIPTION
Relates to: https://github.com/quarkusio/quarkus/issues/47649