### PR TITLE
HttpServerRequest#toNetSocket make the server report its WebSocket capabilities

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -14,8 +14,10 @@ package io.vertx.core.http.impl;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -701,6 +703,11 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
         }
         if (!HttpUtils.isConnectOrUpgrade(requestMethod, requestHeaders)) {
           return context.failedFuture("HTTP method must be CONNECT or an HTTP upgrade to upgrade the connection to a TCP socket");
+        }
+        ChannelPipeline pipeline = conn.channel().pipeline();
+        WebSocketServerExtensionHandler wsHandler = pipeline.get(WebSocketServerExtensionHandler.class);
+        if (wsHandler != null) {
+          pipeline.remove(wsHandler);
         }
         status = requestMethod == HttpMethod.CONNECT ? HttpResponseStatus.OK : HttpResponseStatus.SWITCHING_PROTOCOLS;
         prepareHeaders(-1);

--- a/vertx-core/src/test/java/io/vertx/tests/http/WebSocketTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/WebSocketTest.java
@@ -62,16 +62,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -527,13 +518,41 @@ public class WebSocketTest extends VertxTestBase {
   }
 
   @Test
-  // Let's manually handle the WebSocket handshake and write a frame to the client
   public void testHandleWSManually() throws Exception {
+    testHandleWSManually(false, false);
+  }
+
+  @Test
+  public void testHandleWSManuallyDeclineExtension() throws Exception {
+    testHandleWSManually(true, false);
+  }
+
+  @Test
+  public void testHandleWSManuallyDeclineSubprotocol() throws Exception {
+    testHandleWSManually(false, true);
+  }
+
+  private void testHandleWSManually(boolean declineExtension, boolean declineSubprotocol) throws Exception {
     String path = "/some/path";
     String message = "here is some text data";
+    String extension = "permessage-deflate";
+    String subProtocol = "myprotocol";
 
-    server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).requestHandler(req -> {
-      getUpgradedNetSocket(req, path).onComplete(onSuccess(sock -> {
+    HttpServerOptions serverOptions = new HttpServerOptions()
+      .setPort(DEFAULT_HTTP_PORT)
+      .setPerMessageWebSocketCompressionSupported(true) // This should be ignored if declineExtension is true
+      .setPerFrameWebSocketCompressionSupported(true) // This should be ignored if declineExtension is true
+      .addWebSocketSubProtocol(subProtocol);
+    server = vertx.createHttpServer(serverOptions).requestHandler(req -> {
+      Map<String, String> extraResponseHeaders = new HashMap<>();
+      if (!declineExtension) {
+        assertEquals(extension, req.headers().get("sec-websocket-extensions"));
+        extraResponseHeaders.put("sec-websocket-extensions", extension);
+      }
+      if (!declineSubprotocol) {
+        extraResponseHeaders.put("sec-websocket-protocol", subProtocol);
+      }
+      getUpgradedNetSocket(req, path, extraResponseHeaders).onComplete(onSuccess(sock -> {
         // Let's write a Text frame raw
         Buffer buff = Buffer.buffer();
         buff.appendByte((byte)129); // Text frame
@@ -543,15 +562,40 @@ public class WebSocketTest extends VertxTestBase {
       }));
     });
     awaitFuture(server.listen());
-    client = vertx.createWebSocketClient();
+
+    WebSocketClientOptions clientOptions = new WebSocketClientOptions()
+      .setTryUsePerMessageCompression(true)
+      .setTryUsePerFrameCompression(false);
+    client = vertx.createWebSocketClient(clientOptions);
     vertx.runOnContext(v -> {
-      client.connect(DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST, path).onComplete(onSuccess(ws -> {
-        ws.handler(buff -> {
-          assertEquals(message, buff.toString("UTF-8"));
+      WebSocketConnectOptions connectOptions = new WebSocketConnectOptions()
+        .setHost(DEFAULT_HTTP_HOST)
+        .setPort(DEFAULT_HTTP_PORT)
+        .setURI(path)
+        .addSubProtocol(subProtocol);
+      Handler<AsyncResult<WebSocket>> handler;
+      if (declineSubprotocol) {
+        handler = onFailure(err -> {
           testComplete();
         });
-      }));
+      } else {
+        handler = onSuccess(ws -> {
+          MultiMap headers = ws.headers();
+          if (declineExtension) {
+            assertFalse(headers.contains("sec-websocket-extensions"));
+          } else {
+            assertTrue(headers.contains("sec-websocket-extensions", extension, true));
+          }
+          assertTrue(headers.contains("sec-websocket-protocol", subProtocol, true));
+          ws.handler(buff -> {
+            assertEquals(message, buff.toString("UTF-8"));
+            testComplete();
+          });
+        });
+      }
+      client.connect(connectOptions).onComplete(handler);
     });
+
     await();
   }
 
@@ -649,7 +693,7 @@ public class WebSocketTest extends VertxTestBase {
   }
 
 
-  private Future<NetSocket> getUpgradedNetSocket(HttpServerRequest req, String path) {
+  private Future<NetSocket> getUpgradedNetSocket(HttpServerRequest req, String path, Map<String, String> extraResponseHeaders) {
     assertEquals(path, req.path());
     assertEquals("upgrade", req.headers().get("Connection"));
     String secHeader = req.headers().get("Sec-WebSocket-Key");
@@ -661,6 +705,9 @@ public class WebSocketTest extends VertxTestBase {
     headers.set("upgrade", "WebSocket");
     headers.set("connection", "upgrade");
     headers.set("sec-websocket-accept", encoded);
+    if (extraResponseHeaders != null) {
+      headers.addAll(extraResponseHeaders);
+    }
     return req.toNetSocket();
   }
 
@@ -914,7 +961,7 @@ public class WebSocketTest extends VertxTestBase {
     String continuationFrame = "BBB";
 
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).requestHandler(req -> {
-      getUpgradedNetSocket(req, path).onComplete(onSuccess(sock -> {
+      getUpgradedNetSocket(req, path, null).onComplete(onSuccess(sock -> {
         // Let's write a Text frame raw
         Buffer buff = Buffer.buffer();
         buff.appendByte((byte) 0x01); // Incomplete Text frame
@@ -3165,7 +3212,7 @@ public class WebSocketTest extends VertxTestBase {
   @Test
   public void testReportProtocolViolationOnClient() throws InterruptedException {
     server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).requestHandler(req -> {
-      getUpgradedNetSocket(req, "/some/path").onComplete(onSuccess(sock -> {
+      getUpgradedNetSocket(req, "/some/path", null).onComplete(onSuccess(sock -> {
         // Let's write an invalid frame
         Buffer buff = Buffer.buffer();
         buff.appendByte((byte)(0x8)).appendByte((byte)0); // Violates protocol with V13 (final control frame)


### PR DESCRIPTION
Backported from #5601

See #5600

When the connection is upgraded manually, it's up to the user to manage the handshake, including extensions.