### PR TITLE
Optimize Buffer's bound checks (Fixes #5643)

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -195,7 +195,7 @@ public class BufferImpl implements BufferInternal {
 
   private void checkUpperBound(int index, int size) {
     int length = buffer.writerIndex();
-    if ((index | length - (index + size)) < 0) {
+    if (index < 0 || index + size < 0 || index + size > length) {
       throw new IndexOutOfBoundsException(index + " + " + size + " > " + length);
     }
   }

--- a/vertx-core/src/test/java/io/vertx/benchmarks/BufferReadBenchmark.java
+++ b/vertx-core/src/test/java/io/vertx/benchmarks/BufferReadBenchmark.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.benchmarks;
+
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.ResourceLeakDetector;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.buffer.VertxByteBufAllocator;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(2)
+public class BufferReadBenchmark {
+
+  static {
+    ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
+  }
+
+  private ByteBuf nettyByteBuf;
+  private Buffer vertxBuffer;
+  @Param({"64"})
+  private int batchSize;
+
+  @Setup
+  public void setup() {
+      nettyByteBuf = VertxByteBufAllocator.DEFAULT.heapBuffer(batchSize);
+      nettyByteBuf.ensureWritable(batchSize);
+      vertxBuffer = Buffer.buffer(batchSize);
+      for (int i = 0; i < batchSize; i++) {
+          nettyByteBuf.setByte(i, (byte) i);
+          vertxBuffer.setByte(i, (byte) i);
+      }
+  }
+
+  @Benchmark
+  public void getByteBatchNetty(Blackhole bh) {
+    ByteBuf buffer = this.nettyByteBuf;
+    for (int i = 0, size = batchSize; i < size; i++) {
+      bh.consume(buffer.getByte(i));
+    }
+  }
+
+  @Benchmark
+  public void getByteBatchVertx(Blackhole bh) {
+    Buffer buffer = this.vertxBuffer;
+    for (int i = 0, size = batchSize; i < size; i++) {
+      bh.consume(buffer.getByte(i));
+    }
+  }
+
+  @Benchmark
+  public void getBytesNetty(Blackhole bh) {
+    ByteBuf buffer = this.nettyByteBuf;
+    int readerIndex = buffer.readerIndex();
+    bh.consume(buffer.getByte(readerIndex));
+    readerIndex += 1;
+    bh.consume(buffer.getShortLE(readerIndex));
+    readerIndex += 2;
+    bh.consume(buffer.getIntLE(readerIndex));
+    readerIndex += 4;
+    bh.consume(buffer.getLongLE(readerIndex));
+  }
+
+  @Benchmark
+  public void getBytesVertx(Blackhole bh) {
+    Buffer buffer = this.vertxBuffer;
+    int readerIndex = 0;
+    bh.consume(buffer.getByte(readerIndex));
+    readerIndex += 1;
+    bh.consume(buffer.getShortLE(readerIndex));
+    readerIndex += 2;
+    bh.consume(buffer.getIntLE(readerIndex));
+    readerIndex += 4;
+    bh.consume(buffer.getLongLE(readerIndex));
+  }
+
+  @Benchmark
+  public void getBytesConstantOffsetNetty(Blackhole bh) {
+    ByteBuf buffer = this.nettyByteBuf;
+    bh.consume(buffer.getByte(0));
+    bh.consume(buffer.getShortLE(1));
+    bh.consume(buffer.getIntLE(3));
+    bh.consume(buffer.getLongLE(7));
+  }
+
+  @Benchmark
+  public void getBytesConstantOffsetVertx(Blackhole bh) {
+    Buffer buffer = this.vertxBuffer;
+    bh.consume(buffer.getByte(0));
+    bh.consume(buffer.getShortLE(1));
+    bh.consume(buffer.getIntLE(3));
+    bh.consume(buffer.getLongLE(7));
+  }
+}


### PR DESCRIPTION
Motivation:

It fixes #5643

on `JDK 17`:

The old results vs Netty were:
```
Benchmark                                        (batchSize)  Mode  Cnt   Score   Error  Units
BufferReadBenchmark.getByteBatchNetty                     64  avgt   20  57.338 ± 0.176  ns/op
BufferReadBenchmark.getByteBatchVertx                     64  avgt   20  81.085 ± 0.109  ns/op
BufferReadBenchmark.getBytesConstantOffsetNetty           64  avgt   20   3.764 ± 0.040  ns/op
BufferReadBenchmark.getBytesConstantOffsetVertx           64  avgt   20   6.233 ± 0.196  ns/op
BufferReadBenchmark.getBytesNetty                         64  avgt   20   6.225 ± 0.022  ns/op
BufferReadBenchmark.getBytesVertx                         64  avgt   20   6.124 ± 0.038  ns/op
```
With these changes:
```
Benchmark                                        (batchSize)  Mode  Cnt   Score   Error  Units
BufferReadBenchmark.getByteBatchNetty                     64  avgt   20  57.338 ± 0.176  ns/op
BufferReadBenchmark.getByteBatchVertx                     64  avgt   20  61.578 ± 0.029  ns/op
BufferReadBenchmark.getBytesConstantOffsetNetty           64  avgt   20   3.764 ± 0.040  ns/op
BufferReadBenchmark.getBytesConstantOffsetVertx           64  avgt   20   5.218 ± 0.147  ns/op
BufferReadBenchmark.getBytesNetty                         64  avgt   20   6.225 ± 0.022  ns/op
BufferReadBenchmark.getBytesVertx                         64  avgt   20   5.160 ± 0.009  ns/op
```

while comparing just vertx with itself:
```
                                                        Before         |         After    
Benchmark                                         Score   Error  Units |  Score   Error  Units 
BufferReadBenchmark.getByteBatchVertx            81.085 ± 0.109  ns/op | 61.578 ± 0.029  ns/op 
BufferReadBenchmark.getBytesConstantOffsetVertx   6.233 ± 0.196  ns/op |  5.218 ± 0.147  ns/op
BufferReadBenchmark.getBytesVertx                 6.124 ± 0.038  ns/op |  5.160 ± 0.009  ns/op
```
There's an interesting "plot-twist" on `BufferReadBenchmark.getBytes` since, thank to this patch it appears 
that vertx is faster than Netty, although performing an additional bound check; it's likely that expressing it proved the subsequent one to be redundant/simplified - making some JIT strenght reduction to kicks-in.

Indeed, on my machine (the short LE read in Netty was
```asm
test   %edi,%edi
jl     0x00007f35381f0650
vmovq  %rax,%xmm0
mov    %r10,%rax
lea    -0x7(%rsi),%ebx
mov    %r9d,%edi
or     $0x4,%edi
or     %ecx,%edi
lea    0x7(%r11),%r10d
or     %r10d,%edi
or     %ebx,%edi
movslq %ebp,%r8
movswl 0x10(%rdx,%r8,1),%ebx
```
whilst the vertx one (with this PR in):
```asm
cmp    $0x3,%r9d
jl     0x00007f2ce01ededc
mov    $0x3,%eax
or     %ebx,%eax
lea    -0x3(%rbx),%esi
or     $0x3,%eax
or     %esi,%eax         
test   %eax,%eax
jl     0x00007f2ce01edf10
movswl 0x11(%r12,%rdi,8),%esi
``` 
which contains less math (e.g. `lea` and `or` and an additional `jl` - although I don't see the value of `cmp    $0x3,%r9d` (maybe a JIT bug?) since `r9d` never change (it is written once before all the reads happen).

FYI @vietj it is likely Vertx 4.x to be affected as well, I haven't checked if we have custom bound checks there too

> NOTE: 
the current Netty 4.2 branch is not including an important improvement re bound checks, see https://github.com/netty/netty/pull/15452

 

