### PR TITLE
Allow blocking calls from vert.x-internal-blocking threads

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxThread.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxThread.java
@@ -31,7 +31,7 @@ public class VertxThread extends FastThreadLocalThread {
   public VertxThread(Runnable target, String name, boolean worker, long maxExecTime, TimeUnit maxExecTimeUnit) {
     super(target, name);
     this.worker = worker;
-    this.info = new ThreadInfo(maxExecTimeUnit, maxExecTime);
+    info = new ThreadInfo(maxExecTimeUnit, maxExecTime);
   }
 
   /**
@@ -69,4 +69,8 @@ public class VertxThread extends FastThreadLocalThread {
     return info.maxExecTimeUnit;
   }
 
+  @Override
+  public boolean permitBlockingCalls() {
+    return worker;
+  }
 }


### PR DESCRIPTION
Motivation:

Netty's `BlockHoundIntegration` currently treats `vert.x-internal-blocking` threads as non-blocking by default: https://github.com/netty/netty/blob/4.2/common/src/main/java/io/netty/util/internal/Hidden.java#L189 However, these threads are actually meant for blocking operations in Vert.x. To prevent `BlockHound` from incorrectly flagging blocking calls, we should explicitly override `FastThreadLocalThread.permitBlockingCalls()`.

Modifications:
- Overrode `FastThreadLocalThread.permitBlockingCalls()` for threads `vert.x-internal-blocking-*` to allow blocking operations.

Result:
- Blocking calls from `vert.x-internal-blocking` threads are no longer falsely flagged by `BlockHound`.
