### PR TITLE
Introduce a time unit option that defaults to nanoseconds for hostsRefreshPeriod of AddressResolverOptions

### DIFF
--- a/vertx-core/src/main/generated/io/vertx/core/dns/AddressResolverOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/dns/AddressResolverOptionsConverter.java
@@ -22,6 +22,11 @@ public class AddressResolverOptionsConverter {
             obj.setHostsValue(io.vertx.core.buffer.Buffer.fromJson((String)member.getValue()));
           }
           break;
+        case "hostsRefreshPeriodUnit":
+          if (member.getValue() instanceof String) {
+            obj.setHostsRefreshPeriodUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
+          }
+          break;
         case "hostsRefreshPeriod":
           if (member.getValue() instanceof Number) {
             obj.setHostsRefreshPeriod(((Number)member.getValue()).intValue());
@@ -111,6 +116,9 @@ public class AddressResolverOptionsConverter {
     }
     if (obj.getHostsValue() != null) {
       json.put("hostsValue", obj.getHostsValue().toJson());
+    }
+    if (obj.getHostsRefreshPeriodUnit() != null) {
+      json.put("hostsRefreshPeriodUnit", obj.getHostsRefreshPeriodUnit().name());
     }
     json.put("hostsRefreshPeriod", obj.getHostsRefreshPeriod());
     if (obj.getServers() != null) {

--- a/vertx-core/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
@@ -235,14 +235,14 @@ public class AddressResolverOptions {
   }
 
   /**
-   * @return the hosts configuration refresh period in nanos
+   * @return the hosts configuration refresh period in time unit specified by {@link #getHostsRefreshPeriodUnit()}.
    */
   public int getHostsRefreshPeriod() {
     return hostsRefreshPeriod;
   }
 
   /**
-   * Set the hosts configuration refresh period in nanos, {@code 0} disables it.
+   * Set the hosts configuration refresh period in time unit specified by {@link #getHostsRefreshPeriodUnit()}, {@code 0} disables it.
    * <p/>
    * The resolver caches the hosts configuration {@link #hostsPath file} after it has read it. When
    * the content of this file can change, setting a positive refresh period will load the configuration

--- a/vertx-core/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
@@ -20,6 +20,7 @@ import io.vertx.core.json.JsonObject;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static io.vertx.core.impl.Utils.isLinux;
 import static io.vertx.core.internal.resolver.NameResolver.parseLinux;
@@ -76,7 +77,12 @@ public class AddressResolverOptions {
   public static final int DEFAULT_QUERY_TIMEOUT = 5000;
 
   /**
-   * The default value for the hosts refresh value in nanos = 0 (disabled)
+   * The default time unit for the hosts refresh value = NANOSECONDS
+   */
+  public static final TimeUnit DEFAULT_HOSTS_REFRESH_PERIOD_UNIT = TimeUnit.NANOSECONDS;
+
+  /**
+   * The default value for the hosts refresh value = 0 (disabled)
    */
   public static final int DEFAULT_HOSTS_REFRESH_PERIOD = 0;
 
@@ -112,6 +118,7 @@ public class AddressResolverOptions {
 
   private String hostsPath;
   private Buffer hostsValue;
+  private TimeUnit hostsRefreshPeriodUnit;
   private int hostsRefreshPeriod;
   private List<String> servers;
   private boolean optResourceEnabled;
@@ -139,12 +146,14 @@ public class AddressResolverOptions {
     ndots = DEFAULT_NDOTS;
     rotateServers = DEFAULT_ROTATE_SERVERS;
     roundRobinInetAddress = DEFAULT_ROUND_ROBIN_INET_ADDRESS;
+    hostsRefreshPeriodUnit = DEFAULT_HOSTS_REFRESH_PERIOD_UNIT;
     hostsRefreshPeriod = DEFAULT_HOSTS_REFRESH_PERIOD;
   }
 
   public AddressResolverOptions(AddressResolverOptions other) {
     this.hostsPath = other.hostsPath;
     this.hostsValue = other.hostsValue != null ? other.hostsValue.copy() : null;
+    this.hostsRefreshPeriodUnit = other.getHostsRefreshPeriodUnit() != null ? other.getHostsRefreshPeriodUnit() : DEFAULT_HOSTS_REFRESH_PERIOD_UNIT;
     this.hostsRefreshPeriod = other.hostsRefreshPeriod;
     this.servers = other.servers != null ? new ArrayList<>(other.servers) : null;
     this.optResourceEnabled = other.optResourceEnabled;
@@ -204,6 +213,24 @@ public class AddressResolverOptions {
    */
   public AddressResolverOptions setHostsValue(Buffer hostsValue) {
     this.hostsValue = hostsValue;
+    return this;
+  }
+
+  /**
+   * @return the hosts configuration refresh period time unit
+   */
+  public TimeUnit getHostsRefreshPeriodUnit() {
+    return hostsRefreshPeriodUnit;
+  }
+
+  /**
+   * Set the hosts configuration refresh period time unit. If not specified, default is nanoseconds.
+   *
+   * @param hostsRefreshPeriodUnit specify time unit
+   * @return a reference to this, so the API can be used fluently
+   */
+  public AddressResolverOptions setHostsRefreshPeriodUnit(TimeUnit hostsRefreshPeriodUnit) {
+    this.hostsRefreshPeriodUnit = hostsRefreshPeriodUnit;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsAddressResolverProvider.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsAddressResolverProvider.java
@@ -100,7 +100,7 @@ public class DnsAddressResolverProvider implements AddressResolverProvider, Host
     this.vertx = vertx;
     this.hostsPath = options.getHostsPath();
     this.hostsValue = options.getHostsValue();
-    this.hostsRefreshPeriodNanos = options.getHostsRefreshPeriod();
+    this.hostsRefreshPeriodNanos = options.getHostsRefreshPeriodUnit().toNanos(options.getHostsRefreshPeriod());
 
     DnsNameResolverBuilder builder = new DnsNameResolverBuilder();
     builder.hostsFileEntriesResolver(this);

--- a/vertx-core/src/test/java/io/vertx/tests/dns/NameResolverTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/dns/NameResolverTest.java
@@ -431,25 +431,42 @@ public class NameResolverTest extends VertxTestBase {
   @Test
   public void testRefreshHosts1() throws Exception {
     Assume.assumeFalse(Utils.isWindows());
-    InetAddress addr = testRefreshHosts((int) TimeUnit.SECONDS.toNanos(1));
+    InetAddress addr = testRefreshHosts((int) TimeUnit.SECONDS.toNanos(1), null);
     assertEquals("192.168.0.16", addr.getHostAddress());
     assertEquals("server.net", addr.getHostName());
   }
 
   @Test
   public void testRefreshHosts2() throws Exception {
-    InetAddress addr = testRefreshHosts(0);
+    InetAddress addr = testRefreshHosts(0, null);
     assertEquals("192.168.0.15", addr.getHostAddress());
     assertEquals("server.net", addr.getHostName());
   }
 
-  private InetAddress testRefreshHosts(int period) throws Exception {
+  @Test
+  public void testRefreshHosts3() throws Exception {
+    InetAddress addr = testRefreshHosts(100, TimeUnit.MILLISECONDS);
+    assertEquals("192.168.0.16", addr.getHostAddress());
+    assertEquals("server.net", addr.getHostName());
+  }
+
+  @Test
+  public void testRefreshHosts4() throws Exception {
+    InetAddress addr = testRefreshHosts(2, TimeUnit.SECONDS);
+    assertEquals("192.168.0.15", addr.getHostAddress());
+    assertEquals("server.net", addr.getHostName());
+  }
+
+  private InetAddress testRefreshHosts(int period, TimeUnit timeUnit) throws Exception {
     File hosts = File.createTempFile("vertx", "hosts");
     hosts.deleteOnExit();
     Files.writeString(hosts.toPath(), "192.168.0.15 server.net");
     AddressResolverOptions options = new AddressResolverOptions()
       .setHostsPath(hosts.getAbsolutePath())
       .setHostsRefreshPeriod(period);
+    if (timeUnit != null) {
+      options.setHostsRefreshPeriodUnit(timeUnit);
+    }
     VertxInternal vertx = (VertxInternal) vertx(new VertxOptions().setAddressResolverOptions(options));
     InetAddress addr = awaitFuture(resolve(vertx, "server.net"));
     assertEquals("192.168.0.15", addr.getHostAddress());


### PR DESCRIPTION
See #5666
