### PR TITLE
HTTP server started on a duplicated context shares contextual data

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -185,7 +185,7 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
     ContextInternal listenContext;
     // Not sure of this
     if (context.isEventLoopContext()) {
-      listenContext = context;
+      listenContext = context.unwrap();
     } else {
       listenContext = context.toBuilder()
         .withThreadingModel(ThreadingModel.EVENT_LOOP)
@@ -197,7 +197,7 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
     server.exceptionHandler(exceptionHandler);
     server.connectHandler(so -> {
       NetSocketImpl soi = (NetSocketImpl) so;
-      Supplier<ContextInternal> streamContextSupplier = context::duplicate;
+      Supplier<ContextInternal> streamContextSupplier = context.unwrap()::duplicate;
       String host = address.isInetSocket() ? address.host() : "localhost";
       int port = address.port();
       String serverOrigin = (tcpOptions.isSsl() ? "https" : "http") + "://" + host + ":" + port;

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -7004,4 +7004,28 @@ public abstract class HttpTest extends HttpTestBase {
     await();
     assertEquals("msg1msg2", received.get());
   }
+
+  @Test
+  public void testServerStartedFromDuplicatedContext() throws Exception {
+    ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
+    ContextInternal duplicated = context.duplicate();
+    ContextInternal.LOCAL_MAP.get(duplicated, ConcurrentHashMap::new).put("foo", "bar");
+
+    server.requestHandler(req -> {
+      ContextInternal current = ContextInternal.current();
+      assertTrue("Not a duplicated context", current.isDuplicate());
+      assertNotSame("Request should be handled on a different duplicated context", duplicated, current);
+      ConcurrentMap<Object, Object> localMap = ContextInternal.LOCAL_MAP.get(current, ConcurrentHashMap::new);
+      assertFalse("Local map shouldn't have an entry for the key 'foo'", localMap.containsKey("foo"));
+      req.response().end();
+    });
+    startServer(duplicated);
+
+    client.request(requestOptions)
+      .compose(HttpClientRequest::send)
+      .expecting(HttpResponseExpectation.SC_OK)
+      .onComplete(onSuccess(v -> testComplete()));
+
+    await();
+  }
 }


### PR DESCRIPTION
See #5589

If the server is started from a duplicated context, the listen context should be the underlying context (unwrapped).

And then we should duplicate the unwrapped context.

This is to make sure the creating context and the request context are not sharing local data.