### PR TITLE
Cluster manager updates

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -11,10 +11,7 @@
 
 package io.vertx.core.eventbus.impl;
 
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.eventbus.*;
 import io.vertx.core.impl.Arguments;
 import io.vertx.core.internal.ContextInternal;
@@ -278,24 +275,20 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     return msg;
   }
 
-  protected <T> Consumer<Promise<Void>> addRegistration(String address, HandlerRegistration<T> registration, boolean broadcast, boolean localOnly, Promise<Void> promise) {
+  protected <T> Consumer<Promise<Void>> addRegistration(String address, HandlerRegistration<T> registration, boolean broadcast, boolean localOnly, Completable<Void> promise) {
     HandlerHolder<T> holder = addLocalRegistration(address, registration, localOnly);
     if (broadcast) {
       onLocalRegistration(holder, promise);
     } else {
-      if (promise != null) {
-        promise.complete();
-      }
+      promise.succeed();
     }
     return p -> {
       removeRegistration(holder, broadcast, p);
     };
   }
 
-  protected <T> void onLocalRegistration(HandlerHolder<T> handlerHolder, Promise<Void> promise) {
-    if (promise != null) {
-      promise.complete();
-    }
+  protected <T> void onLocalRegistration(HandlerHolder<T> handlerHolder, Completable<Void> promise) {
+    promise.succeed();
   }
 
   private <T> HandlerHolder<T> addLocalRegistration(String address, HandlerRegistration<T> registration,
@@ -332,8 +325,8 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     }
   }
 
-  protected <T> void onLocalUnregistration(HandlerHolder<T> handlerHolder, Promise<Void> promise) {
-    promise.complete();
+  protected <T> void onLocalUnregistration(HandlerHolder<T> handlerHolder, Completable<Void> promise) {
+    promise.succeed();
   }
 
   private <T> void removeLocalRegistration(HandlerHolder<T> holder) {

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -60,7 +60,7 @@ public abstract class HandlerRegistration<T> implements Closeable {
 
   protected abstract void dispatch(Message<T> msg, ContextInternal context, Handler<Message<T>> handler);
 
-  synchronized void register(boolean broadcast, boolean localOnly, Promise<Void> promise) {
+  synchronized void register(boolean broadcast, boolean localOnly, Completable<Void> promise) {
     if (registered != null) {
       throw new IllegalStateException();
     }

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.eventbus.impl;
 
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -22,6 +23,8 @@ import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
 
 class ReplyHandler<T> extends HandlerRegistration<T> implements Handler<Long> {
+
+  private static final Completable<Void> NULL_COMPLETABLE = (res, err) -> {};
 
   private final Promise<Message<T>> result;
   private final long timeoutID;
@@ -76,7 +79,7 @@ class ReplyHandler<T> extends HandlerRegistration<T> implements Handler<Long> {
   }
 
   void register() {
-    register(false, false, null);
+    register(false, false, NULL_COMPLETABLE);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -11,10 +11,7 @@
 
 package io.vertx.core.eventbus.impl.clustered;
 
-import io.vertx.core.Future;
-import io.vertx.core.MultiMap;
-import io.vertx.core.Promise;
-import io.vertx.core.VertxOptions;
+import io.vertx.core.*;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBusOptions;
 import io.vertx.core.eventbus.MessageCodec;
@@ -196,7 +193,7 @@ public final class ClusteredEventBus extends EventBusImpl {
   }
 
   @Override
-  protected <T> void onLocalRegistration(HandlerHolder<T> handlerHolder, Promise<Void> promise) {
+  protected <T> void onLocalRegistration(HandlerHolder<T> handlerHolder, Completable<Void> promise) {
     RegistrationInfo registrationInfo = new RegistrationInfo(
       nodeId,
       handlerHolder.getSeq(),
@@ -211,15 +208,13 @@ public final class ClusteredEventBus extends EventBusImpl {
   }
 
   @Override
-  protected <T> void onLocalUnregistration(HandlerHolder<T> handlerHolder, Promise<Void> completionHandler) {
+  protected <T> void onLocalUnregistration(HandlerHolder<T> handlerHolder, Completable<Void> completionHandler) {
     RegistrationInfo registrationInfo = new RegistrationInfo(
       nodeId,
       handlerHolder.getSeq(),
       handlerHolder.isLocalOnly()
     );
-    Promise<Void> promise = Promise.promise();
-    clusterManager.removeRegistration(handlerHolder.getHandler().address(), registrationInfo, promise);
-    promise.future().onComplete(completionHandler);
+    clusterManager.removeRegistration(handlerHolder.getHandler().address(), registrationInfo, completionHandler);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/DefaultNodeSelector.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/DefaultNodeSelector.java
@@ -10,8 +10,8 @@
  */
 package io.vertx.core.eventbus.impl.clustered;
 
+import io.netty.util.internal.PlatformDependent;
 import io.vertx.core.Completable;
-import io.vertx.core.Promise;
 import io.vertx.core.eventbus.impl.clustered.selector.*;
 import io.vertx.core.spi.cluster.ClusteredNode;
 import io.vertx.core.spi.cluster.RegistrationInfo;
@@ -20,6 +20,7 @@ import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Node selector implementation that preserves the ordering of select operations.
@@ -27,7 +28,131 @@ import java.util.concurrent.ConcurrentMap;
 public class DefaultNodeSelector implements NodeSelector {
 
   private ClusteredNode clusterManager;
-  private final ConcurrentMap<String, Entry> entries = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Node> entries = new ConcurrentHashMap<>();
+
+  private interface Op<T> {
+    Op<String> SEND = RoundRobinSelector::selectForSend;
+    Op<Iterable<String>> PUBLISH = RoundRobinSelector::selectForPublish;
+    T select(RoundRobinSelector selector);
+  }
+
+  private static class Node {
+
+    final AtomicInteger wip = new AtomicInteger(1);
+    final Queue<Action> queue = PlatformDependent.newMpscQueue();
+    Object value;
+
+    private void signal(Object value, int amount) {
+      while (amount > 0) {
+        for (int i = 0;i < amount;i++) {
+          Action a = queue.poll();
+          assert a != null;
+          if (a instanceof Select) {
+            Select<?> s = (Select<?>) a;
+            if (value instanceof RoundRobinSelector) {
+              s.resolve((RoundRobinSelector) value);
+            } else {
+              s.fail((Throwable) value);
+            }
+          } else if (a instanceof Update) {
+            value = ((Update)a).selector;
+          } else {
+            throw new UnsupportedOperationException();
+          }
+        }
+        // We write the value before writing wip to ensure visibility since wip is read
+        this.value = value;
+        amount = wip.addAndGet(-amount);
+      }
+    }
+  }
+
+  private interface Action {
+  }
+
+  private static class Update implements Action {
+    // null means delete
+    final RoundRobinSelector selector;
+    Update(RoundRobinSelector selector) {
+      this.selector = selector;
+    }
+  }
+
+  private static class Select<T> implements Action {
+    final Op<T> op;
+    final Completable<T> callback;
+    Select(Op<T> op, Completable<T> callback) {
+      this.op = op;
+      this.callback = callback;
+    }
+    void resolve(RoundRobinSelector selector) {
+      callback.succeed(op.select(selector));
+    }
+    void fail(Throwable err) {
+      callback.fail(err);
+    }
+  }
+
+  private <T> void selectFor(String address, Op<T> op, Completable<T> callback) {
+    Node node = entries.get(address);
+    if (node == null) {
+      node = new Node();
+      node.queue.add(new Select<>(op, callback));
+      Node phantom = entries.putIfAbsent(address, node);
+      if (phantom != null) {
+        node = phantom;
+      } else {
+        // Obtained ownership
+        initializeNode(node, address);
+        return;
+      }
+    }
+    if (node.wip.get() == 0) {
+      // wip == 0 implies we can safely read a value
+      Object v = node.value;
+      if (v instanceof RoundRobinSelector) {
+        callback.succeed(op.select((RoundRobinSelector) v));
+      } else {
+        callback.fail((Throwable) v);
+      }
+    } else {
+      node.queue.add(new Select<>(op, callback));
+      int amount = node.wip.incrementAndGet();
+      if (amount == 1) {
+        // Race case obtained incidentally ownership
+        // it happens when a concurrent signal operation finished after we enqueued our select
+        // we can read the node value (since amount was 0) and signal
+        node.signal(node.value, amount);
+      }
+    }
+  }
+
+  private void initializeNode(Node node, String address) {
+    clusterManager.getRegistrations(address, (res, err) -> {
+      if (err == null) {
+        succeed(node, address, res);
+      } else {
+        fail(node, address, err);
+      }
+    });
+  }
+
+  private void succeed(Node node, String address, List<RegistrationInfo> registrations) {
+    List<String> accessible = computeAccessible(registrations);
+    RoundRobinSelector selector = data(accessible);
+    if (selector != null) {
+      node.signal(selector, node.wip.get());
+    } else {
+      if (entries.remove(address, node)) {
+        node.signal(NullRoundRobinSelector.INSTANCE, node.wip.get());
+      }
+    }
+  }
+
+  private void fail(Node node, String address, Throwable cause) {
+    entries.remove(address, node);
+    node.signal(cause, node.wip.get());
+  }
 
   @Override
   public void init(ClusteredNode clusterManager) {
@@ -49,114 +174,19 @@ public class DefaultNodeSelector implements NodeSelector {
     return entries.containsKey(address);
   }
 
-  private interface Op<T> {
-    Op<String> SEND = RoundRobinSelector::selectForSend;
-    Op<Iterable<String>> PUBLISH = RoundRobinSelector::selectForPublish;
-    Op<Object> NOOP = selector -> null;
-    T selectWith(RoundRobinSelector selector);
-  }
-
-  private <T> void selectFor(String address, Op<T> op, Completable<T> promise) {
-    while (true) {
-      Entry entry = entries.get(address);
-      if (entry == null) {
-        WaiterEntry<T> head = new WaiterEntry<>(promise, op);
-        Entry phantom = entries.putIfAbsent(address, head);
-        if (phantom == null) {
-          initialize(head, address, op);
-          break;
-        }
-      } else if (entry instanceof WaiterEntry) {
-        WaiterEntry<T> next = new WaiterEntry<>(promise, op, (WaiterEntry<?>) entry);
-        if (entries.replace(address, entry, next)) {
-          break;
-        }
-      } else if (entry instanceof SelectorEntry) {
-        SelectorEntry re = (SelectorEntry) entry;
-        promise.succeed(op.selectWith(re.selector));
-        break;
-      }
-    }
-  }
-
-  private <T> void initialize(WaiterEntry<?> head, String address, Op<T> k) {
-    Promise<List<RegistrationInfo>> getPromise = Promise.promise();
-    clusterManager.getRegistrations(address, getPromise);
-    getPromise.future().onComplete(ar -> {
-      if (ar.succeeded()) {
-        succeed(head, address, ar.result(), k);
-      } else {
-        fail(head, address, ar.cause());
-      }
-    });
-  }
-
-  private void fail(WaiterEntry<?> head, String address, Throwable cause) {
-    // Check the entry is valid for the assumed head
-    Entry entry = entries.get(address);
-    if (entry instanceof WaiterEntry<?>) {
-      WaiterEntry<?> tail = (WaiterEntry<?>) entry;
-      if (tail.head == head) {
-        // Try remove
-        if (entries.remove(address, tail)) {
-          // Broadcast failure
-          while (tail != null) {
-            tail.waiter.fail(cause);
-            tail = tail.prev;
-          }
-        }
-      }
-    }
-  }
-
-  private <T> void succeed(WaiterEntry<?> head, String address, List<RegistrationInfo> registrations, Op<T> k) {
-    List<String> accessible = computeAccessible(registrations);
-    RoundRobinSelector selector = data(accessible);
-    while (true) {
-      Entry entry = entries.get(address);
-      if (entry == null) {
-        break;
-      } else if (entry instanceof WaiterEntry) {
-        WaiterEntry<?> tail = (WaiterEntry<?>) entry;
-        if (tail.head == head) {
-          if (selector != null) {
-            if (entries.replace(address, tail, WaiterEntry.NOOP)) {
-              broadcastToWaiters(tail, selector);
-              if (entries.replace(address, WaiterEntry.NOOP, new SelectorEntry(selector))) {
-                break;
-              } else {
-                // Another waiter has been added during broadcast, spin again
-                head = WaiterEntry.NOOP;
-              }
-            }
-          } else {
-            // No handlers
-            if (entries.remove(address, tail)) {
-              broadcastToWaiters((WaiterEntry<?>) entry, NullRoundRobinSelector.INSTANCE);
-              break;
-            }
-          }
-        } else {
-          break;
-        }
-      } else {
-        throw new UnsupportedOperationException("Does this case make sense " + entry);
-      }
-    }
-  }
-
   private RoundRobinSelector data(List<String> nodeIds) {
     if (nodeIds == null || nodeIds.isEmpty()) {
       return null;
-    }
-    Map<String, Weight> weights = computeWeights(nodeIds);
-    RoundRobinSelector selector;
-    if (isEvenlyDistributed(weights)) {
-      selector = new SimpleRoundRobinSelector(new ArrayList<>(weights.keySet()));
     } else {
-      selector = new WeightedRoundRobinSelector(weights);
+      Map<String, Weight> weights = computeWeights(nodeIds);
+      RoundRobinSelector selector;
+      if (isEvenlyDistributed(weights)) {
+        selector = new SimpleRoundRobinSelector(new ArrayList<>(weights.keySet()));
+      } else {
+        selector = new WeightedRoundRobinSelector(weights);
+      }
+      return selector;
     }
-    return selector;
   }
 
   private Map<String, Weight> computeWeights(List<String> nodeIds) {
@@ -206,78 +236,21 @@ public class DefaultNodeSelector implements NodeSelector {
   @Override
   public void registrationsUpdated(RegistrationUpdateEvent event) {
     String address = event.address();
-    while (true) {
-      Entry entry = entries.get(address);
-      if (entry == null) {
-        break;
-      } else if (entry instanceof WaiterEntry) {
-        throw new UnsupportedOperationException("Is this case valid ?");
-      } else {
-        SelectorEntry re = (SelectorEntry) entry;
-        List<String> accessible = computeAccessible(event.registrations());
-        RoundRobinSelector selector = data(accessible);
-        if (selector == null) {
-          // Un-registration
-          if (entries.remove(address, re)) {
-            break;
-          }
-        } else {
-          if (entries.replace(address, re, new SelectorEntry(selector))) {
-            break;
-          }
+    List<String> accessible = computeAccessible(event.registrations());
+    RoundRobinSelector selector = data(accessible);
+    if (selector != null) {
+      Node node = entries.get(address);
+      if (node != null) {
+        node.queue.add(new Update(selector));
+        int amount = node.wip.incrementAndGet();
+        if (amount == 1) {
+          node.signal(selector, amount);
         }
+      } else {
+        // ????
       }
-    }
-  }
-
-  private static abstract class Entry {
-  }
-
-  /**
-   * An entry waiting for an address to be resolved.
-   */
-  private static class WaiterEntry<T> extends Entry {
-
-    static final WaiterEntry<?> NOOP = new WaiterEntry<>((a, b) -> {}, Op.NOOP);
-
-    private final Completable<T> waiter;
-    private final WaiterEntry<?> prev;
-    private final WaiterEntry<?> head;
-    private final Op<T> op;
-    private WaiterEntry(Completable<T> waiter, Op<T> op) {
-      this.waiter = waiter;
-      this.prev = null;
-      this.op = op;
-      this.head = this;
-    }
-    private WaiterEntry(Completable<T> waiter, Op<T> op, WaiterEntry<?> prev) {
-      this.waiter = waiter;
-      this.prev = prev;
-      this.op = op;
-      this.head = prev.head;
-    }
-    void complete(RoundRobinSelector selector) {
-      waiter.succeed(op.selectWith(selector));
-    }
-  }
-
-  /**
-   * Terminal entry, no waiter entry should be added after a resolved entry is added to the list
-   */
-  private static class SelectorEntry extends Entry {
-    private final RoundRobinSelector selector;
-    private SelectorEntry(RoundRobinSelector selector) {
-      this.selector = selector;
-    }
-  }
-
-  private static void broadcastToWaiters(WaiterEntry<?> lastWaiter, RoundRobinSelector selector) {
-    List<WaiterEntry<?>> waiters = new ArrayList<>();
-    for (WaiterEntry<?> e = lastWaiter;e != null;e = e.prev) {
-      waiters.add(e);
-    }
-    for (int idx = waiters.size() - 1;idx >= 0;idx--) {
-      waiters.get(idx).complete(selector);
+    } else {
+      entries.remove(address);
     }
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/impl/HAManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/HAManager.java
@@ -215,11 +215,12 @@ public class HAManager {
     if (!stopped) {
       killed = true;
       CountDownLatch latch = new CountDownLatch(1);
-      Promise<Void> promise = Promise.promise();
-      clusterManager.leave(promise);
-      promise.future()
-        .onFailure(t -> log.error("Failed to leave cluster", t))
-        .onComplete(ar -> latch.countDown());
+      clusterManager.leave((res, err) -> {
+        if (err != null) {
+          log.error("Failed to leave cluster", err);
+        }
+        latch.countDown();
+      });
       long timerID = checkQuorumTimerID;
       if (timerID >= 0L) {
         checkQuorumTimerID = -1L;

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -255,15 +255,13 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     clusterManager.registrationListener(nodeSelector);
     clusterManager.init(this);
     Promise<Void> initPromise = Promise.promise();
-    Promise<Void> joinPromise = Promise.promise();
-    joinPromise.future().onComplete(ar -> {
-      if (ar.succeeded()) {
+    clusterManager.join((res, err) -> {
+      if (err == null) {
         createHaManager(options, initPromise);
       } else {
-        initPromise.fail(ar.cause());
+        initPromise.fail(err);
       }
     });
-    clusterManager.join(joinPromise);
     return initPromise
       .future()
       .transform(ar -> {

--- a/vertx-core/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
@@ -12,7 +12,7 @@
 package io.vertx.core.spi.cluster;
 
 
-import io.vertx.core.Promise;
+import io.vertx.core.Completable;
 import io.vertx.core.Vertx;
 import io.vertx.core.internal.VertxBootstrap;
 import io.vertx.core.shareddata.AsyncMap;
@@ -20,7 +20,6 @@ import io.vertx.core.shareddata.Counter;
 import io.vertx.core.shareddata.Lock;
 import io.vertx.core.spi.VertxServiceProvider;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -60,7 +59,7 @@ public interface ClusterManager extends VertxServiceProvider, ClusteredNode {
   /**
    * Return an {@link AsyncMap} for the given {@code name}.
    */
-  <K, V> void getAsyncMap(String name, Promise<AsyncMap<K, V>> promise);
+  <K, V> void getAsyncMap(String name, Completable<AsyncMap<K, V>> promise);
 
   /**
    * Return a synchronous map for the given {@code name}.
@@ -70,12 +69,12 @@ public interface ClusterManager extends VertxServiceProvider, ClusteredNode {
   /**
    * Attempts to acquire a {@link Lock} for the given {@code name} within {@code timeout} milliseconds.
    */
-  void getLockWithTimeout(String name, long timeout, Promise<Lock> promise);
+  void getLockWithTimeout(String name, long timeout, Completable<Lock> promise);
 
   /**
    * Return a {@link Counter} for the given {@code name}.
    */
-  void getCounter(String name, Promise<Counter> promise);
+  void getCounter(String name, Completable<Counter> promise);
 
   /**
    * Set a listener that will be called when a node joins or leaves the cluster.
@@ -85,17 +84,17 @@ public interface ClusterManager extends VertxServiceProvider, ClusteredNode {
   /**
    * Store the details about this clustered node.
    */
-  void setNodeInfo(NodeInfo nodeInfo, Promise<Void> promise);
+  void setNodeInfo(NodeInfo nodeInfo, Completable<Void> promise);
 
   /**
    * Join the cluster.
    */
-  void join(Promise<Void> promise);
+  void join(Completable<Void> promise);
 
   /**
    * Leave the cluster.
    */
-  void leave(Promise<Void> promise);
+  void leave(Completable<Void> promise);
 
   /**
    * Is the cluster manager active?
@@ -115,12 +114,12 @@ public interface ClusterManager extends VertxServiceProvider, ClusteredNode {
   /**
    * Share a new messaging handler registration with other nodes in the cluster.
    */
-  void addRegistration(String address, RegistrationInfo registrationInfo, Promise<Void> promise);
+  void addRegistration(String address, RegistrationInfo registrationInfo, Completable<Void> promise);
 
   /**
    * Signal removal of a messaging handler registration to other nodes in the cluster.
    */
-  void removeRegistration(String address, RegistrationInfo registrationInfo, Promise<Void> promise);
+  void removeRegistration(String address, RegistrationInfo registrationInfo, Completable<Void> promise);
 
   /**
    * If the cluster manager has its own server for data/membership, this returns the host it is listening to.

--- a/vertx-core/src/main/java/io/vertx/core/spi/cluster/ClusteredNode.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/cluster/ClusteredNode.java
@@ -10,7 +10,7 @@
  */
 package io.vertx.core.spi.cluster;
 
-import io.vertx.core.Promise;
+import io.vertx.core.Completable;
 
 import java.util.List;
 
@@ -27,7 +27,7 @@ public interface ClusteredNode {
   /**
    * Get the messaging handler currently registered in the cluster.
    */
-  void getRegistrations(String address, Promise<List<RegistrationInfo>> promise);
+  void getRegistrations(String address, Completable<List<RegistrationInfo>> promise);
 
   /**
    * Get details about this clustered node.
@@ -39,7 +39,7 @@ public interface ClusteredNode {
    *
    * @param nodeId the clustered node id
    */
-  void getNodeInfo(String nodeId, Promise<NodeInfo> promise);
+  void getNodeInfo(String nodeId, Completable<NodeInfo> promise);
 
   /**
    * Return a list of node identifiers corresponding to the nodes in the cluster.

--- a/vertx-core/src/test/java/io/vertx/tests/cluster/DefaultNodeSelectorTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/cluster/DefaultNodeSelectorTest.java
@@ -71,7 +71,7 @@ public class DefaultNodeSelectorTest {
     }
 
     @Override
-    public void getRegistrations(String address, Promise<List<RegistrationInfo>> promise) {
+    public void getRegistrations(String address, Completable<List<RegistrationInfo>> promise) {
       log.add(new GetRegistrationsOp(address, promise));
     }
 
@@ -81,7 +81,7 @@ public class DefaultNodeSelectorTest {
     }
 
     @Override
-    public void getNodeInfo(String nodeId, Promise<NodeInfo> promise) {
+    public void getNodeInfo(String nodeId, Completable<NodeInfo> promise) {
       throw new UnsupportedOperationException();
     }
 

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/WrappedClusterManager.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/WrappedClusterManager.java
@@ -38,7 +38,7 @@ public class WrappedClusterManager implements ClusterManager {
   }
 
   @Override
-  public <K, V> void getAsyncMap(String name, Promise<AsyncMap<K, V>> promise) {
+  public <K, V> void getAsyncMap(String name, Completable<AsyncMap<K, V>> promise) {
     delegate.getAsyncMap(name, promise);
   }
 
@@ -48,12 +48,12 @@ public class WrappedClusterManager implements ClusterManager {
   }
 
   @Override
-  public void getLockWithTimeout(String name, long timeout, Promise<Lock> promise) {
+  public void getLockWithTimeout(String name, long timeout, Completable<Lock> promise) {
     delegate.getLockWithTimeout(name, timeout, promise);
   }
 
   @Override
-  public void getCounter(String name, Promise<Counter> promise) {
+  public void getCounter(String name, Completable<Counter> promise) {
     delegate.getCounter(name, promise);
   }
 
@@ -73,7 +73,7 @@ public class WrappedClusterManager implements ClusterManager {
   }
 
   @Override
-  public void setNodeInfo(NodeInfo nodeInfo, Promise<Void> promise) {
+  public void setNodeInfo(NodeInfo nodeInfo, Completable<Void> promise) {
     delegate.setNodeInfo(nodeInfo, promise);
   }
 
@@ -83,17 +83,17 @@ public class WrappedClusterManager implements ClusterManager {
   }
 
   @Override
-  public void getNodeInfo(String nodeId, Promise<NodeInfo> promise) {
+  public void getNodeInfo(String nodeId, Completable<NodeInfo> promise) {
     delegate.getNodeInfo(nodeId, promise);
   }
 
   @Override
-  public void join(Promise<Void> promise) {
+  public void join(Completable<Void> promise) {
     delegate.join(promise);
   }
 
   @Override
-  public void leave(Promise<Void> promise) {
+  public void leave(Completable<Void> promise) {
     delegate.leave(promise);
   }
 
@@ -139,17 +139,17 @@ public class WrappedClusterManager implements ClusterManager {
   }
 
   @Override
-  public void addRegistration(String address, RegistrationInfo registrationInfo, Promise<Void> promise) {
+  public void addRegistration(String address, RegistrationInfo registrationInfo, Completable<Void> promise) {
     delegate.addRegistration(address, registrationInfo, promise);
   }
 
   @Override
-  public void removeRegistration(String address, RegistrationInfo registrationInfo, Promise<Void> promise) {
+  public void removeRegistration(String address, RegistrationInfo registrationInfo, Completable<Void> promise) {
     delegate.removeRegistration(address, registrationInfo, promise);
   }
 
   @Override
-  public void getRegistrations(String address, Promise<List<RegistrationInfo>> promise) {
+  public void getRegistrations(String address, Completable<List<RegistrationInfo>> promise) {
     delegate.getRegistrations(address, promise);
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/CreateVertxTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/CreateVertxTest.java
@@ -11,10 +11,7 @@
 
 package io.vertx.tests.vertx;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
+import io.vertx.core.*;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakecluster.FakeClusterManager;
@@ -53,7 +50,7 @@ public class CreateVertxTest extends VertxTestBase {
   public void testCreateClusteredVertxAsyncDetectJoinFailure() {
     ClusterManager clusterManager = new FakeClusterManager(){
       @Override
-      public void join(Promise<Void> promise) {
+      public void join(Completable<Void> promise) {
         promise.fail("joinfailure");
       }
     };

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxStartFailureTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxStartFailureTest.java
@@ -12,10 +12,7 @@
 package io.vertx.tests.vertx;
 
 import io.netty.channel.EventLoopGroup;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
+import io.vertx.core.*;
 import io.vertx.core.impl.transports.NioTransport;
 import io.vertx.core.internal.VertxBootstrap;
 import io.vertx.core.spi.cluster.ClusterManager;
@@ -65,7 +62,7 @@ public class VertxStartFailureTest extends AsyncTestBase {
     Exception expected = new Exception();
     FakeClusterManager clusterManager = new FakeClusterManager() {
       @Override
-      public void join(Promise<Void> promise) {
+      public void join(Completable<Void> promise) {
         promise.fail(expected);
       }
     };


### PR DESCRIPTION
# Rewrite the node selector implementation

The node selector implementation can be simplified to use an drain/loop pattern approach which simplifies its implementation. The current implementation already has a queue approach with a linked list of waiters but it mandates to perform CAS like operations in the entries map.
    
Instead we can use a wip/mpsc queue node entry which is equivalent but simpler to understand.

# Update the cluster manager contract to use Completable

instead of Promise as callback argument, this does not force to pass a full promise.