### PR TITLE
Replace Promise<Void> by Completable<Void> in Closeable contract.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/Closeable.java
+++ b/vertx-core/src/main/java/io/vertx/core/Closeable.java
@@ -25,6 +25,5 @@ public interface Closeable {
    *
    * @param completion the promise to signal when close has completed
    */
-  // SHOULD BE COMPLETABLE HERE
-  void close(Promise<Void> completion);
+  void close(Completable<Void> completion);
 }

--- a/vertx-core/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
@@ -22,10 +22,7 @@ import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.Closeable;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.datagram.DatagramSocket;
@@ -314,9 +311,9 @@ public class DatagramSocketImpl implements DatagramSocket, MetricsProvider, Clos
   }
 
   @Override
-  public void close(Promise<Void> completion) {
+  public void close(Completable<Void> completion) {
     if (!channel.isOpen()) {
-      completion.complete();
+      completion.succeed();
     } else {
       // make sure everything is flushed out on close
       channel.flush();

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -147,7 +147,7 @@ public abstract class HandlerRegistration<T> implements Closeable {
   }
 
   @Override
-  public void close(Promise<Void> completion) {
+  public void close(Completable<Void> completion) {
     unregister().onComplete(completion);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -10,8 +10,8 @@
  */
 package io.vertx.core.http.impl;
 
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.http.HttpClientInternal;
@@ -116,7 +116,7 @@ public class CleanableHttpClient implements HttpClientInternal {
   }
 
   @Override
-  public void close(Promise<Void> completion) {
+  public void close(Completable<Void> completion) {
     delegate.close(completion);
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
@@ -11,8 +11,8 @@
 package io.vertx.core.http.impl;
 
 import io.vertx.core.Closeable;
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.http.*;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.spi.metrics.Metrics;
@@ -83,7 +83,7 @@ public class CleanableWebSocketClient implements WebSocketClient, MetricsProvide
   }
 
   @Override
-  public void close(Promise<Void> completion) {
+  public void close(Completable<Void> completion) {
     ((Closeable)delegate).close(completion);
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -65,7 +65,7 @@ public class HttpClientBase implements MetricsProvider, Closeable {
     this.vertx = vertx;
     this.metrics = vertx.metrics() != null ? vertx.metrics().createHttpClientMetrics(options) : null;
     this.options = new HttpClientOptions(options);
-    this.closeSequence = new CloseSequence(this::doClose, this::doShutdown);
+    this.closeSequence = new CloseSequence(p -> doClose(p), p1 -> doShutdown(p1));
     this.proxyFilter = options.getNonProxyHosts() != null ? ProxyFilter.nonProxyHosts(options.getNonProxyHosts()) : ProxyFilter.DEFAULT_PROXY_FILTER;
     this.netClient = new NetClientBuilder(vertx, new NetClientOptions(options).setProxyOptions(null)).metrics(metrics).build();
     this.defaultSslOptions = options.getSslOptions();
@@ -93,7 +93,7 @@ public class HttpClientBase implements MetricsProvider, Closeable {
     return closeSequence.future();
   }
 
-  public void close(Promise<Void> completion) {
+  public void close(Completable<Void> completion) {
     closeSequence.close(completion);
   }
 
@@ -153,11 +153,11 @@ public class HttpClientBase implements MetricsProvider, Closeable {
     return metrics;
   }
 
-  protected void doShutdown(Promise<Void> p) {
+  protected void doShutdown(Completable<Void> p) {
     netClient.shutdown(closeTimeout, closeTimeoutUnit).onComplete(p);
   }
 
-  protected void doClose(Promise<Void> p) {
+  protected void doClose(Completable<Void> p) {
     netClient.close().onComplete(p);
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -11,10 +11,7 @@
 
 package io.vertx.core.http.impl;
 
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
@@ -154,7 +151,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   }
 
   @Override
-  protected void doShutdown(Promise<Void> p) {
+  protected void doShutdown(Completable<Void> p) {
     synchronized (this) {
       if (timerID >= 0) {
         vertx.cancelTimer(timerID);
@@ -166,7 +163,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   }
 
   @Override
-  protected void doClose(Promise<Void> p) {
+  protected void doClose(Completable<Void> p) {
     httpCM.close();
     super.doClose(p);
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -235,11 +235,11 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
     return result.future();
   }
 
-  private void doShutdown(NetServer netServer, Promise<Void> p) {
+  private void doShutdown(NetServer netServer, Completable<Void> p) {
     netServer.shutdown(closeTimeout, closeTimeoutUnit).onComplete(p);
   }
 
-  private void doClose(NetServer netServer, Promise<Void> p) {
+  private void doClose(NetServer netServer, Completable<Void> p) {
     netServer.close().onComplete(p);
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.http.impl;
 
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
@@ -42,12 +43,12 @@ public class WebSocketClientImpl extends HttpClientBase implements WebSocketClie
     this.webSocketCM = new ResourceManager<>();
   }
 
-  protected void doShutdown(Promise<Void> p) {
+  protected void doShutdown(Completable<Void> p) {
     webSocketCM.shutdown();
     super.doShutdown(p);
   }
 
-  protected void doClose(Promise<Void> p) {
+  protected void doClose(Completable<Void> p) {
     webSocketCM.close();
     super.doClose(p);
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/SharedResourceHolder.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/SharedResourceHolder.java
@@ -12,7 +12,7 @@
 package io.vertx.core.impl;
 
 import io.vertx.core.Closeable;
-import io.vertx.core.Promise;
+import io.vertx.core.Completable;
 import io.vertx.core.Vertx;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.shareddata.LocalMap;
@@ -73,7 +73,7 @@ class SharedResourceHolder<C> implements Shareable {
     }
 
     @Override
-    public void close(Promise<Void> completion) {
+    public void close(Completable<Void> completion) {
       LocalMap<String, SharedResourceHolder<C>> localMap1 = vertx.sharedData().getLocalMap(resourceKey);
       SharedResourceHolder<C> res = localMap1.compute(resourceName, (key, value) -> {
         if (value == null) {
@@ -87,7 +87,7 @@ class SharedResourceHolder<C> implements Shareable {
       if (res == null) {
         closeFuture.close(completion);
       } else {
-        completion.complete();
+        completion.succeed();
       }
     }
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -1050,9 +1050,9 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     }
 
     // Called via Context close hook when Verticle is undeployed
-    public void close(Promise<Void> completion) {
+    public void close(Completable<Void> completion) {
       tryCancel();
-      completion.complete();
+      completion.succeed();
     }
   }
 
@@ -1098,7 +1098,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       WorkerPool pool = new WorkerPool(workerExec, workerMetrics);
       cf.add(completion -> {
         pool.close();
-        completion.complete();
+        completion.succeed();
       });
       return pool;
     });

--- a/vertx-core/src/main/java/io/vertx/core/internal/CloseFuture.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/CloseFuture.java
@@ -12,6 +12,7 @@
 package io.vertx.core.internal;
 
 import io.vertx.core.Closeable;
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.logging.Logger;
@@ -180,7 +181,7 @@ public class CloseFuture extends NestedCloseable implements Closeable {
    *
    * @param promise called when all hooks have been executed
    */
-  public void close(Promise<Void> promise) {
+  public void close(Completable<Void> promise) {
     close().onComplete(promise);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/internal/CloseSequence.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/CloseSequence.java
@@ -11,6 +11,7 @@
 package io.vertx.core.internal;
 
 import io.vertx.core.Closeable;
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 
@@ -127,7 +128,7 @@ public class CloseSequence extends NestedCloseable implements Closeable {
   }
 
   @Override
-  public void close(Promise<Void> completion) {
+  public void close(Completable<Void> completion) {
     progressTo(0).onComplete(completion);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/CleanableNetClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/CleanableNetClient.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.net.impl;
 
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
@@ -87,7 +88,7 @@ public class CleanableNetClient implements NetClientInternal {
   }
 
   @Override
-  public void close(Promise<Void> completion) {
+  public void close(Completable<Void> completion) {
     client.close(completion);
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/deployment/DeploymentTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/deployment/DeploymentTest.java
@@ -343,7 +343,7 @@ public class DeploymentTest extends VertxTestBase {
       }));
     }));
     await();
-    assertTrue(verticle2.completion.future().isComplete());
+    assertTrue(((Promise<?>)verticle2.completion).future().isComplete());
   }
 
   @Test
@@ -895,11 +895,11 @@ public class DeploymentTest extends VertxTestBase {
     AtomicInteger closedCount = new AtomicInteger();
     Closeable myCloseable1 = completionHandler -> {
       closedCount.incrementAndGet();
-      completionHandler.handle(Future.succeededFuture());
+      completionHandler.succeed();
     };
     Closeable myCloseable2 = completionHandler -> {
       closedCount.incrementAndGet();
-      completionHandler.handle(Future.succeededFuture());
+      completionHandler.succeed();
     };
     MyAsyncVerticle verticle = new MyAsyncVerticle(f-> {
       ContextInternal ctx = (ContextInternal)Vertx.currentContext();
@@ -1190,7 +1190,7 @@ public class DeploymentTest extends VertxTestBase {
     AtomicBoolean closeHookCalledBeforeDeployFailure = new AtomicBoolean(false);
     Closeable closeable = completionHandler -> {
       closeHookCalledBeforeDeployFailure.set(true);
-      completionHandler.handle(Future.succeededFuture());
+      completionHandler.succeed();
     };
     Verticle v = new AbstractVerticle() {
       @Override
@@ -1307,7 +1307,7 @@ public class DeploymentTest extends VertxTestBase {
           ContextInternal ctx = (ContextInternal) context;
           ctx.addCloseHook(completion -> {
             closeHooks.add(idx);
-            completion.complete();
+            completion.succeed();
           });
           startPromises.put(idx, startPromise);
           if (startPromises.size() == numberOfInstances) {
@@ -1358,7 +1358,7 @@ public class DeploymentTest extends VertxTestBase {
               fail(e);
             }
             hookCompletion.set(true);
-            completion.complete();
+            completion.succeed();
           }).start();
         });
         vertx.close().onComplete(onSuccess(v -> {
@@ -1443,7 +1443,7 @@ public class DeploymentTest extends VertxTestBase {
     int stopAction;
     String deploymentID;
     JsonObject config;
-    Promise<Void> completion;
+    Completable<Void> completion;
 
     MyVerticle() {
       this(NOOP, NOOP);
@@ -1458,7 +1458,7 @@ public class DeploymentTest extends VertxTestBase {
     public void start() throws Exception {
       ((ContextInternal)context).addCloseHook(promise -> {
         completion = promise;
-        promise.complete();
+        promise.succeed();
       });
       switch (startAction) {
         case THROW_EXCEPTION:

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/CloseFutureTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/CloseFutureTest.java
@@ -11,6 +11,7 @@
 package io.vertx.tests.vertx;
 
 import io.vertx.core.Closeable;
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.CloseFuture;
@@ -29,11 +30,11 @@ public class CloseFutureTest extends AsyncTestBase {
   @Test
   public void testHookCompletion() {
     CloseFuture cf = new CloseFuture();
-    AtomicReference<Promise<Void>> ref = new AtomicReference<>();
+    AtomicReference<Completable<Void>> ref = new AtomicReference<>();
     cf.add(completion -> ref.set(completion));
     assertFalse(cf.close().succeeded());
     assertNotNull(ref.get());
-    ref.get().complete();
+    ref.get().succeed();
     assertTrue(cf.close().succeeded());
   }
 
@@ -49,9 +50,9 @@ public class CloseFutureTest extends AsyncTestBase {
 
   @Test
   public void testCloseFutureDuplicateClose() {
-    AtomicReference<Promise<Void>> ref = new AtomicReference<>();
+    AtomicReference<Completable<Void>> ref = new AtomicReference<>();
     CloseFuture fut = new CloseFuture();
-    fut.add(ref::set);
+    fut.add(newValue -> ref.set(newValue));
     Promise<Void> p1 = Promise.promise();
     fut.close(p1);
     assertNotNull(ref.get());
@@ -59,7 +60,7 @@ public class CloseFutureTest extends AsyncTestBase {
     fut.close(p2);
     assertFalse(p1.future().isComplete());
     assertFalse(p2.future().isComplete());
-    ref.get().complete();
+    ref.get().succeed();
     assertTrue(p1.future().isComplete());
     assertTrue(p2.future().isComplete());
   }
@@ -118,9 +119,9 @@ public class CloseFutureTest extends AsyncTestBase {
     private AtomicBoolean closed = new AtomicBoolean();
 
     @Override
-    public void close(Promise<Void> completion) {
+    public void close(Completable<Void> completion) {
       closed.set(true);
-      completion.complete();
+      completion.succeed();
     }
 
     @Override

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/CloseSequenceTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/CloseSequenceTest.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.tests.vertx;
 
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.CloseFuture;
@@ -22,9 +23,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class CloseSequenceTest extends AsyncTestBase {
 
-  private AtomicReference<Promise<Void>> ref1;
-  private AtomicReference<Promise<Void>> ref2;
-  private AtomicReference<Promise<Void>> ref3;
+  private AtomicReference<Completable<Void>> ref1;
+  private AtomicReference<Completable<Void>> ref2;
+  private AtomicReference<Completable<Void>> ref3;
   private CloseSequence seq;
 
   @Override
@@ -34,7 +35,7 @@ public class CloseSequenceTest extends AsyncTestBase {
     ref1 = new AtomicReference<>();
     ref2 = new AtomicReference<>();
     ref3 = new AtomicReference<>();
-    seq = new CloseSequence(ref3::set, ref2::set, ref1::set);
+    seq = new CloseSequence(newValue -> ref3.set(newValue), newValue1 -> ref2.set(newValue1), newValue2 -> ref1.set(newValue2));
   }
 
   @Test
@@ -44,7 +45,7 @@ public class CloseSequenceTest extends AsyncTestBase {
     assertNotNull(ref1.get());
     assertNull(ref2.get());
     assertNull(ref3.get());
-    ref1.get().complete();
+    ref1.get().succeed();
     assertTrue(f1.succeeded());
     assertNotNull(ref1.get());
     assertNull(ref2.get());
@@ -54,7 +55,7 @@ public class CloseSequenceTest extends AsyncTestBase {
     assertNotNull(ref1.get());
     assertNotNull(ref2.get());
     assertNull(ref3.get());
-    ref2.get().complete();
+    ref2.get().succeed();
     assertTrue(f2.succeeded());
     assertNotNull(ref1.get());
     assertNotNull(ref2.get());
@@ -64,7 +65,7 @@ public class CloseSequenceTest extends AsyncTestBase {
     assertNotNull(ref1.get());
     assertNotNull(ref2.get());
     assertNotNull(ref3.get());
-    ref3.get().complete();
+    ref3.get().succeed();
     assertTrue(f3.succeeded());
     assertNotNull(ref1.get());
     assertNotNull(ref2.get());
@@ -78,12 +79,12 @@ public class CloseSequenceTest extends AsyncTestBase {
     assertNotNull(ref1.get());
     assertNull(ref2.get());
     assertNull(ref3.get());
-    ref1.get().complete();
+    ref1.get().succeed();
     assertFalse(fut2.isComplete());
     assertNotNull(ref1.get());
     assertNotNull(ref2.get());
     assertNull(ref3.get());
-    ref2.get().complete();
+    ref2.get().succeed();
     assertTrue(fut2.isComplete());
     assertNotNull(ref1.get());
     assertNotNull(ref2.get());
@@ -99,13 +100,13 @@ public class CloseSequenceTest extends AsyncTestBase {
     assertNotNull(ref1.get());
     assertNull(ref2.get());
     assertNull(ref3.get());
-    ref1.get().complete();
+    ref1.get().succeed();
     assertTrue(fut1.isComplete());
     assertFalse(fut2.isComplete());
     assertNotNull(ref1.get());
     assertNotNull(ref2.get());
     assertNull(ref3.get());
-    ref2.get().complete();
+    ref2.get().succeed();
     assertTrue(fut1.isComplete());
     assertTrue(fut2.isComplete());
     assertNotNull(ref1.get());
@@ -118,9 +119,9 @@ public class CloseSequenceTest extends AsyncTestBase {
     CloseFuture closeFuture = new CloseFuture();
     closeFuture.add(seq);
     seq.close();
-    ref1.get().complete();
-    ref2.get().complete();
-    ref3.get().complete();
+    ref1.get().succeed();
+    ref2.get().succeed();
+    ref3.get().succeed();
     assertFalse(closeFuture.remove(seq));
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
@@ -58,11 +58,11 @@ public class VertxTest extends AsyncTestBase {
     AtomicInteger closedCount = new AtomicInteger();
     Closeable myCloseable1 = completionHandler -> {
       closedCount.incrementAndGet();
-      completionHandler.handle(Future.succeededFuture());
+      completionHandler.succeed();
     };
     Closeable myCloseable2 = completionHandler -> {
       closedCount.incrementAndGet();
-      completionHandler.handle(Future.succeededFuture());
+      completionHandler.succeed();
     };
     VertxInternal vertx = (VertxInternal) Vertx.vertx();
     vertx.addCloseHook(myCloseable1);
@@ -82,11 +82,11 @@ public class VertxTest extends AsyncTestBase {
     AtomicInteger closedCount = new AtomicInteger();
     class Hook implements Closeable {
       @Override
-      public void close(Promise<Void> completion) {
+      public void close(Completable<Void> completion) {
         if (closedCount.incrementAndGet() == 1) {
           throw new RuntimeException("Don't be afraid");
         } else {
-          completion.handle(Future.succeededFuture());
+          completion.succeed();
         }
       }
     }
@@ -108,12 +108,12 @@ public class VertxTest extends AsyncTestBase {
     AtomicInteger closedCount = new AtomicInteger();
     class Hook implements Closeable {
       @Override
-      public void close(Promise<Void> completion) {
+      public void close(Completable<Void> completion) {
         if (closedCount.incrementAndGet() == 1) {
-          completion.handle(Future.succeededFuture());
+          completion.succeed();
           throw new RuntimeException();
         } else {
-          completion.handle(Future.succeededFuture());
+          completion.succeed();
         }
       }
     }
@@ -422,9 +422,9 @@ public class VertxTest extends AsyncTestBase {
   @Test
   public void testCloseVertxShouldWaitConcurrentCloseHook() throws Exception {
     VertxInternal vertx = (VertxInternal) Vertx.vertx();
-    AtomicReference<Promise<Void>> ref = new AtomicReference<>();
+    AtomicReference<Completable<Void>> ref = new AtomicReference<>();
     CloseFuture fut = new CloseFuture();
-    fut.add(ref::set);
+    fut.add(newValue -> ref.set(newValue));
     vertx.addCloseHook(fut);
     Promise<Void> p = Promise.promise();
     fut.close(p);
@@ -432,7 +432,7 @@ public class VertxTest extends AsyncTestBase {
     vertx.close().onComplete(ar -> closed.set(true));
     Thread.sleep(500);
     assertFalse(closed.get());
-    ref.get().complete();
+    ref.get().succeed();
     assertWaitUntil(closed::get);
   }
 


### PR DESCRIPTION
Motivation:

`Closeable#close` should declare its argument with the type `Completable` instead of `Promise` which is more suitable for this since the `Closeable` implementation only cares about completing it and the semantic of `Promise` is not useful here.
