### PR TITLE
Streams doc improvements

### DIFF
--- a/vertx-core/src/main/asciidoc/streams.adoc
+++ b/vertx-core/src/main/asciidoc/streams.adoc
@@ -16,69 +16,61 @@ while any flow control object that can be _read-from_ is said to implement {@lin
 
 Let's take an example where we want to read from a `ReadStream` then write the data to a `WriteStream`.
 
-A very simple example would be reading from a {@link io.vertx.core.net.NetSocket} then writing back to the
-same `NetSocket` - since `NetSocket` implements both `ReadStream` and `WriteStream`. Note that this works
-between any `ReadStream` and `WriteStream` compliant object, including HTTP requests, HTTP responses,
-async files I/O, WebSockets, etc.
+A very simple example would be reading data from a {@link io.vertx.core.net.NetSocket} then writing it to an {@link io.vertx.core.file.AsyncFile}.
 
-A naive way to do this would be to directly take the data that has been read and immediately write it
-to the `NetSocket`:
+NOTE: This works between any `ReadStream` and `WriteStream` compliant object, including HTTP requests, HTTP responses, async files I/O, WebSockets, etc.
+
+A naive way to do this would be to directly take the data that has been read and immediately write it:
 
 [source,$lang]
 ----
-{@link examples.StreamsExamples#pipe1(io.vertx.core.Vertx)}
+{@link examples.StreamsExamples#pipe1(io.vertx.core.Vertx,io.vertx.core.file.AsyncFile)}
 ----
 
-There is a problem with the example above: if data is read from the socket faster than it can be
-written back to the socket, it will build up in the write queue of the `NetSocket`, eventually
-running out of RAM. This might happen, for example if the client at the other end of the socket
-wasn't reading fast enough, effectively putting back-pressure on the connection.
+There is a problem with the example above: if data is read from the socket faster than it can be written to the file, it will build up in the write queue of the `AsyncFile`, eventually running out of RAM.
+This might happen, for example, if the actual file is stored on a slow network file system, effectively putting back-pressure on the connection.
 
-Since `NetSocket` implements `WriteStream`, we can check if the `WriteStream` is full before
-writing to it:
+Since `AsyncFile` implements `WriteStream`, we can check if the `WriteStream` is full before writing to it:
 
 [source,$lang]
 ----
-{@link examples.StreamsExamples#pipe2(io.vertx.core.Vertx)}
+{@link examples.StreamsExamples#pipe2(io.vertx.core.Vertx,io.vertx.core.file.AsyncFile)}
 ----
 
-This example won't run out of RAM but we'll end up losing data if the write queue gets full. What we
-really want to do is pause the `NetSocket` when the write queue is full:
+This example won't run out of RAM, but we'll end up losing data if the write queue gets full.
+What we really want to do is pause the `NetSocket` when the write queue is full:
 
 [source,$lang]
 ----
-{@link examples.StreamsExamples#pipe3(io.vertx.core.Vertx)}
+{@link examples.StreamsExamples#pipe3(io.vertx.core.Vertx,io.vertx.core.file.AsyncFile)}
 ----
 
-We're almost there, but not quite. The `NetSocket` now gets paused when the file is full, but we also need to unpause
-it when the write queue has processed its backlog:
+We're almost there, but not quite.
+The `NetSocket` now gets paused when the file is full, but we also need to unpause it when the write queue has processed its backlog:
 
 [source,$lang]
 ----
-{@link examples.StreamsExamples#pipe4(io.vertx.core.Vertx)}
+{@link examples.StreamsExamples#pipe4(io.vertx.core.Vertx,io.vertx.core.file.AsyncFile)}
 ----
 
-And there we have it. The {@link io.vertx.core.streams.WriteStream#drainHandler} event handler will
-get called when the write queue is ready to accept more data, this resumes the `NetSocket` that
-allows more data to be read.
+And there we have it.
+The {@link io.vertx.core.streams.WriteStream#drainHandler} event handler will get called when the write queue is ready to accept more data, this resumes the `NetSocket` that allows more data to be read.
 
-Wanting to do this is quite common while writing Vert.x applications, so we added the
-{@link io.vertx.core.streams.ReadStream#pipeTo} method that does all of this hard work for you.
+This use case is quite common while writing Vert.x applications, so we added the {@link io.vertx.core.streams.ReadStream#pipeTo} method that does all of this hard work for you.
 You just feed it the `WriteStream` and use it:
 
 [source,$lang]
 ----
-{@link examples.StreamsExamples#pipe5(io.vertx.core.Vertx)}
+{@link examples.StreamsExamples#pipe5(io.vertx.core.Vertx,io.vertx.core.file.AsyncFile)}
 ----
 
-This does exactly the same thing as the more verbose example, plus it handles stream failures and termination: the
-destination `WriteStream` is ended when the pipe completes with success or a failure.
+This does exactly the same thing as the more verbose example, plus it handles stream failures and termination: the destination `WriteStream` is ended when the pipe completes with success or a failure.
 
 You can be notified when the operation completes:
 
 [source,$lang]
 ----
-{@link examples.StreamsExamples#pipe6(io.vertx.core.net.NetServer)}
+{@link examples.StreamsExamples#pipe6(io.vertx.core.net.NetServer,io.vertx.core.file.AsyncFile)}
 ----
 
 When you deal with an asynchronous destination, you can create a {@link io.vertx.core.streams.Pipe} instance that

--- a/vertx-core/src/main/java/examples/StreamsExamples.java
+++ b/vertx-core/src/main/java/examples/StreamsExamples.java
@@ -29,56 +29,55 @@ import java.util.stream.Collectors;
  */
 public class StreamsExamples {
 
-  public void pipe1(Vertx vertx) {
+  public void pipe1(Vertx vertx, AsyncFile asyncFile) {
     NetServer server = vertx.createNetServer(
         new NetServerOptions().setPort(1234).setHost("localhost")
     );
     server.connectHandler(sock -> {
       sock.handler(buffer -> {
-        // Write the data straight back
-        sock.write(buffer);
+        // Write the data straight to the AsyncFile
+        asyncFile.write(buffer);
       });
     }).listen();
   }
 
-  public void pipe2(Vertx vertx) {
+  public void pipe2(Vertx vertx, AsyncFile asyncFile) {
     NetServer server = vertx.createNetServer(
         new NetServerOptions().setPort(1234).setHost("localhost")
     );
     server.connectHandler(sock -> {
       sock.handler(buffer -> {
-        if (!sock.writeQueueFull()) {
-          sock.write(buffer);
+        if (!asyncFile.writeQueueFull()) {
+          asyncFile.write(buffer);
         }
       });
-
     }).listen();
   }
 
-  public void pipe3(Vertx vertx) {
+  public void pipe3(Vertx vertx, AsyncFile asyncFile) {
     NetServer server = vertx.createNetServer(
         new NetServerOptions().setPort(1234).setHost("localhost")
     );
     server.connectHandler(sock -> {
       sock.handler(buffer -> {
-        sock.write(buffer);
-        if (sock.writeQueueFull()) {
+        asyncFile.write(buffer);
+        if (asyncFile.writeQueueFull()) {
           sock.pause();
         }
       });
     }).listen();
   }
 
-  public void pipe4(Vertx vertx) {
+  public void pipe4(Vertx vertx, AsyncFile asyncFile) {
     NetServer server = vertx.createNetServer(
         new NetServerOptions().setPort(1234).setHost("localhost")
     );
     server.connectHandler(sock -> {
       sock.handler(buffer -> {
-        sock.write(buffer);
-        if (sock.writeQueueFull()) {
+        asyncFile.write(buffer);
+        if (asyncFile.writeQueueFull()) {
           sock.pause();
-          sock.drainHandler(done -> {
+          asyncFile.drainHandler(done -> {
             sock.resume();
           });
         }
@@ -86,21 +85,20 @@ public class StreamsExamples {
     }).listen();
   }
 
-  public void pipe5(Vertx vertx) {
+  public void pipe5(Vertx vertx, AsyncFile asyncFile) {
     NetServer server = vertx.createNetServer(
       new NetServerOptions().setPort(1234).setHost("localhost")
     );
     server.connectHandler(sock -> {
-      sock.pipeTo(sock);
+      sock.pipeTo(asyncFile);
     }).listen();
   }
 
-  public void pipe6(NetServer server) {
+  public void pipe6(NetServer server, AsyncFile asyncFile) {
     server.connectHandler(sock -> {
 
-      // Pipe the socket providing an handler to be notified of the result
-      sock
-        .pipeTo(sock)
+      // Pipe the socket providing a handler to be notified of the result
+      sock.pipeTo(asyncFile)
         .onComplete(ar -> {
           if (ar.succeeded()) {
             System.out.println("Pipe succeeded");


### PR DESCRIPTION
Currently, the doc uses the same `NetServer` socket as a `ReadStream` and as `WriteStream` for examples.

This can cause some confusion: snippets effectively show the `WriteStream` being paused when the write queue is full...

To avoid that sort of confusion, we can use different types for streams: `NetSocket` for `ReadStream`, `AsyncFile` for `WriteStream`.

In fact, the documentation talks about files already, which makes me think we might have used these types originally and then changed for some reason.