### PR TITLE
Decouple HttpServerMetrics and HttpClientMetrics from TCPMetrics.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
@@ -47,7 +47,7 @@ import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.spi.metrics.NetworkMetrics;
-import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -58,7 +58,7 @@ public abstract class Http2MultiplexConnection<S extends Http2Stream> extends Co
 
   protected final Http2MultiplexHandler handler;
   private final IntObjectMap<StreamChannel> channels;
-  private final TCPMetrics<?> tcpMetrics;
+  private final TransportMetrics<?> transportMetrics;
   private final Deque<Promise<Buffer>> pendingPingAcks;
   private boolean initialSettingsReceived;
   private int windowSize;
@@ -67,10 +67,10 @@ public abstract class Http2MultiplexConnection<S extends Http2Stream> extends Co
   private Handler<GoAway> goAwayHandler;
   private Handler<Buffer> pingHandler;
 
-  public Http2MultiplexConnection(Http2MultiplexHandler handler, TCPMetrics<?> tcpMetrics, ChannelHandlerContext chctx, ContextInternal context) {
+  public Http2MultiplexConnection(Http2MultiplexHandler handler, TransportMetrics<?> transportMetrics, ChannelHandlerContext chctx, ContextInternal context) {
     super(context, chctx);
     this.handler = handler;
-    this.tcpMetrics = tcpMetrics;
+    this.transportMetrics = transportMetrics;
     this.channels = new IntObjectHashMap<>();
     this.initialSettingsReceived = false;
     this.pendingPingAcks = new ArrayDeque<>();
@@ -79,7 +79,7 @@ public abstract class Http2MultiplexConnection<S extends Http2Stream> extends Co
 
   @Override
   public NetworkMetrics<?> metrics() {
-    return tcpMetrics;
+    return transportMetrics;
   }
 
   final S stream(int id) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/WebSocketConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/WebSocketConnectionImpl.java
@@ -21,10 +21,7 @@ import io.vertx.core.http.WebSocketFrameType;
 import io.vertx.core.http.impl.HttpUtils;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.net.impl.VertxConnection;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
-import io.vertx.core.spi.metrics.HttpServerMetrics;
-import io.vertx.core.spi.metrics.NetworkMetrics;
-import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.core.spi.metrics.*;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -42,14 +39,14 @@ public final class WebSocketConnectionImpl extends VertxConnection {
   private final long closingTimeoutMS;
   private ScheduledFuture<?> closingTimeout;
   private final boolean server;
-  private final TCPMetrics metrics;
+  private final TransportMetrics<?> metrics;
   private WebSocketImplBase<?> webSocket;
   private boolean closeSent;
   private ChannelPromise closePromise;
   private Object closeReason;
   private boolean closeReceived;
 
-  public WebSocketConnectionImpl(ContextInternal context, ChannelHandlerContext chctx, boolean server, long closingTimeoutMS, TCPMetrics metrics) {
+  public WebSocketConnectionImpl(ContextInternal context, ChannelHandlerContext chctx, boolean server, long closingTimeoutMS, TransportMetrics<?> metrics) {
     super(context, chctx);
     this.closingTimeoutMS = closingTimeoutMS;
     this.metrics = metrics;

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientBuilder.java
@@ -14,6 +14,7 @@ import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.net.NetClientInternal;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 
 /**
  * A builder to configure NetClient plugins.
@@ -22,14 +23,14 @@ public class NetClientBuilder {
 
   private VertxInternal vertx;
   private NetClientOptions options;
-  private TCPMetrics metrics;
+  private TransportMetrics metrics;
 
   public NetClientBuilder(VertxInternal vertx, NetClientOptions options) {
     this.vertx = vertx;
     this.options = options;
   }
 
-  public NetClientBuilder metrics(TCPMetrics metrics) {
+  public NetClientBuilder metrics(TransportMetrics metrics) {
     this.metrics = metrics;
     return this;
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
@@ -34,6 +34,7 @@ import io.vertx.core.net.impl.ProxyFilter;
 import io.vertx.core.net.impl.VertxHandler;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 
 import java.io.FileNotFoundException;
 import java.net.ConnectException;
@@ -59,10 +60,10 @@ class NetClientImpl implements NetClientInternal {
   private final SslContextManager sslContextManager;
   private volatile ClientSSLOptions sslOptions;
   public final ConnectionGroup channelGroup;
-  private final TCPMetrics metrics;
+  private final TransportMetrics metrics;
   private final Predicate<SocketAddress> proxyFilter;
 
-  public NetClientImpl(VertxInternal vertx, TCPMetrics metrics, NetClientOptions options) {
+  public NetClientImpl(VertxInternal vertx, TransportMetrics metrics, NetClientOptions options) {
 
     this.vertx = vertx;
     this.channelGroup = new ConnectionGroup(vertx.acceptorEventLoopGroup().next()) {

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerImpl.java
@@ -59,6 +59,7 @@ import io.vertx.core.net.impl.SocketAddressImpl;
 import io.vertx.core.net.impl.VertxHandler;
 import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 
 import java.net.InetAddress;
@@ -98,7 +99,7 @@ public class NetServerImpl implements Closeable, MetricsProvider, NetServerInter
   private GlobalTrafficShapingHandler trafficShapingHandler;
   private ServerChannelLoadBalancer channelBalancer;
   private Future<Channel> bindFuture;
-  private TCPMetrics<?> metrics;
+  private TransportMetrics<?> metrics;
   private volatile int actualPort;
 
   public NetServerImpl(VertxInternal vertx, NetServerOptions options) {
@@ -258,7 +259,7 @@ public class NetServerImpl implements Closeable, MetricsProvider, NetServerInter
 
     private void connected(Channel ch, SslContextManager sslContextManager, SSLOptions sslOptions) {
       initChannel(ch.pipeline(), options.isSsl());
-      TCPMetrics<?> metrics = getMetrics();
+      TransportMetrics<?> metrics = getMetrics();
       VertxHandler<NetSocketImpl> handler = VertxHandler.create(ctx -> new NetSocketImpl(context, ctx, sslContextManager, sslOptions, metrics, options.isRegisterWriteHandler()));
       handler.removeHandler(NetSocketImpl::unregisterEventBusHandler);
       handler.addHandler(conn -> {
@@ -575,7 +576,7 @@ public class NetServerImpl implements Closeable, MetricsProvider, NetServerInter
     return listening;
   }
 
-  private TCPMetrics<?> createMetrics(SocketAddress localAddress) {
+  private TransportMetrics<?> createMetrics(SocketAddress localAddress) {
     VertxMetrics metrics = vertx.metrics();
     if (metrics != null) {
       if (options instanceof HttpServerOptions) {
@@ -627,7 +628,7 @@ public class NetServerImpl implements Closeable, MetricsProvider, NetServerInter
   }
 
   @Override
-  public synchronized TCPMetrics<?> getMetrics() {
+  public synchronized TransportMetrics<?> getMetrics() {
     return actualServer != null ? actualServer.metrics : null;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetSocketImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetSocketImpl.java
@@ -32,6 +32,7 @@ import io.vertx.core.net.*;
 import io.vertx.core.internal.net.NetSocketInternal;
 import io.vertx.core.net.impl.SocketBase;
 import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 
 import java.util.UUID;
 
@@ -44,7 +45,7 @@ public class NetSocketImpl extends SocketBase<NetSocketImpl> implements NetSocke
   private final SslContextManager sslContextManager;
   private final SSLOptions sslOptions;
   private final SocketAddress remoteAddress;
-  private final TCPMetrics metrics;
+  private final TransportMetrics<?> metrics;
   private final String negotiatedApplicationLayerProtocol;
   private MessageConsumer registration;
 
@@ -52,7 +53,7 @@ public class NetSocketImpl extends SocketBase<NetSocketImpl> implements NetSocke
                        ChannelHandlerContext channel,
                        SslContextManager sslContextManager,
                        SSLOptions sslOptions,
-                       TCPMetrics metrics,
+                       TransportMetrics<?> metrics,
                        boolean registerWriteHandler) {
     this(context, channel, null, sslContextManager, sslOptions, metrics, null, registerWriteHandler);
   }
@@ -62,7 +63,7 @@ public class NetSocketImpl extends SocketBase<NetSocketImpl> implements NetSocke
                        SocketAddress remoteAddress,
                        SslContextManager sslContextManager,
                        SSLOptions sslOptions,
-                       TCPMetrics metrics,
+                       TransportMetrics<?> metrics,
                        String negotiatedApplicationLayerProtocol,
                        boolean registerWriteHandler) {
     super(context, channel);
@@ -90,7 +91,7 @@ public class NetSocketImpl extends SocketBase<NetSocketImpl> implements NetSocke
   }
 
   @Override
-  public TCPMetrics metrics() {
+  public TransportMetrics<?> metrics() {
     return metrics;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
@@ -35,7 +35,7 @@ import io.vertx.core.spi.observability.HttpResponse;
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
-public interface HttpClientMetrics<R, W, S> extends TCPMetrics<S> {
+public interface HttpClientMetrics<R, W, S> extends TransportMetrics<S> {
 
   /**
    * Provides metrics for a particular endpoint

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpServerMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpServerMetrics.java
@@ -35,7 +35,7 @@ import io.vertx.core.spi.observability.HttpResponse;
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
-public interface HttpServerMetrics<R, W, S> extends TCPMetrics<S> {
+public interface HttpServerMetrics<R, W, S> extends TransportMetrics<S> {
 
   /**
    * Called when an http server request begins. Vert.x will invoke {@link #responseEnd} when the response has ended

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/QuicEndpointMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/QuicEndpointMetrics.java
@@ -15,8 +15,6 @@ package io.vertx.core.spi.metrics;
  * <p>An SPI used internally by Vert.x to gather metrics on a socket transport which serves
  * as a base class for things like HttpServer and HttpClient, all of which serve connections.</p>
  *
- * <p>Transport can be TCP or QUIC.</p>
- *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
 public interface QuicEndpointMetrics<C, S> extends TransportMetrics<C> {

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/TCPMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/TCPMetrics.java
@@ -12,8 +12,7 @@
 package io.vertx.core.spi.metrics;
 
 /**
- * An SPI used internally by Vert.x to gather metrics on a TCP socket which serves
- * as a base class for things like HttpServer and HttpClient, all of which serve TCP connections.<p/>
+ * An SPI used internally by Vert.x to gather metrics on a TCP socket.<p/>
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsContextTest.java
@@ -115,6 +115,10 @@ public class MetricsContextTest extends VertxTestBase {
       public HttpServerMetrics createHttpServerMetrics(HttpServerOptions options, SocketAddress localAddress) {
         return new HttpServerMetrics<Void, Void, Void>() {
           @Override
+          public String type() {
+            return "tcp";
+          }
+          @Override
           public Void requestBegin(Void socketMetric, HttpRequest request) {
             requestBeginCalled.set(true);
             return null;
@@ -198,6 +202,10 @@ public class MetricsContextTest extends VertxTestBase {
       @Override
       public HttpServerMetrics createHttpServerMetrics(HttpServerOptions options, SocketAddress localAddress) {
         return new HttpServerMetrics<Void, Void, Void>() {
+          @Override
+          public String type() {
+            return "tcp";
+          }
           @Override
           public Void requestBegin(Void socketMetric, HttpRequest request) {
             switch (request.uri()) {
@@ -298,6 +306,10 @@ public class MetricsContextTest extends VertxTestBase {
       @Override
       public HttpServerMetrics createHttpServerMetrics(HttpServerOptions options, SocketAddress localAddress) {
         return new HttpServerMetrics<Void, Void, Void>() {
+          @Override
+          public String type() {
+            return "tcp";
+          }
           @Override
           public Void requestBegin(Void socketMetric, HttpRequest request) {
             assertEquals(0, httpLifecycle.getAndIncrement());
@@ -416,6 +428,10 @@ public class MetricsContextTest extends VertxTestBase {
       public HttpClientMetrics createHttpClientMetrics(HttpClientOptions options) {
         return new HttpClientMetrics<Void, Void, Void>() {
           @Override
+          public String type() {
+            return "tcp";
+          }
+          @Override
           public ClientMetrics<Void, HttpRequest, HttpResponse> createEndpointMetrics(SocketAddress remoteAddress, int maxPoolSize) {
             return new ClientMetrics<>() {
               @Override
@@ -515,6 +531,10 @@ public class MetricsContextTest extends VertxTestBase {
       @Override
       public HttpClientMetrics createHttpClientMetrics(HttpClientOptions options) {
         return new HttpClientMetrics<Void, Void, Void>() {
+          @Override
+          public String type() {
+            return "tcp";
+          }
           @Override
           public ClientMetrics<Void, HttpRequest, HttpResponse> createEndpointMetrics(SocketAddress remoteAddress, int maxPoolSize) {
             return new ClientMetrics<>() {

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsTest.java
@@ -1236,6 +1236,10 @@ public class MetricsTest extends VertxTestBase {
           lifecycle.compareAndSet(0, 1);
           return new HttpServerMetrics<>() {
             @Override
+            public String type() {
+              return "tcp";
+            }
+            @Override
             public void close() {
               lifecycle.compareAndSet(1, 2);
               HttpServerMetrics.super.close();


### PR DESCRIPTION
Motivation:

HttpServerMetrics and HttpClientMetrics should extend the new TransportMetrics instead of TCPMetrics.
