### PR TITLE
Deployment options set via sys props are ignored

### DIFF
--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
@@ -360,7 +360,7 @@ public class BareCommand extends ClasspathHandler {
     return eventBusOptions;
   }
 
-  private static final ThreadLocal<Logger> configureFromSystemProperties = new ThreadLocal<>();
+  protected static final ThreadLocal<Logger> configureFromSystemProperties = new ThreadLocal<>();
 
   /**
    * This is used as workaround to retain the existing behavior of the Vert.x CLI and won't be executed

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -254,8 +254,16 @@ public class RunCommand extends BareCommand implements Closeable {
       }
 
       deploymentOptions = new DeploymentOptions();
-      configureFromSystemProperties(deploymentOptions, DEPLOYMENT_OPTIONS_PROP_PREFIX);
-      deploymentOptions.setConfig(conf).setWorker(worker).setHa(ha).setInstances(instances);
+      configureFromSystemProperties.set(log);
+      try {
+        configureFromSystemProperties(deploymentOptions, DEPLOYMENT_OPTIONS_PROP_PREFIX);
+      } finally {
+        configureFromSystemProperties.set(null);
+      }
+      deploymentOptions.setConfig(conf).setHa(ha).setInstances(instances);
+      if (worker) {
+        deploymentOptions.setThreadingModel(ThreadingModel.WORKER);
+      }
       beforeDeployingVerticle(deploymentOptions);
       deploy();
     } else {


### PR DESCRIPTION
This is a regression from https://github.com/eclipse-vertx/vert.x/issues/3772 that was never reported/fixed before.