### PR TITLE
Simplify HttpServerConfig compression to only require HttpCompressionOptions and configure the supported flag with the presence or absence of the compression config.

### DIFF
--- a/vertx-core/src/test/java/io/vertx/test/http/HttpConfig.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/HttpConfig.java
@@ -82,13 +82,14 @@ public interface HttpConfig {
           return this;
         }
         @Override
-        public HttpServerConfig setCompressionSupported(boolean supported) {
-          options.setCompressionSupported(supported);
-          return this;
-        }
-        @Override
         public HttpServerConfig setCompression(HttpCompressionOptions compression) {
-          options.setCompression(compression);
+          if (compression != null) {
+            options.setCompressionSupported(true);
+            options.setCompression(compression);
+          } else {
+            options.setCompressionSupported(false);
+            options.setCompression(null);
+          }
           return this;
         }
         @Override

--- a/vertx-core/src/test/java/io/vertx/test/http/HttpServerConfig.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/HttpServerConfig.java
@@ -9,7 +9,6 @@ import java.time.Duration;
 public interface HttpServerConfig {
 
   HttpServerConfig setDecompressionSupported(boolean supported);
-  HttpServerConfig setCompressionSupported(boolean supported);
   HttpServerConfig setCompression(HttpCompressionOptions compression);
   HttpServerConfig setMaxFormBufferedBytes(int maxFormBufferedBytes);
   HttpServerConfig setMaxFormAttributeSize(int maxSize);

--- a/vertx-core/src/test/java/io/vertx/tests/http/compression/Http1xCompressionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/compression/Http1xCompressionTest.java
@@ -49,7 +49,6 @@ public class Http1xCompressionTest extends HttpCompressionTest {
   public void testServerCompressionAboveThreshold() throws Exception {
     // set compression threshold to be less than the content string size so it WILL be compressed
     HttpServerConfig httpServerOptions = config.forServer();
-    httpServerOptions.setCompressionSupported(true);
     httpServerOptions.setCompression(serverCompressionConfig().get().setContentSizeThreshold(COMPRESS_TEST_STRING.length() / 2));
 
     doTest(httpServerOptions, onSuccess(resp -> {

--- a/vertx-core/src/test/java/io/vertx/tests/http/compression/Http1xCompressionThresholdTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/compression/Http1xCompressionThresholdTest.java
@@ -54,7 +54,6 @@ public class Http1xCompressionThresholdTest extends HttpCompressionTestBase {
   public void testServerCompressionBelowThreshold() throws Exception {
     // set compression threshold to be greater than the content string size so it WILL NOT be compressed
     HttpServerConfig httpServerOptions = config.forServer();
-    httpServerOptions.setCompressionSupported(true);
     httpServerOptions.setCompression(new HttpCompressionOptions()
       .addCompressor(CompressionConfig.gzip(6).compressor)
       .setContentSizeThreshold(COMPRESS_TEST_STRING.length() * 2)
@@ -77,7 +76,6 @@ public class Http1xCompressionThresholdTest extends HttpCompressionTestBase {
   public void testServerCompressionAboveThreshold() throws Exception {
     // set compression threshold to be less than the content string size so it WILL be compressed
     HttpServerConfig config = this.config.forServer();
-    config.setCompressionSupported(true);
     config.setCompression(new HttpCompressionOptions()
       .addCompressor(CompressionConfig.gzip(6).compressor)
       .setContentSizeThreshold(COMPRESS_TEST_STRING.length() / 2)

--- a/vertx-core/src/test/java/io/vertx/tests/http/compression/HttpCompressionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/compression/HttpCompressionTest.java
@@ -79,7 +79,7 @@ public abstract class HttpCompressionTest extends HttpCompressionTestBase {
   @Test
   public void testSkipEncoding() throws Exception {
     server.close();
-    server = config.forServer().setCompressionSupported(true).create(vertx);
+    server = config.forServer().setCompression(new HttpCompressionOptions().addCompressor(CompressionConfig.gzip(6).compressor)).create(vertx);
     server.requestHandler(req -> {
       assertNotNull(req.headers().get(HttpHeaders.ACCEPT_ENCODING));
       req.response()
@@ -119,7 +119,6 @@ public abstract class HttpCompressionTest extends HttpCompressionTestBase {
     waitFor(2);
     server.close();
     HttpServerConfig options = config.forServer();
-    options.setCompressionSupported(true);
     options.setCompression(serverCompressionConfig().get());
     server = options.create(vertx);
     server.requestHandler(req -> {


### PR DESCRIPTION
Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
