### PR TITLE
Remove System.out.println("pause") in Http1xClientConnection.java

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -333,7 +333,6 @@ public class Http1xClientConnection extends Http1xConnectionBase<WebSocketImpl> 
     readWindow += len;
     boolean gt = readWindow > highWaterMark;
     if (le && gt) {
-      System.out.println("pause");
       doPause();
     }
   }


### PR DESCRIPTION
Motivation:

Removes a `System.out.println("pause")` call in `Http1xClientConnection as this creates noise and doesn't conform to logging standards.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
