### PR TITLE
HttpClient timeout exception message contains null address

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -32,7 +32,6 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
 
   protected final ContextInternal context;
   protected final HttpClientStream stream;
-  protected final SocketAddress server;
   protected final boolean ssl;
   private io.vertx.core.http.HttpMethod method;
   private String host;
@@ -53,7 +52,6 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
     this.context = responsePromise.context();
     this.uri = uri;
     this.method = method;
-    this.server = server;
     this.host = host;
     this.port = port;
     this.ssl = stream.connection().isSsl();
@@ -233,7 +231,7 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
           return;
         }
       }
-      cause = timeoutEx(timeoutMs, method, server, uri);
+      cause = timeoutEx(timeoutMs, method, stream.connection().remoteAddress(), uri);
     }
     reset(cause);
   }

--- a/src/test/java/io/vertx/core/http/HttpClientTimeoutTest.java
+++ b/src/test/java/io/vertx/core/http/HttpClientTimeoutTest.java
@@ -29,6 +29,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.CoreMatchers.containsString;
+
 public abstract class HttpClientTimeoutTest extends HttpTestBase {
 
   @Test
@@ -266,6 +268,7 @@ public abstract class HttpClientTimeoutTest extends HttpTestBase {
         resp.exceptionHandler(t -> {
           if (count.getAndIncrement() == 0) {
             assertTrue(t instanceof TimeoutException);
+            assertThat(t.getMessage(), containsString(testAddress.toString()));
             assertEquals(expected, received);
             complete();
           }
@@ -286,6 +289,7 @@ public abstract class HttpClientTimeoutTest extends HttpTestBase {
       req.exceptionHandler(t -> {
         if (count.getAndIncrement() == 0) {
           assertTrue(t instanceof TimeoutException);
+          assertThat(t.getMessage(), containsString(testAddress.toString()));
           assertEquals(expected, received);
           complete();
         }
@@ -363,7 +367,10 @@ public abstract class HttpClientTimeoutTest extends HttpTestBase {
     for (int i = 0; i < 5; i++) {
       client.request(new RequestOptions(requestOptions).setIdleTimeout(500))
         .compose(HttpClientRequest::send)
-        .onComplete(onFailure(t -> assertTrue(t instanceof TimeoutException)));
+        .onComplete(onFailure(t -> {
+          assertTrue(t instanceof TimeoutException);
+          assertThat(t.getMessage(), containsString(testAddress.toString()));
+        }));
     }
     // Now another request that should not timeout
     client.request(new RequestOptions(requestOptions).setIdleTimeout(3000))


### PR DESCRIPTION
See #5775

The server field is no longer used, the info can be retrieved from the HTTP stream.