### PR TITLE
Initialize the HTTP/2 client connection expiration timestamp before recycle gets called

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -38,6 +38,10 @@ import java.util.function.BiConsumer;
  */
 class Http2ClientConnection extends Http2ConnectionBase implements HttpClientConnection {
 
+  private static long expirationTimestamp(int timeout) {
+    return timeout > 0 ? System.currentTimeMillis() + timeout * 1000L : 0L;
+  }
+
   private final HttpClientBase client;
   private final ClientMetrics metrics;
   private Handler<Void> evictionHandler = DEFAULT_EVICTION_HANDLER;
@@ -50,6 +54,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
                         VertxHttp2ConnectionHandler connHandler,
                         ClientMetrics metrics) {
     super(context, connHandler);
+    this.expirationTimestamp = expirationTimestamp(client.options.getHttp2KeepAliveTimeout());
     this.metrics = metrics;
     this.client = client;
   }
@@ -171,8 +176,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
   }
 
   private void recycle() {
-    int timeout = client.options().getHttp2KeepAliveTimeout();
-    expirationTimestamp = timeout > 0 ? System.currentTimeMillis() + timeout * 1000L : 0L;
+    expirationTimestamp = expirationTimestamp(client.options.getHttp2KeepAliveTimeout());
   }
 
   @Override

--- a/src/test/java/io/vertx/core/http/Http2Test.java
+++ b/src/test/java/io/vertx/core/http/Http2Test.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -1223,6 +1224,38 @@ public class Http2Test extends HttpTest {
       }
     }, new DeploymentOptions().setThreadingModel(ThreadingModel.WORKER).setInstances(numVerticles));
 
+    await();
+  }
+
+  @Test
+  public void testClientKeepAliveTimeoutNoStreams() throws Exception {
+    server.close();
+    server = vertx.createHttpServer(createBaseServerOptions().setInitialSettings(new Http2Settings().setMaxConcurrentStreams(0)));
+    server.requestHandler(req -> {
+      req.response().end();
+    });
+    startServer();
+    client.close();
+    AtomicBoolean closed = new AtomicBoolean();
+    client = vertx
+      .httpClientBuilder()
+      .withConnectHandler(conn -> {
+        conn.closeHandler(v -> {
+          // We will have retry when the connection is closed
+          if (closed.compareAndSet(false, true)) {
+            client.close().onComplete(v2 -> {
+              testComplete();
+            });
+          }
+        });
+      })
+      .with(createBaseClientOptions().setHttp2KeepAliveTimeout(1))
+      .build();
+    client.request(requestOptions).onComplete(ar -> {
+      if (ar.succeeded()) {
+        ar.result().send();
+      }
+    });
     await();
   }
 }


### PR DESCRIPTION
Motivation:

The HTTP/2 client connection sets the connection expiration timestamp when the connection is recycled, assuming it will have at least one stream created.

When no streams is created, the expiration timestamp is not set and the connection is not recycled by the pool.

Changes:

Set the connection expiration timestamp in the connection constructor.
