### PR TITLE
Quic key log file support.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/QuicClientAddressValidation.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicClientAddressValidation.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net;
+
+/**
+ * Quic client address validation on the server.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public enum QuicClientAddressValidation {
+
+  /**
+   * The server won't perform any validation (no Retry packet is emitted).
+   */
+  NONE,
+
+  /**
+   * The server performs basic token validation without any crypto.
+   */
+  BASIC,
+
+  /**
+   * The server performs validation using cryptography.
+   */
+  CRYPTO
+
+}

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicClientOptions.java
@@ -33,6 +33,11 @@ public class QuicClientOptions extends QuicEndpointOptions {
   }
 
   @Override
+  public QuicClientOptions setKeyLogFile(String keyLogFile) {
+    return (QuicClientOptions) super.setKeyLogFile(keyLogFile);
+  }
+
+  @Override
   public ClientSSLOptions getSslOptions() {
     return (ClientSSLOptions) super.getSslOptions();
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicEndpointOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicEndpointOptions.java
@@ -24,6 +24,7 @@ public abstract class QuicEndpointOptions {
   private QuicOptions transportOptions;
   private SSLOptions sslOptions;
   private QLogConfig qLogConfig;
+  private String keyLogFile;
 
   public QuicEndpointOptions() {
     this.transportOptions = new QuicOptions();
@@ -36,6 +37,7 @@ public abstract class QuicEndpointOptions {
     this.transportOptions = other.transportOptions.copy();
     this.sslOptions = other.sslOptions.copy();
     this.qLogConfig = qLogConfig != null ? new QLogConfig(qLogConfig) : null;
+    this.keyLogFile = other.keyLogFile;
   }
 
   public QuicEndpointOptions(JsonObject json) {
@@ -80,6 +82,31 @@ public abstract class QuicEndpointOptions {
    */
   public QuicEndpointOptions setQLogConfig(QLogConfig qLogConfig) {
     this.qLogConfig = qLogConfig;
+    return this;
+  }
+
+  /**
+   * @return the path of the configured key log file or {@code null} (default).
+   */
+  public String getKeyLogFile() {
+    return keyLogFile;
+  }
+
+  /**
+   * <p>Configures the endpoint to dump the cryptographic secrets using in TLS in the
+   * <a href="https://www.ietf.org/archive/id/draft-thomson-tls-keylogfile-00.html">{@code SSLKEYLOGFILE}</a> format.</p>
+   *
+   * <p>The file might exist or will be created (in which case the parent file must exist), content will be appended
+   * to the file.</p>
+   *
+   * <p>This should be used only for debugging purpose and must not be used in production. This feature is disabled
+   * by default.</p>
+   *
+   * @param keyLogFile the path to the key log file
+   * @return this exact object instance
+   */
+  public QuicEndpointOptions setKeyLogFile(String keyLogFile) {
+    this.keyLogFile = keyLogFile;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicServerOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicServerOptions.java
@@ -13,6 +13,7 @@ package io.vertx.core.net;
 import io.vertx.codegen.annotations.DataObject;
 
 import java.time.Duration;
+import java.util.Objects;
 
 /**
  * Config operations of a Quic server.
@@ -23,18 +24,18 @@ import java.time.Duration;
 public class QuicServerOptions extends QuicEndpointOptions {
 
   public static final boolean DEFAULT_LOAD_BALANCED = false;
-  public static final boolean DEFAULT_VALIDATE_CLIENT_ADDRESS = false;
+  public static final QuicClientAddressValidation DEFAULT_CLIENT_ADDRESS_VALIDATION = QuicClientAddressValidation.BASIC;
   public static final KeyCertOptions DEFAULT_CLIENT_ADDRESS_VALIDATION_KEY = null;
   public static final Duration DEFAULT_CLIENT_ADDRESS_VALIDATION_TIME_WINDOW = Duration.ofSeconds(30);
 
   private boolean loadBalanced;
-  private boolean validateClientAddress;
+  private QuicClientAddressValidation clientAddressValidation;
   private Duration clientAddressValidationTimeWindow;
   private KeyCertOptions clientAddressValidationKey;
 
   public QuicServerOptions() {
     loadBalanced = DEFAULT_LOAD_BALANCED;
-    validateClientAddress = DEFAULT_VALIDATE_CLIENT_ADDRESS;
+    clientAddressValidation = DEFAULT_CLIENT_ADDRESS_VALIDATION;
     clientAddressValidationKey = DEFAULT_CLIENT_ADDRESS_VALIDATION_KEY;
     clientAddressValidationTimeWindow = DEFAULT_CLIENT_ADDRESS_VALIDATION_TIME_WINDOW;
   }
@@ -45,7 +46,7 @@ public class QuicServerOptions extends QuicEndpointOptions {
     KeyCertOptions tokenValidationKey = other.clientAddressValidationKey;
 
     this.loadBalanced = other.loadBalanced;
-    this.validateClientAddress = other.validateClientAddress;
+    this.clientAddressValidation = other.clientAddressValidation;
     this.clientAddressValidationTimeWindow = other.clientAddressValidationTimeWindow;
     this.clientAddressValidationKey = tokenValidationKey != null ? tokenValidationKey.copy() : null;
   }
@@ -53,6 +54,11 @@ public class QuicServerOptions extends QuicEndpointOptions {
   @Override
   public QuicServerOptions setQLogConfig(QLogConfig qLogConfig) {
     return (QuicServerOptions) super.setQLogConfig(qLogConfig);
+  }
+
+  @Override
+  public QuicServerOptions setKeyLogFile(String keyLogFile) {
+    return (QuicServerOptions) super.setKeyLogFile(keyLogFile);
   }
 
   @Override
@@ -87,8 +93,8 @@ public class QuicServerOptions extends QuicEndpointOptions {
   /**
    * @return whether the server performs address validation
    */
-  public boolean getValidateClientAddress() {
-    return validateClientAddress;
+  public QuicClientAddressValidation getClientAddressValidation() {
+    return clientAddressValidation;
   }
 
   /**
@@ -97,11 +103,11 @@ public class QuicServerOptions extends QuicEndpointOptions {
    *
    * <p>Client address validation requires you to also {@link #setClientAddressValidationKey(KeyCertOptions) set} a key for token signing/verification.</p>
    *
-   * @param validateClientAddress whether to perform address validation
+   * @param clientAddressValidation whether to perform address validation
    * @return this exact object instance
    */
-  public QuicServerOptions setValidateClientAddress(boolean validateClientAddress) {
-    this.validateClientAddress = validateClientAddress;
+  public QuicServerOptions setClientAddressValidation(QuicClientAddressValidation clientAddressValidation) {
+    this.clientAddressValidation = Objects.requireNonNull(clientAddressValidation);
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/KeyLogFile.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/KeyLogFile.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net.impl.quic;
+
+import io.netty.handler.codec.quic.BoringSSLKeylog;
+
+import javax.net.ssl.SSLEngine;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+class KeyLogFile implements BoringSSLKeylog {
+
+  private final File file;
+
+  KeyLogFile(File file) {
+    this.file = file;
+  }
+
+  @Override
+  public void logKey(SSLEngine engine, String key) {
+    try (PrintWriter out = new PrintWriter(new FileWriter(file, StandardCharsets.UTF_8, true))) {
+      out.println(key);
+      out.flush();
+    } catch (Exception ignore) {
+    }
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/spi/tls/QuicSslContextFactory.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/tls/QuicSslContextFactory.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.spi.tls;
 
+import io.netty.handler.codec.quic.BoringSSLKeylog;
 import io.netty.handler.codec.quic.QuicSslContextBuilder;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ClientAuth;
@@ -21,10 +22,8 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLSessionContext;
-import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.*;
+import java.io.File;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -37,9 +36,6 @@ import java.util.Set;
  */
 public class QuicSslContextFactory implements SslContextFactory {
 
-  public QuicSslContextFactory() {
-  }
-
   private boolean forServer;
   private boolean forClient;
   private Set<String> enabledProtocols;
@@ -51,6 +47,11 @@ public class QuicSslContextFactory implements SslContextFactory {
   private ClientAuth clientAuth;
   private KeyManagerFactory kmf;
   private TrustManagerFactory tmf;
+  private final BoringSSLKeylog keylog;
+
+  public QuicSslContextFactory(BoringSSLKeylog keylog) {
+    this.keylog = keylog;
+  }
 
   @Override
   public SslContextFactory useAlpn(boolean useAlpn) {
@@ -121,6 +122,7 @@ public class QuicSslContextFactory implements SslContextFactory {
         builder.clientAuth(clientAuth);
       }
     }
+    builder.keylog(keylog);
 /*
     Collection<String> cipherSuites = enabledCipherSuites;
     switch (sslProvider) {


### PR DESCRIPTION
Motivation:

Support Quic endpoint secrets dump in a keylog file, this is useful for debugging Quic or HTTP/3

Changes:

Implement key logging

Update server's client address validation to avoid sending retry packets if needed.
