### PR TITLE
HTTP test configuration improvements

### DIFF
--- a/vertx-core/src/test/java/io/vertx/test/http/AbstractHttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/AbstractHttpTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.test.http;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.*;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.test.core.VertxTestBase;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
+ */
+public abstract class AbstractHttpTest extends VertxTestBase {
+
+  public static final String DEFAULT_HTTP_HOST = "localhost";
+  public static final int DEFAULT_HTTP_PORT = Integer.parseInt(System.getProperty("vertx.httpPort", "8080"));
+  public static final String DEFAULT_HTTP_HOST_AND_PORT = DEFAULT_HTTP_HOST + ":" +  DEFAULT_HTTP_PORT;
+  public static final String DEFAULT_HTTPS_HOST = "localhost";
+  public static final int DEFAULT_HTTPS_PORT = Integer.parseInt(System.getProperty("vertx.httpsPort", "4043"));;
+  public static final String DEFAULT_HTTPS_HOST_AND_PORT = DEFAULT_HTTPS_HOST + ":" + DEFAULT_HTTPS_PORT;;
+  public static final String DEFAULT_TEST_URI = "some-uri";
+
+  protected HttpServer server;
+  protected HttpClientAgent client;
+  protected SocketAddress testAddress;
+  protected RequestOptions requestOptions;
+  private File tmp;
+
+  protected abstract HttpServer createHttpServer();
+
+  protected abstract HttpClientAgent createHttpClient();
+
+  protected HttpServer createHttpServer(HttpServerOptions options) {
+    return vertx.createHttpServer(options);
+  }
+
+  protected HttpClientAgent createHttpClient(HttpClientOptions options) {
+    return httpClientBuilder().with(options).build();
+  }
+
+  protected final HttpClientAgent createHttpClient(HttpClientOptions options, PoolOptions pool) {
+    return httpClientBuilder().with(options).with(pool).build();
+  }
+
+  protected final HttpClientAgent createHttpClient(PoolOptions pool) {
+    return httpClientBuilder().with(pool).build();
+  }
+
+  protected final HttpClientBuilder httpClientBuilder() {
+    return httpClientBuilder(vertx);
+  }
+
+  protected abstract HttpClientBuilder httpClientBuilder(Vertx vertx);
+
+  public void setUp() throws Exception {
+    super.setUp();
+    server = createHttpServer();
+    client = createHttpClient();
+  }
+
+  protected void startServer() throws Exception {
+    startServer(vertx.getOrCreateContext());
+  }
+
+  protected void startServer(SocketAddress bindAddress) throws Exception {
+    startServer(bindAddress, vertx.getOrCreateContext());
+  }
+
+  protected void startServer(HttpServer server) throws Exception {
+    startServer(vertx.getOrCreateContext(), server);
+  }
+
+  protected void startServer(SocketAddress bindAddress, HttpServer server) throws Exception {
+    startServer(bindAddress, vertx.getOrCreateContext(), server);
+  }
+
+  protected void startServer(Context context) throws Exception {
+    startServer(context, server);
+  }
+
+  protected void startServer(SocketAddress bindAddress, Context context) throws Exception {
+    startServer(bindAddress, context, server);
+  }
+
+  protected void startServer(Context context, HttpServer server) throws Exception {
+    startServer(null, context, server);
+  }
+
+  protected void startServer(SocketAddress bindAddress, Context context, HttpServer server) throws Exception {
+    CompletableFuture<Void> latch = new CompletableFuture<>();
+    context.runOnContext(v -> {
+      Future<HttpServer> fut;
+      if (bindAddress != null) {
+        fut = server.listen(bindAddress);
+      } else {
+        fut = server.listen();
+      }
+      fut.onComplete(ar -> {
+        if (ar.succeeded()) {
+          latch.complete(null);
+        } else {
+          latch.completeExceptionally(ar.cause());
+        }
+      });
+    });
+    try {
+      latch.get(20, TimeUnit.SECONDS);
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception) {
+        throw (Exception) cause;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  protected File setupFile(String fileName, String content) throws Exception {
+    Path dir = Files.createTempDirectory("vertx");
+    File file = new File(dir.toFile(), fileName);
+    if (file.exists()) {
+      file.delete();
+    }
+    file.deleteOnExit();
+    try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8))) {
+      out.write(content);
+    }
+    return file;
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/test/http/HttpClientConfig.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/HttpClientConfig.java
@@ -1,0 +1,24 @@
+package io.vertx.test.http;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientAgent;
+import io.vertx.core.http.HttpClientBuilder;
+import io.vertx.core.http.PoolOptions;
+
+import java.time.Duration;
+
+public interface HttpClientConfig {
+  HttpClientConfig setConnectTimeout(Duration connectTimeout);
+  HttpClientConfig setIdleTimeout(Duration timeout);
+  HttpClientConfig setKeepAliveTimeout(Duration timeout);
+  HttpClientConfig setDecompressionSupported(boolean decompressionSupported);
+  HttpClientConfig setLocalAddress(String localAddress);
+  HttpClientConfig setLogActivity(boolean logActivity);
+  default HttpClientAgent create(Vertx vertx, PoolOptions poolOptions) {
+    return builder(vertx).with(poolOptions).build();
+  }
+  default HttpClientAgent create(Vertx vertx) {
+    return builder(vertx).build();
+  }
+  HttpClientBuilder builder(Vertx vertx);
+}

--- a/vertx-core/src/test/java/io/vertx/test/http/HttpConfig.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/HttpConfig.java
@@ -1,0 +1,198 @@
+package io.vertx.test.http;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.*;
+import io.vertx.core.net.SSLEngineOptions;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.tests.http.Http2TestBase;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static io.vertx.test.http.HttpTestBase.*;
+
+public interface HttpConfig {
+
+  int port();
+
+  String host();
+
+  HttpServerConfig forServer();
+  HttpClientConfig forClient();
+
+  abstract class Http1xOr2Config implements HttpConfig {
+
+
+    public abstract HttpServerOptions createBaseServerOptions();
+
+    public abstract HttpClientOptions createBaseClientOptions();
+
+    @Override
+    public HttpClientConfig forClient() {
+      HttpClientOptions options = createBaseClientOptions();
+      return new HttpClientConfig() {
+        @Override
+        public HttpClientConfig setConnectTimeout(Duration connectTimeout) {
+          options.setConnectTimeout((int)connectTimeout.toMillis());
+          return this;
+        }
+        @Override
+        public HttpClientConfig setDecompressionSupported(boolean decompressionSupported) {
+          options.setDecompressionSupported(decompressionSupported);
+          return this;
+        }
+        @Override
+        public HttpClientConfig setLocalAddress(String localAddress) {
+          options.setLocalAddress(localAddress);
+          return this;
+        }
+        @Override
+        public HttpClientConfig setLogActivity(boolean logActivity) {
+          options.setLogActivity(logActivity);
+          return this;
+        }
+        @Override
+        public HttpClientConfig setIdleTimeout(Duration timeout) {
+          options.setIdleTimeout((int)timeout.toMillis());
+          options.setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+          return this;
+        }
+
+        @Override
+        public HttpClientConfig setKeepAliveTimeout(Duration timeout) {
+          options.setKeepAliveTimeout((int)timeout.toSeconds());
+          options.setHttp2KeepAliveTimeout((int)timeout.toSeconds());
+          return this;
+        }
+        @Override
+        public HttpClientBuilder builder(Vertx vertx) {
+          return vertx.httpClientBuilder().with(options);
+        }
+      };
+    }
+
+    @Override
+    public HttpServerConfig forServer() {
+      HttpServerOptions options = createBaseServerOptions();
+      return new HttpServerConfig() {
+        @Override
+        public HttpServerConfig setMaxFormBufferedBytes(int maxFormBufferedBytes) {
+          options.setMaxFormBufferedBytes(maxFormBufferedBytes);
+          return this;
+        }
+        @Override
+        public HttpServerConfig setMaxFormAttributeSize(int maxSize) {
+          options.setMaxFormAttributeSize(maxSize);
+          return this;
+        }
+        @Override
+        public HttpServerConfig setMaxFormFields(int maxFormFields) {
+          options.setMaxFormFields(maxFormFields);
+          return this;
+        }
+        @Override
+        public HttpServerConfig setLogActivity(boolean logActivity) {
+          options.setLogActivity(logActivity);
+          return this;
+        }
+        @Override
+        public HttpServerConfig setIdleTimeout(Duration timeout) {
+          options.setIdleTimeout((int)timeout.toMillis());
+          options.setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+          return this;
+        }
+        @Override
+        public HttpServerConfig setHandle100ContinueAutomatically(boolean b) {
+          options.setHandle100ContinueAutomatically(b);
+          return this;
+        }
+        @Override
+        public HttpServer create(Vertx vertx) {
+          return vertx.createHttpServer(options);
+        }
+      };
+    }
+  }
+
+  class Http1x extends Http1xOr2Config {
+
+    public static HttpConfig DEFAULT = new HttpConfig.Http1x();
+
+    private final int port;
+    private final String host;
+
+    public Http1x(String host, int port) {
+      this.port =  port;
+      this.host = host;
+    }
+
+    protected Http1x() {
+      this(DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT);
+    }
+
+    @Override
+    public int port() {
+      return port;
+    }
+
+    @Override
+    public String host() {
+      return host;
+    }
+
+    @Override
+    public HttpServerOptions createBaseServerOptions() {
+      return new HttpServerOptions().setPort(port).setHost(host);
+    }
+
+    @Override
+    public HttpClientOptions createBaseClientOptions() {
+      return new HttpClientOptions().setDefaultPort(port).setDefaultHost(host);
+    }
+  }
+
+  class Http2 extends Http1xOr2Config {
+
+    public static HttpConfig CODEC = new HttpConfig.Http2(false);
+    public static HttpConfig MULTIPLEX = new HttpConfig.Http2(true);
+
+    private final boolean multiplex;
+    private final int port;
+    private final String host;
+
+    public Http2(boolean multiplex) {
+      this(multiplex, DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT);
+    }
+
+    public Http2(boolean multiplex, String host, int port) {
+      this.multiplex = multiplex;
+      this.port = port;
+      this.host = host;
+    }
+
+    @Override
+    public int port() {
+      return port;
+    }
+
+    @Override
+    public String host() {
+      return host;
+    }
+
+    @Override
+    public HttpServerOptions createBaseServerOptions() {
+      return Http2TestBase.createHttp2ServerOptions(port, host)
+        .setHttp2MultiplexImplementation(multiplex);
+    }
+
+    @Override
+    public HttpClientOptions createBaseClientOptions() {
+      return Http2TestBase.createHttp2ClientOptions()
+        .setDefaultPort(port)
+        .setDefaultHost(host)
+        .setHttp2MultiplexImplementation(multiplex);
+    }
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/test/http/HttpServerConfig.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/HttpServerConfig.java
@@ -1,0 +1,18 @@
+package io.vertx.test.http;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+
+import java.time.Duration;
+
+public interface HttpServerConfig {
+
+  HttpServerConfig setMaxFormBufferedBytes(int maxFormBufferedBytes);
+  HttpServerConfig setMaxFormAttributeSize(int maxSize);
+  HttpServerConfig setMaxFormFields(int maxFormFields);
+  HttpServerConfig setIdleTimeout(Duration timeout);
+  HttpServerConfig setLogActivity(boolean logActivity);
+  HttpServerConfig setHandle100ContinueAutomatically(boolean b);
+  HttpServer create(Vertx vertx);
+
+}

--- a/vertx-core/src/test/java/io/vertx/test/http/SimpleHttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/SimpleHttpTest.java
@@ -1,0 +1,39 @@
+package io.vertx.test.http;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.*;
+import io.vertx.core.net.SocketAddress;
+
+public class SimpleHttpTest extends AbstractHttpTest {
+
+  protected final HttpConfig config;
+
+  public SimpleHttpTest(HttpConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    testAddress = SocketAddress.inetSocketAddress(config.port(), config.host());
+    requestOptions = new RequestOptions()
+      .setHost(config.host())
+      .setPort(config.port())
+      .setURI(DEFAULT_TEST_URI);
+  }
+
+  @Override
+  protected HttpServer createHttpServer() {
+    return config.forServer().create(vertx);
+  }
+
+  @Override
+  protected HttpClientAgent createHttpClient() {
+    return config.forClient().create(vertx);
+  }
+
+  @Override
+  protected HttpClientBuilder httpClientBuilder(Vertx vertx) {
+    return config.forClient().builder(vertx);
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2MultiplexTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2MultiplexTest.java
@@ -17,14 +17,8 @@ import org.junit.Test;
 
 public class Http2MultiplexTest extends Http2Test {
 
-  @Override
-  protected HttpServerOptions createBaseServerOptions() {
-    return super.createBaseServerOptions().setHttp2MultiplexImplementation(true);
-  }
-
-  @Override
-  protected HttpClientOptions createBaseClientOptions() {
-    return super.createBaseClientOptions().setHttp2MultiplexImplementation(true);
+  public Http2MultiplexTest() {
+    super(true);
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2TestBase.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2TestBase.java
@@ -29,6 +29,10 @@ import java.util.concurrent.TimeUnit;
  */
 public class Http2TestBase extends HttpTestBase {
 
+  public static HttpServerOptions createHttp2ServerOptions() {
+    return createHttp2ServerOptions(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST);
+  }
+
   public static HttpServerOptions createHttp2ServerOptions(int port, String host) {
     return new HttpServerOptions()
         .setPort(port)

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http1xClientFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http1xClientFileUploadTest.java
@@ -10,5 +10,11 @@
  */
 package io.vertx.tests.http.fileupload;
 
+import io.vertx.test.http.HttpConfig;
+
 public class Http1xClientFileUploadTest extends HttpClientFileUploadTest {
+
+  public Http1xClientFileUploadTest() {
+    super(HttpConfig.Http1x.DEFAULT);
+  }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http1xServerFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http1xServerFileUploadTest.java
@@ -10,12 +10,17 @@
  */
 package io.vertx.tests.http.fileupload;
 
+import io.vertx.test.http.HttpConfig;
 import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  */
 public class Http1xServerFileUploadTest extends HttpServerFileUploadTest {
+
+  public Http1xServerFileUploadTest() {
+    super(HttpConfig.Http1x.DEFAULT);
+  }
 
   @Ignore
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2ClientFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2ClientFileUploadTest.java
@@ -10,20 +10,15 @@
  */
 package io.vertx.tests.http.fileupload;
 
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.test.http.HttpTestBase;
-import io.vertx.tests.http.Http2TestBase;
+import io.vertx.test.http.HttpConfig;
 
 public class Http2ClientFileUploadTest extends HttpClientFileUploadTest {
 
-  @Override
-  protected HttpServerOptions createBaseServerOptions() {
-    return Http2TestBase.createHttp2ServerOptions(HttpTestBase.DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST);
+  public Http2ClientFileUploadTest() {
+    this(false);
   }
 
-  @Override
-  protected HttpClientOptions createBaseClientOptions() {
-    return Http2TestBase.createHttp2ClientOptions();
+  protected Http2ClientFileUploadTest(boolean multiplex) {
+    super(new HttpConfig.Http2(multiplex));
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2MultiplexClientFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2MultiplexClientFileUploadTest.java
@@ -10,20 +10,9 @@
  */
 package io.vertx.tests.http.fileupload;
 
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.test.http.HttpTestBase;
-import io.vertx.tests.http.Http2TestBase;
-
 public class Http2MultiplexClientFileUploadTest extends Http2ClientFileUploadTest {
 
-  @Override
-  protected HttpServerOptions createBaseServerOptions() {
-    return super.createBaseServerOptions().setHttp2MultiplexImplementation(true);
-  }
-
-  @Override
-  protected HttpClientOptions createBaseClientOptions() {
-    return super.createBaseClientOptions().setHttp2MultiplexImplementation(true);
+  public Http2MultiplexClientFileUploadTest() {
+    super(true);
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2MultiplexServerFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2MultiplexServerFileUploadTest.java
@@ -10,21 +10,11 @@
  */
 package io.vertx.tests.http.fileupload;
 
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.tests.http.Http2TestBase;
-
 /**
  */
 public class Http2MultiplexServerFileUploadTest extends Http2ServerFileUploadTest {
 
-  @Override
-  protected HttpServerOptions createBaseServerOptions() {
-    return super.createBaseServerOptions().setHttp2MultiplexImplementation(true);
-  }
-
-  @Override
-  protected HttpClientOptions createBaseClientOptions() {
-    return super.createBaseClientOptions().setHttp2MultiplexImplementation(true);
+  public Http2MultiplexServerFileUploadTest() {
+    super(true);
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2ServerFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2ServerFileUploadTest.java
@@ -10,22 +10,17 @@
  */
 package io.vertx.tests.http.fileupload;
 
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.tests.http.Http2TestBase;
+import io.vertx.test.http.HttpConfig;
 
 /**
  */
 public class Http2ServerFileUploadTest extends HttpServerFileUploadTest {
 
-  @Override
-  protected HttpServerOptions createBaseServerOptions() {
-    return Http2TestBase.createHttp2ServerOptions(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST);
+  public Http2ServerFileUploadTest() {
+    this(false);
   }
 
-  @Override
-  protected HttpClientOptions createBaseClientOptions() {
-    return Http2TestBase.createHttp2ClientOptions();
+  protected Http2ServerFileUploadTest(boolean multiplex) {
+    super(new HttpConfig.Http2(multiplex));
   }
-
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2WithUpgradeClientFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2WithUpgradeClientFileUploadTest.java
@@ -12,13 +12,18 @@ package io.vertx.tests.http.fileupload;
 
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.test.http.HttpConfig;
 
 public class Http2WithUpgradeClientFileUploadTest extends HttpClientFileUploadTest {
 
-  @Override
-  protected HttpClientOptions createBaseClientOptions() {
-    return new HttpClientOptions()
-      .setProtocolVersion(HttpVersion.HTTP_2)
-      .setHttp2ClearTextUpgrade(true);
+  public Http2WithUpgradeClientFileUploadTest() {
+    super(new HttpConfig.Http1x(DEFAULT_HTTPS_HOST, DEFAULT_HTTP_PORT) {
+      @Override
+      public HttpClientOptions createBaseClientOptions() {
+        return new HttpClientOptions()
+          .setProtocolVersion(HttpVersion.HTTP_2)
+          .setHttp2ClearTextUpgrade(true);
+      }
+    });
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2WithUpgradeServerFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/Http2WithUpgradeServerFileUploadTest.java
@@ -12,16 +12,20 @@ package io.vertx.tests.http.fileupload;
 
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.test.http.HttpConfig;
 
 /**
  */
 public class Http2WithUpgradeServerFileUploadTest extends HttpServerFileUploadTest {
 
-  @Override
-  protected HttpClientOptions createBaseClientOptions() {
-    return new HttpClientOptions()
-      .setProtocolVersion(HttpVersion.HTTP_2)
-      .setHttp2ClearTextUpgrade(true);
+  public Http2WithUpgradeServerFileUploadTest() {
+    super(new HttpConfig.Http1x(DEFAULT_HTTPS_HOST, DEFAULT_HTTP_PORT) {
+      @Override
+      public HttpClientOptions createBaseClientOptions() {
+        return new HttpClientOptions()
+          .setProtocolVersion(HttpVersion.HTTP_2)
+          .setHttp2ClearTextUpgrade(true);
+      }
+    });
   }
-
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/HttpClientFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/HttpClientFileUploadTest.java
@@ -18,7 +18,9 @@ import io.vertx.core.http.*;
 import io.vertx.core.impl.Utils;
 import io.vertx.test.core.Repeat;
 import io.vertx.test.core.TestUtils;
+import io.vertx.test.http.HttpConfig;
 import io.vertx.test.http.HttpTestBase;
+import io.vertx.test.http.SimpleHttpTest;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,10 +38,14 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-public abstract class HttpClientFileUploadTest extends HttpTestBase {
+public abstract class HttpClientFileUploadTest extends SimpleHttpTest {
 
   @Rule
   public TemporaryFolder testFolder = new TemporaryFolder();
+
+  protected HttpClientFileUploadTest(HttpConfig config) {
+    super(config);
+  }
 
   @Test
   public void testFormUrlEncoded() throws Exception {

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/HttpServerFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/HttpServerFileUploadTest.java
@@ -18,7 +18,9 @@ import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.test.core.TestUtils;
+import io.vertx.test.http.HttpConfig;
 import io.vertx.test.http.HttpTestBase;
+import io.vertx.test.http.SimpleHttpTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -36,12 +38,16 @@ import java.util.function.BooleanSupplier;
 
 /**
  */
-public abstract class HttpServerFileUploadTest extends HttpTestBase {
+public abstract class HttpServerFileUploadTest extends SimpleHttpTest {
 
   @Rule
   public TemporaryFolder testFolder = new TemporaryFolder();
 
   protected File testDir;
+
+  protected HttpServerFileUploadTest(HttpConfig config) {
+    super(config);
+  }
 
   @Override
   public void setUp() throws Exception {
@@ -558,7 +564,7 @@ public abstract class HttpServerFileUploadTest extends HttpTestBase {
   @Test
   public void testAttributeSizeOverflow() {
     server.close();
-    server = vertx.createHttpServer(createBaseServerOptions().setMaxFormAttributeSize(9));
+    server = config.forServer().setMaxFormAttributeSize(9).create(vertx);
     server.requestHandler(req -> {
       if (req.method() == HttpMethod.POST) {
         assertEquals(req.path(), "/form");
@@ -650,7 +656,7 @@ public abstract class HttpServerFileUploadTest extends HttpTestBase {
   private void testMaxFormFieldOverride(boolean pass) throws Exception {
     int newMax = 512;
     server.close();
-    server = vertx.createHttpServer(createBaseServerOptions().setMaxFormFields(newMax));
+    server = config.forServer().setMaxFormFields(newMax).create(vertx);
     testMaxFormFields(pass ? newMax : (newMax + 2), pass);
   }
 
@@ -716,7 +722,7 @@ public abstract class HttpServerFileUploadTest extends HttpTestBase {
   private void testFormMaxBufferedBytesOverride(boolean pass) throws Exception {
     int newMax = 2048;
     server.close();
-    server = vertx.createHttpServer(createBaseServerOptions().setMaxFormBufferedBytes(newMax));
+    server = config.forServer().setMaxFormBufferedBytes(newMax).create(vertx);
     testFormMaxBufferedBytes(pass ? newMax : (newMax + 1), pass);
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/Http1xMetricsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/Http1xMetricsTest.java
@@ -11,7 +11,9 @@
 package io.vertx.tests.metrics;
 
 import io.vertx.core.ThreadingModel;
+import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.test.http.HttpConfig;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -23,7 +25,7 @@ public class Http1xMetricsTest extends HttpMetricsTestBase {
   }
 
   protected Http1xMetricsTest(ThreadingModel threadingModel) {
-    super(HttpVersion.HTTP_1_1, threadingModel);
+    super(HttpConfig.Http1x.DEFAULT, HttpVersion.HTTP_1_1, threadingModel);
   }
 
   @Test
@@ -33,7 +35,7 @@ public class Http1xMetricsTest extends HttpMetricsTestBase {
     });
     startServer(testAddress);
     CountDownLatch latch = new CountDownLatch(1);
-    client = vertx.createHttpClient(createBaseClientOptions().setIdleTimeout(2));
+    client = vertx.createHttpClient(new HttpClientOptions().setIdleTimeout(2));
     client.request(requestOptions).onComplete(onSuccess(req -> {
       req.exceptionHandler(err -> {
         latch.countDown();

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicServerTest.java
@@ -24,6 +24,7 @@ import io.vertx.core.internal.quic.QuicConnectionInternal;
 import io.vertx.core.internal.quic.QuicStreamInternal;
 import io.vertx.core.net.*;
 import io.vertx.test.core.LinuxOrOsx;
+import io.vertx.test.core.Repeat;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.tls.Cert;
 import org.junit.Test;
@@ -430,8 +431,12 @@ public class QuicServerTest extends VertxTestBase {
       assertWaitUntil(() -> received.get() > 0);
       stream.abort(10);
       try {
-        streamRef.get().write("test").await();
-        fail();
+        QuicStream ref = streamRef.get();
+        long now = System.currentTimeMillis();
+        while (true) {
+          ref.write("test").await();
+          assert(System.currentTimeMillis() - now < 10_000);
+        }
       } catch (Exception e) {
         assertEquals(ChannelOutputShutdownException.class, e.getClass());
         assertEquals("STOP_SENDING frame received", e.getMessage());

--- a/vertx-core/src/test/java/io/vertx/tests/tracing/Http1xTracerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tracing/Http1xTracerTest.java
@@ -10,5 +10,11 @@
  */
 package io.vertx.tests.tracing;
 
+import io.vertx.test.http.HttpConfig;
+
 public class Http1xTracerTest extends HttpTracerTestBase {
+
+  public Http1xTracerTest() {
+    super(HttpConfig.Http1x.DEFAULT);
+  }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/tracing/Http1xTracingTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tracing/Http1xTracingTest.java
@@ -10,5 +10,11 @@
  */
 package io.vertx.tests.tracing;
 
+import io.vertx.test.http.HttpConfig;
+
 public class Http1xTracingTest extends HttpTracingTestBase {
+
+  public Http1xTracingTest() {
+    super(HttpConfig.Http1x.DEFAULT);
+  }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/tracing/Http2MultiplexTracerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tracing/Http2MultiplexTracerTest.java
@@ -10,25 +10,9 @@
  */
 package io.vertx.tests.tracing;
 
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.http.HttpVersion;
-import io.vertx.core.tracing.TracingPolicy;
-import io.vertx.test.faketracer.FakeTracer;
-import io.vertx.tests.http.Http2TestBase;
-import org.junit.Assert;
-import org.junit.Test;
-
 public class Http2MultiplexTracerTest extends Http2TracerTest {
 
-  @Override
-  protected HttpServerOptions createBaseServerOptions() {
-    return super.createBaseServerOptions().setHttp2MultiplexImplementation(true);
+  public Http2MultiplexTracerTest() {
+    super(true);
   }
-
-  @Override
-  protected HttpClientOptions createBaseClientOptions() {
-    return super.createBaseClientOptions().setHttp2MultiplexImplementation(true);
-  }
-
 }

--- a/vertx-core/src/test/java/io/vertx/tests/tracing/Http2MultiplexTracingTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tracing/Http2MultiplexTracingTest.java
@@ -10,19 +10,9 @@
  */
 package io.vertx.tests.tracing;
 
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.tests.http.Http2TestBase;
-
 public class Http2MultiplexTracingTest extends Http2TracingTest {
 
-  @Override
-  protected HttpServerOptions createBaseServerOptions() {
-    return super.createBaseServerOptions().setHttp2MultiplexImplementation(true);
-  }
-
-  @Override
-  protected HttpClientOptions createBaseClientOptions() {
-    return Http2TestBase.createHttp2ClientOptions().setHttp2MultiplexImplementation(true);
+  public Http2MultiplexTracingTest() {
+    super(true);
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/tracing/Http2TracerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tracing/Http2TracerTest.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.tests.tracing;
 
+import io.vertx.test.http.HttpConfig;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,14 +27,12 @@ public class Http2TracerTest extends HttpTracerTestBase {
   private static final String SPAN_KIND_CLIENT = "client";
   private static final String SPAN_KIND_KEY = "span_kind";
 
-  @Override
-  protected HttpServerOptions createBaseServerOptions() {
-    return Http2TestBase.createHttp2ServerOptions(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST);
+  public Http2TracerTest() {
+    this(false);
   }
 
-  @Override
-  protected HttpClientOptions createBaseClientOptions() {
-    return Http2TestBase.createHttp2ClientOptions();
+  protected Http2TracerTest(boolean multiplex) {
+    super(new HttpConfig.Http2(multiplex));
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/tracing/Http2TracingTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tracing/Http2TracingTest.java
@@ -10,19 +10,15 @@
  */
 package io.vertx.tests.tracing;
 
-import io.vertx.tests.http.Http2TestBase;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpServerOptions;
+import io.vertx.test.http.HttpConfig;
 
 public class Http2TracingTest extends HttpTracingTestBase {
 
-  @Override
-  protected HttpServerOptions createBaseServerOptions() {
-    return Http2TestBase.createHttp2ServerOptions(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST);
+  public Http2TracingTest() {
+    this(false);
   }
 
-  @Override
-  protected HttpClientOptions createBaseClientOptions() {
-    return Http2TestBase.createHttp2ClientOptions();
+  protected Http2TracingTest(boolean multiplex) {
+    super(new HttpConfig.Http2(multiplex));
   }
 }


### PR DESCRIPTION
With the advent of HTTP/3 we need HTTP tests configuration to be more flexible.

Among everything, HTTP/3 configuration requires specific options that are different from the existing ones (`HttpServerOptions` and `HttpClientOptions`).