### PR TITLE
Implement per connection QuicClient SSL options.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextManager.java
@@ -113,6 +113,14 @@ public class SslContextManager {
     this(sslEngineOptions, 256);
   }
 
+  public Future<SslContextProvider> resolveSslContextProvider(SSLOptions options, ContextInternal ctx) {
+    if (options instanceof ClientSSLOptions) {
+      return resolveSslContextProvider((ClientSSLOptions) options, ctx);
+    } else {
+      return resolveSslContextProvider((ServerSSLOptions) options, ctx);
+    }
+  }
+
   public Future<SslContextProvider> resolveSslContextProvider(ServerSSLOptions options, ContextInternal ctx) {
     ClientAuth clientAuth = options.getClientAuth();
     if (clientAuth == null) {

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicClient.java
@@ -46,6 +46,15 @@ public interface QuicClient extends QuicEndpoint {
   Future<QuicConnection> connect(SocketAddress address);
 
   /**
+   * Connect to a Quic server with a specific {@code sslOptions}.
+   *
+   * @param address the server address
+   * @param sslOptions the ssl options
+   * @return a Quic connection as a future
+   */
+  Future<QuicConnection> connect(SocketAddress address, ClientSSLOptions sslOptions);
+
+  /**
    * Connect to a Quic server with a specific {@code qLogConfig}.
    *
    * @param address the server address
@@ -53,5 +62,15 @@ public interface QuicClient extends QuicEndpoint {
    * @return a Quic connection as a future
    */
   Future<QuicConnection> connect(SocketAddress address, QLogConfig qLogConfig);
+
+  /**
+   * Connect to a Quic server with a specific {@code qLogConfig} and a specific {@code sslOptions}.
+   *
+   * @param address the server address
+   * @param qLogConfig the qlog config for this specific connection
+   * @param sslOptions the ssl options
+   * @return a Quic connection as a future
+   */
+  Future<QuicConnection> connect(SocketAddress address, QLogConfig qLogConfig, ClientSSLOptions sslOptions);
 
 }


### PR DESCRIPTION
Motivation:

QuicClient should support per connection SSL options.
