### PR TITLE
Improve ReadStream documentation

### DIFF
--- a/vertx-core/src/main/asciidoc/streams.adoc
+++ b/vertx-core/src/main/asciidoc/streams.adoc
@@ -138,9 +138,11 @@ or when end of request is reached if it's an HTTP request, or when the connectio
 
 A read stream is either in _flowing_ or _fetch_ mode
 
-* initially the stream is in <i>flowing</i> mode
 * when the stream is in _flowing_ mode, elements are delivered to the handler
 * when the stream is in _fetch_ mode, only the number of requested elements will be delivered to the handler
+
+When a hot read stream is obtained (e.g. `HttpServerRequest`), the read stream is in flowing mode, when a cold read stream
+is obtained (e.g. `AsyncFile`), the read stream is in fetch mode with no demand.
 
 {@link io.vertx.core.streams.ReadStream#pause()}, {@link io.vertx.core.streams.ReadStream#resume()} and {@link io.vertx.core.streams.ReadStream#fetch}
 change the mode

--- a/vertx-core/src/main/java/io/vertx/core/streams/ReadStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/streams/ReadStream.java
@@ -49,6 +49,9 @@ import java.util.stream.StreamSupport;
  *   <li>Calling {@link #fetch(long)} requests a specific amount of elements and adds it to the actual demand</li>
  * </ul>
  *
+ * <p>When a hot read stream is obtained (e.g. `HttpServerRequest`), the read stream is in flowing mode, when a cold
+ * read stream is obtained (e.g. `AsyncFile`), the read stream is in fetch mode with no demand.
+ *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen(concrete = false)
@@ -96,6 +99,7 @@ public interface ReadStream<T> extends StreamBase {
    * be added to the current stream demand.
    *
    * @return a reference to this, so the API can be used fluently
+   * @throws IllegalArgumentException when the amount is a negative value
    */
   @Fluent
   ReadStream<T> fetch(long amount);


### PR DESCRIPTION
Motivation:

The `ReadStream` documentation lacks of precision on a couple of items.
