### PR TITLE
Let Vertx#deploy(Supplier<? extends Deployable>) to be present in RxJava like generators

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/Vertx.java
+++ b/vertx-core/src/main/java/io/vertx/core/Vertx.java
@@ -496,7 +496,7 @@ public interface Vertx extends Measured {
    *
    * @return a future completed with the result
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Future<String> deployVerticle(Supplier<? extends Deployable> supplier, DeploymentOptions options);
 
   /**


### PR DESCRIPTION
Motivation:

Since codegen supports wildcard declarations for permitted types we can promote `Vertx#deploy(Supplier<? extends Deployable>)` to a permitted type translation.

Changes:

Change `Vertx#deploy(Supplier<? extends Deployable>)` from `@GenIgnore` to `@GenIgnore("permitted-type")`
