### PR TITLE
Let the DeliveryContext next implementation work correctly when used by different threads

### DIFF
--- a/src/test/java/io/vertx/core/eventbus/EventBusInterceptorTest.java
+++ b/src/test/java/io/vertx/core/eventbus/EventBusInterceptorTest.java
@@ -384,6 +384,7 @@ public class EventBusInterceptorTest extends VertxTestBase {
 
   @Test
   public void testInboundInterceptorFromNonVertxThreadDispatch() {
+    disableThreadChecks();
     AtomicReference<Thread> interceptorThread = new AtomicReference<>();
     AtomicReference<Thread> th = new AtomicReference<>();
     eb.addInboundInterceptor(sc -> {
@@ -393,12 +394,13 @@ public class EventBusInterceptorTest extends VertxTestBase {
       }).start();
     });
     eb.addInboundInterceptor(sc -> {
+      assertTrue(!Context.isOnEventLoopThread());
       interceptorThread.set(Thread.currentThread());
     });
     eb.consumer("some-address", msg -> {
     });
     eb.send("some-address", "armadillo");
-    waitUntil(() -> interceptorThread.get() != null);
+    assertWaitUntil(() -> interceptorThread.get() != null);
     assertSame(th.get(), interceptorThread.get());
   }
 


### PR DESCRIPTION
Motivation:

The current implementation of `DeliveryContext#next` assumes the same thread makes interceptor delivery progress, this API however assumes any thread can make interceptor progress.

Changes:

Rewrite the implementation of `DeliveryContext#next` with an atomic interceptor index that guarantees that progress is visible across threads until the last interceptor is invoked.
