### PR TITLE
Fix incorrect Http2UpgradeClientConnection write

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/HttpClientFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/HttpClientFileUploadTest.java
@@ -201,7 +201,7 @@ public abstract class HttpClientFileUploadTest extends HttpTestBase {
       assertEquals("vert.x", req.getFormAttribute("toolkit"));
       assertEquals("jvm", req.getFormAttribute("runtime"));
     });
-    assertEquals(1, uploads.size());
+    assertWaitUntil(() -> uploads.size() == 1);
     assertEquals("test", uploads.get(0).name);
     assertEquals("test.txt", uploads.get(0).filename);
     assertEquals(content, uploads.get(0).data);


### PR DESCRIPTION
Motivation:

`Http2UpgradeClientConnection#write` has two issues

- the returned promise/future is not completed by the delegate write
- the event `SEND_BUFFERED_MESSAGES_EVENT` can end the http request before all chunks have been written

Changes:

- return the actual future of the delegate write operation
- delay `SEND_BUFFERED_MESSAGES_EVENT` when the last chunk has been written
