### PR TITLE
Re-enable WebSocket TLS tests

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/http/WebSocketTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/WebSocketTest.java
@@ -424,9 +424,6 @@ public class WebSocketTest extends VertxTestBase {
                        boolean sni,
                        String[] enabledCipherSuites,
                        Function<WebSocketClient, Future<WebSocket>> wsProvider) throws Exception {
-    if (true) {
-      return;
-    }
     WebSocketClientOptions options = new WebSocketClientOptions();
     options.setSsl(clientSsl);
     options.setTrustAll(clientTrustAll);


### PR DESCRIPTION
Incidentally left disabled after https://github.com/eclipse-vertx/vert.x/pull/5195