### PR TITLE
Let an HTTP server request handler implement Closeable to be notified of the server closing

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -241,7 +241,14 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
   }
 
   private void doClose(NetServer netServer, Completable<Void> p) {
-    netServer.close().onComplete(p);
+    if (requestHandler instanceof Closeable) {
+      Closeable closeable = (Closeable) requestHandler;
+      closeable.close((res, err) -> {
+        netServer.close().onComplete(p);
+      });
+    } else {
+      netServer.close().onComplete(p);
+    }
   }
 
   public Future<Void> shutdown(long timeout, TimeUnit unit) {

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpServerCloseSequenceTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpServerCloseSequenceTest.java
@@ -1,0 +1,85 @@
+package io.vertx.tests.http;
+
+import io.vertx.core.Closeable;
+import io.vertx.core.Completable;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpResponseExpectation;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.impl.HttpServerImpl;
+import io.vertx.test.http.HttpTestBase;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class HttpServerCloseSequenceTest extends HttpTestBase {
+
+  @Test
+  public void testHttpServerImplCloseSequence() throws Exception {
+
+    TestHandler testHandler = new TestHandler();
+
+    HttpServer customServer = vertx.createHttpServer(createBaseServerOptions())
+      .requestHandler(testHandler);
+
+    server.requestHandler(testHandler);
+
+    startServer(testAddress, customServer);
+
+    client.request(requestOptions)
+      .compose(req -> req
+        .send()
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::body))
+      .await();
+
+    assertFalse(testHandler.isClosed());
+    assertFalse(testHandler.isClosing());
+
+    customServer
+      .shutdown(10, TimeUnit.SECONDS)
+      .onComplete(onSuccess(v2 -> {
+        assertTrue(((HttpServerImpl) customServer).isClosed());
+        assertTrue("TestHandler should be closed during shutdown", testHandler.isClosed());
+        testComplete();
+      }));
+
+    vertx.setTimer(15, v -> {
+      assertFalse(testHandler.isClosed());
+      assertTrue(testHandler.isClosing());
+      testHandler.close();
+    });
+
+    await();
+  }
+
+  private static class TestHandler implements Handler<HttpServerRequest>, Closeable {
+
+    private volatile boolean closed = false;
+    private volatile Completable<Void> closing;
+
+    @Override
+    public void handle(HttpServerRequest event) {
+      event.response().end("OK");
+    }
+
+    void close() {
+      closed = true;
+      closing.succeed();
+    }
+
+    @Override
+    public void close(Completable<Void> completion) {
+      closing = completion;
+    }
+
+    public boolean isClosed() {
+      return closed;
+    }
+
+    public boolean isClosing() {
+      return closing != null;
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

This is rather an internal implementation detail that is useful for gRPC server to be notified of the server shutdown to close its bound services.

We might make this more formal in the future with an API.
