### PR TITLE
Fix incorrect padded buffer length method calculation.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -528,7 +528,7 @@ public class BufferImpl implements BufferInternal {
   }
 
   public int length() {
-    return buffer.writerIndex();
+    return buffer.readableBytes();
   }
 
   public BufferImpl copy() {

--- a/vertx-core/src/test/java/io/vertx/tests/buffer/BufferTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/buffer/BufferTest.java
@@ -1140,6 +1140,7 @@ public class BufferTest {
     byte[] bytes = TestUtils.randomByteArray(100);
     BufferInternal buffer = BufferInternal.buffer(bytes);
     assertEquals(100, BufferInternal.buffer(buffer.getByteBuf()).length());
+    assertEquals(100, TestUtils.leftPad(1, BufferInternal.buffer(buffer.getByteBuf())).length());
   }
 
   @Test


### PR DESCRIPTION
Motivation:

Buffer#length() returns an incorrect value when dealing with padded ByteBuf.

Changes:

Buffer#length() should use readableBytes() instead of writerIndex().
