### PR TITLE
Avoid extra byte copy inside FileSystemImpl.readFileInternal

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,45 +14,21 @@ package io.vertx.core.file.impl;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.file.AsyncFile;
-import io.vertx.core.file.CopyOptions;
-import io.vertx.core.file.FileProps;
+import io.vertx.core.file.*;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.FileSystemException;
-import io.vertx.core.file.FileSystemProps;
-import io.vertx.core.file.OpenOptions;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.buffer.BufferInternal;
 
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.file.CopyOption;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileStore;
-import java.nio.file.FileVisitOption;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.GroupPrincipal;
-import java.nio.file.attribute.PosixFileAttributeView;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.nio.file.attribute.UserPrincipal;
-import java.nio.file.attribute.UserPrincipalLookupService;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.nio.channels.FileChannel;
+import java.nio.file.*;
+import java.nio.file.attribute.*;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
@@ -876,8 +852,17 @@ public class FileSystemImpl implements FileSystem {
       public Buffer perform() {
         try {
           Path target = resolveFile(path).toPath();
-          byte[] bytes = Files.readAllBytes(target);
-          return Buffer.buffer(bytes);
+          try (FileChannel fc = FileChannel.open(target, StandardOpenOption.READ)) {
+            long size = fc.size();
+            if (size > (long) Integer.MAX_VALUE) {
+              // Throwing OOM as Files#readAllLines would in this case
+              throw new OutOfMemoryError("File is too big");
+            }
+            int len = (int) size;
+            BufferInternal res = BufferInternal.buffer(len);
+            res.unwrap().writeBytes(fc, 0, len);
+            return res;
+          }
         } catch (IOException e) {
           throw new FileSystemException(getFileAccessErrorMessage("read", path), e);
         }

--- a/vertx-core/src/test/java/io/vertx/benchmarks/ReadFileBenchmark.java
+++ b/vertx-core/src/test/java/io/vertx/benchmarks/ReadFileBenchmark.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.benchmarks;
+
+import io.netty.util.ResourceLeakDetector;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.internal.buffer.BufferInternal;
+import org.openjdk.jmh.annotations.*;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(5)
+public class ReadFileBenchmark {
+
+  static {
+    ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
+  }
+
+  @Param({"128", "4096", "65536", "1048576"})
+  private int fileSize;
+
+  private Path tempFile;
+
+  @Setup
+  public void setup() throws IOException {
+    tempFile = Files.createTempFile("vertx-bench-", ".dat");
+    byte[] data = new byte[fileSize];
+    ThreadLocalRandom.current().nextBytes(data);
+    Files.write(tempFile, data);
+  }
+
+  @TearDown
+  public void tearDown() throws IOException {
+    Files.deleteIfExists(tempFile);
+  }
+
+  @Benchmark
+  public Buffer readAllBytes() throws IOException {
+    byte[] bytes = Files.readAllBytes(tempFile);
+    return Buffer.buffer(bytes);
+  }
+
+  @Benchmark
+  public Buffer fileChannel() throws IOException {
+    try (FileChannel fc = FileChannel.open(tempFile, StandardOpenOption.READ)) {
+      int len = (int) fc.size();
+      BufferInternal res = BufferInternal.buffer(len);
+      res.unwrap().writeBytes(fc, 0, len);
+      return res;
+    }
+  }
+}


### PR DESCRIPTION
See #5665

The improvement consists in creating the buffer upfront and using Netty API to read the file channel.