### PR TITLE
Encapsulate Http2ConnectionHandler in Http2ConnectionBase

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -49,6 +49,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
   private Handler<Long> concurrencyChangeHandler = DEFAULT_CONCURRENCY_CHANGE_HANDLER;
   private long expirationTimestamp;
   private boolean evicted;
+  private final VertxHttp2ConnectionHandler handler;
 
   Http2ClientConnection(HttpClientBase client,
                         ContextInternal context,
@@ -63,6 +64,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
     this.authority = authority;
     this.pooled = pooled;
     this.lifetimeEvictionTimestamp = maxLifetime > 0 ? System.currentTimeMillis() + maxLifetime : Long.MAX_VALUE;
+    this.handler = connHandler;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -41,6 +41,7 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
   private final HttpServerMetrics metrics;
   private final Function<String, String> encodingDetector;
   private final Supplier<ContextInternal> streamContextSupplier;
+  private final VertxHttp2ConnectionHandler handler;
 
   Handler<HttpServerRequest> requestHandler;
   private int concurrentStreams;
@@ -61,6 +62,7 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
     this.encodingDetector = encodingDetector;
     this.streamContextSupplier = streamContextSupplier;
     this.metrics = metrics;
+    this.handler = connHandler;
   }
 
   @Override


### PR DESCRIPTION
Motivation:

The Http2ConnectionHandler is leaking to `VertxHttp2Stream`, instead it should be encapsulated in `Http2ConnectionBase`.
