### PR TITLE
Http1xClientResponse should be acked its read window when it has been fully received

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -333,25 +333,23 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     readWindow += len;
     boolean gt = readWindow > highWaterMark;
     if (le && gt) {
+      System.out.println("pause");
       doPause();
     }
   }
 
-  private void ackBytes(int len) {
-    EventLoop eventLoop = context.nettyEventLoop();
-    if (eventLoop.inEventLoop()) {
-      boolean gt = readWindow > lowWaterMark;
-      readWindow -= len;
-      boolean le = readWindow <= lowWaterMark;
-      if (gt && le) {
-        doResume();
-      }
-    } else {
-      eventLoop.execute(() -> ackBytes(len));
+  private void ackBytes(long len) {
+    boolean gt = readWindow > lowWaterMark;
+    readWindow -= len;
+    boolean le = readWindow <= lowWaterMark;
+    if (gt && le) {
+      doResume();
     }
   }
 
   private abstract static class Stream {
+
+    protected final Http1xClientConnection conn;
 
     protected final Promise<HttpClientStream> promise;
     protected final ContextInternal context;
@@ -365,11 +363,32 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     private boolean responseEnded;
     private long bytesRead;
     private long bytesWritten;
+    private long readWindow;
 
-    Stream(ContextInternal context, int id) {
+    Stream(Http1xClientConnection conn, ContextInternal context, int id) {
+      this.conn = conn;
       this.context = context;
       this.id = id;
       this.promise = context.promise();
+    }
+
+    protected final void ackBytes(long len) {
+      EventLoop eventLoop = context.nettyEventLoop();
+      if (eventLoop.inEventLoop()) {
+        if (!responseEnded) {
+          readWindow -= len;
+          conn.ackBytes(len);
+        }
+      } else {
+        eventLoop.execute(() -> ackBytes(len));
+      }
+    }
+
+    void receiveChunk(Buffer chunk) {
+      int len = chunk.length();
+      bytesRead += len;
+      readWindow += len;
+      context.execute(chunk, this::handleChunk);
     }
 
     // Not really elegant... but well
@@ -398,7 +417,6 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
    */
   private static class StreamImpl extends Stream implements HttpClientStream {
 
-    private final Http1xClientConnection conn;
     private final InboundBuffer<Object> queue;
     private Throwable reset;
     private boolean closed;
@@ -414,9 +432,8 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     private Handler<Void> closeHandler;
 
     StreamImpl(ContextInternal context, Http1xClientConnection conn, int id) {
-      super(context, id);
+      super(conn, context, id);
 
-      this.conn = conn;
       this.queue = new InboundBuffer<>(context, 5)
         .handler(item -> {
           if (reset == null) {
@@ -428,7 +445,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
             } else {
               Buffer buffer = (Buffer) item;
               int len = buffer.length();
-              conn.ackBytes(len);
+              ackBytes(len);
               Handler<Buffer> handler = chunkHandler;
               if (handler != null) {
                 handler.handle(buffer);
@@ -911,8 +928,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     Buffer buff = Buffer.buffer(VertxHandler.safeBuffer(chunk));
     int len = buff.length();
     receiveBytes(len);
-    stream.bytesRead += len;
-    stream.context.execute(buff, stream::handleChunk);
+    stream.receiveChunk(buff);
   }
 
   private void handleResponseEnd(Stream stream, LastHttpContent trailer) {
@@ -949,6 +965,7 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
           }
         }
       }
+      ackBytes(stream.readWindow);
       stream.responseEnded = true;
       check = requests.peek() != stream;
     }

--- a/src/test/java/io/vertx/core/http/Http1xTest.java
+++ b/src/test/java/io/vertx/core/http/Http1xTest.java
@@ -2261,6 +2261,43 @@ public class Http1xTest extends HttpTest {
   }
 
   @Test
+  public void testAckHttpClientResponseReadWindowOnEnd() throws Exception {
+    int highWaterMark = 65536;
+    int numRequests = 10;
+    waitFor(numRequests);
+    Buffer buffer = TestUtils.randomBuffer(highWaterMark);
+    server.requestHandler(req -> {
+      req.response().end(buffer);
+    });
+    startServer(testAddress);
+    client.close();
+    client = vertx.createHttpClient(createBaseClientOptions(), new PoolOptions().setHttp1MaxSize(1));
+    List<HttpClientResponse> responses = new ArrayList<>();
+    for (int i = 0;i < numRequests;i++) {
+      client.request(requestOptions).onComplete(onSuccess(req -> {
+        req.send().onComplete(onSuccess(resp -> {
+          resp.pause();
+          resp.endHandler(v -> {
+            complete();
+          });
+          List<HttpClientResponse> responsesToResume;
+          synchronized (responses) {
+            responses.add(resp);
+            if (responses.size() < 10) {
+              return;
+            }
+            responsesToResume = new ArrayList<>(responses);
+          }
+          for (HttpClientResponse responseToResume : responsesToResume) {
+            responseToResume.resume();
+          }
+        }));
+      }));
+    }
+    await();
+  }
+
+  @Test
   public void testEndServerResponseResumeTheConnection() throws Exception {
     server.requestHandler(req -> {
       req.endHandler(v -> {


### PR DESCRIPTION
Motivation:

`Http1xClientResponse` flow control uses a read window (an amount of pending bytes received but not yet delivered) that is decremented when the buffer is consumed by the application. When the response is fully received it can happen that the client has not yet consumed it fully, leaving the connection paused until the remaining bytes are consumed. While this is correct, the connection is returned to the pool and we assume capable of servicing a new request and it actually is not.

Changes:

When the last chunk of a response is received, ack the entirety of the stream pending bytes. To do this we introduce a stream read windows that is incremented when a chunk is received and decremented when the chunk is acked. When the last chunk is received we can substract the stream read windows from the connection read window. When a stream chunk is acked, we only ack at the connection level when the response is not ended to avoid a double accounting.
