### PR TITLE
4.x backport - 5553 permits access to `:authority` HTTP/2 pseudo header value

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -137,13 +137,25 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   String query();
 
   /**
-   * @return the request authority. For HTTP/2 the {@literal :authority} pseudo header is returned, for HTTP/1.x the
-   *         {@literal Host} header is returned or {@code null} when no such header is present. When the authority
-   *         string does not carry a port, the {@link HostAndPort#port()} returns {@code -1} to indicate the
-   *         scheme port is prevalent.
+   * @return the request authority.
+   *         <ul>
+   *           <li>HTTP/2: the {@literal :authority} pseudo header is returned if present, otherwise the {@literal Host}
+   *           header value is returned.
+   *           <li>HTTP/1.x: the {@literal Host} header is returned
+   *           <li>or {@code null} when no such header is present
+   *         </ul>
+   *         When the authority string does not carry a port, the {@link HostAndPort#port()} returns {@code -1} to
+   *         indicate the scheme port is prevalent.
    */
   @Nullable
   HostAndPort authority();
+
+  /**
+   * @param real whether to return the value of the real HTTP/2 {@literal :authority} header, or the computed one.
+   * @return the authority, either computed or real. May be null when {@literal real} is {@code true}.
+   */
+  @Nullable
+  HostAndPort authority(boolean real);
 
   /**
    * @return the request host. For HTTP2 it returns the {@literal :authority} pseudo header otherwise it returns the {@literal Host} header

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -276,6 +276,11 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   }
 
   @Override
+  public HostAndPort authority(boolean real) {
+    return real ? null : authority();
+  }
+
+  @Override
   public @Nullable String host() {
     return getHeader(HttpHeaderNames.HOST);
   }

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -85,7 +85,7 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
     }
 
     if (request.method == HttpMethod.CONNECT) {
-      if (request.scheme != null || request.uri != null || request.authority == null) {
+      if (request.scheme != null || request.uri != null || request.authority() == null) {
         return true;
       }
     } else {
@@ -94,13 +94,13 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
       }
     }
     if (request.hasAuthority) {
-      if (request.authority == null) {
+      if (request.authority() == null) {
         return true;
       }
       CharSequence hostHeader = request.headers.get(HttpHeaders.HOST);
       if (hostHeader != null) {
         HostAndPort host = HostAndPort.parseAuthority(hostHeader.toString(), -1);
-        return host == null || (!request.authority.host().equals(host.host()) || request.authority.port() != host.port());
+        return host == null || (!request.authority().host().equals(host.host()) || request.authority().port() != host.port());
       }
     }
     return false;
@@ -129,18 +129,20 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
 
   private Http2ServerStream createStream(Http2Headers headers, boolean streamEnded) {
     CharSequence schemeHeader = headers.getAndRemove(HttpHeaders.PSEUDO_SCHEME);
-    HostAndPort authority = null;
+    HostAndPort computedAuthority = null;
+    HostAndPort realAuthority = null;
     String authorityHeaderAsString;
     CharSequence authorityHeader = headers.getAndRemove(HttpHeaders.PSEUDO_AUTHORITY);
     if (authorityHeader != null) {
       authorityHeaderAsString = authorityHeader.toString();
-      authority = HostAndPort.parseAuthority(authorityHeaderAsString, -1);
+      realAuthority = HostAndPort.parseAuthority(authorityHeaderAsString, -1);
+      computedAuthority = realAuthority;
     }
     CharSequence hostHeader = null;
-    if (authority == null) {
+    if (computedAuthority == null) {
       hostHeader = headers.getAndRemove(HttpHeaders.HOST);
       if (hostHeader != null) {
-        authority = HostAndPort.parseAuthority(hostHeader.toString(), -1);
+        computedAuthority = HostAndPort.parseAuthority(hostHeader.toString(), -1);
       }
     }
     CharSequence pathHeader = headers.getAndRemove(HttpHeaders.PSEUDO_PATH);
@@ -151,7 +153,8 @@ public class Http2ServerConnection extends Http2ConnectionBase implements HttpSe
       headers,
       schemeHeader != null ? schemeHeader.toString() : null,
       authorityHeader != null || hostHeader != null,
-      authority,
+      realAuthority,
+      computedAuthority,
       methodHeader != null ? HttpMethod.valueOf(methodHeader.toString()) : null,
       pathHeader != null ? pathHeader.toString() : null,
       options.getTracingPolicy(), streamEnded);

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -328,7 +328,12 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
 
   @Override
   public @Nullable HostAndPort authority() {
-    return stream.authority;
+    return stream.authority();
+  }
+
+  @Override
+  public @Nullable HostAndPort authority(boolean real) {
+    return stream.authority(real);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -727,7 +727,7 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
       throw new IllegalStateException("A push response cannot promise another push");
     }
     if (authority == null) {
-      authority = stream.authority;
+      authority = stream.authority();
     }
     synchronized (conn) {
       checkValid();
@@ -747,7 +747,7 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
       hostAndPort = HostAndPort.parseAuthority(authority, -1);
     }
     if (hostAndPort == null) {
-      hostAndPort = stream.authority;
+      hostAndPort = stream.authority();
     }
     synchronized (conn) {
       checkValid();

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
@@ -41,7 +41,8 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
   protected final String uri;
   protected final String host; // deprecated
   protected final boolean hasAuthority;
-  protected final HostAndPort authority;
+  private final HostAndPort computedAuthority;
+  private final HostAndPort realAuthority;
   private final TracingPolicy tracingPolicy;
   private Object metric;
   private Object trace;
@@ -64,7 +65,8 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
     this.scheme = null;
     this.host = null;
     this.hasAuthority = false;
-    this.authority = null;
+    this.computedAuthority = null;
+    this.realAuthority = null;
     this.tracingPolicy = tracingPolicy;
     this.halfClosedRemote = halfClosedRemote;
   }
@@ -74,7 +76,8 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
                     Http2Headers headers,
                     String scheme,
                     boolean hasAuthority,
-                    HostAndPort authority,
+                    HostAndPort realAuthority,
+                    HostAndPort computedAuthority,
                     HttpMethod method,
                     String uri,
                     TracingPolicy tracingPolicy,
@@ -84,8 +87,9 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
     this.scheme = scheme;
     this.headers = headers;
     this.hasAuthority = hasAuthority;
-    this.authority = authority;
-    this.host = authority != null ? authority.toString() : null;
+    this.realAuthority = realAuthority;
+    this.computedAuthority = computedAuthority;
+    this.host = computedAuthority != null ? computedAuthority.toString() : null;
     this.uri = uri;
     this.method = method;
     this.tracingPolicy = tracingPolicy;
@@ -103,6 +107,14 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
         }
       }
     }
+  }
+
+  public HostAndPort authority() {
+    return computedAuthority;
+  }
+
+  public HostAndPort authority(boolean real) {
+    return real ? realAuthority : computedAuthority;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
@@ -119,6 +119,11 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
+  public @Nullable HostAndPort authority(boolean real) {
+    return delegate.authority(real);
+  }
+
+  @Override
   public boolean isValidAuthority() {
     return delegate.isValidAuthority();
   }


### PR DESCRIPTION
And fix the `HttpServerRequest#autority()` javadoc, which was incorrect. And have a single source of authority truth between the Http2ServerStream and Http2ServerRequest

(cherry picked from commit 532e42837ac12c7a9890f5c44016b49a82690cb0)

Motivation:

4.x Backport of https://github.com/eclipse-vertx/vert.x/pull/5664
