### PR TITLE
Let the WebSocket indicate the correct status code when no close frame has been received

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -75,7 +75,6 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
   private Handler<Void> closeHandler;
   private Handler<Void> endHandler;
   private Handler<Throwable> exceptionHandler;
-  private boolean closing;
   private boolean closed;
   private Short closeStatusCode;
   private String closeReason;
@@ -208,9 +207,13 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
 
   @Override
   public Short closeStatusCode() {
+    Short sc;
+    boolean isClosed;
     synchronized (this) {
-      return closeStatusCode;
+      sc = closeStatusCode;
+      isClosed = closed;
     }
+    return isClosed ? (sc == null ? 1006 : sc) : sc;
   }
 
   @Override
@@ -441,13 +444,6 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
         fetch(1);
         break;
     }
-  }
-
-  /**
-   * Close the connection.
-   */
-  void closeConnection() {
-    chctx.close();
   }
 
   private class FrameAggregator implements Handler<WebSocketFrameInternal> {

--- a/vertx-core/src/test/java/io/vertx/tests/http/WebSocketTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/WebSocketTest.java
@@ -3062,16 +3062,21 @@ public class WebSocketTest extends VertxTestBase {
 
   @Test
   public void testClientConnectionCloseTimeout() {
-    testClientConnectionCloseTimeout(1);
+    testClientConnectionCloseTimeout(1, true, 1000);
   }
 
   @Test
   public void testClientConnectionCloseImmediately() {
-    testClientConnectionCloseTimeout(0);
+    testClientConnectionCloseTimeout(0, true, 1000);
   }
 
-  public void testClientConnectionCloseTimeout(int timeout) {
-    waitFor(timeout > 0L ? 3 : 2);
+  @Test
+  public void testClientConnectionCloseTimeoutWithoutCloseFrame() {
+    testClientConnectionCloseTimeout(1, false, 1006);
+  }
+
+  public void testClientConnectionCloseTimeout(int timeout, boolean respondWithCloseFrame, int expectedStatusCode) {
+    waitFor(3);
     List<Object> received = Collections.synchronizedList(new ArrayList<>());
     server = vertx.createHttpServer();
     server.requestHandler(req -> {
@@ -3081,41 +3086,39 @@ public class WebSocketTest extends VertxTestBase {
         soi.channelHandlerContext().pipeline().addBefore("handler", "decoder", new WebSocket13FrameDecoder(true, false, 1000));
         soi.messageHandler(msg -> {
           received.add(msg);
-          if (msg instanceof CloseWebSocketFrame) {
+          if (msg instanceof CloseWebSocketFrame && respondWithCloseFrame) {
             CloseWebSocketFrame frame = (CloseWebSocketFrame) msg;
             soi.writeMessage(new CloseWebSocketFrame(frame.statusCode(), frame.reasonText()));
           }
         });
-        soi.closeHandler(v -> {
-          complete();
-        });
+        soi.closeHandler(v -> complete());
       }));
     });
-    server.listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST).onComplete(onSuccess(v1 -> {
-      client = vertx.createWebSocketClient(new WebSocketClientOptions().setClosingTimeout(timeout));
-      client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/chat").onComplete(onSuccess(ws -> {
-        if (timeout > 0L) {
-          ws.endHandler(v -> {
-            complete();
-          });
-          ws.exceptionHandler(err -> fail());
+    server.listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST).await();
+    client = vertx.createWebSocketClient(new WebSocketClientOptions().setClosingTimeout(timeout));
+    WebSocket ws = client.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/chat").await();
+    ws.endHandler(v -> {
+      complete();
+    });
+    ws.exceptionHandler(err -> {
+      complete();
+    });
+    ws.closeHandler(v -> {
+      if (timeout > 0L) {
+        assertEquals(1, received.size());
+        Object msg = received.get(0);
+        try {
+          assertNotNull(ws.closeStatusCode());
+          assertEquals(expectedStatusCode, (short)ws.closeStatusCode());
+          assertEquals(msg.getClass(), CloseWebSocketFrame.class);
+        } finally {
+          ReferenceCountUtil.release(msg);
         }
-        ws.closeHandler(v -> {
-          if (timeout > 0L) {
-            assertEquals(1, received.size());
-            Object msg = received.get(0);
-            try {
-              assertEquals(msg.getClass(), CloseWebSocketFrame.class);
-            } finally {
-              ReferenceCountUtil.release(msg);
-            }
-          }
-          complete();
-        });
-        // Client sends a close frame but server will not close the TCP connection as expected
-        ws.close();
-      }));
-    }));
+      }
+      complete();
+    });
+    // Client sends a close frame but server will not close the TCP connection as expected
+    ws.close();
     await();
   }
 


### PR DESCRIPTION
Motivation:

When closing a client WebSocket, the client sends a close frame and expects the server to respond with a close frame and then close the connection.

Some servers can misbhave by ignoring the close frame and this let the client deal with the socket.

For this case we should the specific status code.

Changes:

When a WebSocket closes without receiving a close frame, the WebSocket status code is the value 1006 (per https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.5)
