### PR TITLE
Ensure HttpServerResponse#endHandler and HttpServerResponse#bodyEndHandler are always executed before VertxTracer#sendResponse

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerResponse.java
@@ -445,13 +445,13 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
         msg = new AssembledLastHttpContent(data, trailingHeaders);
       }
       conn.writeToChannel(msg, listener);
-      conn.responseComplete();
       if (bodyEndHandler != null) {
         bodyEndHandler.handle(null);
       }
       if (!closed && endHandler != null) {
         endHandler.handle(null);
       }
+      conn.responseComplete();
       if (!keepAlive) {
         closed = true;
       }


### PR DESCRIPTION
Motivation:

`HttpServerResponse#endHandler` and `HttpServerResponse#bodyEndHandler` are after `VertxTracer#sendResponse` for HTTP/1.x and before for HTTP/2.

We should have a consistent behaviour on ordering in order to guarantee predictability for users of this API and ensure that those handlers are invoked before the span end is signalled.
