### PR TITLE
Introduce an option for HTTP/2 upgrade max content length

### DIFF
--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -85,6 +85,11 @@ public class HttpClientOptionsConverter {
             obj.setHttp2MultiplexingLimit(((Number)member.getValue()).intValue());
           }
           break;
+        case "http2UpgradeMaxContentLength":
+          if (member.getValue() instanceof Number) {
+            obj.setHttp2UpgradeMaxContentLength(((Number)member.getValue()).intValue());
+          }
+          break;
         case "initialSettings":
           if (member.getValue() instanceof JsonObject) {
             obj.setInitialSettings(new io.vertx.core.http.Http2Settings((io.vertx.core.json.JsonObject)member.getValue()));
@@ -254,6 +259,7 @@ public class HttpClientOptionsConverter {
     json.put("http2KeepAliveTimeout", obj.getHttp2KeepAliveTimeout());
     json.put("http2MaxPoolSize", obj.getHttp2MaxPoolSize());
     json.put("http2MultiplexingLimit", obj.getHttp2MultiplexingLimit());
+    json.put("http2UpgradeMaxContentLength", obj.getHttp2UpgradeMaxContentLength());
     if (obj.getInitialSettings() != null) {
       json.put("initialSettings", obj.getInitialSettings().toJson());
     }

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -163,6 +163,11 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final boolean DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE_WITH_PREFLIGHT_REQUEST = false;
 
   /**
+   * Default maximum length of the aggregated content in bytes
+   */
+  public static final int DEFAULT_HTTP2_UPGRADE_MAX_CONTENT_LENGTH = 65536;
+
+  /**
    * Default WebSocket masked bit is true as depicted by RFC = {@code false}
    */
   public static final boolean DEFAULT_SEND_UNMASKED_FRAMES = false;
@@ -245,6 +250,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   private int http2MultiplexingLimit;
   private int http2ConnectionWindowSize;
   private int http2KeepAliveTimeout;
+  private int http2UpgradeMaxContentLength;
 
   private boolean decompressionSupported;
   private int maxWebSocketFrameSize;
@@ -312,6 +318,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.http2MultiplexingLimit = other.http2MultiplexingLimit;
     this.http2ConnectionWindowSize = other.http2ConnectionWindowSize;
     this.http2KeepAliveTimeout = other.getHttp2KeepAliveTimeout();
+    this.http2UpgradeMaxContentLength = other.getHttp2UpgradeMaxContentLength();
     this.decompressionSupported = other.decompressionSupported;
     this.maxWebSocketFrameSize = other.maxWebSocketFrameSize;
     this.maxWebSocketMessageSize = other.maxWebSocketMessageSize;
@@ -376,6 +383,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     http2MultiplexingLimit = DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
     http2ConnectionWindowSize = DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE;
     http2KeepAliveTimeout = DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT;
+    http2UpgradeMaxContentLength = DEFAULT_HTTP2_UPGRADE_MAX_CONTENT_LENGTH;
     decompressionSupported = DEFAULT_DECOMPRESSION_SUPPORTED;
     maxWebSocketFrameSize = DEFAULT_MAX_WEBSOCKET_FRAME_SIZE;
     maxWebSocketMessageSize = DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE;
@@ -728,6 +736,28 @@ public class HttpClientOptions extends ClientOptionsBase {
       throw new IllegalArgumentException("HTTP/2 keepAliveTimeout must be >= 0");
     }
     this.http2KeepAliveTimeout = keepAliveTimeout;
+    return this;
+  }
+
+
+  /**
+   * @return the HTTP/2 upgrade maximum length of the aggregated content in bytes
+   */
+  public int getHttp2UpgradeMaxContentLength() {
+    return http2UpgradeMaxContentLength;
+  }
+
+  /**
+   * Set the HTTP/2 upgrade maximum length of the aggregated content in bytes.
+   * This is only taken into account when {@link HttpClientOptions#http2ClearTextUpgradeWithPreflightRequest} is set to {@code false} (which is the default).
+   * When {@link HttpClientOptions#http2ClearTextUpgradeWithPreflightRequest} is {@code true}, then the client makes a preflight OPTIONS request
+   * and the upgrade will not send a body, voiding the requirements.
+   *
+   * @param http2UpgradeMaxContentLength the length, in bytes
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientOptions setHttp2UpgradeMaxContentLength(int http2UpgradeMaxContentLength) {
+    this.http2UpgradeMaxContentLength = http2UpgradeMaxContentLength;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradeClientConnection.java
@@ -430,7 +430,7 @@ public class Http2UpgradeClientConnection implements HttpClientConnection {
           handler.clientUpgrade(ctx);
         }
       };
-      HttpClientUpgradeHandler upgradeHandler = new HttpClientUpgradeHandler(httpCodec, upgradeCodec, 65536) {
+      HttpClientUpgradeHandler upgradeHandler = new HttpClientUpgradeHandler(httpCodec, upgradeCodec, upgradedConnection.client.options().getHttp2UpgradeMaxContentLength()) {
 
         private long bufferedSize = 0;
         private Deque<Object> buffered = new ArrayDeque<>();

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -182,6 +182,13 @@ public class Http1xTest extends HttpTest {
     assertEquals(options, options.setHttp2MultiplexingLimit(-1));
     assertEquals(-1, options.getHttp2MultiplexingLimit());
 
+    assertEquals(HttpClientOptions.DEFAULT_HTTP2_UPGRADE_MAX_CONTENT_LENGTH, options.getHttp2UpgradeMaxContentLength());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setHttp2UpgradeMaxContentLength(rand));
+    assertEquals(rand, options.getHttp2UpgradeMaxContentLength());
+    assertEquals(options, options.setHttp2UpgradeMaxContentLength(-1));
+    assertEquals(-1, options.getHttp2UpgradeMaxContentLength());
+
     assertEquals(HttpClientOptions.DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE, options.getHttp2ConnectionWindowSize());
     rand = TestUtils.randomPositiveInt();
     assertEquals(options, options.setHttp2ConnectionWindowSize(rand));
@@ -445,6 +452,7 @@ public class Http1xTest extends HttpTest {
     int http2MaxPoolSize = TestUtils.randomPositiveInt();
     int http2MultiplexingLimit = TestUtils.randomPositiveInt();
     int http2ConnectionWindowSize = TestUtils.randomPositiveInt();
+    int http2UpgradeMaxContentLength = TestUtils.randomPositiveInt();
     boolean decompressionSupported = rand.nextBoolean();
     HttpVersion protocolVersion = HttpVersion.HTTP_1_0;
     int maxChunkSize = TestUtils.randomPositiveInt();
@@ -501,6 +509,7 @@ public class Http1xTest extends HttpTest {
     options.setDecoderInitialBufferSize(decoderInitialBufferSize);
     options.setKeepAliveTimeout(keepAliveTimeout);
     options.setHttp2KeepAliveTimeout(http2KeepAliveTimeout);
+    options.setHttp2UpgradeMaxContentLength(http2UpgradeMaxContentLength);
     HttpClientOptions copy = new HttpClientOptions(options);
     checkCopyHttpClientOptions(options, copy);
     HttpClientOptions copy2 = new HttpClientOptions(options.toJson());
@@ -563,6 +572,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(def.getDecoderInitialBufferSize(), json.getDecoderInitialBufferSize());
     assertEquals(def.getKeepAliveTimeout(), json.getKeepAliveTimeout());
     assertEquals(def.getHttp2KeepAliveTimeout(), json.getHttp2KeepAliveTimeout());
+    assertEquals(def.getHttp2UpgradeMaxContentLength(), json.getHttp2UpgradeMaxContentLength());
   }
 
   @Test
@@ -615,6 +625,7 @@ public class Http1xTest extends HttpTest {
     int decoderInitialBufferSize = TestUtils.randomPositiveInt();
     int keepAliveTimeout = TestUtils.randomPositiveInt();
     int http2KeepAliveTimeout = TestUtils.randomPositiveInt();
+    int http2UpgradeMaxContentLength = TestUtils.randomPositiveInt();
 
     JsonObject json = new JsonObject();
     json.put("sendBufferSize", sendBufferSize)
@@ -661,7 +672,8 @@ public class Http1xTest extends HttpTest {
       .put("localAddress", localAddress)
       .put("decoderInitialBufferSize", decoderInitialBufferSize)
       .put("keepAliveTimeout", keepAliveTimeout)
-      .put("http2KeepAliveTimeout", http2KeepAliveTimeout);
+      .put("http2KeepAliveTimeout", http2KeepAliveTimeout)
+      .put("http2UpgradeMaxContentLength", http2UpgradeMaxContentLength);
 
     HttpClientOptions options = new HttpClientOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());


### PR DESCRIPTION
Cherry-picked from 0c43faaa0150845de85726ba8e252ec1159aeec9