### PR TITLE
HostAndPortImpl#isDIGIT throws ArrayOtOfboundException

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/impl/HostAndPortImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/HostAndPortImpl.java
@@ -1,8 +1,8 @@
 package io.vertx.core.net.impl;
 
-import java.util.Arrays;
-
 import io.vertx.core.net.HostAndPort;
+
+import java.util.Arrays;
 
 public class HostAndPortImpl implements HostAndPort {
 
@@ -126,7 +126,10 @@ public class HostAndPortImpl implements HostAndPort {
   }
 
   private static boolean isDIGIT(char ch) {
-    return DIGITS[ch] != -1;
+    if (ch < 128) {
+      return DIGITS[ch] != -1;
+    }
+    return false;
   }
 
   private static boolean isSubDelims(char ch) {

--- a/vertx-core/src/test/java/io/vertx/tests/net/HostAndPortTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/HostAndPortTest.java
@@ -92,6 +92,8 @@ public class HostAndPortTest {
     assertFalse(HostAndPortImpl.isValidAuthority("http://localhost:8080"));
     assertNull(HostAndPortImpl.parseAuthority("^", -1));
     assertFalse(HostAndPortImpl.isValidAuthority("^"));
+    assertNull(HostAndPortImpl.parseAuthority("bücher.de", -1));
+    assertFalse(HostAndPortImpl.isValidAuthority("bücher.de"));
   }
 
   private void assertHostAndPort(String expectedHost, int expectedPort, String actual) {


### PR DESCRIPTION
See #5691

Happens when non-ascii characters are used in domain names