### PR TITLE
Remove NoStackThrowable uses in code.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/Completable.java
+++ b/vertx-core/src/main/java/io/vertx/core/Completable.java
@@ -10,8 +10,6 @@
  */
 package io.vertx.core;
 
-import io.vertx.core.impl.NoStackTraceThrowable;
-
 /**
  * A view of something that can be completed with a success or failure.
  *
@@ -57,7 +55,7 @@ public interface Completable<T> {
    * @throws IllegalStateException when this instance is already completed or failed
    */
   default void fail(String message) {
-    complete(null, new NoStackTraceThrowable(message));
+    complete(null, new VertxException(message));
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/Promise.java
+++ b/vertx-core/src/main/java/io/vertx/core/Promise.java
@@ -13,7 +13,6 @@ package io.vertx.core;
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
-import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.impl.future.PromiseImpl;
 
 import java.util.function.BiConsumer;
@@ -145,7 +144,7 @@ public interface Promise<T> extends Completable<T> {
    * @return false when the future is already completed
    */
   default boolean tryFail(String message) {
-    return tryFail(new NoStackTraceThrowable(message));
+    return tryFail(new VertxException(message));
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/impl/future/FailedFuture.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/future/FailedFuture.java
@@ -11,12 +11,8 @@
 
 package io.vertx.core.impl.future;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Completable;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
+import io.vertx.core.*;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.impl.NoStackTraceThrowable;
 
 import java.util.function.Function;
 
@@ -43,7 +39,7 @@ public final class FailedFuture<T> extends FutureBase<T> {
    */
   public FailedFuture(ContextInternal context, Throwable t) {
     super(context);
-    this.cause = t != null ? t : new NoStackTraceThrowable(null);
+    this.cause = t != null ? t : new VertxException((String) null);
   }
 
   /**
@@ -59,7 +55,7 @@ public final class FailedFuture<T> extends FutureBase<T> {
    * @param failureMessage the failure message
    */
   public FailedFuture(ContextInternal context, String failureMessage) {
-    this(context, new NoStackTraceThrowable(failureMessage));
+    this(context, new VertxException(failureMessage));
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/future/FutureImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/future/FutureImpl.java
@@ -12,7 +12,6 @@
 package io.vertx.core.impl.future;
 
 import io.vertx.core.*;
-import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.internal.ContextInternal;
 
 import java.util.ArrayList;
@@ -171,7 +170,7 @@ public class FutureImpl<T> extends FutureBase<T> {
 
   public final boolean tryFail(Throwable cause) {
     if (cause == null) {
-      cause = new NoStackTraceThrowable(null);
+      cause = new VertxException((String) null);
     }
     return completeInternal(null, cause);
   }

--- a/vertx-core/src/test/java/io/vertx/tests/future/FutureTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/future/FutureTest.java
@@ -14,7 +14,6 @@ package io.vertx.tests.future;
 import io.vertx.core.*;
 import io.vertx.core.Future;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.test.core.Repeat;
 import org.junit.Ignore;
@@ -199,7 +198,7 @@ public class FutureTest extends FutureTestBase {
   public void testCreateFailedWithNullFailure() {
     io.vertx.core.Future<String> future = io.vertx.core.Future.failedFuture((Throwable)null);
     Checker<String> checker = new Checker<>(future);
-    NoStackTraceThrowable failure = (NoStackTraceThrowable) checker.assertFailed();
+    VertxException failure = (VertxException) checker.assertFailed();
     assertNull(failure.getMessage());
   }
 
@@ -208,7 +207,7 @@ public class FutureTest extends FutureTestBase {
     Promise<String> promise = Promise.promise();
     promise.fail((Throwable)null);
     Checker<String> checker = new Checker<>(promise.future());
-    NoStackTraceThrowable failure = (NoStackTraceThrowable) checker.assertFailed();
+    VertxException failure = (VertxException) checker.assertFailed();
     assertNull(failure.getMessage());
   }
 
@@ -1732,7 +1731,7 @@ public class FutureTest extends FutureTestBase {
   @Test
   public void testAndThenComplete() {
     waitFor(4);
-    Throwable throwable = new NoStackTraceThrowable("test");
+    Throwable throwable = new VertxException("test");
 
     testAndThen(io.vertx.core.Future.succeededFuture(), null, null);
 
@@ -1753,7 +1752,7 @@ public class FutureTest extends FutureTestBase {
   @Repeat(times = 50)
   public void testAndThenCompleteContextual() {
     waitFor(4);
-    Throwable throwable = new NoStackTraceThrowable("test");
+    Throwable throwable = new VertxException("test");
 
     ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
 


### PR DESCRIPTION
Motivation:

Since `NoStackTraceThrowable` is a deprecated method that is marked for removal, all the definitions where `NoStackTraceThrowable` is used is now replaced with `VertxException` so that none of the methods that have been defined use deprecated methods and use the latest methods that are used for handling failures.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md

I have signed the Eclipse Contributor Agreement

Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines

I am adhering to the code style guidelines.