### PR TITLE
Enable io_uring testing in CI

### DIFF
--- a/.github/workflows/ci-5.x.yml
+++ b/.github/workflows/ci-5.x.yml
@@ -14,3 +14,4 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.event.pull_request.head.sha || github.ref_name }}
+      io_uring_supported: true

--- a/.github/workflows/ci-matrix-5.x.yml
+++ b/.github/workflows/ci-matrix-5.x.yml
@@ -5,6 +5,9 @@ on:
       branch:
         required: true
         type: string
+      io_uring_supported:
+        default: false
+        type: boolean
 jobs:
   CI:
     strategy:
@@ -15,9 +18,9 @@ jobs:
           - os: ubuntu-latest
             jdk: 11
             profile: '-PNativeEpoll'
-#          - os: ubuntu-latest
-#            jdk: 11
-#            profile: '-PNativeIoUring'
+          - os: ubuntu-latest
+            jdk: 11
+            profile: '-PNativeIoUring'
           - os: ubuntu-latest
             jdk: 11
             profile: '-PNativeEpoll+DomainSockets'
@@ -35,6 +38,7 @@ jobs:
       jdk: ${{ matrix.jdk }}
       os: ${{ matrix.os }}
       profile: ${{ matrix.profile }}
+      io_uring_supported: ${{ inputs.io_uring_supported }}
     secrets: inherit
   Deploy:
     if: ${{ github.repository_owner == 'eclipse-vertx' && (github.event_name == 'push' || github.event_name == 'schedule') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       profile:
         default: ''
         type: 'string'
+      io_uring_supported:
+        default: false
+        type: boolean
 jobs:
   Test:
     name: Run tests
@@ -29,4 +32,11 @@ jobs:
           java-version: ${{ inputs.jdk }}
           distribution: temurin
       - name: Run tests
+        if: ${{ runner.os != 'Linux' || inputs.profile != '-PNativeIoUring'}}
         run: mvn -s .github/maven-ci-settings.xml -q clean verify -B ${{ inputs.profile }}
+      - name: Run tests
+        if: ${{ runner.os == 'Linux' && inputs.profile == '-PNativeIoUring' && inputs.io_uring_supported }}
+        run: |
+          # io_uring testing requires more locked memory for kernel ring buffers than the default 8MB limit
+          sudo prlimit --pid $$ --memlock=16777216:16777216
+          mvn -s .github/maven-ci-settings.xml -q clean verify -B ${{ inputs.profile }}

--- a/vertx-core/pom.xml
+++ b/vertx-core/pom.xml
@@ -880,6 +880,20 @@
         <vertx.surefire.useDomainSockets>false</vertx.surefire.useDomainSockets>
         <vertx.surefire.useModulePath>false</vertx.surefire.useModulePath>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables combine.children="append">
+                <io.netty.iouring.ringSize>512</io.netty.iouring.ringSize>
+                <io.netty.iouring.cqSize>1024</io.netty.iouring.cqSize>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/HttpServerConnectionInitializer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/HttpServerConnectionInitializer.java
@@ -270,10 +270,10 @@ public class HttpServerConnectionInitializer {
    * @return the name of the handler to use
    */
   private static String computeChannelName(ChannelPipeline pipeline) {
-    if (pipeline.get(ChunkedWriteHandler.class) != null) {
-      return "chunkedWriter";
-    } else if (pipeline.get(IdleStateHandler.class) != null) {
+    if (pipeline.get(IdleStateHandler.class) != null) {
       return "idle";
+    } else if (pipeline.get(ChunkedWriteHandler.class) != null) {
+      return "chunkedWriter";
     } else {
       return "handler";
     }

--- a/vertx-core/src/test/java/io/vertx/it/transport/TransportTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/transport/TransportTest.java
@@ -55,6 +55,12 @@ public class TransportTest extends AsyncTestBase {
     } catch (ClassNotFoundException ignore) {
       // Expected
     }
+    try {
+      Class<?> clazz = classLoader.loadClass("io.netty.channel.uring.IoUring");
+      fail("Was not expected to load IoUring class from " + clazz.getProtectionDomain().getCodeSource().getLocation());
+    } catch (ClassNotFoundException ignore) {
+      // Expected
+    }
     testNetServer(new VertxOptions());
     assertFalse(vertx.isNativeTransportEnabled());
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -38,7 +38,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.streams.WriteStream;
-import io.vertx.core.transport.Transport;
 import io.vertx.test.core.*;
 import io.vertx.test.fakedns.DnsRecord;
 import io.vertx.test.fakedns.WithDnsServer;
@@ -60,7 +59,6 @@ import java.util.stream.Stream;
 import static io.vertx.core.http.HttpMethod.PUT;
 import static io.vertx.test.core.AssertExpectations.that;
 import static io.vertx.test.core.TestUtils.*;
-import static io.vertx.test.core.VertxTestBase.TRANSPORT;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.Assert.*;
 
@@ -1061,7 +1059,6 @@ public class Http1xTest extends HttpTest {
 
   @Test
   public void testPipeliningOrder(Checkpoint checkpoint) throws Exception {
-    Assume.assumeFalse(TRANSPORT == Transport.IO_URING);
     client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(true).setPipelining(true), new PoolOptions().setHttp1MaxSize(1));
     int requests = 100;
 

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2Test.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2Test.java
@@ -897,7 +897,7 @@ public class Http2Test extends HttpTest {
     Path webroot = Files.createTempDirectory("webroot");
     File res = new File(webroot.toFile(), "large.dat");
     RandomAccessFile f = new RandomAccessFile(res, "rw");
-    f.setLength(1024 * 1024);
+    f.setLength(16 * 1024 * 1024);
 
     AtomicInteger errors = new AtomicInteger();
     vertx.getOrCreateContext().exceptionHandler(err -> {

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ServerTest.java
@@ -26,10 +26,12 @@ import io.vertx.core.net.QuicServer;
 import io.vertx.core.net.QuicStream;
 import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.core.transport.Transport;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.tls.Cert;
 import io.vertx.test.core.TestUtils;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
@@ -174,6 +176,8 @@ public class Http3ServerTest extends VertxTestBase {
 
   @Test
   public void testServerShutdown() throws Exception{
+    // See https://github.com/netty/netty/issues/16718
+    Assume.assumeFalse("Not supported yet with io_uring", TRANSPORT == Transport.IO_URING);
     testServerConnectionShutdown(false);
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetBandwidthLimitingTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetBandwidthLimitingTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.vertx.core.net.*;
-import io.vertx.core.transport.Transport;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 
@@ -84,7 +83,6 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
 
   @Test
   public void sendBufferThrottled() {
-    Assume.assumeFalse(TRANSPORT == Transport.IO_URING);
     long startTime = System.nanoTime();
 
     Buffer expected = TestUtils.randomBuffer(64 * 1024 * 4);
@@ -117,7 +115,6 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
 
   @Test
   public void sendFileIsThrottled() throws Exception {
-    Assume.assumeFalse(TRANSPORT == Transport.IO_URING);
     long startTime = System.nanoTime();
 
     File fDir = testFolder.newFolder();
@@ -153,7 +150,6 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
 
   @Test
   public void dataUploadIsThrottled() {
-    Assume.assumeFalse(TRANSPORT == Transport.IO_URING);
     long startTime = System.nanoTime();
 
     Buffer expected = TestUtils.randomBuffer(64 * 1024 * 4);
@@ -185,7 +181,6 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
 
   @Test
   public void fileUploadIsThrottled() throws Exception {
-    Assume.assumeFalse(TRANSPORT == Transport.IO_URING);
     long startTime = System.nanoTime();
 
     File fDir = testFolder.newFolder();
@@ -220,7 +215,6 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
 
   @Test
   public void testSendBufferIsTrafficShapedWithSharedServers() throws Exception {
-    Assume.assumeFalse(TRANSPORT == Transport.IO_URING);
     Buffer expected = TestUtils.randomBuffer(64 * 1024 * 4);
 
     int numEventLoops = 4; // We start a shared TCP server with 4 event-loops
@@ -264,8 +258,6 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
 
   @Test
   public void testDynamicInboundRateUpdate() {
-    Assume.assumeFalse(TRANSPORT == Transport.IO_URING);
-
     Buffer expected = TestUtils.randomBuffer(64 * 1024 * 4);
     NetServer server = netServer();
 
@@ -299,7 +291,6 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
 
   @Test
   public void testDynamicOutboundRateUpdate() {
-    Assume.assumeFalse(TRANSPORT == Transport.IO_URING);
     long startTime = System.nanoTime();
 
     Buffer expected = TestUtils.randomBuffer(64 * 1024 * 4);
@@ -338,7 +329,6 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
 
   @Test(expected = IllegalStateException.class)
   public void testRateUpdateWhenServerStartedWithoutTrafficShaping() throws Exception {
-    Assume.assumeFalse(TRANSPORT == Transport.IO_URING);
     NetServerOptions options = new NetServerOptions().setHost(DEFAULT_HOST).setPort(DEFAULT_PORT);
     NetServer testServer = netServer(options);
 

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -873,8 +873,6 @@ public class NetTest {
 
   @Test
   public void testWriteHandlerFailure() throws Exception {
-    // Todo : investigate this
-    Assume.assumeFalse(TRANSPORT == Transport.IO_URING);
     AtomicReference<NetSocket> serverSocket = new AtomicReference<>();
     server.connectHandler(socket -> {
       serverSocket.set(socket);
@@ -3611,7 +3609,6 @@ public class NetTest {
   }
 
   private void testIdleTimeoutSendChunkedFile(Checkpoint checkpoint, boolean idleOnServer) throws Exception {
-    Assume.assumeFalse(TRANSPORT == Transport.IO_URING);
     int expected = 16 * 1024 * 1024; // We estimate this will take more than 200ms to transfer with a 1ms pause in chunks
     File sent = TestUtils.tmpFile(".dat", expected);
     AtomicReference<AsyncResult<Void>> sendResult = new AtomicReference<>();

--- a/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
@@ -29,10 +29,8 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.impl.ShutdownEvent;
 import io.vertx.core.net.impl.VertxConnection;
 import io.vertx.core.net.impl.VertxHandler;
-import io.vertx.core.transport.Transport;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
-import org.junit.Assume;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -267,8 +265,6 @@ public class VertxConnectionTest extends VertxTestBase {
 
   @Test
   public void testFailedQueueMessages() throws Exception {
-    // Todo : investigate this
-    Assume.assumeFalse(TRANSPORT == Transport.IO_URING);
     BufferInternal buffer = BufferInternal.buffer(TestUtils.randomAlphaString(16 * 1024));
     CompletableFuture<Void> latch = new CompletableFuture<>();
     connectHandler = conn -> {
@@ -304,9 +300,7 @@ public class VertxConnectionTest extends VertxTestBase {
                 assertTrue(ctx.channel().isWritable());
                 ChannelFuture f = ctx.write(BufferInternal.buffer(TestUtils.randomAlphaString((int) ctx.channel().bytesBeforeUnwritable())).getByteBuf());
                 assertFalse(ctx.channel().isWritable());
-                // Flush to trigger writability change
                 ctx.flush();
-                assertTrue(ctx.channel().isWritable());
                 break;
               case "msg2":
                 testComplete();

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicServerTest.java
@@ -22,10 +22,12 @@ import io.vertx.core.http.ClientAuth;
 import io.vertx.core.internal.quic.QuicConnectionInternal;
 import io.vertx.core.internal.quic.QuicStreamInternal;
 import io.vertx.core.net.*;
+import io.vertx.core.transport.Transport;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.tls.Cert;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import javax.crypto.KeyGenerator;
@@ -319,6 +321,8 @@ public class QuicServerTest extends VertxTestBase {
   }
 
   private void testShutdownServer(Duration grace) throws Exception {
+    // See https://github.com/netty/netty/issues/16718
+    Assume.assumeFalse("Not supported yet with io_uring", TRANSPORT == Transport.IO_URING);
     disableThreadChecks();
     int numStreams = 5;
     int numConnections = 2;


### PR DESCRIPTION
- [x] Add new job to actions
- [x] `TransportTest#testNoNative` does not check for `io_uring`
- [x] Remove no `io_uring` transport assumptions where possible (e.g. not yet possible for tests that require Unix Domain Socket or file regions support)