### PR TITLE
Disable shadow context

### DIFF
--- a/vertx-core/pom.xml
+++ b/vertx-core/pom.xml
@@ -192,6 +192,13 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Scope test to declare soft dependency related to maven-compiler-plugin usage -->
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- JMH -->
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
@@ -227,13 +234,6 @@
               </configuration>
             </execution>
           </executions>
-          <dependencies>
-            <dependency>
-              <groupId>io.vertx</groupId>
-              <artifactId>vertx-codegen</artifactId>
-              <version>${project.version}</version>
-            </dependency>
-          </dependencies>
         </plugin>
 
         <plugin>

--- a/vertx-core/src/main/java/io/vertx/core/ThreadingModel.java
+++ b/vertx-core/src/main/java/io/vertx/core/ThreadingModel.java
@@ -34,8 +34,8 @@ public enum ThreadingModel {
 
   /**
    * Tasks are scheduled on threads not managed by the current vertx instance, the nature of the thread is unknown
-   * to the vertx instance. Note that an event-loop thread of another vertx instance falls in this category.
+   * to the vertx instance. An event-loop thread of another vertx instance falls in this category.
    */
-  OTHER
+  EXTERNAL
 }
 

--- a/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentMap;
  *
  * <p>The following can be expected of a shadow context
  * <ul>
- *   <li>{@link #threadingModel()} returns the {@link ThreadingModel#OTHER}</li>
+ *   <li>{@link #threadingModel()} returns the {@link ThreadingModel#EXTERNAL}</li>
  *   <li>{@link #nettyEventLoop()} returns an event-loop of the {@link #owner()}</li>
  *   <li>{@link #owner()} returns the Vertx instance that created it</li>
  *   <li>{@link #executor()} returns the event executor of the shadowed context</li>
@@ -171,7 +171,7 @@ public final class ShadowContext extends ContextBase {
 
   @Override
   public ThreadingModel threadingModel() {
-    return ThreadingModel.OTHER;
+    return ThreadingModel.EXTERNAL;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxBootstrapImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxBootstrapImpl.java
@@ -45,6 +45,7 @@ public class VertxBootstrapImpl implements VertxBootstrap {
   private static final Logger log = LoggerFactory.getLogger(VertxBootstrapImpl.class);
 
   private VertxOptions options;
+  private boolean enableShadowContext;
   private JsonObject config;
   private Transport transport;
   private EventExecutorProvider eventExecutorProvider;
@@ -61,10 +62,12 @@ public class VertxBootstrapImpl implements VertxBootstrap {
   public VertxBootstrapImpl(JsonObject config) {
     this(new VertxOptions(config));
     this.config = config;
+    this.enableShadowContext = false;
   }
 
   public VertxBootstrapImpl(VertxOptions options) {
     this.options = options;
+    this.enableShadowContext = false;
   }
 
   public VertxBootstrapImpl() {
@@ -78,6 +81,12 @@ public class VertxBootstrapImpl implements VertxBootstrap {
   @Override
   public VertxBootstrap options(VertxOptions options) {
     this.options = options;
+    return this;
+  }
+
+  @Override
+  public VertxBootstrap enableShadowContext(boolean option) {
+    this.enableShadowContext = option;
     return this;
   }
 
@@ -230,7 +239,8 @@ public class VertxBootstrapImpl implements VertxBootstrap {
       fileResolver,
       threadFactory,
       executorServiceFactory,
-      eventExecutorProvider);
+      eventExecutorProvider,
+      enableShadowContext);
   }
 
   public Vertx vertx() {

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxBootstrap.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxBootstrap.java
@@ -51,6 +51,14 @@ public interface VertxBootstrap {
   VertxBootstrap options(VertxOptions options);
 
   /**
+   * Set whether to enable shadow contexts.
+   *
+   * @param option the value
+   * @return this builder instance
+   */
+  VertxBootstrap enableShadowContext(boolean option);
+
+  /**
    * Set an event executor {@code provider} to use.
    *
    * @param provider a provider to use

--- a/vertx-core/src/main/java/io/vertx/core/spi/context/executor/EventExecutorProvider.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/context/executor/EventExecutorProvider.java
@@ -34,7 +34,7 @@ public interface EventExecutorProvider extends VertxServiceProvider {
    *
    * @param thread the thread for which an executor is required
    * @return an executor suitable for the given thread, tasks executed on this executor will be declared as
-   * running on {@link io.vertx.core.ThreadingModel#OTHER}.
+   * running on {@link io.vertx.core.ThreadingModel#EXTERNAL}.
    */
   java.util.concurrent.Executor eventExecutorFor(Thread thread);
 

--- a/vertx-core/src/test/java/io/vertx/it/eventexecutor/CustomEventExecutorTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/eventexecutor/CustomEventExecutorTest.java
@@ -41,7 +41,7 @@ public class CustomEventExecutorTest {
     });
     thread.start();
     thread.join();
-    assertEquals(ThreadingModel.OTHER, context.threadingModel());
+    assertEquals(ThreadingModel.EXTERNAL, context.threadingModel());
     int[] executions = new int[1];
     context.runOnContext(v -> {
       executions[0]++;

--- a/vertx-core/src/test/java/io/vertx/tests/context/EventExecutorProviderTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/EventExecutorProviderTest.java
@@ -14,14 +14,12 @@ import io.vertx.core.Context;
 import io.vertx.core.ThreadingModel;
 import io.vertx.core.Vertx;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.EventExecutor;
 import io.vertx.core.internal.VertxBootstrap;
 import io.vertx.test.core.AsyncTestBase;
 import org.junit.Test;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.Executor;
 
 public class EventExecutorProviderTest extends AsyncTestBase {
 
@@ -33,7 +31,7 @@ public class EventExecutorProviderTest extends AsyncTestBase {
     bootstrap.init();
     Vertx vertx = bootstrap.vertx();
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-    assertEquals(ThreadingModel.OTHER, ctx.threadingModel());
+    assertEquals(ThreadingModel.EXTERNAL, ctx.threadingModel());
     assertEquals(0, toRun.size());
     int[] cnt = new int[1];
     ctx.runOnContext(v -> {


### PR DESCRIPTION
Motivation:

For Vert.x 5.0 disable the shadow context feature as we are still lacking good naming and documentation for it. It should be promoted when it becomes more mature.

Changes:

Disable shadow context by default, it can still be configured on a `VertxBootstrap`.
