### PR TITLE
Rename HttpClientRequest#sendHead to HttpClientResponse#writeHead

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -278,10 +278,25 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    * This is normally used to implement HTTP 100-continue handling, see {@link #continueHandler(io.vertx.core.Handler)} for
    * more information.
    *
-   * @return a future notified when the {@link HttpVersion} if it can be determined or {@code null} otherwise
-   * @throws java.lang.IllegalStateException when no response handler is set
+   * @return a future notified with the result of the write operation
+   * @throws java.lang.IllegalStateException if the head has already been written
+   * @deprecated instead use {@link #writeHead()}, this is scheduled for removal in Vert.x 6
    */
+  @Deprecated(since = "5.1.0", forRemoval = true)
   Future<Void> sendHead();
+
+  /**
+   * Write the head of the request.
+   * <p>
+   * This can be used to implement HTTP 100-continue handling, see {@link #continueHandler(io.vertx.core.Handler)} for
+   * more information.
+   *
+   * @return a future notified with the result of the write operation
+   * @throws java.lang.IllegalStateException if the head has already been written
+   */
+  default Future<Void> writeHead() {
+    return sendHead();
+  }
 
   /**
    * Create an HTTP tunnel to the server.

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -206,6 +206,11 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   @Fluent
   HttpServerResponse endHandler(@Nullable Handler<Void> handler);
 
+  /**
+   * Send the response headers.
+   *
+   * @return a future notified by the success or failure of the write
+   */
   Future<Void> writeHead();
 
   /**


### PR DESCRIPTION
Motivation:
    
`HttpServerResponse#writehead` has been added, `HttpClientRequest#sendHead` is the same operation. The semantic of send is to fully handle the operation and send the entire body. It is preferrable to rename `sendHead` to `writeHead` and align with other write operations on the API.
    
Changes:
    
- add default method `HttpClientRequest#writeHead` that delegates to `HttpClientRequest#sendHead`
- deprecate `HttpClientRequest#sendHead` for removal in Vert.x 6

