### PR TITLE
Fix incorrect padded buffer length method calculation.

### DIFF
--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -514,7 +514,7 @@ public class BufferImpl implements Buffer {
   }
 
   public int length() {
-    return buffer.writerIndex();
+    return buffer.readableBytes();
   }
 
   public Buffer copy() {

--- a/src/test/java/io/vertx/core/buffer/BufferTest.java
+++ b/src/test/java/io/vertx/core/buffer/BufferTest.java
@@ -1102,7 +1102,7 @@ public class BufferTest {
   public void testLength() throws Exception {
     byte[] bytes = TestUtils.randomByteArray(100);
     Buffer buffer = Buffer.buffer(bytes);
-    assertEquals(100, Buffer.buffer(buffer.getByteBuf()).length());
+    assertEquals(100, TestUtils.leftPad(1, Buffer.buffer(buffer.getByteBuf())).length());
   }
 
   @Test


### PR DESCRIPTION
Motivation:

Buffer#length() returns an incorrect value when dealing with padded ByteBuf.

Changes:

Buffer#length() should use readableBytes() instead of writerIndex().
