### PR TITLE
Propagate correctly the HTTP connection metric to the WebSocket connection metric during the server upgrade

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/ServerWebSocketHandshaker.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/ServerWebSocketHandshaker.java
@@ -177,7 +177,7 @@ public class ServerWebSocketHandshaker extends FutureImpl<ServerWebSocket> imple
       long closingTimeoutMS = options.getWebSocketClosingTimeout() >= 0 ? options.getWebSocketClosingTimeout() * 1000L : 0L;
       WebSocketConnectionImpl webSocketConn = new WebSocketConnectionImpl(request.context, ctx, true, closingTimeoutMS,httpConn.metrics);
       ServerWebSocketImpl webSocket = new ServerWebSocketImpl(
-        (ContextInternal) request.context(),
+        request.context(),
         webSocketConn,
         handshaker.version() != WebSocketVersion.V00,
         request,
@@ -187,7 +187,7 @@ public class ServerWebSocketHandshaker extends FutureImpl<ServerWebSocket> imple
       String subprotocol = handshaker.selectedSubprotocol();
       webSocket.subProtocol(subprotocol);
       webSocketConn.webSocket(webSocket);
-      webSocketConn.metric(webSocketConn.metric());
+      webSocketConn.metric(httpConn.metric());
       return webSocketConn;
     });
     CompletableFuture<Void> latch = new CompletableFuture<>();


### PR DESCRIPTION
Motivation:

During a server WebSocket upgrade, the HTTP connection metric is not correctly set to the WebSocket connection metric.

This leads to calling the metric implementation with a null instance of the metric instead of the the instance it was provided.

Changes:

During the server WebSocket upgrade set the HTTP connection metric onto the WebSocket connection metric.
