### PR TITLE
Avoid closing FileChannel/RandomAccessFile passed to HttpServerResponse#sendFile

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -493,12 +493,6 @@ public class VertxConnection extends ConnectionBase {
     }
   }
 
-  public ChannelFuture sendFile(RandomAccessFile raf, long offset, long length) {
-    ChannelFuture writeFuture = sendFile(raf.getChannel(), offset, length);
-    writeFuture.addListener(fut -> raf.close());
-    return writeFuture;
-  }
-
   public ChannelFuture sendFile(FileChannel fc, long offset, long length) {
     // Write the content.
     ChannelPromise writeFuture = chctx.newPromise();


### PR DESCRIPTION
`FileChannel`/`RandomAccessFile` passed to `HttpServerResponse#sendFile` are currently closed and they should not be per contract.
