### PR TITLE
Add of() overloading with variable map entries.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/JsonObject.java
@@ -396,6 +396,19 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   }
 
   /**
+   * Create a JsonObject from the given map entries.
+   * @param entries All the map entries to add the JSON object.
+   * @return a JsonObject containing the specified mappings.
+   */
+  public static JsonObject of(Map.Entry<String, Object>... entries) {
+    JsonObject obj = new JsonObject(new LinkedHashMap<>(entries.length));
+    for (Map.Entry<String, Object> entry : entries) {
+      obj.put(entry.getKey(), entry.getValue());
+    }
+    return obj;
+  }
+
+  /**
    * Create a JsonObject from the fields of a Java object.
    * Faster than calling `new JsonObject(Json.encode(obj))`.
    * <p/

--- a/vertx-core/src/test/java/io/vertx/tests/json/JsonObjectTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/json/JsonObjectTest.java
@@ -1989,6 +1989,22 @@ public class JsonObjectTest {
   }
 
   @Test
+  public void testJsonObjectOfMapEntryArgs() {
+    Map.Entry<String, Object> e1 = Map.entry("key1", "value1");
+    Map.Entry<String, Object> e2 = Map.entry("key2", "value2");
+    Map.Entry<String, Object> e3 = Map.entry("key3", "value3");
+    Map.Entry<String, Object> e4 = Map.entry("key4", "value4");
+    Map.Entry<String, Object> e5 = Map.entry("key5", "value5");
+    JsonObject jobj = JsonObject.of(e1, e2, e3, e4, e5);
+
+    assertEquals("value1", jobj.getString("key1"));
+    assertEquals("value2", jobj.getString("key2"));
+    assertEquals("value3", jobj.getString("key3"));
+    assertEquals("value4", jobj.getString("key4"));
+    assertEquals("value5", jobj.getString("key5"));
+  }
+
+  @Test
   public void testJsonObjectOfEmpty() {
     assertEquals(new JsonObject(), JsonObject.of());
   }


### PR DESCRIPTION
Motivation:

Currently the static method `JsonObject.of()` method has 10 different definitions to accept key value pairs as parameters to create a new JSON object. The new implementation of this method intends to ensure that we do not need 10 different definitions based on the number of parameters to create a JSON object. Instead, the new method implements an array of map entries (tuples) that consists of a key and a value corresponding to the key. It is possible to have multiple such map entries, so instead of defining the `of()` method 10 times, this method should be declared only once with the ability to process a variable number of arguments.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md

I have signed the Eclipse Contributor Agreement.

Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines

I am adhering to the code style guidelines.