### PR TITLE
Deprecate SelfSignedCertificate and update accordingly

### DIFF
--- a/vertx-core/pom.xml
+++ b/vertx-core/pom.xml
@@ -158,8 +158,8 @@
       <version>${apacheds-protocol-dns.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>bouncycastle</groupId>
-          <artifactId>bcprov-jdk15</artifactId>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
       <scope>test</scope>
@@ -180,20 +180,6 @@
       <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-      <version>${org.bouncycastle.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <version>${org.bouncycastle.version}</version>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>

--- a/vertx-core/src/main/asciidoc/net.adoc
+++ b/vertx-core/src/main/asciidoc/net.adoc
@@ -710,35 +710,6 @@ NOTE: The options object is compared (using `equals`) against the existing optio
 are equals since loading options can be costly. When object are equals, you can use the `force` parameter to force
 the update.
 
-==== Self-signed certificates for testing and development purposes
-
-CAUTION: Do not use this in production settings, and note that the generated keys are very insecure.
-
-It is very often the case that self-signed certificates are required, be it for unit / integration tests or for
-running a development version of an application.
-
-{@link io.vertx.core.net.SelfSignedCertificate} can be used to provide self-signed PEM certificate helpers and
-give {@link io.vertx.core.net.KeyCertOptions} and {@link io.vertx.core.net.TrustOptions} configurations:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example48}
-----
-
-The client can also be configured to trust all certificates:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example49}
-----
-
-Note that self-signed certificates also work for other TCP protocols like HTTPS:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example50}
-----
-
 ==== Revoking certificate authorities
 
 Trust can be configured to use a certificate revocation list (CRL) for revoked certificates that should no

--- a/vertx-core/src/main/java/examples/NetExamples.java
+++ b/vertx-core/src/main/java/examples/NetExamples.java
@@ -642,50 +642,10 @@ public class NetExamples {
     NetClient client = vertx.createNetClient(options);
   }
 
-  public void example48(Vertx vertx) throws CertificateException {
-    SelfSignedCertificate certificate = SelfSignedCertificate.create();
-
-    NetServerOptions serverOptions = new NetServerOptions()
-      .setSsl(true)
-      .setKeyCertOptions(certificate.keyCertOptions())
-      .setTrustOptions(certificate.trustOptions());
-
-    vertx.createNetServer(serverOptions)
-      .connectHandler(socket -> socket.end(Buffer.buffer("Hello!")))
-      .listen(1234, "localhost");
-
-    NetClientOptions clientOptions = new NetClientOptions()
-      .setSsl(true)
-      .setKeyCertOptions(certificate.keyCertOptions())
-      .setTrustOptions(certificate.trustOptions());
-
-    NetClient client = vertx.createNetClient(clientOptions);
-    client
-      .connect(1234, "localhost")
-      .onComplete(ar -> {
-        if (ar.succeeded()) {
-          ar.result().handler(buffer -> System.out.println(buffer));
-        } else {
-          System.err.println("Woops: " + ar.cause().getMessage());
-        }
-      });
-  }
-
   public void example49() {
     NetClientOptions clientOptions = new NetClientOptions()
       .setSsl(true)
       .setTrustAll(true);
-  }
-
-  public void example50(Vertx vertx) throws CertificateException {
-    SelfSignedCertificate certificate = SelfSignedCertificate.create();
-
-    vertx.createHttpServer(new HttpServerOptions()
-      .setSsl(true)
-      .setKeyCertOptions(certificate.keyCertOptions())
-      .setTrustOptions(certificate.trustOptions()))
-      .requestHandler(req -> req.response().end("Hello!"))
-      .listen(8080);
   }
 
   public void example51(Vertx vertx) {

--- a/vertx-core/src/main/java/io/vertx/core/net/SelfSignedCertificate.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/SelfSignedCertificate.java
@@ -21,7 +21,9 @@ import io.vertx.core.net.impl.SelfSignedCertificateImpl;
  * While it helps for testing and development, it should never ever be used in production settings.
  *
  * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
+ * @deprecated this class does not work reliably and consistently on stock Java distributions
  */
+@Deprecated(forRemoval = true)
 @DataObject
 public interface SelfSignedCertificate {
 

--- a/vertx-core/src/test/java/io/vertx/tests/tls/HttpTLSTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tls/HttpTLSTest.java
@@ -322,11 +322,11 @@ public abstract class HttpTLSTest extends HttpTestBase {
   }
 
   @Test
-  // Provide an host name with a trailing dot
+  // Provide a host name with a trailing dot
   public void testTLSTrailingDotHost() throws Exception {
-    // We just need a vanilla cert for this test
-    SelfSignedCertificate cert = SelfSignedCertificate.create("host2.com");
-    TLSTest test = testTLS(Cert.NONE, cert::trustOptions, cert::keyCertOptions, Trust.NONE)
+    // Reuse SNI test certificate because it is convenient
+    TLSTest test = testTLS(Cert.NONE, Trust.SNI_JKS_HOST2, Cert.SNI_JKS, Trust.NONE)
+      .serverSni()
       .requestOptions(new RequestOptions().setSsl(true).setPort(DEFAULT_HTTPS_PORT).setHost("host2.com."))
       .pass();
     assertEquals("host2.com", TestUtils.cnOf(test.clientPeerCert()));


### PR DESCRIPTION
Motivation:

`SelfSignedCertificate` does not work consistently on stock Java distribution and requires Bouncy Castle. As consequence it cannot really be used for testing and is complicated to test as well.

Changes:

- Deprecate `SelfSignedCertificate`
- Replace usage of `SelfSignedCertificate` in testing
- Remove `SelfSignedCertificate` from documentation
