### PR TITLE
Encapsulate multiplex HTTP observability integration.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xOrH2ChannelConnector.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http1xOrH2ChannelConnector.java
@@ -260,7 +260,7 @@ public class Http1xOrH2ChannelConnector implements HttpChannelConnector {
                 future.tryComplete(unwrap);
               });
               stream.exceptionHandler(future::tryFail);
-              HttpRequestHead request = new HttpRequestHead(OPTIONS, "/", HttpHeaders.headers(), HostAndPort.authority(server.host(), server.port()),
+              HttpRequestHead request = new HttpRequestHead("http", OPTIONS, "/", HttpHeaders.headers(), HostAndPort.authority(server.host(), server.port()),
                 "http://" + server + "/", null);
               stream.writeHead(request, false, null, true, null, false);
             } else {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -532,7 +532,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
       if (uri.isEmpty()) {
         uri = "/";
       }
-      HttpRequestHead head = new HttpRequestHead(method, uri, headers, authority(), absoluteURI(), traceOperation);
+      HttpRequestHead head = new HttpRequestHead(ssl ? "http" : "https", method, uri, headers, authority(), absoluteURI(), traceOperation);
       future = stream.writeHead(head, chunked, buff, writeEnd, priority, connect);
     } else {
       if (buff == null && !end) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpRequestHead.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpRequestHead.java
@@ -19,10 +19,9 @@ import io.vertx.core.spi.observability.HttpRequest;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class HttpRequestHead implements HttpRequest {
+public class HttpRequestHead {
 
-  public String scheme;
-  public SocketAddress remoteAddress;
+  public final String scheme;
   public final HttpMethod method;
   public final String uri;
   public final MultiMap headers;
@@ -30,7 +29,8 @@ public class HttpRequestHead implements HttpRequest {
   public final String absoluteURI;
   public final String traceOperation;
 
-  public HttpRequestHead(HttpMethod method, String uri, MultiMap headers, HostAndPort authority, String absoluteURI, String traceOperation) {
+  public HttpRequestHead(String scheme, HttpMethod method, String uri, MultiMap headers, HostAndPort authority, String absoluteURI, String traceOperation) {
+    this.scheme = scheme;
     this.method = method;
     this.uri = uri;
     this.headers = headers;
@@ -39,32 +39,22 @@ public class HttpRequestHead implements HttpRequest {
     this.traceOperation = traceOperation;
   }
 
-  @Override
   public MultiMap headers() {
     return headers;
   }
 
-  @Override
-  public SocketAddress remoteAddress() {
-    return remoteAddress;
-  }
-
-  @Override
   public String absoluteURI() {
     return absoluteURI;
   }
 
-  @Override
   public int id() {
     return 1;
   }
 
-  @Override
   public String uri() {
     return uri;
   }
 
-  @Override
   public HttpMethod method() {
     return method;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpResponseHead.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpResponseHead.java
@@ -17,7 +17,7 @@ import io.vertx.core.spi.observability.HttpResponse;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class HttpResponseHead implements HttpResponse {
+public class HttpResponseHead {
 
   public final int statusCode;
   public final String statusMessage;
@@ -29,12 +29,10 @@ public class HttpResponseHead implements HttpResponse {
     this.headers = headers;
   }
 
-  @Override
   public int statusCode() {
     return statusCode;
   }
 
-  @Override
   public MultiMap headers() {
     return headers;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/headers/HttpResponseHeaders.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/headers/HttpResponseHeaders.java
@@ -12,11 +12,35 @@ package io.vertx.core.http.impl.headers;
 
 import io.netty.handler.codec.Headers;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.vertx.core.spi.tracing.TagExtractor;
 
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
 public class HttpResponseHeaders extends HttpHeaders {
+
+  public static final TagExtractor<HttpResponseHeaders> CLIENT_TAG_EXTRACTOR = new TagExtractor<>() {
+    @Override
+    public int len(HttpResponseHeaders resp) {
+      return 1;
+    }
+
+    @Override
+    public String name(HttpResponseHeaders resp, int index) {
+      if (index == 0) {
+        return "http.response.status_code";
+      }
+      throw new IndexOutOfBoundsException("Invalid tag index " + index);
+    }
+
+    @Override
+    public String value(HttpResponseHeaders resp, int index) {
+      if (index == 0) {
+        return Integer.toString(resp.status());
+      }
+      throw new IndexOutOfBoundsException("Invalid tag index " + index);
+    }
+  };
 
   private Integer status;
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/observality/ClientStreamObserver.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/observality/ClientStreamObserver.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl.observality;
+
+import io.vertx.core.http.impl.HttpUtils;
+import io.vertx.core.http.impl.headers.HttpHeaders;
+import io.vertx.core.http.impl.headers.HttpRequestHeaders;
+import io.vertx.core.http.impl.headers.HttpResponseHeaders;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.core.spi.observability.HttpRequest;
+import io.vertx.core.spi.observability.HttpResponse;
+import io.vertx.core.spi.tracing.SpanKind;
+import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingPolicy;
+
+import java.util.function.BiConsumer;
+
+public class ClientStreamObserver extends StreamObserver {
+
+  private final ClientMetrics<Object, HttpRequest, HttpResponse> clientMetrics;
+  private Object metric;
+  private Object trace;
+  private HttpResponseHeaders inboundHeaders;
+
+  public ClientStreamObserver(ContextInternal context, TracingPolicy tracingPolicy, ClientMetrics<Object, HttpRequest, HttpResponse> clientMetrics, VertxTracer tracer, SocketAddress remoteAddress) {
+    super(context, remoteAddress, tracingPolicy, tracer);
+    this.clientMetrics = clientMetrics;
+  }
+
+  public void observePush(HttpRequestHeaders headers) {
+    if (clientMetrics != null) {
+      Object metric = clientMetrics.requestBegin(headers.path().toString(), observableRequest(headers, remoteAddress));
+      this.metric = metric;
+      clientMetrics.requestEnd(metric, 0L);
+    }
+  }
+
+  public void observeUpgrade(Object metric, Object trace) {
+    this.metric = metric;
+    this.trace = trace;
+  }
+
+  public void observeOutboundHeaders(HttpHeaders headers) {
+    HttpRequestHeaders r = (HttpRequestHeaders) headers;
+    if (clientMetrics != null) {
+      metric = clientMetrics.requestBegin(r.path(), observableRequest(r, remoteAddress));
+    }
+    VertxTracer tracer = context.tracer();
+    if (tracer != null) {
+      BiConsumer<String, String> headers_ = (key, val) -> headers.add(key, val);
+      String traceOperation = r.trace();
+      if (traceOperation == null) {
+        traceOperation = r.method().toString();
+      }
+      trace = tracer.sendRequest(context, SpanKind.RPC, tracingPolicy, r, traceOperation, headers_, HttpRequestHeaders.CLIENT_TAG_EXTRACTOR);
+    }
+  }
+
+  public void observeInboundTrailers(long bytesRead) {
+    if (clientMetrics != null) {
+      clientMetrics.responseEnd(metric, bytesRead);
+    }
+    VertxTracer tracer = context.tracer();
+    if (tracer != null && trace != null) {
+      tracer.receiveResponse(context, inboundHeaders, trace, null, HttpResponseHeaders.CLIENT_TAG_EXTRACTOR);
+    }
+  }
+
+  public void observeReset() {
+    if (clientMetrics != null) {
+      clientMetrics.requestReset(metric);
+    }
+    VertxTracer tracer = context.tracer();
+    if (tracer != null && trace != null) {
+      tracer.receiveResponse(context, inboundHeaders, trace, HttpUtils.STREAM_CLOSED_EXCEPTION, HttpResponseHeaders.CLIENT_TAG_EXTRACTOR);
+    }
+  }
+
+  public void observeInboundHeaders(HttpHeaders headers) {
+    inboundHeaders = (HttpResponseHeaders) headers;
+    if (clientMetrics != null) {
+      clientMetrics.responseBegin(metric, observableResponse(inboundHeaders, remoteAddress));
+    }
+  }
+
+  public void observeOutboundTrailers(long bytesWritten) {
+    if (clientMetrics != null) {
+      clientMetrics.requestEnd(metric, bytesWritten);
+    }
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/observality/ServerStreamObserver.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/observality/ServerStreamObserver.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl.observality;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.impl.HttpUtils;
+import io.vertx.core.http.impl.headers.HttpHeaders;
+import io.vertx.core.http.impl.headers.HttpRequestHeaders;
+import io.vertx.core.http.impl.headers.HttpResponseHeaders;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.metrics.HttpServerMetrics;
+import io.vertx.core.spi.metrics.Metrics;
+import io.vertx.core.spi.tracing.SpanKind;
+import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingPolicy;
+
+import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
+
+public class ServerStreamObserver extends StreamObserver {
+
+  private final HttpServerMetrics serverMetrics;
+  private final Object socketMetric;
+
+  public ServerStreamObserver(ContextInternal context, HttpServerMetrics serverMetrics, VertxTracer tracer, Object socketMetric, TracingPolicy tracingPolicy, SocketAddress remoteAddress) {
+    super(context, remoteAddress, tracingPolicy, tracer);
+    this.serverMetrics = serverMetrics;
+    this.socketMetric = socketMetric;
+  }
+
+  public void observeOutboundHeaders(HttpHeaders headers) {
+    if (Metrics.METRICS_ENABLED) {
+      if (serverMetrics != null) {
+        serverMetrics.responseBegin(metric, observableResponse((HttpResponseHeaders) headers, remoteAddress));
+      }
+    }
+    VertxTracer tracer = context.tracer();
+    Object trace = this.trace;
+    if (tracer != null && trace != null) {
+      tracer.sendResponse(context, observableResponse((HttpResponseHeaders) headers, remoteAddress), trace, null, HttpUtils.SERVER_RESPONSE_TAG_EXTRACTOR);
+    }
+  }
+
+  public void observeInboundTrailers(long bytesRead) {
+    if (Metrics.METRICS_ENABLED) {
+      if (serverMetrics != null) {
+        serverMetrics.requestEnd(metric, observableRequest, bytesRead);
+      }
+    }
+  }
+
+  public void observeInboundHeaders(HttpHeaders headers) {
+    if (METRICS_ENABLED) {
+      if (serverMetrics != null) {
+        metric = serverMetrics.requestBegin(socketMetric, observableRequest((HttpRequestHeaders) headers, remoteAddress));
+      }
+    }
+    VertxTracer tracer = context.tracer();
+    if (tracer != null) {
+      trace = tracer.receiveRequest(context, SpanKind.RPC, tracingPolicy, headers, ((HttpRequestHeaders) headers).method().name(), headers, HttpRequestHeaders.SERVER_TAG_EXTRACTOR);
+    }
+  }
+
+  public void observeOutboundTrailers(long bytesWritten) {
+    if (serverMetrics != null) {
+      serverMetrics.responseEnd(metric, observableResponse, bytesWritten);
+    }
+  }
+
+  public void observeReset() {
+    if (serverMetrics != null) {
+      serverMetrics.requestReset(metric);
+    }
+    VertxTracer tracer = context.tracer();
+    Object trace = this.trace;
+    if (tracer != null && trace != null) {
+      tracer.sendResponse(context, null, trace, HttpUtils.STREAM_CLOSED_EXCEPTION, HttpUtils.SERVER_RESPONSE_TAG_EXTRACTOR);
+    }
+  }
+
+  public void observeRoute(String route) {
+    if (serverMetrics != null) {
+      serverMetrics.requestRouted(metric, route);
+    }
+  }
+
+  public void observePush(HttpResponseHeaders headers, HttpMethod method, String uri) {
+    if (serverMetrics != null) {
+      metric = serverMetrics.responsePushed(socketMetric, method, uri, observableResponse(headers, remoteAddress));
+    }
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/observality/StreamObserver.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/observality/StreamObserver.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl.observality;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.impl.headers.HttpHeaders;
+import io.vertx.core.http.impl.headers.HttpRequestHeaders;
+import io.vertx.core.http.impl.headers.HttpResponseHeaders;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.observability.HttpRequest;
+import io.vertx.core.spi.observability.HttpResponse;
+import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingPolicy;
+
+/**
+ * Encapsulate observability state and interactions with the observability layer.
+ */
+public abstract class StreamObserver {
+
+  final ContextInternal context;
+  final SocketAddress remoteAddress;
+  final TracingPolicy tracingPolicy;
+  final VertxTracer tracer;
+  Object metric;
+  Object trace;
+  HttpRequest observableRequest;
+  HttpResponse observableResponse;
+
+  public StreamObserver(ContextInternal context, SocketAddress remoteAddress, TracingPolicy tracingPolicy, VertxTracer tracer) {
+    this.context = context;
+    this.remoteAddress = remoteAddress;
+    this.tracingPolicy = tracingPolicy;
+    this.tracer = tracer;
+  }
+
+  public Object metric() {
+    return metric;
+  }
+
+  public Object trace() {
+    return trace;
+  }
+
+  public abstract void observeReset();
+
+  public abstract void observeInboundHeaders(HttpHeaders headers);
+
+  public abstract void observeOutboundTrailers(long bytesWritten);
+
+  public abstract void observeOutboundHeaders(HttpHeaders headers);
+
+  public abstract void observeInboundTrailers(long bytesRead);
+
+  HttpRequest observableRequest(HttpRequestHeaders requestHeaders, SocketAddress remoteAddress) {
+    if (observableRequest == null) {
+      observableRequest = new HttpRequest() {
+        @Override
+        public int id() {
+          return 1;
+        }
+
+        @Override
+        public String uri() {
+          return requestHeaders.path();
+        }
+
+        @Override
+        public String absoluteURI() {
+          return requestHeaders.absoluteUri();
+        }
+
+        @Override
+        public HttpMethod method() {
+          return requestHeaders.method();
+        }
+
+        @Override
+        public MultiMap headers() {
+          return requestHeaders;
+        }
+
+        @Override
+        public SocketAddress remoteAddress() {
+          return remoteAddress;
+        }
+      };
+    }
+    return observableRequest;
+  }
+
+  HttpResponse observableResponse(HttpResponseHeaders responseHeaders, SocketAddress remoteAddress) {
+    if (observableResponse == null) {
+      observableResponse = new HttpResponse() {
+        @Override
+        public int statusCode() {
+          return responseHeaders.status();
+        }
+
+        @Override
+        public MultiMap headers() {
+          return responseHeaders;
+        }
+      };
+    }
+    return observableResponse;
+  }
+}

--- a/vertx-core/src/main/java/module-info.java
+++ b/vertx-core/src/main/java/module-info.java
@@ -127,5 +127,6 @@ module io.vertx.core {
   exports io.vertx.core.net.impl.tcp to io.vertx.core.tests;
   exports io.vertx.core.net.impl.quic to io.vertx.core.tests;
   exports io.vertx.core.http.impl.http1x to io.vertx.core.tests;
+  exports io.vertx.core.http.impl.observality to io.vertx.core.tests;
 
 }

--- a/vertx-core/src/test/java/io/vertx/tests/tracing/HttpTracerTestBase.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tracing/HttpTracerTestBase.java
@@ -28,6 +28,7 @@ import io.vertx.core.spi.context.storage.ContextLocal;
 import io.vertx.core.spi.observability.HttpRequest;
 import io.vertx.core.spi.observability.HttpResponse;
 import io.vertx.core.tracing.TracingPolicy;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.UUID;
@@ -174,7 +175,6 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
         assertTrue(seq.compareAndSet(0, 1));
         headers.accept("X-B3-TraceId", traceId);
         assertNotNull(request);
-        assertTrue(request instanceof HttpRequest);
         assertEquals(expectedOperation, operation);
         return request;
       }
@@ -183,7 +183,6 @@ public abstract class HttpTracerTestBase extends HttpTestBase {
         assertSame(val, key.get(context));
         key.remove(context);
         assertNotNull(response);
-        assertTrue(response instanceof HttpResponse);
         assertNull(failure);
         assertTrue(seq.compareAndSet(1, 2));
       }


### PR DESCRIPTION
Motivation:

Encapsulate HTTP/2 observability integration in order to reuse it for HTTP/3.
