### PR TITLE
Remove HTTP options ALPN version field

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
@@ -31,8 +31,6 @@ import java.util.concurrent.TimeUnit;
 @JsonGen(publicConverter = false)
 public class EventBusOptions extends TCPSSLOptions {
 
-
-
   /**
    * The default cluster host = null which means use the same as the cluster manager, if possible.
    */

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpVersion.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpVersion.java
@@ -34,4 +34,18 @@ public enum HttpVersion {
   public String alpnName() {
     return alpnName;
   }
+
+  public static HttpVersion fromAlpnName(String alpnName) {
+    switch (alpnName) {
+      case "http/1.0":
+        return HTTP_1_0;
+      case "http/1.1":
+        return HTTP_1_1;
+      case "h2":
+        return HTTP_2;
+      default:
+        return null;
+    }
+  }
+
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -26,10 +26,8 @@ import io.vertx.core.net.impl.tcp.NetSocketImpl;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -70,7 +68,6 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
       throw new IllegalStateException("Not listening");
     }
     options = options.copy();
-    configureApplicationLayerProtocols(options);
     return s.updateSSLOptions(options, force);
   }
 
@@ -180,9 +177,6 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
     }
     HttpServerOptions options = this.options;
     HttpServerOptions tcpOptions = new HttpServerOptions(options);
-    if (tcpOptions.getSslOptions() != null) {
-      configureApplicationLayerProtocols(tcpOptions.getSslOptions());
-    }
     ContextInternal context = vertx.getOrCreateContext();
     ContextInternal listenContext;
     // Not sure of this
@@ -269,18 +263,6 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
       seq.close().onComplete(p);
       return p.future();
     }
-  }
-
-  /**
-   * Configure the {@code options} to match the server configured HTTP versions.
-   */
-  private void configureApplicationLayerProtocols(ServerSSLOptions options) {
-    List<String> applicationProtocols = this.options
-      .getAlpnVersions()
-      .stream()
-      .map(HttpVersion::alpnName)
-      .collect(Collectors.toList());
-    options.setApplicationLayerProtocols(applicationProtocols);
   }
 
   private boolean isListening() {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -51,6 +51,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED;
 import static io.netty.handler.codec.http.HttpHeaderValues.MULTIPART_FORM_DATA;
@@ -995,5 +996,19 @@ public final class HttpUtils {
       SMALL_POSITIVE_LONGS[index] = str;
     }
     return str;
+  }
+
+  public static List<String> fromHttpAlpnVersions(List<io.vertx.core.http.HttpVersion> alpnVersions) {
+    return alpnVersions
+      .stream()
+      .map(io.vertx.core.http.HttpVersion::alpnName)
+      .collect(Collectors.toList());
+  }
+
+  public static List<io.vertx.core.http.HttpVersion> toHttpAlpnVersions(List<String> alpnVersions) {
+    return alpnVersions
+      .stream()
+      .map(io.vertx.core.http.HttpVersion::fromAlpnName)
+      .collect(Collectors.toList());
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/ClientOptionsBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/ClientOptionsBase.java
@@ -109,6 +109,11 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
     return (ClientSSLOptions) super.getOrCreateSSLOptions();
   }
 
+  @Override
+  protected ClientSSLOptions createSSLOptions() {
+    return new ClientSSLOptions();
+  }
+
   /**
    *
    * @return true if all server certificates should be trusted

--- a/vertx-core/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -147,6 +147,11 @@ public class NetServerOptions extends TCPSSLOptions {
   }
 
   @Override
+  protected ServerSSLOptions createSSLOptions() {
+    return new ServerSSLOptions();
+  }
+
+  @Override
   public NetServerOptions setSendBufferSize(int sendBufferSize) {
     super.setSendBufferSize(sendBufferSize);
     return this;

--- a/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -227,7 +227,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
 
   protected SSLOptions getOrCreateSSLOptions() {
     if (sslOptions == null) {
-      sslOptions = this instanceof ClientOptionsBase ? new ClientSSLOptions() : new ServerSSLOptions();
+      sslOptions = createSSLOptions();
       // Necessary hacks because we return lazy created collections so we need to care about that
       if (enabledCipherSuites != null) {
         sslOptions.enabledCipherSuites = enabledCipherSuites;
@@ -246,6 +246,10 @@ public abstract class TCPSSLOptions extends NetworkOptions {
       }
     }
     return sslOptions;
+  }
+
+  protected SSLOptions createSSLOptions() {
+    return new SSLOptions();
   }
 
   @GenIgnore


### PR DESCRIPTION
Motivation:

HTTP options classes define a List<HttpVersion> as ALPN versions to use.

Since the encapsulation of SSL options in SSLOptions, the HTTP options ALPN field mirrors the state of the underlying nested SSL options field.

Updating HTTP ALPN fields is not correlated to the nested ALPN generic field and thus the TCP client/server code needs to calculate it to reflect it.

Changes:
    
Remove the HTTP options ALPN version field and make the getter/setter delegate to the SSL options generic ALPN field.

