### PR TITLE
Exclude connections with outstanding bytes to read from being used via connection pooling. Fixes #5663

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/SharedClientHttpStreamEndpoint.java
+++ b/src/main/java/io/vertx/core/http/impl/SharedClientHttpStreamEndpoint.java
@@ -45,9 +45,11 @@ class SharedClientHttpStreamEndpoint extends ClientHttpEndpointBase<Lease<HttpCl
       if (pooled.available() > 0) {
         HttpClientConnection conn = pooled.get();
         if (selected == null) {
-          selected = pooled;
+          if (pooled.get().isValid()) {
+            selected = pooled;
+          }
         } else {
-          if (conn.lastResponseReceivedTimestamp() > last) {
+          if (conn.lastResponseReceivedTimestamp() > last && conn.isValid()) {
             selected = pooled;
           }
         }

--- a/src/test/java/io/vertx/core/http/Http1xClientConnectionTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xClientConnectionTest.java
@@ -11,15 +11,28 @@
 package io.vertx.core.http;
 
 import io.netty.buffer.Unpooled;
+import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.impl.HttpRequestHead;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class Http1xClientConnectionTest extends HttpClientConnectionTest {
+  private static final Logger log = LoggerFactory.getLogger(Http1xClientConnectionTest.class);;
 
   @Test
   public void testResetStreamBeforeSend() throws Exception {
@@ -97,5 +110,148 @@ public class Http1xClientConnectionTest extends HttpClientConnectionTest {
       }));
     }));
     await();
+  }
+
+  @Test
+  /*
+   * This test reproduces an issue involving connection pooling and parallel reads to the same server. When
+   * you have a client which pauses its reading of data AND that remaining data is able to be read into InboundBuffer,
+   * AND then you have another client to the same server on the same port (via pooling) which attempts to read all
+   * of the data. Then the second client will "hang" and eventually fail due to a timeout (if there is one).
+   *
+   * In order to avoid this as-is, connection pooling has to be disabled which may not be practical.
+   */
+  public void testConnectionReuseLeadsToStuckGetRequest() throws TimeoutException, ExecutionException, InterruptedException {
+    // This magic number is based on the high watermark of Http1xClientConnection, which is based on Netty.
+    // The HTTP client uses Netty's HTTP object decoder, which uses a chunk size of 8KiB. This means that
+    // a socket read of 64KiB (the write queue limit of the channel) will result in up to 8 messages which are
+    // passed down to the Vert.x handler. When the original request is paused after reading one buffer, it
+    // leaves 56KiB in the bytesWindow (not enough to hit the HWM and disable autoRead).
+    // When the next request comes in, it will read 64KiB from the socket. Then 8KiB into the InboundBuffer. Since
+    // this will be > the HWM (64KiB + 1), autoRead will be disabled. The second request is not paused, so it will
+    // then read the 8KiB which was buffered. However, since autoRead is disabled now, no further bytes will be read
+    int contentLength = 57344 + 1;
+    // This is the max number of requests to make before considering the test a success
+    int maxRequests = 5000;
+    // The idle timeout is arbitrary, but is long to show that the request will never complete
+    int idleTimeout = 30000;
+    Map<Integer, Integer> ports = new HashMap<>();
+    HttpClient client = vertx.createHttpClient();
+    HttpServer server = vertx.createHttpServer();
+
+    // Set up a generic server which responds with data that will exceed the HWM of Http1xClientConnection (64KiB)
+    // However, the data can't be too large because it needs to all be buffered by InboundBuffer, otherwise
+    // the original request which is paused won't be complete
+    Future<HttpServer> listen = server.requestHandler(req -> {
+      req.response().putHeader("Content-Length", contentLength + "");
+      req.response().write(Buffer.buffer(new byte[contentLength]));
+      req.response().end();
+    }).listen(0);
+
+    CompletableFuture<Void> serverStarted = new CompletableFuture<>();
+    listen.onComplete(event -> serverStarted.complete(null));
+    serverStarted.get(idleTimeout, TimeUnit.MILLISECONDS);
+    int portToUse = listen.result().actualPort();
+    log.debug("Started server on port: " + portToUse);
+
+    // Sequence to reproduce:
+    // first request - reads 56KiB + 1 from socket. auto read -> true. bytes window: 0
+    // first request client stream is paused. bytes window: 56KiB + 1. auto read -> true
+    // first request - complete because socket read was complete. connection is back to pool. bytes window: 56KiB + 1, auto read -> true
+    // second request - read some amount of data < total content length from socket
+    // second request - splits into 8KiB chunks, passes one to Vert.x. bytes window: 64KiB + 1. auto read -> false
+    // second request - not paused, so it will ack 8KiB + 1. bytes window: 56KiB. auto read -> false
+    // second request - will read remaining content that was read from socket. But since auto read is false,
+    // it will never read any additional data from the socket and will hang
+
+    AtomicInteger pausedRequestPort = new AtomicInteger();
+    AtomicReference<String> pausedRequestId = new AtomicReference<>();
+    AtomicInteger pausedRequestBuffer = new AtomicInteger();
+
+    Future<HttpClientRequest> originalRequest = client.request(HttpMethod.GET, portToUse, "localhost", "/");
+    originalRequest.onComplete(response -> {
+      HttpClientRequest result = response.result();
+      String requestId = UUID.randomUUID().toString();
+      pausedRequestId.set(requestId);
+      pausedRequestPort.set(response.result().connection().localAddress().port());
+      log.error("The problematic request id is: " + requestId);
+      ports.putIfAbsent(pausedRequestPort.get(), 0);
+      ports.put(pausedRequestPort.get(), ports.get(pausedRequestPort.get()) + 1);
+
+      result.response().onComplete(arResult -> {
+        HttpClientResponse res = arResult.result();
+        // Even though the response stream is paused, the remaining data will fit into InboundBuffer's pending
+        // queue. This means its own end handler will be triggered, and the connection is available for reuse
+        res.handler(event -> pausedRequestBuffer.getAndAdd(event.length()));
+        res.pause();
+      });
+      result.end();
+    });
+
+    // Now loop until we can get a request which shares the same port as the original request which is paused
+    // This means the connection was reused
+    int requestCount = 0;
+    while (requestCount < maxRequests) {
+      requestCount++;
+      // We create requests sequentially and block on the future completing. The future is complete when all data
+      // is retrieved. There is no need to do parallel requests to reproduce the issue.
+      CompletableFuture<Void> future = new CompletableFuture<>();
+      String requestId = UUID.randomUUID().toString();
+      AtomicInteger buffer = new AtomicInteger();
+
+      client.request(HttpMethod.GET, portToUse, "localhost", "/").onComplete(response -> {
+        HttpClientRequest result = response.result();
+        int localPort = response.result().connection().localAddress().port();
+        ports.putIfAbsent(localPort, 0);
+        ports.put(localPort, ports.get(localPort) + 1);
+
+        if (localPort == pausedRequestPort.get()) {
+          // We can detect that this request should hang because it's reusing the paused request's port.
+          log.error(String.format("%s should be a stuck get on port %d which is caused by %s",
+            requestId, pausedRequestPort.get(), pausedRequestId.get()));
+        }
+
+        // This block of code just processes the results from the server. It completes the request future once
+        // the end handler runs. If the end handler never runs, it means we have successfully hit a "stuck get"
+        result.response().onComplete(arResult -> {
+          HttpClientResponse res = arResult.result();
+          if (res == null) {
+            log.error(requestId + " had a null result, oops");
+            future.completeExceptionally(new NullPointerException());
+          } else {
+            res.handler(event -> {
+              buffer.getAndAdd(event.length());
+            });
+            res.endHandler(event -> {
+              if (buffer.get() != contentLength) {
+                future.completeExceptionally(new RuntimeException(String.format("content length doesn't match: Was %s" +
+                  " but expected %s", buffer.get(), contentLength)));
+              } else {
+                future.complete(null);
+              }
+            });
+            res.exceptionHandler(t -> {
+              log.error(t.getMessage(), t);
+              future.completeExceptionally(t);
+            });
+          }
+        });
+        result.end();
+      });
+      try {
+        log.debug("Waiting on: " + requestId);
+        future.get(idleTimeout, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      } catch (TimeoutException e) {
+        log.error(String.format("Timed out waiting on: %s. Received %d out of %d bytes", requestId, buffer.get(),
+          contentLength));
+        log.error(ports);
+        throw e;
+      }
+    }
+    log.debug(String.format("Ports in use are below. The problematic request was on port %d so there must be > 1 " +
+      "request on that port to reproduce this issue", pausedRequestPort.get()));
+    log.debug(ports);
   }
 }


