### PR TITLE
Update connection pool contract to use Completable over Future

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/internal/pool/ConnectionPool.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/pool/ConnectionPool.java
@@ -11,6 +11,7 @@
 package io.vertx.core.internal.pool;
 
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.internal.ContextInternal;
@@ -76,14 +77,8 @@ public interface ConnectionPool<C> {
    *
    * @param context the context
    * @param kind the connection kind wanted which is an index in the max size array provided when constructing the pool
-   * @return the future notified with the result
    */
-  Future<Lease<C>> acquire(ContextInternal context, int kind);
-
-  @Deprecated(forRemoval = true)
-  default void acquire(ContextInternal context, int kind, Handler<AsyncResult<Lease<C>>> handler) {
-    acquire(context, kind).onComplete(handler);
-  }
+  void acquire(ContextInternal context, int kind, Completable<Lease<C>> handler);
 
   /**
    * Acquire a connection from the pool.
@@ -91,14 +86,8 @@ public interface ConnectionPool<C> {
    * @param context the context
    * @param listener the waiter event listener
    * @param kind the connection kind wanted which is an index in the max size array provided when constructing the pool
-   * @return the future notified with the result
    */
-  Future<Lease<C>> acquire(ContextInternal context, PoolWaiter.Listener<C> listener, int kind);
-
-  @Deprecated(forRemoval = true)
-  default void acquire(ContextInternal context, PoolWaiter.Listener<C> listener, int kind, Handler<AsyncResult<Lease<C>>> handler) {
-    acquire(context, listener, kind).onComplete(handler);
-  }
+  void acquire(ContextInternal context, PoolWaiter.Listener<C> listener, int kind, Completable<Lease<C>> handler);
 
   /**
    * Cancel a waiter.
@@ -109,14 +98,8 @@ public interface ConnectionPool<C> {
    * notified with a result.
    *
    * @param waiter the waiter to cancel
-   * @return the future notified with the result
    */
-  Future<Boolean> cancel(PoolWaiter<C> waiter);
-
-  @Deprecated(forRemoval = true)
-  default void cancel(PoolWaiter<C> waiter, Handler<AsyncResult<Boolean>> handler) {
-    cancel(waiter).onComplete(handler);
-  }
+  void cancel(PoolWaiter<C> waiter, Completable<Boolean> handler);
 
   /**
    * <p> Evict connections from the pool with a {@code predicate}, only unused connection can be evicted.
@@ -124,29 +107,16 @@ public interface ConnectionPool<C> {
    * <p> The operation returns the list of connections evicted from the pool as is.
    *
    * @param predicate to determine whether a connection should be evicted
-   * @return the future notified with the result
    */
-  Future<List<C>> evict(Predicate<C> predicate);
-
-  @Deprecated(forRemoval = true)
-  default void evict(Predicate<C> predicate, Handler<AsyncResult<List<C>>> handler) {
-    evict(predicate).onComplete(handler);
-  }
+  void evict(Predicate<C> predicate, Completable<List<C>> handler);
 
   /**
    * Close the pool.
    *
    * <p> This will not close the connections, instead a list of connections to be closed is returned
    * to the completion {@code handler}.
-   *
-   * @return the future notified with the result
    */
-  Future<List<Future<C>>> close();
-
-  @Deprecated(forRemoval = true)
-  default void close(Handler<AsyncResult<List<Future<C>>>> handler) {
-    close().onComplete(handler);
-  }
+  void close(Completable<List<Future<C>>> handler);
 
   /**
    * @return the number of managed connections - the program should not use the value

--- a/vertx-core/src/main/java/io/vertx/core/internal/pool/PoolWaiter.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/pool/PoolWaiter.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.internal.pool;
 
+import io.vertx.core.Completable;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
 
@@ -46,13 +47,13 @@ public class PoolWaiter<C> {
   final PoolWaiter.Listener<C> listener;
   final ContextInternal context;
   final int capacity;
-  final Promise<Lease<C>> handler;
+  final Completable<Lease<C>> handler;
   PoolWaiter<C> prev;
   PoolWaiter<C> next;
   boolean disposed;
   boolean queued;
 
-  PoolWaiter(PoolWaiter.Listener<C> listener, ContextInternal context, final int capacity, Promise<Lease<C>> handler) {
+  PoolWaiter(PoolWaiter.Listener<C> listener, ContextInternal context, final int capacity, Completable<Lease<C>> handler) {
     this.listener = listener;
     this.context = context;
     this.capacity = capacity;

--- a/vertx-core/src/main/java/io/vertx/core/internal/pool/SimpleConnectionPool.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/pool/SimpleConnectionPool.java
@@ -76,6 +76,7 @@ import java.util.function.Predicate;
 public class SimpleConnectionPool<C> implements ConnectionPool<C> {
 
   private static final Future POOL_CLOSED = Future.failedFuture("Pool closed");
+  private static final VertxException POOL_CLOSED_EXCEPTION = new VertxException("Pool closed", true);
 
   /**
    * Select the first available available connection with the same event loop.
@@ -369,13 +370,13 @@ public class SimpleConnectionPool<C> implements ConnectionPool<C> {
         @Override
         public void run() {
           if (waiter != null) {
-            Future<Lease<C>> waiterFailure;
+            Throwable waiterFailure;
             if (pool.closed) {
-              waiterFailure = POOL_CLOSED;
+              waiterFailure = POOL_CLOSED_EXCEPTION;
             } else {
-              waiterFailure = Future.failedFuture(cause);
+              waiterFailure = cause;
             }
-            removed.context.emit(waiterFailure, waiter.handler::handle);
+            waiter.handler.fail(waiterFailure);
           }
           removed.result.fail(cause);
         }
@@ -498,9 +499,9 @@ public class SimpleConnectionPool<C> implements ConnectionPool<C> {
   private static class Evict<C> implements Executor.Action<SimpleConnectionPool<C>> {
 
     private final Predicate<C> predicate;
-    private final Promise<List<C>> handler;
+    private final Completable<List<C>> handler;
 
-    public Evict(Predicate<C> predicate, Promise<List<C>> handler) {
+    public Evict(Predicate<C> predicate, Completable<List<C>> handler) {
       this.predicate = predicate;
       this.handler = handler;
     }
@@ -511,7 +512,7 @@ public class SimpleConnectionPool<C> implements ConnectionPool<C> {
         return new Task() {
           @Override
           public void run() {
-            handler.handle(POOL_CLOSED);
+            handler.fail(POOL_CLOSED_EXCEPTION);
           }
         };
       }
@@ -527,7 +528,7 @@ public class SimpleConnectionPool<C> implements ConnectionPool<C> {
       Task head = new Task() {
         @Override
         public void run() {
-          handler.handle(Future.succeededFuture(res));
+          handler.succeed(res);
         }
       };
       Task tail = head;
@@ -543,15 +544,13 @@ public class SimpleConnectionPool<C> implements ConnectionPool<C> {
   }
 
   @Override
-  public Future<List<C>> evict(Predicate<C> predicate) {
-    Promise<List<C>> promise = Promise.promise();
-    execute(new Evict<>(predicate, promise));
-    return promise.future();
+  public void evict(Predicate<C> predicate, Completable<List<C>> handler) {
+    execute(new Evict<>(predicate, handler));
   }
 
   private static class Acquire<C> extends PoolWaiter<C> implements Executor.Action<SimpleConnectionPool<C>> {
 
-    public Acquire(ContextInternal context, PoolWaiter.Listener<C> listener, int capacity, Promise<Lease<C>> handler) {
+    public Acquire(ContextInternal context, PoolWaiter.Listener<C> listener, int capacity, Completable<Lease<C>> handler) {
       super(listener, context, capacity, handler);
     }
 
@@ -637,33 +636,27 @@ public class SimpleConnectionPool<C> implements ConnectionPool<C> {
   }
 
   @Override
-  public Future<Lease<C>> acquire(ContextInternal context, int kind) {
-    LazyFuture<Lease<C>> fut = new LazyFuture<>();
-    execute(new Acquire<>(context, PoolWaiter.NULL_LISTENER, capacityFactors[kind], fut));
-    return fut;
+  public void acquire(ContextInternal context, int kind, Completable<Lease<C>> handler) {
+    execute(new Acquire<>(context, PoolWaiter.NULL_LISTENER, capacityFactors[kind], handler));
   }
 
   @Override
-  public Future<Lease<C>> acquire(ContextInternal context, PoolWaiter.Listener<C> listener, int kind) {
-    LazyFuture<Lease<C>> fut = new LazyFuture<>();
-    execute(new Acquire<>(context, listener, capacityFactors[kind], fut));
-    return fut;
+  public void acquire(ContextInternal context, PoolWaiter.Listener<C> listener, int kind, Completable<Lease<C>> handler) {
+    execute(new Acquire<>(context, listener, capacityFactors[kind], handler));
   }
 
   @Override
-  public Future<Boolean> cancel(PoolWaiter<C> waiter) {
-    Promise<Boolean> promise = Promise.promise();
-    execute(new Cancel<>(waiter, promise));
-    return promise.future();
+  public void cancel(PoolWaiter<C> waiter, Completable<Boolean> handler) {
+    execute(new Cancel<>(waiter, handler));
   }
 
   private static class Cancel<C> extends Task implements Executor.Action<SimpleConnectionPool<C>> {
 
     private final PoolWaiter<C> waiter;
-    private final Promise<Boolean> handler;
+    private final Completable<Boolean> handler;
     private boolean cancelled;
 
-    public Cancel(PoolWaiter<C> waiter, Promise<Boolean> handler) {
+    public Cancel(PoolWaiter<C> waiter, Completable<Boolean> handler) {
       this.waiter = waiter;
       this.handler = handler;
     }
@@ -674,7 +667,7 @@ public class SimpleConnectionPool<C> implements ConnectionPool<C> {
         return new Task() {
           @Override
           public void run() {
-            handler.handle(POOL_CLOSED);
+            handler.fail(POOL_CLOSED_EXCEPTION);
           }
         };
       }
@@ -692,18 +685,18 @@ public class SimpleConnectionPool<C> implements ConnectionPool<C> {
 
     @Override
     public void run() {
-      handler.handle(Future.succeededFuture(cancelled));
+      handler.succeed(cancelled);
     }
   }
 
   static class LeaseImpl<C> implements Lease<C> {
 
-    private final Promise<Lease<C>> handler;
+    private final Completable<Lease<C>> handler;
     private final Slot<C> slot;
     private final C connection;
     private boolean recycled;
 
-    public LeaseImpl(Slot<C> slot, Promise<Lease<C>> handler) {
+    public LeaseImpl(Slot<C> slot, Completable<Lease<C>> handler) {
       this.handler = handler;
       this.slot = slot;
       this.connection = slot.connection;
@@ -776,9 +769,9 @@ public class SimpleConnectionPool<C> implements ConnectionPool<C> {
 
   private static class Close<C> implements Executor.Action<SimpleConnectionPool<C>> {
 
-    private final Promise<List<Future<C>>> handler;
+    private final Completable<List<Future<C>>> handler;
 
-    private Close(Promise<List<Future<C>>> handler) {
+    private Close(Completable<List<Future<C>>> handler) {
       this.handler = handler;
     }
 
@@ -788,7 +781,7 @@ public class SimpleConnectionPool<C> implements ConnectionPool<C> {
         return new Task() {
           @Override
           public void run() {
-            handler.handle(POOL_CLOSED);
+            handler.fail(POOL_CLOSED_EXCEPTION);
           }
         };
       }
@@ -811,18 +804,18 @@ public class SimpleConnectionPool<C> implements ConnectionPool<C> {
       return new Task() {
         @Override
         public void run() {
-          waiters.forEach(w -> w.context.emit(POOL_CLOSED, w.handler::handle));
-          handler.handle(Future.succeededFuture(list));
+          waiters.forEach(w -> {
+            w.handler.fail(POOL_CLOSED_EXCEPTION);
+          });
+          handler.succeed(list);
         }
       };
     }
   }
 
   @Override
-  public Future<List<Future<C>>> close() {
-    Promise<List<Future<C>>> promise = Promise.promise();
-    execute(new Close<>(promise));
-    return promise.future();
+  public void close(Completable<List<Future<C>>> handler) {
+    execute(new Close<>(handler));
   }
 
   private static class Waiters<C> implements Iterable<PoolWaiter<C>> {

--- a/vertx-core/src/test/java/io/vertx/test/core/AsyncTestBase.java
+++ b/vertx-core/src/test/java/io/vertx/test/core/AsyncTestBase.java
@@ -11,11 +11,8 @@
 
 package io.vertx.test.core;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Handler;
+import io.vertx.core.*;
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.impl.Utils;
 import io.vertx.core.internal.logging.Logger;
@@ -606,6 +603,13 @@ public class AsyncTestBase {
     };
   }
 
+  protected <T> Completable<T> onFailure2(Consumer<Throwable> consumer) {
+    return (res, err) -> {
+      assertNotNull(err);
+      consumer.accept(err);
+    };
+  }
+
   protected <T> T awaitFuture(Future<T> latch) throws InterruptedException {
     return awaitFuture(latch, 10, TimeUnit.SECONDS);
   }
@@ -677,6 +681,17 @@ public class AsyncTestBase {
         return false;
       }
     }
+  }
+
+  protected <T> Completable<T> onSuccess2(Consumer<T> consumer) {
+    return (res, err) -> {
+      if (err != null) {
+        err.printStackTrace();
+        fail(err.getMessage());
+      } else {
+        consumer.accept(res);
+      }
+    };
   }
 
   protected <T> Handler<AsyncResult<T>> onSuccess(Consumer<T> consumer) {

--- a/vertx-core/src/test/java/io/vertx/tests/pool/StressTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/pool/StressTest.java
@@ -38,12 +38,11 @@ public class StressTest extends VertxTestBase {
 
     void getConnection(FakeWaiter waiter) {
       pool
-        .acquire(waiter.context, 0)
-        .onComplete(ar -> {
-          if (ar.succeeded()) {
-            waiter.handleConnection(ar.result());
+        .acquire(waiter.context, 0, (res, err) -> {
+          if (err == null) {
+            waiter.handleConnection(res);
           } else {
-            waiter.handleFailure(ar.cause());
+            waiter.handleFailure(err);
           }
         });
     }
@@ -210,9 +209,8 @@ public class StressTest extends VertxTestBase {
     // This is synchronous
     CountDownLatch latch = new CountDownLatch(1);
     mgr.pool
-      .close()
-      .onComplete(ar -> {
-        if (ar.succeeded()) {
+      .close((res, err) -> {
+        if (err == null) {
 /*
         List<Future> list = (List) ar.result();
         CompositeFuture.all(list).onSuccess(c -> {


### PR DESCRIPTION
Motivation:

The connection pool cares about signalling as simply as possible the caller which is often Vert.x middleware. It does not need to expose an API based on Future and instead Completable can be used, leading to less garbage and reduce stack usage in pool signals.

Changes:

- remove the deprecated Handler<AsyncResult> callbacks
- transform Future returning methods to Completable methods
