### PR TITLE
Vert.x HTTP client should sanitize chunked transfer encoding header for HTTP/2

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xUpgradeToH2CHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xUpgradeToH2CHandler.java
@@ -103,7 +103,7 @@ public class Http1xUpgradeToH2CHandler extends ChannelInboundHandlerAdapter {
               request.headers().remove("host");
               request.headers().forEach(header -> {
                 if (!HttpHeaderValidationUtil.isConnectionHeader(header.getKey(), true)) {
-                  headers.set(header.getKey().toLowerCase(), header.getValue());
+                  headers.add(header.getKey().toLowerCase(), header.getValue());
                 }
               });
               ctx.fireChannelRead(new DefaultHttp2HeadersFrame(headers, false));

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -601,6 +601,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
           headers.add(HttpUtils.toLowerCase(header.getKey()), header.getValue());
         }
       }
+      headers.remove(HttpHeaders.TRANSFER_ENCODING);
       if (conn.client.options().isDecompressionSupported() && headers.get(HttpHeaderNames.ACCEPT_ENCODING) == null) {
         headers.set(HttpHeaderNames.ACCEPT_ENCODING, Http1xClientConnection.determineCompressionAcceptEncoding());
       }

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http1xClientFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http1xClientFileUploadTest.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.http.fileupload;
+
+public class Http1xClientFileUploadTest extends HttpClientFileUploadTest {
+}

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2ClientFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2ClientFileUploadTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.http.fileupload;
+
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.test.http.HttpTestBase;
+import io.vertx.tests.http.Http2TestBase;
+
+public class Http2ClientFileUploadTest extends HttpClientFileUploadTest {
+
+  @Override
+  protected HttpServerOptions createBaseServerOptions() {
+    return Http2TestBase.createHttp2ServerOptions(HttpTestBase.DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST);
+  }
+
+  @Override
+  protected HttpClientOptions createBaseClientOptions() {
+    return Http2TestBase.createHttp2ClientOptions();
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2WithUpgradeClientFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2WithUpgradeClientFileUploadTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.http.fileupload;
+
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpVersion;
+
+public class Http2WithUpgradeClientFileUploadTest extends HttpClientFileUploadTest {
+
+  @Override
+  protected HttpClientOptions createBaseClientOptions() {
+    return new HttpClientOptions()
+      .setProtocolVersion(HttpVersion.HTTP_2)
+      .setHttp2ClearTextUpgrade(true);
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/HttpClientFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/HttpClientFileUploadTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.tests.http.fileupload;
 
 import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder;
@@ -5,8 +15,10 @@ import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
+import io.vertx.core.impl.Utils;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.http.HttpTestBase;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -22,7 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-public class HttpClientFileUploadTest extends HttpTestBase {
+public abstract class HttpClientFileUploadTest extends HttpTestBase {
 
   @Rule
   public TemporaryFolder testFolder = new TemporaryFolder();
@@ -163,6 +175,7 @@ public class HttpClientFileUploadTest extends HttpTestBase {
 
   @Test
   public void testFileUploadFormMultipart32M() throws Exception {
+    Assume.assumeTrue(!Utils.isWindows());
     testFileUploadFormMultipart(32 * 1024 * 1024, false);
   }
 
@@ -369,8 +382,10 @@ public class HttpClientFileUploadTest extends HttpTestBase {
         .await();
     } catch (Exception err) {
       assertEquals(err.getClass(), StreamResetException.class);
-      assertEquals(err.getCause().getClass(), HttpPostRequestEncoder.ErrorDataEncoderException.class);
-      assertEquals(err.getCause().getCause().getClass(), FileNotFoundException.class);
+      if (err.getCause() != null) {
+        assertEquals(err.getCause().getClass(), HttpPostRequestEncoder.ErrorDataEncoderException.class);
+        assertEquals(err.getCause().getCause().getClass(), FileNotFoundException.class);
+      }
     }
     assertTrue(request.response().failed());
   }


### PR DESCRIPTION
Motivation:

One should use `setChunked` on `HttpClientRequest` to set the chunked encoding header when necessary, however the user of the request might not be aware of this and set manually a chunked transfer-encoding header, such as the client form API.

Changes:

Remove the transfer encoding header in HTTP/2 client stream before passing headers to the actual implementation.

Add client multipart / form tests.
