### PR TITLE
Revert the default behavior of the internal duplication of a context to avoid the copy of local context data

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -194,7 +194,7 @@ public final class ContextImpl extends ContextBase implements ContextInternal {
   }
 
   @Override
-  public ContextInternal duplicate() {
+  public ContextInternal duplicate(boolean copy) {
     return new DuplicatedContext(this, locals.length == 0 ? VertxImpl.EMPTY_CONTEXT_LOCALS : new Object[locals.length]);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -141,9 +141,11 @@ final class DuplicatedContext extends ContextBase implements ContextInternal {
   }
 
   @Override
-  public ContextInternal duplicate() {
+  public ContextInternal duplicate(boolean copy) {
     DuplicatedContext duplicate = new DuplicatedContext(delegate, locals.length == 0 ? VertxImpl.EMPTY_CONTEXT_LOCALS : new Object[locals.length]);
-    delegate.owner().duplicate(this, duplicate);
+    if (copy) {
+      delegate.owner().duplicate(this, duplicate);
+    }
     return duplicate;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ShadowContext.java
@@ -121,8 +121,8 @@ public final class ShadowContext extends ContextBase {
   }
 
   @Override
-  public ContextInternal duplicate() {
-    return new ShadowContext(owner, eventLoop, delegate.duplicate());
+  public ContextInternal duplicate(boolean copy) {
+    return new ShadowContext(owner, eventLoop, delegate.duplicate(copy));
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
@@ -367,13 +367,17 @@ public interface ContextInternal extends Context {
    * <p>
    * The duplicate context has its own
    * <ul>
-   *   <li>local context data</li>
+   *   <li>local context data, initialized with a copy of the existing local context data when {@code copy} is {@code true}</li>
    *   <li>worker task queue</li>
    * </ul>
    *
    * @return a duplicate of this context
    */
-  ContextInternal duplicate();
+  ContextInternal duplicate(boolean copy);
+
+  default ContextInternal duplicate() {
+    return duplicate(false);
+  }
 
   /**
    * Like {@link Vertx#setPeriodic(long, Handler)} except the periodic timer will fire on this context and the

--- a/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
@@ -1222,13 +1222,16 @@ public class ContextTest extends VertxTestBase {
     ctx.putLocal("foo", "bar");
     Object expected = new Object();
     ctx.putLocal(contextLocal, AccessMode.CONCURRENT, expected);
-    ContextInternal duplicate = ctx.duplicate();
+    ContextInternal duplicate = ctx.duplicate(true);
     assertEquals("bar", duplicate.getLocal("foo"));
     assertEquals(expected, duplicate.getLocal(contextLocal));
     ctx.removeLocal("foo");
     ctx.removeLocal(contextLocal, AccessMode.CONCURRENT);
     assertEquals("bar", duplicate.getLocal("foo"));
     assertEquals(expected, duplicate.getLocal(contextLocal));
+    duplicate = ctx.duplicate();
+    assertNull(duplicate.getLocal("foo"));
+    assertNull(duplicate.getLocal(contextLocal));
   }
 
   @Test


### PR DESCRIPTION
Motivation:

Copying the local data of a duplicated context was introduced to duplicate a context and copy its local data in order to implement specific behavior such as the support of grpc context.

This behavior is unexpected for some users of this API and we should preserve the previous behavior by default.

Changes:

- Context duplication does not anymore copy the local data of a context.
- A new duplicate(boolean copy) method is added in order to continue support this use case for grpc context implementation
