### PR TITLE
Revert the default behavior of the internal duplication of a context to avoid the copy of local context data

### DIFF
--- a/src/main/java/io/vertx/core/impl/DuplicatedContext.java
+++ b/src/main/java/io/vertx/core/impl/DuplicatedContext.java
@@ -180,9 +180,7 @@ final class DuplicatedContext extends ContextBase implements ContextInternal {
 
   @Override
   public ContextInternal duplicate() {
-    DuplicatedContext duplicate = new DuplicatedContext(delegate);
-    delegate.owner().duplicate(this, duplicate);
-    return duplicate;
+    return new DuplicatedContext(delegate);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -78,7 +78,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -792,17 +791,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
         });
       });
     });
-  }
-
-  void duplicate(ContextBase src, ContextBase dst) {
-    for (int i = 0;i < contextLocals.length;i++) {
-      ContextLocalImpl<?> contextLocal = (ContextLocalImpl<?>) contextLocals[i];
-      Object local = src.get(i);
-      if (local != null) {
-        local = ((Function)contextLocal.duplicator).apply(local);
-      }
-      dst.set(i, local);
-    }
   }
 
   @Override

--- a/src/test/java/io/vertx/core/ContextTest.java
+++ b/src/test/java/io/vertx/core/ContextTest.java
@@ -1246,12 +1246,8 @@ public class ContextTest extends VertxTestBase {
     Object expected = new Object();
     ctx.putLocal(contextLocal, AccessMode.CONCURRENT, expected);
     ContextInternal duplicate = ctx.duplicate();
-    assertEquals("bar", duplicate.getLocal("foo"));
-    assertEquals(expected, duplicate.getLocal(contextLocal));
-    ctx.removeLocal("foo");
-    ctx.removeLocal(contextLocal, AccessMode.CONCURRENT);
-    assertEquals("bar", duplicate.getLocal("foo"));
-    assertEquals(expected, duplicate.getLocal(contextLocal));
+    assertNull(duplicate.getLocal("foo"));
+    assertNull(duplicate.getLocal(contextLocal));
   }
 
   @Test


### PR DESCRIPTION
Motivation:

Copying the local data of a duplicated context was introduced to duplicate a context and copy its local data in order to implement specific behavior such as the support of grpc context. This behavior is only necessary in Vert.x 5 and this change has been back-ported to Vert.x 4.x to provide a similar implementation of context locals.

This behavior is unexpected for some users of this API and we should preserve the previous behavior by default.

Changes:

Context duplication does not anymore copy the local data of a context.
