### PR TITLE
Create Virtual Thread worker pool metrics only if needed

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -203,7 +203,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     PoolMetrics internalBlockingPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-internal-blocking", internalBlockingPoolSize) : null;
 
     ThreadFactory virtualThreadFactory = virtualThreadFactory();
-    PoolMetrics virtualThreadWorkerPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-virtual-thread", -1) : null;
+    PoolMetrics virtualThreadWorkerPoolMetrics = metrics != null && virtualThreadFactory != null ? metrics.createPoolMetrics("worker", "vert.x-virtual-thread", -1) : null;
 
     contextLocals = LocalSeq.get();
     contextLocalsList = Collections.unmodifiableList(Arrays.asList(contextLocals));


### PR DESCRIPTION
Follows-up on #5705

Without this change, virtual thread worker pool metrics are registered and published, even when the applications run on JVM without VT support.