### PR TITLE
5.0 backport - 5553 permits access to `:authority` HTTP/2 pseudo header value

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -117,13 +117,25 @@ public interface HttpServerRequest extends ReadStream<Buffer>, HttpRequestHead {
   String scheme();
 
   /**
-   * @return the request authority. For HTTP/2 the {@literal :authority} pseudo header is returned, for HTTP/1.x the
-   *         {@literal Host} header is returned or {@code null} when no such header is present. When the authority
-   *         string does not carry a port, the {@link HostAndPort#port()} returns {@code -1} to indicate the
-   *         scheme port is prevalent.
+   * @return the request authority.
+   *         <ul>
+   *           <li>HTTP/2: the {@literal :authority} pseudo header is returned if present, otherwise the {@literal Host}
+   *           header value is returned.
+   *           <li>HTTP/1.x: the {@literal Host} header is returned
+   *           <li>or {@code null} when no such header is present
+   *         </ul>
+   *         When the authority string does not carry a port, the {@link HostAndPort#port()} returns {@code -1} to
+   *         indicate the scheme port is prevalent.
    */
   @Nullable
   HostAndPort authority();
+
+  /**
+   * @param real whether to return the value of the real HTTP/2 {@literal :authority} header, or the computed one.
+   * @return the authority, either computed or real. May be null when {@literal real} is {@code true}.
+   */
+  @Nullable
+  HostAndPort authority(boolean real);
 
   /**
    * @return the total number of bytes read for the body of the request.

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -283,6 +283,11 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   }
 
   @Override
+  public HostAndPort authority(boolean real) {
+    return real ? null : authority();
+  }
+
+  @Override
   public long bytesRead() {
     synchronized (conn) {
       return bytesRead;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -321,7 +321,12 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
 
   @Override
   public @Nullable HostAndPort authority() {
-    return stream.authority;
+    return stream.authority();
+  }
+
+  @Override
+  public @Nullable HostAndPort authority(boolean real) {
+    return stream.authority(real);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerResponse.java
@@ -639,7 +639,7 @@ public class Http2ServerResponse implements HttpServerResponse, HttpResponse {
       throw new IllegalStateException("A push response cannot promise another push");
     }
     if (authority == null) {
-      authority = stream.authority;
+      authority = stream.authority();
     }
     synchronized (conn) {
       checkValid();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ServerStream.java
@@ -39,7 +39,8 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
   protected final HttpMethod method;
   protected final String uri;
   protected final boolean hasAuthority;
-  protected final HostAndPort authority;
+  private final HostAndPort computedAuthority;
+  private final HostAndPort realAuthority;
   private final TracingPolicy tracingPolicy;
   private Object metric;
   private Object trace;
@@ -62,7 +63,8 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
     this.uri = uri;
     this.scheme = null;
     this.hasAuthority = false;
-    this.authority = null;
+    this.computedAuthority = null;
+    this.realAuthority = null;
     this.tracingPolicy = tracingPolicy;
     this.halfClosedRemote = halfClosedRemote;
   }
@@ -72,7 +74,8 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
                     Http2Headers headers,
                     String scheme,
                     boolean hasAuthority,
-                    HostAndPort authority,
+                    HostAndPort realAuthority,
+                    HostAndPort computedAuthority,
                     HttpMethod method,
                     String uri,
                     TracingPolicy tracingPolicy,
@@ -82,7 +85,8 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
     this.scheme = scheme;
     this.headers = headers;
     this.hasAuthority = hasAuthority;
-    this.authority = authority;
+    this.realAuthority = realAuthority;
+    this.computedAuthority = computedAuthority;
     this.uri = uri;
     this.method = method;
     this.tracingPolicy = tracingPolicy;
@@ -100,6 +104,14 @@ class Http2ServerStream extends VertxHttp2Stream<Http2ServerConnection> {
         }
       }
     }
+  }
+
+  public HostAndPort authority() {
+    return computedAuthority;
+  }
+
+  public HostAndPort authority(boolean real) {
+    return real ? realAuthority : computedAuthority;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
@@ -102,6 +102,11 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
+  public @Nullable HostAndPort authority(boolean real) {
+    return delegate.authority(real);
+  }
+
+  @Override
   public boolean isValidAuthority() {
     return delegate.isValidAuthority();
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
@@ -365,6 +365,7 @@ public class Http2ClientTest extends Http2TestBase {
     server.requestHandler(req -> {
       assertEquals("localhost", req.authority().host());
       assertEquals(4444, req.authority().port());
+      assertEquals(req.authority(), req.authority(true));
       req.response().end();
     });
     startServer(testAddress);
@@ -379,26 +380,19 @@ public class Http2ClientTest extends Http2TestBase {
 
   @Test
   public void testNoAuthority() throws Exception {
-    ServerBootstrap bootstrap = createH2Server((decoder, encoder) -> new Http2EventAdapter() {
-      @Override
-      public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) throws Http2Exception {
-        vertx.runOnContext(v -> {
-          assertNull(headers.authority());
-          encoder.writeHeaders(ctx, streamId, new DefaultHttp2Headers().status("200"), 0, true, ctx.newPromise());
-          ctx.flush();
-        });
-      }
+    server.requestHandler(req -> {
+      assertEquals("fromHost", req.authority().host());
+      assertEquals(1234, req.authority().port());
+      assertNull(req.authority(true));
+      req.response().end();
     });
-    ChannelFuture s = bootstrap.bind(DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT).sync();
+    startServer(testAddress);
     client.request(new RequestOptions().setServer(testAddress)
-        .setPort(4444)
-        .setHost("localhost")
-      )
-      .compose(request -> {
-        request.authority(null);
-        return request.send();
-      })
-      .onComplete(onSuccess(resp -> testComplete()));
+                                       .addHeader("Host", "fromHost:1234")
+          )
+          .onSuccess(req -> req.authority(null))
+          .compose(HttpClientRequest::send)
+          .onComplete(onSuccess(resp -> testComplete()));
     await();
   }
 


### PR DESCRIPTION
And fix the `HttpServerRequest#autority()` javadoc, which was incorrect. And have a single source of authority truth between the Http2ServerStream and Http2ServerRequest

(cherry picked from commit 532e42837ac12c7a9890f5c44016b49a82690cb0)

Motivation:

5.x Backport of https://github.com/eclipse-vertx/vert.x/pull/5664