### PR TITLE
Stream cancellation API

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -469,8 +469,9 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    * Reset this request:
    * <p/>
    * <ul>
-   *   <li>for HTTP/2, this performs send an HTTP/2 reset frame with the specified error {@code code}</li>
    *   <li>for HTTP/1.x, this closes the connection when the current request is inflight</li>
+   *   <li>for HTTP/2, this performs send an HTTP/2 reset frame with the specified error {@code code}</li>
+   *   <li>for HTTP/3, this is only effective if the stream has not been fully sent</li>
    * </ul>
    * <p/>
    * When the request has not yet been sent, the request will be aborted and false is returned as indicator.
@@ -480,6 +481,17 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    * @return {@code true} when reset has been performed
    */
   Future<Void> reset(long code);
+
+  /**
+   * Attempt to cancel the request according to the semantics of the underlying HTTP implementation.
+   * <ul>
+   *   <li>for HTTP/1.x, this closes the connection when the current request is inflight</li>
+   *   <li>for HTTP/2, this performs send an HTTP/2 reset frame with the error {@code 0x08}</li>
+   *   <li>for HTTP/3, this resets or abort reading the underlying QUIC stream with code {@code 0x10c}</li>
+   * </ul>
+   * @return a future notifying the cancellation outcome
+   */
+  Future<Boolean> cancel();
 
   /**
    * Reset this request:

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -614,6 +614,17 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   Future<Void> reset(long code);
 
   /**
+   * Attempt to cancel the request according to the semantics of the underlying HTTP implementation.
+   * <ul>
+   *   <li>for HTTP/1.x, this closes the connection when the current request is inflight</li>
+   *   <li>for HTTP/2, this performs send an HTTP/2 reset frame with the error {@code 0x08}</li>
+   *   <li>for HTTP/3, this resets or abort reading the underlying QUIC stream with code {@code 0x10c}</li>
+   * </ul>
+   * @return a future notifying the cancellation outcome
+   */
+  Future<Boolean> cancel();
+
+  /**
    * Write an HTTP/2 frame to the response, allowing to extend the HTTP/2 protocol.<p>
    *
    * The frame is sent immediatly and is not subject to flow control.

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -253,6 +253,16 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
     return stream.writeReset(code);
   }
 
+  public Future<Boolean> cancel() {
+    synchronized (this) {
+      if (reset != null) {
+        return context.failedFuture("Already reset");
+      }
+      reset = new StreamResetException(0x08);
+    }
+    return stream.cancel();
+  }
+
   @Override
   public Future<HttpClientResponse> response() {
     return responsePromise.future();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -713,6 +713,11 @@ public class HttpServerResponseImpl implements HttpServerResponse {
   }
 
   @Override
+  public Future<Boolean> cancel() {
+    return stream.cancel();
+  }
+
+  @Override
   public Future<HttpServerResponse> push(HttpMethod method, HostAndPort authority, String path, MultiMap headers) {
     if (push) {
       throw new IllegalStateException("A push response cannot promise another push");

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpStream.java
@@ -45,6 +45,8 @@ public interface HttpStream {
   Future<Void> writeFrame(int type, int flags, Buffer payload);
   Future<Void> writeReset(long code);
 
+  Future<Boolean> cancel();
+
   HttpStream resetHandler(Handler<Long> handler);
   HttpStream exceptionHandler(Handler<Throwable> handler);
   HttpStream customFrameHandler(Handler<HttpFrame> handler);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
@@ -170,6 +170,11 @@ class StatisticsGatheringHttpClientStream implements HttpClientStream {
   }
 
   @Override
+  public Future<Boolean> cancel() {
+    return delegate.cancel();
+  }
+
+  @Override
   public Future<Void> writeReset(long code) {
     return delegate.writeReset(code);
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1x/Http1xClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1x/Http1xClientConnection.java
@@ -645,6 +645,11 @@ public class Http1xClientConnection extends Http1xConnection implements io.vertx
     }
 
     @Override
+    public Future<Boolean> cancel() {
+      return writeReset(0x8).map(true);
+    }
+
+    @Override
     public Future<Void> writeReset(long code) {
       Promise<Void> promise = context.promise();
       EventLoop eventLoop = conn.context.nettyEventLoop();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1x/Http1xServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1x/Http1xServerResponse.java
@@ -788,6 +788,11 @@ public class Http1xServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   @Override
+  public Future<Boolean> cancel() {
+    return reset().map(true);
+  }
+
+  @Override
   public Future<HttpServerResponse> push(HttpMethod method, HostAndPort authority, String path, MultiMap headers) {
     return context.failedFuture("HTTP/1 does not support response push");
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1x/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1x/Http2UpgradeClientConnection.java
@@ -237,6 +237,11 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
     }
 
     @Override
+    public Future<Boolean> cancel() {
+      return delegate.cancel();
+    }
+
+    @Override
     public StreamPriority priority() {
       return delegate.priority();
     }
@@ -670,6 +675,15 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
         return upgradedStream.writeReset(code);
       } else {
         return upgradingStream.writeReset(code);
+      }
+    }
+
+    @Override
+    public Future<Boolean> cancel() {
+      if (upgradedStream != null) {
+        return upgradedStream.cancel();
+      } else {
+        return upgradingStream.cancel();
       }
     }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2Stream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2Stream.java
@@ -418,6 +418,11 @@ abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements Ht
     connection.writeData(id, chunk, end, promise);
   }
 
+  @Override
+  public Future<Boolean> cancel() {
+    return writeReset(0x08L).map(true);
+  }
+
   public final Future<Void> writeReset(long code) {
     if (code < 0L) {
       throw new IllegalArgumentException("Invalid reset code value");

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
@@ -516,6 +516,6 @@ abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameL
 
   @Override
   public void writeReset(int streamId, long code, Promise<Void> promise) {
-    handler.writeReset(streamId, code, null);
+    handler.writeReset(streamId, code, (FutureListener<Void>) promise);
   }
 }


### PR DESCRIPTION
Motivation:

HTTP/2 provides bidirectional reset capabilities, HTTP/3 has a different semantic since reset is only outbound and inbound means abort reading a stream.

In addition of providing the reset API, we should have a stream cancellation API that can be implemented more universally for HTTP/2 and HTTP/3
