### PR TITLE
Remove obsolete generic type from static Future joins. Fixes #5765

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/Future.java
+++ b/vertx-core/src/main/java/io/vertx/core/Future.java
@@ -87,7 +87,7 @@ public interface Future<T> extends AsyncResult<T> {
    *
    * When the list is empty, the returned future will be already completed.
    */
-  static <T> CompositeFuture all(List<? extends Future<?>> futures) {
+  static CompositeFuture all(List<? extends Future<?>> futures) {
     return CompositeFutureImpl.all(futures.toArray(new Future[0]));
   }
 
@@ -137,7 +137,7 @@ public interface Future<T> extends AsyncResult<T> {
    *
    * When the list is empty, the returned future will be already completed.
    */
-  static <T> CompositeFuture any(Future<?> ... futures) {
+  static CompositeFuture any(Future<?> ... futures) {
     return CompositeFutureImpl.any(futures);
   }
 
@@ -196,7 +196,7 @@ public interface Future<T> extends AsyncResult<T> {
    *
    * When the list is empty, the returned future will be already completed.
    */
-  static <T> CompositeFuture join(Future<?> ... futures) {
+  static CompositeFuture join(Future<?> ... futures) {
     return CompositeFutureImpl.join(futures);
   }
 


### PR DESCRIPTION
Motivation:

Fixes https://github.com/eclipse-vertx/vert.x/issues/5765

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
