### PR TITLE
Issue 5661: Virtual thread worker metrics

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -203,7 +203,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     PoolMetrics internalBlockingPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-internal-blocking", internalBlockingPoolSize) : null;
 
     ThreadFactory virtualThreadFactory = virtualThreadFactory();
-    PoolMetrics virtualThreadWorkerPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-virtual-thread", options.getWorkerPoolSize()) : null;
+    PoolMetrics virtualThreadWorkerPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-virtual-thread", -1) : null;
 
     contextLocals = LocalSeq.get();
     contextLocalsList = Collections.unmodifiableList(Arrays.asList(contextLocals));

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -148,7 +148,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   private final List<ContextLocal<?>> contextLocalsList;
   final WorkerPool workerPool;
   final WorkerPool internalWorkerPool;
-  final WorkerPool virtualThreaWorkerPool;
+  final WorkerPool virtualThreadWorkerPool;
   private final VertxThreadFactory threadFactory;
   private final ExecutorServiceFactory executorServiceFactory;
   private final ThreadFactory eventLoopThreadFactory;
@@ -203,6 +203,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     PoolMetrics internalBlockingPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-internal-blocking", internalBlockingPoolSize) : null;
 
     ThreadFactory virtualThreadFactory = virtualThreadFactory();
+    PoolMetrics virtualThreadWorkerPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-virtual-thread", options.getWorkerPoolSize()) : null;
 
     contextLocals = LocalSeq.get();
     contextLocalsList = Collections.unmodifiableList(Arrays.asList(contextLocals));
@@ -215,7 +216,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     // under a lot of load
     acceptorEventLoopGroup = transport.eventLoopGroup(Transport.ACCEPTOR_EVENT_LOOP_GROUP, 1, acceptorEventLoopThreadFactory, 100);
     virtualThreadExecutor = virtualThreadFactory != null ? new ThreadPerTaskExecutorService(virtualThreadFactory) : null;
-    virtualThreaWorkerPool = virtualThreadFactory != null ? new WorkerPool(virtualThreadExecutor, null) : null;
+    virtualThreadWorkerPool = virtualThreadFactory != null ? new WorkerPool(virtualThreadExecutor, virtualThreadWorkerPoolMetrics) : null;
     internalWorkerPool = new WorkerPool(internalWorkerExec, internalBlockingPoolMetrics);
     workerPool = new WorkerPool(workerExec, workerPoolMetrics);
     defaultWorkerPoolSize = options.getWorkerPoolSize();
@@ -609,8 +610,8 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
         if (!isVirtualThreadAvailable()) {
           throw new IllegalStateException("This Java runtime does not support virtual threads");
         }
-        wp = virtualThreaWorkerPool;
-        eventExecutor = new WorkerExecutor(virtualThreaWorkerPool, new WorkerTaskQueue());
+        wp = virtualThreadWorkerPool;
+        eventExecutor = new WorkerExecutor(virtualThreadWorkerPool, new WorkerTaskQueue());
         break;
       default:
         throw new UnsupportedOperationException();

--- a/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
@@ -21,6 +21,7 @@ import io.vertx.core.spi.context.storage.AccessMode;
 import io.vertx.core.spi.context.storage.ContextLocal;
 import io.vertx.test.core.ContextLocalHelper;
 import io.vertx.test.core.VertxTestBase;
+import io.vertx.test.fakemetrics.FakeMetricsFactory;
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -1240,5 +1241,15 @@ public class ContextTest extends VertxTestBase {
     assertSame(ContextInternal.LOCAL_MAP, locals.get(0));
     assertSame(contextLocal, locals.get(1));
     assertSame(locals, ((VertxInternal) vertx).contextLocals());
+  }
+
+  @Test
+  public void testVirtualThreadContextHasPoolMetrics() {
+    Assume.assumeTrue(isVirtualThreadAvailable());
+    Vertx vertxWithMetrics = Vertx.builder()
+      .withMetrics(new FakeMetricsFactory())
+      .build();
+    ContextInternal context = ((VertxImpl) vertxWithMetrics).createVirtualThreadContext();
+    assertNotNull(context.workerPool().metrics());
   }
 }


### PR DESCRIPTION
# Motivation

This PR adds feature requested in [#5661](https://github.com/eclipse-vertx/vert.x/issues/5661).

The following changes are done.

1. Added worker pool metrics for VIRTUAL_THREAD deployment (Kept max size as -1 as it cannot be determined and it can spawn any number of worker threads).
https://github.com/eclipse-vertx/vert.x/blob/2f11b16833f0f1885949c5eccfb2588bf94717c9/vertx-core/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java#L133-L143
2. Corrected typo in the naming.
3. Added Unit Test for the verification of the same

## Results on sample app created

Repo: https://github.com/go2hel/VirtualThreads-Metrics-VertX

### With Metrics
<img width="440" height="370" alt="with-metrics" src="https://github.com/user-attachments/assets/8b1a5adf-6b51-4de8-87f2-276b6757ac51" />

### Without Metrics
<img width="438" height="368" alt="without-metrics" src="https://github.com/user-attachments/assets/ebe6cf67-3fdd-459c-bbc5-8d5fda18983c" />

# Conformance

- I've signed Eclipse Contributor Agreement.
- I am adhering to the code style guidelines as per: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
