### PR TITLE
Fix incorrect client WebSocket upgrade handshake timeout cancellation

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -1000,7 +1000,7 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
       WebSocketHandshakeInboundHandler handshakeInboundHandler = new WebSocketHandshakeInboundHandler(handshaker, upgrade);
       p.addBefore("handler", "handshakeCompleter", handshakeInboundHandler);
       upgrade.addListener((GenericFutureListener<io.netty.util.concurrent.Future<HttpHeaders>>) future -> {
-        if (timer > 0L) {
+        if (timer > -1L) {
           vertx.cancelTimer(timer);
         }
         if (future.isSuccess()) {


### PR DESCRIPTION
Motivation:

When the HTTP client connection ugprades to a WebSocket it sets a timeout for the WebSocket handshake, when the upgrade is succesfull it cancels the timeout timer.

The current cancellation check does not account for the initial timer ID that is 0.

Changes:

Cancel correctly the timeout timer.
