### PR TITLE
Incorrect VirtualThreadDeploymentTest.testExecuteBlocking

### DIFF
--- a/vertx-core/src/test/java/io/vertx/test/core/AsyncTestBase.java
+++ b/vertx-core/src/test/java/io/vertx/test/core/AsyncTestBase.java
@@ -13,8 +13,8 @@ package io.vertx.test.core;
 
 import io.vertx.core.*;
 import io.vertx.core.Future;
-import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.impl.Utils;
+import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import org.hamcrest.Matcher;
@@ -500,6 +500,19 @@ public class AsyncTestBase {
     checkThread();
     try {
       Assert.assertNotSame(message, unexpected, actual);
+    } catch (AssertionError e) {
+      handleThrowable(e);
+    }
+  }
+
+  protected void assertNotEquals(Object unexpected, Object actual) {
+    assertNotEquals(null, unexpected, actual);
+  }
+
+  protected void assertNotEquals(String message, Object unexpected, Object actual) {
+    checkThread();
+    try {
+      Assert.assertNotEquals(message, unexpected, actual);
     } catch (AssertionError e) {
       handleThrowable(e);
     }

--- a/vertx-core/src/test/java/io/vertx/tests/deployment/VirtualThreadDeploymentTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/deployment/VirtualThreadDeploymentTest.java
@@ -24,7 +24,6 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -91,7 +90,7 @@ public class VirtualThreadDeploymentTest extends VertxTestBase {
           p.fail(e);
           return;
         }
-        assertNotSame(Thread.currentThread().getName(), res);
+        assertNotEquals(Thread.currentThread().getName(), res);
         p.complete();
       }
     }, new DeploymentOptions().setThreadingModel(ThreadingModel.VIRTUAL_THREAD)).await();


### PR DESCRIPTION
The test checks thread names are not same (identical) but it should compare the contents.