### PR TITLE
Avoid the event-bus delivery context machinery when there are not interceptors.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
@@ -57,7 +57,7 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
           handler = MessageConsumerImpl.this.handler;
         }
         if (handler != null) {
-          dispatch(handler, msg, context.duplicate());
+          dispatchMessage(handler, (MessageImpl<?, T>) msg, context.duplicate());
         } else {
           handleDiscard(msg, false);
         }
@@ -118,7 +118,7 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
   }
 
   @Override
-  protected void dispatch(Message<T> msg, ContextInternal context, Handler<Message<T>> handler) {
+  protected void dispatchMessage(Message<T> msg, ContextInternal context, Handler<Message<T>> handler) {
     if (handler == null) {
       throw new NullPointerException();
     }

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
@@ -75,7 +75,7 @@ class ReplyHandler<T> extends HandlerRegistration<T> implements Handler<Long> {
 
   @Override
   protected void doReceive(Message<T> reply) {
-    dispatch(null, reply, context);
+    dispatchMessage(null, (MessageImpl<?, T>) reply, context);
   }
 
   void register() {
@@ -83,7 +83,7 @@ class ReplyHandler<T> extends HandlerRegistration<T> implements Handler<Long> {
   }
 
   @Override
-  protected void dispatch(Message<T> reply, ContextInternal context, Handler<Message<T>> handler /* null */) {
+  protected void dispatchMessage(Message<T> reply, ContextInternal context, Handler<Message<T>> handler /* null */) {
     if (context.owner().cancelTimer(timeoutID)) {
       unregister();
       if (reply.body() instanceof ReplyException) {

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/SendContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/SendContext.java
@@ -11,7 +11,9 @@
 package io.vertx.core.eventbus.impl;
 
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.eventbus.DeliveryContext;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.eventbus.impl.clustered.ClusteredMessage;
@@ -24,23 +26,30 @@ import io.vertx.core.tracing.TracingPolicy;
 
 import java.util.function.BiConsumer;
 
-public class OutboundDeliveryContext<T> extends DeliveryContextBase<T> implements Promise<Void> {
+public class SendContext<T> implements Promise<Void> {
 
+  private final ReplyHandler<T> replyHandler;
+  private boolean src;
+  public final MessageImpl<?, T> message;
   public final ContextInternal ctx;
   public final DeliveryOptions options;
-  public final ReplyHandler<T> replyHandler;
   public final Promise<Void> writePromise;
-  private boolean src;
 
   EventBusImpl bus;
   EventBusMetrics metrics;
 
-  OutboundDeliveryContext(ContextInternal ctx, MessageImpl message, DeliveryOptions options, ReplyHandler<T> replyHandler) {
-    super(message, message.bus.outboundInterceptors(), ctx);
+  SendContext(ContextInternal ctx, MessageImpl<?, T> message, DeliveryOptions options, ReplyHandler<T> replyHandler) {
+    this.message = message;
     this.ctx = ctx;
     this.options = options;
     this.replyHandler = replyHandler;
     this.writePromise = ctx.promise();
+  }
+
+  public void send() {
+    Handler<DeliveryContext<?>>[] interceptors = message.bus.outboundInterceptors();
+    DeliveryContextImpl<T> deliveryContext = new DeliveryContextImpl<>(message, interceptors, ctx,  message.sentBody, this::execute);
+    deliveryContext.next();
   }
 
   @Override
@@ -100,7 +109,6 @@ public class OutboundDeliveryContext<T> extends DeliveryContextBase<T> implement
     }
   }
 
-  @Override
   protected void execute() {
     VertxTracer tracer = ctx.tracer();
     if (tracer != null) {
@@ -120,13 +128,4 @@ public class OutboundDeliveryContext<T> extends DeliveryContextBase<T> implement
     bus.sendOrPub(this);
   }
 
-  @Override
-  public boolean send() {
-    return message.isSend();
-  }
-
-  @Override
-  public Object body() {
-    return message.sentBody;
-  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/SendContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/SendContext.java
@@ -46,10 +46,14 @@ public class SendContext<T> implements Promise<Void> {
     this.writePromise = ctx.promise();
   }
 
-  public void send() {
+  void send() {
     Handler<DeliveryContext<?>>[] interceptors = message.bus.outboundInterceptors();
-    DeliveryContextImpl<T> deliveryContext = new DeliveryContextImpl<>(message, interceptors, ctx,  message.sentBody, this::execute);
-    deliveryContext.next();
+    if (interceptors.length > 0) {
+      DeliveryContextImpl<T> deliveryContext = new DeliveryContextImpl<>(message, interceptors, ctx,  message.sentBody, this::sendOrPub);
+      deliveryContext.next();
+    } else {
+      sendOrPub();
+    }
   }
 
   @Override
@@ -109,7 +113,7 @@ public class SendContext<T> implements Promise<Void> {
     }
   }
 
-  protected void execute() {
+  private void sendOrPub() {
     VertxTracer tracer = ctx.tracer();
     if (tracer != null) {
       if (message.trace == null) {


### PR DESCRIPTION
Motivation:
    
When the event-bus interceptor chain is empty we can skip the delivery context machinery that is not necessary as it involves creating garbage and atomics. This is possible due to a recent refactoring change.
    
Changes:
    
When the interceptor chain is obtained, bypass the delivery context machinery when the chain is empty.
