### PR TITLE
Fix EventBus cluster manager node lookup failure.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -385,7 +385,10 @@ public final class ClusteredEventBus extends EventBusImpl {
           });
           conn.connected(connection);
         } else {
-          log.warn("Connecting to server " + conn.remoteNodeId() + " failed", ar.cause());
+          if (log.isWarnEnabled()) {
+            log.warn("Connecting to server " + conn.remoteNodeId() + " failed", ar.cause());
+          }
+          outboundConnections.remove(conn.remoteNodeId(), conn);
           conn.handleClose(ar.cause());
         }
       });


### PR DESCRIPTION
Motivation:

When the EventBus allocated a connection for a given node, it reserves a slot in a map to cumulate messages until the connection is established. When connection fails, the allocated connection slot should be removed to let further reconnect attempts work.
