### PR TITLE
Let the WebSocket indicate the correct status code when no close frame has been received.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -75,7 +75,6 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
   private Handler<Void> closeHandler;
   private Handler<Void> endHandler;
   private Handler<Throwable> exceptionHandler;
-  private boolean closing;
   private boolean closed;
   private Short closeStatusCode;
   private String closeReason;
@@ -208,9 +207,13 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
 
   @Override
   public Short closeStatusCode() {
+    Short sc;
+    boolean isClosed;
     synchronized (this) {
-      return closeStatusCode;
+      sc = closeStatusCode;
+      isClosed = closed;
     }
+    return isClosed ? (sc == null ? 1006 : sc) : sc;
   }
 
   @Override
@@ -441,13 +444,6 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
         fetch(1);
         break;
     }
-  }
-
-  /**
-   * Close the connection.
-   */
-  void closeConnection() {
-    chctx.close();
   }
 
   private class FrameAggregator implements Handler<WebSocketFrameInternal> {


### PR DESCRIPTION
Motivation:

When closing a client WebSocket, the client sends a close frame and expects the server to respond with a close frame and then close the connection.

Some servers can misbhave by ignoring the close frame and this let the client deal with the socket.

For this case we should the specific status code.

Changes:

When a WebSocket closes without receiving a close frame, the WebSocket status code is the value 1006 (per https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.5)