### PR TITLE
Add javadocs for JsonUtil.compare.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/json/impl/JsonUtil.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/impl/JsonUtil.java
@@ -121,6 +121,27 @@ public final class JsonUtil {
     }
   }
 
+  /**
+   * Compares two objects to check if they are equal. This method handled the equality comparison
+   * in the following order.
+   *
+   * <ol>
+   *   <li>Check if both the objects are numbers. If both the objects are numbers, then the
+   *   equality of numbers will be checked.</li>
+   *   <li>If both the numbers are of different types, both the objects will be cast to the
+   *   class {@code Numbers}, and then both the numbers are compared for equality.</li>
+   *   <li>If both the objects are of a {@code CharSequence} type, then both the objects
+   *   will be converted to strings to check for the equality of the string representation
+   *   of the objects.</li>
+   *   <li>Finally, if none of the objects are equal, then the objets are compared to each
+   *   other for equality. In this case, it is the responsibility of the developer to define
+   *   the {@code equals(Object o1, Object o2)} for the class they define.</li>
+   * </ol>
+   *
+   * @param o1 The first object that will be compared.
+   * @param o2 The second object that will be compared.
+   * @return True, if the two objects are equal, false otherwise.
+   */
   public static boolean compare(Object o1, Object o2) {
     if (o1 instanceof Number && o2 instanceof Number) {
       if (o1.getClass() == o2.getClass()) {


### PR DESCRIPTION
Motivation:

In the file `vertx-core/src/main/java/io/vertx/core/json/impl/JsonUtil.java`, the method compare(Object o1, Object o2) that checks 2 objects for equality does not have any existing documentation that explains how the two objects are compared. Therefore, javadocs have been explained the working of the function to make it understandable for new developers.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md (The Eclipse Contributor Agreement has been signed.)
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines (Only javadocs are being added in this repository, no code has been added.)
