### PR TITLE
Allow an HTTP client request to have a null authority

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -187,7 +187,9 @@ public class Http1xClientConnection extends Http1xConnection implements HttpClie
       }
     }
     if (!headers.contains(HOST)) {
-      request.headers().set(HOST, authority.toString(ssl));
+      if (authority != null) {
+        request.headers().set(HOST, authority.toString(ssl));
+      }
     } else {
       headers.remove(TRANSFER_ENCODING);
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -117,7 +117,6 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
 
   @Override
   public synchronized HttpClientRequest authority(HostAndPort authority) {
-    Objects.requireNonNull(authority);
     this.authority = authority;
     return this;
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -5431,7 +5431,7 @@ public class Http1xTest extends HttpTest {
   }
 
   @Test
-  public void testMissingHostHeader() throws Exception {
+  public void testServerMissingHostHeader() throws Exception {
     server.requestHandler(req -> {
       assertEquals(null, req.authority());
       assertFalse(((HttpServerRequestInternal) req).isValidAuthority());
@@ -5443,6 +5443,23 @@ public class Http1xTest extends HttpTest {
       so.write("GET / HTTP/1.1\r\n\r\n");
     }));
     await();
+  }
+
+  @Test
+  public void testClientMissingHostHeader() throws Exception {
+    server.requestHandler(req -> {
+      assertEquals(null, req.authority());
+      assertFalse(((HttpServerRequestInternal) req).isValidAuthority());
+      req.response().end();
+    });
+    startServer(testAddress);
+    client.request(requestOptions)
+      .compose(request -> request
+        .authority(null)
+        .send()
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::end))
+      .await();
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
@@ -379,6 +379,31 @@ public class Http2ClientTest extends Http2TestBase {
   }
 
   @Test
+  public void testNoAuthority() throws Exception {
+    ServerBootstrap bootstrap = createH2Server((decoder, encoder) -> new Http2EventAdapter() {
+      @Override
+      public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) throws Http2Exception {
+        vertx.runOnContext(v -> {
+          assertNull(headers.authority());
+          encoder.writeHeaders(ctx, streamId, new DefaultHttp2Headers().status("200"), 0, true, ctx.newPromise());
+          ctx.flush();
+        });
+      }
+    });
+    ChannelFuture s = bootstrap.bind(DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT).sync();
+    client.request(new RequestOptions().setServer(testAddress)
+        .setPort(4444)
+        .setHost("localhost")
+      )
+      .compose(request -> {
+        request.authority(null);
+        return request.send();
+      })
+      .onComplete(onSuccess(resp -> testComplete()));
+    await();
+  }
+
+  @Test
   public void testTrailers() throws Exception {
     server.requestHandler(req -> {
       HttpServerResponse resp = req.response();


### PR DESCRIPTION
Motivation:

In some cases it is desirable to send an HTTP request that does not carry the http2 pseudo authority header, nor the host header.
