### PR TITLE
Quic connect options.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/QuicClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicClient.java
@@ -43,34 +43,17 @@ public interface QuicClient extends QuicEndpoint {
    * @param address the server address
    * @return a Quic connection as a future
    */
-  Future<QuicConnection> connect(SocketAddress address);
+  default Future<QuicConnection> connect(SocketAddress address) {
+    return connect(address, QuicClientImpl.DEFAULT_CONNECT_OPTIONS);
+  }
 
   /**
    * Connect to a Quic server with a specific {@code sslOptions}.
    *
    * @param address the server address
-   * @param sslOptions the ssl options
+   * @param options the connect options
    * @return a Quic connection as a future
    */
-  Future<QuicConnection> connect(SocketAddress address, ClientSSLOptions sslOptions);
-
-  /**
-   * Connect to a Quic server with a specific {@code qLogConfig}.
-   *
-   * @param address the server address
-   * @param qLogConfig the qlog config for this specific connection
-   * @return a Quic connection as a future
-   */
-  Future<QuicConnection> connect(SocketAddress address, QLogConfig qLogConfig);
-
-  /**
-   * Connect to a Quic server with a specific {@code qLogConfig} and a specific {@code sslOptions}.
-   *
-   * @param address the server address
-   * @param qLogConfig the qlog config for this specific connection
-   * @param sslOptions the ssl options
-   * @return a Quic connection as a future
-   */
-  Future<QuicConnection> connect(SocketAddress address, QLogConfig qLogConfig, ClientSSLOptions sslOptions);
+  Future<QuicConnection> connect(SocketAddress address, QuicConnectOptions options);
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicClientOptions.java
@@ -11,6 +11,9 @@
 package io.vertx.core.net;
 
 import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.net.impl.quic.QuicClientImpl;
+
+import java.time.Duration;
 
 /**
  * Config operations of a Quic client.
@@ -20,11 +23,21 @@ import io.vertx.codegen.annotations.DataObject;
 @DataObject
 public class QuicClientOptions extends QuicEndpointOptions {
 
+  /**
+   * The default value of connect timeout = 60 seconds
+   */
+  public static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(60);
+
+  private Duration connectTimeout;
+
   public QuicClientOptions() {
+    this.connectTimeout = DEFAULT_CONNECT_TIMEOUT;
   }
 
   public QuicClientOptions(QuicClientOptions other) {
     super(other);
+
+    this.connectTimeout = other.connectTimeout;
   }
 
   @Override
@@ -45,5 +58,26 @@ public class QuicClientOptions extends QuicEndpointOptions {
   @Override
   protected ClientSSLOptions getOrCreateSSLOptions() {
     return new ClientSSLOptions();
+  }
+
+  /**
+   * @return the value of connect timeout
+   */
+  public Duration getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  /**
+   * Set the connect timeout.
+   *
+   * @param connectTimeout  connect timeout
+   * @return a reference to this, so the API can be used fluently
+   */
+  public QuicClientOptions setConnectTimeout(Duration connectTimeout) {
+    if (connectTimeout.isNegative()) {
+      throw new IllegalArgumentException("connectTimeout must be >= 0");
+    }
+    this.connectTimeout = connectTimeout;
+    return this;
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicConnectOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicConnectOptions.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net;
+
+import io.vertx.codegen.annotations.DataObject;
+
+import java.time.Duration;
+
+/**
+ * Options for configuring how to connect to a QUIC server.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@DataObject
+public class QuicConnectOptions {
+
+  private ClientSSLOptions sslOptions;
+  private QLogConfig qlogConfig;
+  private Duration timeout;
+
+  public QuicConnectOptions() {
+  }
+
+  public QuicConnectOptions(QuicConnectOptions that) {
+
+    ClientSSLOptions sslOptions = that.sslOptions;
+    if (sslOptions != null) {
+      sslOptions = sslOptions.copy();
+    }
+    QLogConfig qlogConfig = that.qlogConfig;
+    if (qlogConfig != null) {
+      qlogConfig = new QLogConfig(qlogConfig);
+    }
+    Duration timeout = that.timeout;
+
+    this.sslOptions = sslOptions;
+    this.timeout = timeout;
+    this.qlogConfig = qlogConfig;
+  }
+
+  /**
+   * @return the SSL options overriding the client ssl options
+   */
+  public ClientSSLOptions getSslOptions() {
+    return sslOptions;
+  }
+
+  /**
+   * Set the SSL to connect with, if none is set, the client one is used.
+   *
+   * @param sslOptions ssl options
+   * @return a reference to this, so the API can be used fluently
+   */
+  public QuicConnectOptions setSslOptions(ClientSSLOptions sslOptions) {
+    this.sslOptions = sslOptions;
+    return this;
+  }
+
+  /**
+   * @return the QLog config overriding the client config
+   */
+  public QLogConfig getQLogConfig() {
+    return qlogConfig;
+  }
+
+  /**
+   * Set a QLof config to connect with, if none is set, the client one is used.
+   *
+   * @param config the config
+   * @return a reference to this, so the API can be used fluently
+   */
+  public QuicConnectOptions setQLogConfig(QLogConfig config) {
+    this.qlogConfig = config;
+    return this;
+  }
+
+  /**
+   * @return the connect timeout duration
+   */
+  public Duration getTimeout() {
+    return timeout;
+  }
+
+  /**
+   * Override the client connect timeout.
+   *
+   * @param timeout connect timeout
+   * @return a reference to this, so the API can be used fluently
+   */
+  public QuicConnectOptions setTimeout(Duration timeout) {
+    if (timeout != null && timeout.isNegative()) {
+      throw new IllegalArgumentException("Timeout must be >= 0");
+    }
+    this.timeout = timeout;
+    return this;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicEndpointOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicEndpointOptions.java
@@ -23,7 +23,7 @@ public abstract class QuicEndpointOptions {
 
   private QuicOptions transportOptions;
   private SSLOptions sslOptions;
-  private QLogConfig qLogConfig;
+  private QLogConfig qlogConfig;
   private String keyLogFile;
 
   public QuicEndpointOptions() {
@@ -32,11 +32,11 @@ public abstract class QuicEndpointOptions {
 
   public QuicEndpointOptions(QuicEndpointOptions other) {
 
-    QLogConfig qLogConfig = other.qLogConfig;
+    QLogConfig qLogConfig = other.qlogConfig;
 
     this.transportOptions = other.transportOptions.copy();
     this.sslOptions = other.sslOptions.copy();
-    this.qLogConfig = qLogConfig != null ? new QLogConfig(qLogConfig) : null;
+    this.qlogConfig = qLogConfig != null ? new QLogConfig(qLogConfig) : null;
     this.keyLogFile = other.keyLogFile;
   }
 
@@ -69,7 +69,7 @@ public abstract class QuicEndpointOptions {
    * @return the endpoint QLog config.
    */
   public QLogConfig getQLogConfig() {
-    return qLogConfig;
+    return qlogConfig;
   }
 
   /**
@@ -81,7 +81,7 @@ public abstract class QuicEndpointOptions {
    * @return this exact object instance
    */
   public QuicEndpointOptions setQLogConfig(QLogConfig qLogConfig) {
-    this.qLogConfig = qLogConfig;
+    this.qlogConfig = qLogConfig;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicEndpointImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicEndpointImpl.java
@@ -228,7 +228,12 @@ public abstract class QuicEndpointImpl implements QuicEndpointInternal, MetricsP
 
   @Override
   public Future<Void> shutdown(Duration timeout) {
-    return connectionGroup.shutdown(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    ConnectionGroup group = connectionGroup;
+    if (group == null) {
+      return vertx.getOrCreateContext().succeededFuture();
+    } else {
+      return group.shutdown(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
   }
 
   @Override

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QLogTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QLogTest.java
@@ -11,11 +11,7 @@
 package io.vertx.tests.net.quic;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.SocketAddress;
-import io.vertx.core.net.QLogConfig;
-import io.vertx.core.net.QuicClient;
-import io.vertx.core.net.QuicConnection;
-import io.vertx.core.net.QuicServer;
+import io.vertx.core.net.*;
 import io.vertx.test.core.LinuxOrOsx;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
@@ -82,7 +78,8 @@ public class QLogTest extends VertxTestBase {
     // Test client with a qlog file
     File qlogFile = File.createTempFile("vertx", ".qlog");
     assertTrue(qlogFile.delete());
-    QuicConnection connection = client.connect(SocketAddress.inetSocketAddress(9999, "localhost"), qlogConfig(qlogFile, "the title", "the description")).await();
+    QuicConnectOptions connectOptions = new QuicConnectOptions().setQLogConfig(qlogConfig(qlogFile, "the title", "the description"));
+    QuicConnection connection = client.connect(SocketAddress.inetSocketAddress(9999, "localhost"), connectOptions).await();
     connection.close().await();
     List<JsonObject> qlog = parseQLog(qlogFile);
     assertTrue(!qlog.isEmpty());


### PR DESCRIPTION
Motivation:

Introduce Quic connect options to avoid proliferation of QuicClient#connect method overloading.

Changes:

Replace non trivial QuicClient#connect methods by a single method consuming a QuicConnectOptions object.

Support connect timeout options as well.
