### PR TITLE
Replace with logger.error.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/json/pointer/impl/JsonPointerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/pointer/impl/JsonPointerImpl.java
@@ -282,14 +282,13 @@ public class JsonPointerImpl implements JsonPointer {
     return replaceFragment(oldURI, null);
   }
 
-  private URI replaceFragment(URI oldURI, String fragment) {
+  private URI replaceFragment(URI oldURI, String fragment) throws VertxException {
     try {
       if (oldURI != null) {
         return new URI(oldURI.getScheme(), oldURI.getSchemeSpecificPart(), fragment);
       } else return new URI(null, null, fragment);
     } catch (URISyntaxException e) {
-      // throw new VertxException("Error creating URI: " + e.getMessage() + Arrays.toString(e.getStackTrace()));
-      return null;
+      throw new VertxException("Error creating URI: " + e.getMessage() + Arrays.toString(e.getStackTrace()));
     }
   }
 }


### PR DESCRIPTION
Motivation:

Currently, line 290 in the `private URI replaceFragment(URI oldURI, String fragment)` method of the `JsonPointerImpl` class has the functionality to replace an old fragment in the JSON URL with a new fragment in the URL. In case this operation fails, the `e.printStackTrace()` method that can cause various problems such as the inability to distinguish log levels and being hard to filter logs in the production environment. Therefore `e.printStackTrace()` is being replaced with the  `logger.error()` method.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md

I have signed the eclipse contributor agreement.

Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines

I am adhering to the code style guidelines.