### PR TITLE
NetSocket.exceptionHandler reports UnsupportedOperationException on close

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/impl/SocketBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/SocketBase.java
@@ -264,6 +264,7 @@ public abstract class SocketBase<S extends SocketBase<S>> extends VertxConnectio
     }
     if (handler != null) {
       context.emit(timeout, handler);
+      completeWhenChannelIsClosed(promise);
     } else {
       super.handleShutdown(timeout, promise);
     }


### PR DESCRIPTION
Follows-up on https://github.com/eclipse-vertx/vert.x/pull/5783

If the user closes the connection and then the client is closed, UnsupportedOperationException is reported to the socket exception handler.

Instead of throwing UOE, the redundant shutdown event coming is ignored.

Also, make sure to complete channel promises when the channel is closed.
Otherwise, the connection close future won't be completed. 