### PR TITLE
Improve HTTP/1.1 response send file implementation

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -355,6 +355,12 @@ public interface HttpHeaders {
   CharSequence APPLICATION_X_WWW_FORM_URLENCODED = HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED;
 
   /**
+   * application/application/octet-stream header value
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence APPLICATION_OCTET_STREAM = HttpHeaderValues.APPLICATION_OCTET_STREAM;
+
+  /**
    * multipart/form-data header value
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -423,7 +423,7 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   @Unstable
   default Future<Void> sendFile(RandomAccessFile file) {
-    return sendFile(file.getChannel(), 0);
+    return sendFile(file, 0);
   }
 
   /**
@@ -437,7 +437,7 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   @Unstable
   default Future<Void> sendFile(RandomAccessFile file, long offset) {
-    return sendFile(file.getChannel(), offset, Long.MAX_VALUE);
+    return sendFile(file, offset, Long.MAX_VALUE);
   }
 
   /**
@@ -450,9 +450,7 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   @Unstable
-  default Future<Void> sendFile(RandomAccessFile file, long offset, long length) {
-    return sendFile(file.getChannel(), offset, length);
-  }
+  Future<Void> sendFile(RandomAccessFile file, long offset, long length);
 
   /**
    * @return has the response already ended?

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -34,6 +34,7 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.spi.observability.HttpResponse;
 import io.vertx.core.streams.ReadStream;
 
+import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -568,6 +569,11 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
         return fut
           .eventually(file::close);
     });
+  }
+
+  @Override
+  public Future<Void> sendFile(RandomAccessFile file, long offset, long length) {
+    return stream.context.failedFuture("HTTP/2 does not support sending random access file for now");
   }
 
   @Override

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -2305,114 +2305,70 @@ public abstract class HttpTest extends HttpTestBase {
 
   @Test
   public void testSendFileWithFileChannel() throws Exception {
-    int expected = 16 * 1024 * 1024;
-    File file = TestUtils.tmpFile(".dat", expected);
-    FileChannel channel = FileChannel.open(file.toPath());
-    server.requestHandler(
-        req -> {
-          req.response().sendFile(channel).onFailure(
-            t -> {
-              if (HttpTest.this instanceof Http2Test) {
-                req.response().end();
-              }
-            }
-          );
-        });
-    startServer(testAddress);
-    Object[] res = {0, ""};
-    Object[] r = client.request(requestOptions)
-      .compose(req -> req.send()
-        .compose(resp -> {
-          resp.handler(buff -> {
-            Integer length = (Integer) res[0];
-            length += buff.length();
-            res[0] = length;
-          });
-          res[1] = resp.getHeader("Content-Type");
-          resp.exceptionHandler(this::fail);
-          return resp.end();
-        }))
-      .map(v -> res).await();
-    if (this instanceof Http1xTest){
-      assertEquals((int) r[0], file.length());
-      assertEquals("application/octet-stream", r[1]);
-    }
+    int fileLength = 16 * 1024 * 1024;
+    BiFunction<RandomAccessFile, HttpServerResponse, Future<?>> sender = (file, response) -> response.sendFile(file.getChannel());
+    testSendFileWithFileChannel(fileLength, sender, "application/octet-stream", fileLength);
   }
 
   @Test
   public void testSendFileWithFileChannelAndExtension() throws Exception {
-    int expected = 16 * 1024 * 1024;
-    File file = TestUtils.tmpFile(".dat", expected);
-    FileChannel channel = FileChannel.open(file.toPath());
-    server.requestHandler(
-        req -> {
-          req.response()
-            .putHeader(HttpHeaders.CONTENT_TYPE, "video/mp4")
-            .sendFile(channel).onFailure(
-            t -> {
-              if (HttpTest.this instanceof Http2Test) {
-                req.response().end();
-              }
-            }
-          );
-        });
-    startServer(testAddress);
-    Object[] res = {0, ""};
-    Object[] r = client.request(requestOptions)
-      .compose(req -> req.send()
-        .compose(resp -> {
-          resp.handler(buff -> {
-            Integer length = (Integer) res[0];
-            length += buff.length();
-            res[0] = length;
-          });
-          res[1] = resp.getHeader("Content-Type");
-          resp.exceptionHandler(this::fail);
-          return resp.end();
-        }))
-      .map(v -> res).await();
-    if (this instanceof Http1xTest){
-      assertEquals((int)r[0], file.length());
-      assertEquals(r[1], "video/mp4");
-    }
+    int fileLength = 16 * 1024 * 1024;
+    BiFunction<RandomAccessFile, HttpServerResponse, Future<?>> sender = (file, response) -> response
+      .putHeader(HttpHeaders.CONTENT_TYPE, "video/mp4")
+      .sendFile(file.getChannel());
+    testSendFileWithFileChannel(fileLength, sender, "video/mp4", fileLength);
   }
 
   @Test
   public void testSendFileWithFileChannelRange() throws Exception {
     int fileLength = 16 * 1024 * 1024;
-    File file = TestUtils.tmpFile(".dat", fileLength);
-    FileChannel channel = FileChannel.open(file.toPath());
     int offset = 1024 * 4;
     int expectedRange = fileLength - offset;
-    server.requestHandler(
-        req -> {
-          req.response().putHeader(HttpHeaders.CONTENT_TYPE, "video/mp4");
-          req.response().sendFile(channel, offset, expectedRange).onFailure(
-            t -> {
-              if (HttpTest.this instanceof Http2Test) {
-                req.response().end();
-              }
-            }
-          );
-        });
-    startServer(testAddress);
-    Object[] res = {0, ""};
-    Object[] r = client.request(requestOptions)
-      .compose(req -> req.send()
-        .compose(resp -> {
-          resp.handler(buff -> {
-            Integer length = (Integer) res[0];
-            length += buff.length();
-            res[0] = length;
-          });
-          res[1] = resp.getHeader("Content-Type");
-          resp.exceptionHandler(this::fail);
-          return resp.end();
-        }))
-      .map(v -> res).await();
-    if (this instanceof Http1xTest) {
-      assertEquals(expectedRange, (int) r[0]);
-      assertEquals("video/mp4", r[1]);
+    BiFunction<RandomAccessFile, HttpServerResponse, Future<?>> sender = (file, response) -> response
+      .putHeader(HttpHeaders.CONTENT_TYPE, "video/mp4")
+      .sendFile(file.getChannel(), offset, expectedRange);
+    testSendFileWithFileChannel(fileLength, sender, "video/mp4", expectedRange);
+  }
+
+  @Test
+  public void testSendFileWithRandomAccessFile() throws Exception {
+    int fileLength = 16 * 1024 * 1024;
+    BiFunction<RandomAccessFile, HttpServerResponse, Future<?>> sender = (file, response) -> response.sendFile(file);
+    testSendFileWithFileChannel(fileLength, sender, "application/octet-stream", fileLength);
+  }
+
+  @Test
+  public void testSendFileWithRandomAccessFileAndExtension() throws Exception {
+    int fileLength = 16 * 1024 * 1024;
+    BiFunction<RandomAccessFile, HttpServerResponse, Future<?>> sender = (file, response) -> response
+      .putHeader(HttpHeaders.CONTENT_TYPE, "video/mp4")
+      .sendFile(file);
+    testSendFileWithFileChannel(fileLength, sender, "video/mp4", fileLength);
+  }
+
+  @Test
+  public void testSendFileWithRandomAccessFileRange() throws Exception {
+    int fileLength = 16 * 1024 * 1024;
+    int offset = 1024 * 4;
+    int expectedRange = fileLength - offset;
+    BiFunction<RandomAccessFile, HttpServerResponse, Future<?>> sender = (file, response) -> response
+      .putHeader(HttpHeaders.CONTENT_TYPE, "video/mp4")
+      .sendFile(file, offset, expectedRange);
+    testSendFileWithFileChannel(fileLength, sender, "video/mp4", expectedRange);
+  }
+
+  private void testSendFileWithFileChannel(int flen, BiFunction<RandomAccessFile, HttpServerResponse, Future<?>> sender, String expectedContentType, long expectedLength) throws Exception {
+    Assume.assumeTrue(this instanceof Http1xTest);
+    File file = TestUtils.tmpFile(".dat", flen);
+    try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+      server.requestHandler(req -> sender.apply(raf, req.response()).onComplete(onSuccess(v -> testComplete())));
+      startServer(testAddress);
+      Buffer body = client.request(requestOptions)
+        .compose(req -> req.send()
+          .expecting(HttpResponseExpectation.contentType(expectedContentType))
+          .compose(HttpClientResponse::body)).await();
+      assertEquals(body.length(), expectedLength);
+      await();
     }
   }
 


### PR DESCRIPTION
Motivation:

The implementation of HTTP/1.1 send file can be simplied by using two arguments `FileChannel`/`RandomAccessFile` instead of trying to abstract them.

In addition we can set the response content type earlier when a file name is provided.

Changes:

Make `Http1xServerResponse#sendFileInternal` accept both `FileChannel`/`RandomAccessFile` as those are the only arguments we can actually use.

Set the response content type when a file name is available and to _application/octet-stream_ in the generic case.

Add test for sending `RandomAccessFile` instances.
