### PR TITLE
Upon a shutdown event avoid the creation of a timer task to timeout the vertx connection.

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
@@ -621,7 +621,8 @@ public class VertxConnectionTest extends VertxTestBase {
     channel.advanceTimeBy(100, TimeUnit.MILLISECONDS);
     assertEquals(-1, channel.runScheduledPendingTasks());
     assertEquals(1L, shutdown.get());
-    assertEquals(1L, closed.get());
+    // The broadcaster of the event controls the channel close
+    assertEquals(0L, closed.get());
   }
 
   private <C extends VertxConnection> EmbeddedChannel channel(BiFunction<ContextInternal, ChannelHandlerContext, C> connectionFactory) {


### PR DESCRIPTION
## Motivation

`VertxConnection` handles the internal shutdown event by setting a per connection timer to close the connection.

This is not necessary since shutdown event broadcasting is done by the `ConnectionGroup` that will eventually close the connection when the group grace period terminates.

This also gives more predictable connection group close behavior, that allows to perform an action before a connection group closes reliably before each connection of the group is closed.

## Changes

`VertxConnection#handleEvent` does not call anymore shutdown, instead it sets a shutdown promises and calls `handleShutdown` or `close` without scheduling a shutdown timeout.
