### PR TITLE
Use long to set the DNS hosts file refresh period instead of int

### DIFF
--- a/vertx-core/src/main/generated/io/vertx/core/dns/AddressResolverOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/dns/AddressResolverOptionsConverter.java
@@ -24,7 +24,7 @@ public class AddressResolverOptionsConverter {
           break;
         case "hostsRefreshPeriod":
           if (member.getValue() instanceof Number) {
-            obj.setHostsRefreshPeriod(((Number)member.getValue()).intValue());
+            obj.setHostsRefreshPeriod(((Number)member.getValue()).longValue());
           }
           break;
         case "servers":

--- a/vertx-core/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
@@ -78,7 +78,7 @@ public class AddressResolverOptions {
   /**
    * The default value for the hosts refresh value in nanos = 0 (disabled)
    */
-  public static final int DEFAULT_HOSTS_REFRESH_PERIOD = 0;
+  public static final long DEFAULT_HOSTS_REFRESH_PERIOD = 0;
 
   /**
    * The default value for the max dns queries per query = 4
@@ -112,7 +112,7 @@ public class AddressResolverOptions {
 
   private String hostsPath;
   private Buffer hostsValue;
-  private int hostsRefreshPeriod;
+  private long hostsRefreshPeriod;
   private List<String> servers;
   private boolean optResourceEnabled;
   private int cacheMinTimeToLive;
@@ -210,7 +210,7 @@ public class AddressResolverOptions {
   /**
    * @return the hosts configuration refresh period in nanos
    */
-  public int getHostsRefreshPeriod() {
+  public long getHostsRefreshPeriod() {
     return hostsRefreshPeriod;
   }
 
@@ -223,7 +223,7 @@ public class AddressResolverOptions {
    *
    * @param hostsRefreshPeriod the hosts configuration refresh period
    */
-  public AddressResolverOptions setHostsRefreshPeriod(int hostsRefreshPeriod) {
+  public AddressResolverOptions setHostsRefreshPeriod(long hostsRefreshPeriod) {
     if (hostsRefreshPeriod < 0) {
       throw new IllegalArgumentException("hostsRefreshPeriod must be >= 0");
     }


### PR DESCRIPTION
Motivation:
  int can only express nanoseconds of less than 3 seconds, which is probably not enough

See #5666