### PR DESCRIPTION
Applies to 4.x

Motivation:

This is a proposed fix for https://github.com/eclipse-vertx/vert.x/issues/5663. This issue can cause a request using Vert.x client to "hang" if it involves connection reuse which has a previous request on it. The previous request must have already ended (as in all data was retrieved) but the data was not consumed (as in, the client response stream was paused). If this occurs, then the subsequent request can hang because the readWindow value, which is used to determine if the Channel auto read setting is enabled, is left over from the previous request. Under the right conditions, it can be impossible for the second request to make progress.

In this fix, connections are not reused from the connection pool if there is an outstanding value for readWindow by adding an isValid check before a connection is checked out (This would be correct anyway in case the connection has since expired but the PoolChecker has not cleaned it up yet). This means the outstanding request will need to complete before a second request can use the same connection. However, in the scenario above the second request would never succeed, so there is no loss in throughput there.

I ran the same test described in https://github.com/eclipse-vertx/vert.x/issues/5663. I ran it on the 4.x branch and it still occurs, but with this fix applied it no longer occurs. 

Before fix, where the request using the same port hangs indefinitely
```
Ports in use are below. The problematic request was on port 127.0.0.1:63902 so there must be > 1 request on that port to reproduce this issue 
{127.0.0.1:63902=3, 127.0.0.1:63903=1098} 
cc483753-b354-4352-9fef-0da3df6c24bb should be a stuck get on port 127.0.0.1:63902 which is caused by 2f39ec98-75c0-4833-8d4b-622e586daa6e
```

After fix, since the connection is available for reuse, a new connection is opened (which then itself is reused many times).
```
Ports in use are below. The problematic request was on port 127.0.0.1:63917 so there must be > 1 request on that port to reproduce this issue 
{127.0.0.1:63917=1, 127.0.0.1:63918=3943, 127.0.0.1:63919=1057} 
```

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
