### PR TITLE
Handle stale outbound connections after connection failures in clustered event bus

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTest.java
@@ -752,4 +752,32 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
     Future.future(eventBus::close).await();
     assertWaitUntil(() -> numberOfOutboundConnections.get() == 0 && numberOfInboundConnections.get() == 0);
   }
+
+  @Test
+  public void testHandleCloseRemovesStaleOutboundConnectionOnConnectFailure() {
+    AtomicInteger idx = new AtomicInteger();
+    startNodes(2, () -> new WrappedClusterManager(getClusterManager()) {
+      @Override
+      public void getNodeInfo(String nodeId, Completable<io.vertx.core.spi.cluster.NodeInfo> promise) {
+        if (idx.getAndIncrement() == 0) {
+          promise.fail("induced failure");
+        } else {
+          super.getNodeInfo(nodeId, promise);
+        }
+      }
+    });
+    vertices[1].eventBus().consumer(ADDRESS1, msg -> {
+      testComplete();
+    }).completion().onComplete(onSuccess(v -> {
+        vertices[0].eventBus().sender(ADDRESS1).write("will fail").onComplete(ar -> {
+          if (ar.failed()) {
+            vertices[0].eventBus().request(ADDRESS1, "will succeed");
+          } else {
+            fail("Should have failed");
+          }
+        });
+      }
+    ));
+    await();
+  }
 }


### PR DESCRIPTION
Motivation:

Fixes a bug where a failed attempt to establish a clustered event bus connection leaves a stale OutboundConnection instance in the outboundConnections map. 
This prevents subsequent reconnect attempts and can cause writes to hang/fail repeatedly. The fix ensures the failed connection is cleaned up consistently, enabling a fresh connection on the next send. 
A regression test is added.

This problem was introduced during refactoring in commit ffb5d7fb. 
That cleanup path was dropped, causing a regression where stale entries could persist and block reconnection.
