### PR TITLE
Add support for hybrid key exchange protocol x25519mlkem768.

### DIFF
--- a/.github/workflows/ci-4.x.yml
+++ b/.github/workflows/ci-4.x.yml
@@ -20,6 +20,7 @@ jobs:
         jdk: [8]
         include:
           - os: ubuntu-latest
+            container: 'ubuntu:26.04'
             jdk: 25
           - os: ubuntu-latest
             jdk: 8
@@ -28,7 +29,11 @@ jobs:
             jdk: 8
             profile: '-PtestDomainSockets'
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container || null }}
     steps:
+      - name: Install container dependencies
+        if: ${{ matrix.container != '' }}
+        run: apt-get update && apt-get install -y git maven openssl libssl-dev libapr1t64
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install JDK

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <vertx.testNativeTransport>false</vertx.testNativeTransport>
     <vertx.testDomainSockets>false</vertx.testDomainSockets>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
+    <smallrye.openssl.version>0.1.4</smallrye.openssl.version>
   </properties>
 
   <dependencyManagement>
@@ -206,8 +207,7 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <scope>test</scope>
+      <artifactId>netty-tcnative-classes</artifactId>
     </dependency>
     <dependency>
       <groupId>com.aayushatharva.brotli4j</groupId>
@@ -482,7 +482,8 @@
                 <vertx-test-alpn-openssl>false</vertx-test-alpn-openssl>
               </systemProperties>
               <classpathDependencyExcludes>
-                <classpathDependencyExclude>io.netty:netty-tcnative-boringssl-static</classpathDependencyExclude>
+                  <classpathDependencyExclude>io.smallrye:smallrye-openssl</classpathDependencyExclude>
+                  <classpathDependencyExclude>io.netty:netty-tcnative-boringssl-static</classpathDependencyExclude>
               </classpathDependencyExcludes>
             </configuration>
           </execution>
@@ -499,6 +500,18 @@
               <systemProperties>
                 <vertx-test-alpn-openssl>true</vertx-test-alpn-openssl>
               </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>hybrid-key-exchange</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>io/vertx/it/HybridKeyExchangeTest.java</include>
+              </includes>
             </configuration>
           </execution>
           <execution>
@@ -985,6 +998,13 @@
           <classifier>linux-x86_64</classifier>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>io.smallrye</groupId>
+          <artifactId>smallrye-openssl</artifactId>
+          <classifier>linux-x86_64</classifier>
+          <version>${smallrye.openssl.version}</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
     </profile>
 
@@ -1006,6 +1026,12 @@
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-kqueue</artifactId>
+          <classifier>osx-x86_64</classifier>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
           <classifier>osx-x86_64</classifier>
           <scope>test</scope>
         </dependency>
@@ -1033,9 +1059,13 @@
           <classifier>osx-aarch_64</classifier>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+          <classifier>osx-aarch_64</classifier>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
     </profile>
-
   </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1067,5 +1067,21 @@
         </dependency>
       </dependencies>
     </profile>
+
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -41,6 +41,16 @@ To handle `h2` requests, TLS must be enabled along with {@link io.vertx.core.htt
 {@link examples.HTTP2Examples#example0}
 ----
 
+The rise of quantum computers will make key exchange protocols such as x25519 obsolete as they will be able to "crack" secret keys quickly.
+Vert.x proposes a quantum-safe key exchange protocol, x25519MLKEM768 (official recommendation of NIST) to ensure sessions over TLS are safe against quantum computers.
+
+Hybrid key exchange must be enabled with {@link io.vertx.core.net.SSLOptions#setUseHybridKeyExchangeProtocol(boolean)} and **requires OpenSSL** — it does not work with the JDK SSL engine. You must configure {@link io.vertx.core.net.OpenSSLEngineOptions} and add the following dependencies:
+
+- `io.netty:netty-tcnative-classes` (version managed by the Netty BOM)
+- An OpenSSL provider such as `io.smallrye:smallrye-openssl`
+
+If OpenSSL is not available at runtime, the TLS handshake will fail rather than silently falling back to a non-quantum-safe key exchange.
+
 ALPN is a TLS extension that negotiates the protocol before the client and the server start to exchange data.
 
 Clients that don't support ALPN will still be able to do a _classic_ SSL handshake.

--- a/src/main/generated/io/vertx/core/eventbus/EventBusOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/eventbus/EventBusOptionsConverter.java
@@ -279,6 +279,11 @@ public class EventBusOptionsConverter {
             obj.setUseAlpn((Boolean)member.getValue());
           }
           break;
+        case "useHybridKeyExchangeProtocol":
+          if (member.getValue() instanceof Boolean) {
+            obj.setUseHybridKeyExchangeProtocol((Boolean)member.getValue());
+          }
+          break;
         case "writeIdleTimeout":
           if (member.getValue() instanceof Number) {
             obj.setWriteIdleTimeout(((Number)member.getValue()).intValue());
@@ -388,6 +393,7 @@ public class EventBusOptionsConverter {
       json.put("trustStoreOptions", obj.getTrustStoreOptions().toJson());
     }
     json.put("useAlpn", obj.isUseAlpn());
+    json.put("useHybridKeyExchangeProtocol", obj.isUseHybridKeyExchangeProtocol());
     json.put("writeIdleTimeout", obj.getWriteIdleTimeout());
   }
 }

--- a/src/main/generated/io/vertx/core/net/SSLOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/net/SSLOptionsConverter.java
@@ -69,6 +69,11 @@ public class SSLOptionsConverter {
             obj.setUseAlpn((Boolean)member.getValue());
           }
           break;
+        case "useHybridKeyExchangeProtocol":
+          if (member.getValue() instanceof Boolean) {
+            obj.setUseHybridKeyExchangeProtocol((Boolean)member.getValue());
+          }
+          break;
       }
     }
   }
@@ -103,5 +108,6 @@ public class SSLOptionsConverter {
       json.put("sslHandshakeTimeoutUnit", obj.getSslHandshakeTimeoutUnit().name());
     }
     json.put("useAlpn", obj.isUseAlpn());
+    json.put("useHybridKeyExchangeProtocol", obj.isUseHybridKeyExchangeProtocol());
   }
 }

--- a/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
@@ -179,6 +179,11 @@ public class TCPSSLOptionsConverter {
             obj.setUseAlpn((Boolean)member.getValue());
           }
           break;
+        case "useHybridKeyExchangeProtocol":
+          if (member.getValue() instanceof Boolean) {
+            obj.setUseHybridKeyExchangeProtocol((Boolean)member.getValue());
+          }
+          break;
         case "writeIdleTimeout":
           if (member.getValue() instanceof Number) {
             obj.setWriteIdleTimeout(((Number)member.getValue()).intValue());
@@ -258,6 +263,7 @@ public class TCPSSLOptionsConverter {
       json.put("trustStoreOptions", obj.getTrustStoreOptions().toJson());
     }
     json.put("useAlpn", obj.isUseAlpn());
+    json.put("useHybridKeyExchangeProtocol", obj.isUseHybridKeyExchangeProtocol());
     json.put("writeIdleTimeout", obj.getWriteIdleTimeout());
   }
 }

--- a/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
@@ -476,6 +476,11 @@ public class EventBusOptions extends TCPSSLOptions {
   }
 
   @Override
+  public EventBusOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
+    return (EventBusOptions) super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
+  }
+
+  @Override
   public EventBusOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     return (EventBusOptions) super.setSslEngineOptions(sslEngineOptions);
   }

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -1155,6 +1155,11 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public HttpClientOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
+    return (HttpClientOptions) super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
+  }
+
+  @Override
   public HttpClientOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     return (HttpClientOptions) super.setSslEngineOptions(sslEngineOptions);
   }

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -430,6 +430,13 @@ public class HttpServerOptions extends NetServerOptions {
   }
 
   @Override
+  public HttpServerOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
+    super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
+    return this;
+  }
+
+
+  @Override
   public HttpServerOptions setKeyCertOptions(KeyCertOptions options) {
     super.setKeyCertOptions(options);
     return this;

--- a/src/main/java/io/vertx/core/http/WebSocketClientOptions.java
+++ b/src/main/java/io/vertx/core/http/WebSocketClientOptions.java
@@ -553,6 +553,11 @@ public class WebSocketClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public WebSocketClientOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
+    return (WebSocketClientOptions)super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
+  }
+
+  @Override
   public WebSocketClientOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     return (WebSocketClientOptions)super.setSslEngineOptions(sslEngineOptions);
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
@@ -57,6 +57,7 @@ public class HttpChannelConnector {
   private final ClientMetrics metrics;
   private final boolean ssl;
   private final boolean useAlpn;
+  private final boolean useHybridKeyExchangeProtocol;
   private final HttpVersion version;
   private final SocketAddress peerAddress;
   private final SocketAddress server;
@@ -68,6 +69,7 @@ public class HttpChannelConnector {
                               HttpVersion version,
                               boolean ssl,
                               boolean useAlpn,
+                              boolean useHybridKeyExchangeProtocol,
                               SocketAddress peerAddress,
                               SocketAddress server) {
     this.client = client;
@@ -77,6 +79,7 @@ public class HttpChannelConnector {
     this.proxyOptions = proxyOptions;
     this.ssl = ssl;
     this.useAlpn = useAlpn;
+    this.useHybridKeyExchangeProtocol = useHybridKeyExchangeProtocol;
     this.version = version;
     this.peerAddress = peerAddress;
     this.server = server;
@@ -87,7 +90,7 @@ public class HttpChannelConnector {
   }
 
   private void connect(ContextInternal context, Promise<NetSocket> promise) {
-    netClient.connectInternal(proxyOptions, server, peerAddress, this.options.isForceSni() ? peerAddress.host() : null, ssl, useAlpn, false, promise, context, 0);
+    netClient.connectInternal(proxyOptions, server, peerAddress, this.options.isForceSni() ? peerAddress.host() : null, ssl, useAlpn, useHybridKeyExchangeProtocol, false, promise, context, 0);
   }
 
   public Future<HttpClientConnection> wrap(ContextInternal context, NetSocket so_) {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -190,7 +190,7 @@ public class HttpClientBase implements MetricsProvider, Closeable {
       public Endpoint<HttpClientConnection> create(ContextInternal ctx, Runnable dispose) {
         int maxPoolSize = options.getMaxWebSockets();
         ClientMetrics metrics = HttpClientBase.this.metrics != null ? HttpClientBase.this.metrics.createEndpointMetrics(key.serverAddr, maxPoolSize) : null;
-        HttpChannelConnector connector = new HttpChannelConnector(HttpClientBase.this, netClient, proxyOptions, metrics, HttpVersion.HTTP_1_1, key.ssl, false, key.peerAddr, key.serverAddr);
+        HttpChannelConnector connector = new HttpChannelConnector(HttpClientBase.this, netClient, proxyOptions, metrics, HttpVersion.HTTP_1_1, key.ssl, false, false, key.peerAddr, key.serverAddr);
         return new WebSocketEndpoint(null, maxPoolSize, connector, dispose);
       }
     };

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -172,7 +172,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   public Future<HttpClientConnection> connect(SocketAddress server, SocketAddress peer) {
     ContextInternal context = vertx.getOrCreateContext();
     Promise<HttpClientConnection> promise = context.promise();
-    HttpChannelConnector connector = new HttpChannelConnector(this, netClient, null, null, options.getProtocolVersion(), options.isSsl(), options.isUseAlpn(), peer, server);
+    HttpChannelConnector connector = new HttpChannelConnector(this, netClient, null, null, options.getProtocolVersion(), options.isSsl(), options.isUseAlpn(), options.isUseHybridKeyExchangeProtocol(), peer, server);
     connector.httpConnect(context, promise);
     return promise.future();
   }
@@ -353,7 +353,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
       public Endpoint<Lease<HttpClientConnection>> create(ContextInternal ctx, Runnable dispose) {
         int maxPoolSize = Math.max(poolOptions.getHttp1MaxSize(), poolOptions.getHttp2MaxSize());
         ClientMetrics metrics = HttpClientImpl.this.metrics != null ? HttpClientImpl.this.metrics.createEndpointMetrics(key.serverAddr, maxPoolSize) : null;
-        HttpChannelConnector connector = new HttpChannelConnector(HttpClientImpl.this, netClient, proxyOptions, metrics, options.getProtocolVersion(), key.ssl, options.isUseAlpn(), key.peerAddr, key.serverAddr);
+        HttpChannelConnector connector = new HttpChannelConnector(HttpClientImpl.this, netClient, proxyOptions, metrics, options.getProtocolVersion(), key.ssl, options.isUseAlpn(), options.isUseHybridKeyExchangeProtocol(), key.peerAddr, key.serverAddr);
         return new SharedClientHttpStreamEndpoint(
           HttpClientImpl.this,
           metrics,

--- a/src/main/java/io/vertx/core/net/ClientOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/ClientOptionsBase.java
@@ -341,6 +341,11 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
   }
 
   @Override
+  public ClientOptionsBase setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
+    return (ClientOptionsBase) super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
+  }
+
+  @Override
   public ClientOptionsBase setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     return (ClientOptionsBase) super.setSslEngineOptions(sslEngineOptions);
   }

--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -264,6 +264,11 @@ public class NetClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public NetClientOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
+    return (NetClientOptions) super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
+  }
+
+  @Override
   public NetClientOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     return (NetClientOptions) super.setSslEngineOptions(sslEngineOptions);
   }

--- a/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -227,6 +227,12 @@ public class NetServerOptions extends TCPSSLOptions {
   }
 
   @Override
+  public NetServerOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
+    super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
+    return this;
+  }
+
+  @Override
   public NetServerOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     super.setSslEngineOptions(sslEngineOptions);
     return this;

--- a/src/main/java/io/vertx/core/net/SSLOptions.java
+++ b/src/main/java/io/vertx/core/net/SSLOptions.java
@@ -40,6 +40,11 @@ public class SSLOptions {
   public static final boolean DEFAULT_USE_ALPN = false;
 
   /**
+   * Default use hybrid = false
+   */
+  public static final boolean DEFAULT_USE_HYBRID = false;
+
+  /**
    * The default value of SSL handshake timeout = 10
    */
   public static final long DEFAULT_SSL_HANDSHAKE_TIMEOUT = 10L;
@@ -66,6 +71,7 @@ public class SSLOptions {
   private ArrayList<String> crlPaths;
   private ArrayList<Buffer> crlValues;
   private boolean useAlpn;
+  private boolean useHybridKeyExchangeProtocol;
   private Set<String> enabledSecureTransportProtocols;
 
   /**
@@ -99,6 +105,7 @@ public class SSLOptions {
     this.crlPaths = new ArrayList<>(other.getCrlPaths());
     this.crlValues = new ArrayList<>(other.getCrlValues());
     this.useAlpn = other.useAlpn;
+    this.useHybridKeyExchangeProtocol = other.useHybridKeyExchangeProtocol;
     this.enabledSecureTransportProtocols = other.getEnabledSecureTransportProtocols() == null ? new LinkedHashSet<>() : new LinkedHashSet<>(other.getEnabledSecureTransportProtocols());
   }
 
@@ -110,6 +117,7 @@ public class SSLOptions {
     crlPaths = new ArrayList<>();
     crlValues = new ArrayList<>();
     useAlpn = DEFAULT_USE_ALPN;
+    useHybridKeyExchangeProtocol = DEFAULT_USE_HYBRID;
     enabledSecureTransportProtocols = new LinkedHashSet<>(DEFAULT_ENABLED_SECURE_TRANSPORT_PROTOCOLS);
   }
 
@@ -247,6 +255,36 @@ public class SSLOptions {
   }
 
   /**
+   * @return whether the hybrid key exchange protocol X25519MLKEM768 is enabled
+   */
+  public boolean isUseHybridKeyExchangeProtocol() {
+    return useHybridKeyExchangeProtocol;
+  }
+
+  /**
+   * Enable or disable the hybrid post-quantum key exchange protocol X25519MLKEM768.
+   * <p>
+   * When enabled, TLS connections will use X25519MLKEM768 for key exchange, providing
+   * protection against quantum computer attacks.
+   * <p>
+   * This feature requires OpenSSL and will not work with the JDK SSL engine. You must:
+   * <ul>
+   *   <li>Use {@link OpenSSLEngineOptions} as the SSL engine</li>
+   *   <li>Have {@code io.netty:netty-tcnative-classes} on the classpath</li>
+   *   <li>Have an OpenSSL provider (e.g. {@code io.smallrye:smallrye-openssl}) on the classpath</li>
+   * </ul>
+   * If OpenSSL is not available, the TLS handshake will fail rather than silently falling back
+   * to a non-quantum-safe key exchange.
+   *
+   * @param useHybridKeyExchangeProtocol {@code true} to enable hybrid key exchange
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SSLOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
+    this.useHybridKeyExchangeProtocol = useHybridKeyExchangeProtocol;
+    return this;
+  }
+
+  /**
    * Returns the enabled SSL/TLS protocols
    * @return the enabled protocols
    */
@@ -340,6 +378,7 @@ public class SSLOptions {
          Objects.equals(crlPaths, that.crlPaths) &&
          Objects.equals(crlValues, that.crlValues) &&
          useAlpn == that.useAlpn &&
+         useHybridKeyExchangeProtocol == that.useHybridKeyExchangeProtocol &&
          Objects.equals(enabledSecureTransportProtocols, that.enabledSecureTransportProtocols);
     }
     return false;

--- a/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -723,6 +723,24 @@ public abstract class TCPSSLOptions extends NetworkOptions {
   }
 
   /**
+   * @return whether to use or not Hybrid key exchange protocol x25519MLKEM768
+   */
+  public boolean isUseHybridKeyExchangeProtocol() {
+    SSLOptions o = sslOptions;
+    return o != null && o.isUseHybridKeyExchangeProtocol();
+  }
+
+  /**
+   * Set the ALPN usage.
+   *
+   * @param useHybridKeyExchangeProtocol true when hybrid key exchange protocol should be used
+   */
+  public TCPSSLOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
+    sslOptions.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
+    return this;
+  }
+
+  /**
    * @return the SSL engine implementation to use
    */
   public SSLEngineOptions getSslEngineOptions() {

--- a/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
@@ -93,13 +93,13 @@ public final class ChannelProvider {
     return applicationProtocol;
   }
 
-  public Future<Channel> connect(SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn) {
+  public Future<Channel> connect(SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, boolean useHybridKeyExchangeProtocol) {
     Promise<Channel> p = context.nettyEventLoop().newPromise();
-    connect(handler, remoteAddress, peerAddress, serverName, ssl, useAlpn, p);
+    connect(handler, remoteAddress, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, p);
     return p;
   }
 
-  private void connect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, Promise<Channel> p) {
+  private void connect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, boolean useHybridKeyExchangeProtocol, Promise<Channel> p) {
     try {
       bootstrap.channelFactory(context.owner().transport().channelFactory(remoteAddress.isDomainSocket()));
     } catch (Exception e) {
@@ -107,15 +107,15 @@ public final class ChannelProvider {
       return;
     }
     if (proxyOptions != null) {
-      handleProxyConnect(handler, remoteAddress, peerAddress, serverName, ssl, useAlpn, p);
+      handleProxyConnect(handler, remoteAddress, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, p);
     } else {
-      handleConnect(handler, remoteAddress, peerAddress, serverName, ssl, useAlpn, p);
+      handleConnect(handler, remoteAddress, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, p);
     }
   }
 
-  private void initSSL(Handler<Channel> handler, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, Channel ch, Promise<Channel> channelHandler) {
+  private void initSSL(Handler<Channel> handler, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, boolean useHybridKeyExchangeProtocol, Channel ch, Promise<Channel> channelHandler) {
     if (ssl) {
-      SslHandler sslHandler = sslContextProvider.createClientSslHandler(peerAddress, serverName, useAlpn);
+      SslHandler sslHandler = sslContextProvider.createClientSslHandler(peerAddress, serverName, useAlpn, useHybridKeyExchangeProtocol);
       ChannelPipeline pipeline = ch.pipeline();
       pipeline.addLast("ssl", sslHandler);
       pipeline.addLast(new ChannelInboundHandlerAdapter() {
@@ -149,13 +149,13 @@ public final class ChannelProvider {
   }
 
 
-  private void handleConnect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, Promise<Channel> channelHandler) {
+  private void handleConnect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, boolean useHybridKeyExchangeProtocol, Promise<Channel> channelHandler) {
     VertxInternal vertx = context.owner();
     bootstrap.resolver(vertx.nettyAddressResolverGroup());
     bootstrap.handler(new ChannelInitializer<Channel>() {
       @Override
       protected void initChannel(Channel ch) {
-        initSSL(handler, peerAddress, serverName, ssl, useAlpn, ch, channelHandler);
+        initSSL(handler, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, ch, channelHandler);
       }
     });
     ChannelFuture fut = bootstrap.connect(vertx.transport().convert(remoteAddress));
@@ -187,7 +187,7 @@ public final class ChannelProvider {
   /**
    * A channel provider that connects via a Proxy : HTTP or SOCKS
    */
-  private void handleProxyConnect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, Promise<Channel> channelHandler) {
+  private void handleProxyConnect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, boolean useHybridKeyExchangeProtocol, Promise<Channel> channelHandler) {
 
     final VertxInternal vertx = context.owner();
     final String proxyHost = proxyOptions.getHost();
@@ -237,7 +237,7 @@ public final class ChannelProvider {
                 if (evt instanceof ProxyConnectionEvent) {
                   pipeline.remove(proxy);
                   pipeline.remove(this);
-                  initSSL(handler, peerAddress, serverName, ssl, useAlpn, ch, channelHandler);
+                  initSSL(handler, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, ch, channelHandler);
                   connected(handler, ch, ssl, channelHandler);
                 }
                 ctx.fireUserEventTriggered(evt);

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -225,7 +225,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
         proxyOptions = null;
       }
     }
-    connectInternal(proxyOptions, remoteAddress, peerAddress, serverName, options.isSsl(), options.isUseAlpn(), options.isRegisterWriteHandler(), connectHandler, ctx, options.getReconnectAttempts());
+    connectInternal(proxyOptions, remoteAddress, peerAddress, serverName, options.isSsl(), options.isUseAlpn(), options.isUseHybridKeyExchangeProtocol(),  options.isRegisterWriteHandler(), connectHandler, ctx, options.getReconnectAttempts());
   }
 
   /**
@@ -237,6 +237,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
    * @param serverName the SNI server name (along with SSL)
    * @param ssl whether to use SSL
    * @param useAlpn wether to use ALPN (along with SSL)
+   * @param useHybridKeyExchangeProtocol wether to use Hybrid Key Exchange Protocol (along with SSL)
    * @param registerWriteHandlers whether to register event-bus write handlers
    * @param connectHandler the promise to resolve with the connect result
    * @param context the socket context
@@ -248,6 +249,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
                                 String serverName,
                                 boolean ssl,
                                 boolean useAlpn,
+                                boolean useHybridKeyExchangeProtocol,
                                 boolean registerWriteHandlers,
                                 Promise<NetSocket> connectHandler,
                                 ContextInternal context,
@@ -270,7 +272,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
       }
       fut.onComplete(ar -> {
         if (ar.succeeded()) {
-          connectInternal2(proxyOptions, remoteAddress, peerAddress, ar.result().sslChannelProvider(), serverName, ssl, useAlpn, registerWriteHandlers, connectHandler, context, remainingAttempts);
+          connectInternal2(proxyOptions, remoteAddress, peerAddress, ar.result().sslChannelProvider(), serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, registerWriteHandlers, connectHandler, context, remainingAttempts);
         } else {
           connectHandler.fail(ar.cause());
         }
@@ -285,6 +287,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
                               String serverName,
                               boolean ssl,
                               boolean useAlpn,
+                              boolean useHybridKeyExchangeProtocol,
                               boolean registerWriteHandlers,
                               Promise<NetSocket> connectHandler,
                               ContextInternal context,
@@ -305,7 +308,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
 
       channelProvider.handler(ch -> connected(context, ch, connectHandler, remoteAddress, sslChannelProvider, channelProvider.applicationProtocol(), registerWriteHandlers));
 
-      io.netty.util.concurrent.Future<Channel> fut = channelProvider.connect(remoteAddress, peerAddress, serverName, ssl, useAlpn);
+      io.netty.util.concurrent.Future<Channel> fut = channelProvider.connect(remoteAddress, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol);
       fut.addListener((GenericFutureListener<io.netty.util.concurrent.Future<Channel>>) future -> {
         if (!future.isSuccess()) {
           Throwable cause = future.cause();
@@ -316,7 +319,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
               log.debug("Failed to create connection. Will retry in " + options.getReconnectInterval() + " milliseconds");
               //Set a timer to retry connection
               vertx.setTimer(options.getReconnectInterval(), tid ->
-                connectInternal(proxyOptions, remoteAddress, peerAddress, serverName, ssl, useAlpn, registerWriteHandlers, connectHandler, context, remainingAttempts == -1 ? remainingAttempts : remainingAttempts - 1)
+                connectInternal(proxyOptions, remoteAddress, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, registerWriteHandlers, connectHandler, context, remainingAttempts == -1 ? remainingAttempts : remainingAttempts - 1)
               );
             });
           } else {
@@ -325,7 +328,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
         }
       });
     } else {
-      eventLoop.execute(() -> connectInternal2(proxyOptions, remoteAddress, peerAddress, sslChannelProvider, serverName, ssl, useAlpn, registerWriteHandlers, connectHandler, context, remainingAttempts));
+      eventLoop.execute(() -> connectInternal2(proxyOptions, remoteAddress, peerAddress, sslChannelProvider, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, registerWriteHandlers, connectHandler, context, remainingAttempts));
     }
   }
 

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -336,7 +336,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
           channelPromise.addListener(promise);
           ChannelHandler sslHandler;
           if (remoteAddress != null) {
-            sslHandler = sslChannelProvider.createClientSslHandler(remoteAddress, serverName, false);
+            sslHandler = sslChannelProvider.createClientSslHandler(remoteAddress, serverName, false, false);
           } else {
             sslHandler = sslChannelProvider.createServerHandler(HttpUtils.socketAddressToHostAndPort(chctx.channel().remoteAddress()));
           }

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -128,6 +128,7 @@ public class SSLHelper {
   private final ClientAuth clientAuth;
   private final boolean client;
   private final boolean useAlpn;
+  private final boolean useHybridKeyExchangeProtocol;
   private final String endpointIdentificationAlgorithm;
   private final SSLEngineOptions sslEngineOptions;
   private final List<String> applicationProtocols;
@@ -142,6 +143,7 @@ public class SSLHelper {
     this.sslEngineOptions = options.getSslEngineOptions();
     this.ssl = options.isSsl();
     this.useAlpn = options.isUseAlpn();
+    this.useHybridKeyExchangeProtocol = options.isUseHybridKeyExchangeProtocol();
     this.client = options instanceof ClientOptionsBase;
     this.trustAll = options instanceof ClientOptionsBase && ((ClientOptionsBase)options).isTrustAll();
     this.clientAuth = options instanceof NetServerOptions ? ((NetServerOptions)options).getClientAuth() : ClientAuth.NONE;
@@ -263,6 +265,7 @@ public class SSLHelper {
       c.sslContextProvider(), c.sslOptions.getSslHandshakeTimeout(), c.sslOptions.getSslHandshakeTimeoutUnit(), sni,
       trustAll,
       useAlpn,
+      useHybridKeyExchangeProtocol,
       ctx.owner().getInternalWorkerPool().executor(),
       c.useWorkerPool
     ));

--- a/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
@@ -12,18 +12,23 @@ package io.vertx.core.net.impl;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandler;
+import io.netty.handler.ssl.ReferenceCountedOpenSslEngine;
 import io.netty.handler.ssl.SniHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.internal.tcnative.SSL;
 import io.netty.util.AsyncMapping;
 import io.netty.util.concurrent.ImmediateExecutor;
 import io.vertx.core.VertxException;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.impl.utils.LruCache;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -44,6 +49,7 @@ public class SslChannelProvider {
   private final boolean useWorkerPool;
   private final boolean sni;
   private final boolean useAlpn;
+  private final boolean useHybridKeyExchangeProtocol;
   private final boolean trustAll;
   private final SslContextProvider sslContextProvider;
   private final SslContext[] sslContexts = new SslContext[2];
@@ -51,17 +57,21 @@ public class SslChannelProvider {
     new LruCache<>(DEFAULT_SNI_CACHE_SIZE), new LruCache<>(DEFAULT_SNI_CACHE_SIZE)
   };
 
+  private static final Logger log = LoggerFactory.getLogger(SslChannelProvider.class);
+
   public SslChannelProvider(SslContextProvider sslContextProvider,
                             long sslHandshakeTimeout,
                             TimeUnit sslHandshakeTimeoutUnit,
                             boolean sni,
                             boolean trustAll,
                             boolean useAlpn,
+                            boolean useHybridKeyExchangeProtocol,
                             Executor workerPool,
                             boolean useWorkerPool) {
     this.workerPool = workerPool;
     this.useWorkerPool = useWorkerPool;
     this.useAlpn = useAlpn;
+    this.useHybridKeyExchangeProtocol = useHybridKeyExchangeProtocol;
     this.sni = sni;
     this.trustAll = trustAll;
     this.sslHandshakeTimeout = sslHandshakeTimeout;
@@ -143,7 +153,7 @@ public class SslChannelProvider {
     };
   }
 
-  public SslHandler createClientSslHandler(SocketAddress remoteAddress, String serverName, boolean useAlpn) {
+  public SslHandler createClientSslHandler(SocketAddress remoteAddress, String serverName, boolean useAlpn, boolean useHybridKeyExchangeProtocol) {
     SslContext sslContext = sslClientContext(serverName, useAlpn);
     SslHandler sslHandler;
     Executor delegatedTaskExec = useWorkerPool ? workerPool : ImmediateExecutor.INSTANCE;
@@ -152,19 +162,22 @@ public class SslChannelProvider {
     } else {
       sslHandler = sslContext.newHandler(ByteBufAllocator.DEFAULT, remoteAddress.host(), remoteAddress.port(), delegatedTaskExec);
     }
+    if (useHybridKeyExchangeProtocol) {
+      applyHybridCurves(sslHandler);
+    }
     sslHandler.setHandshakeTimeout(sslHandshakeTimeout, sslHandshakeTimeoutUnit);
     return sslHandler;
   }
 
   public ChannelHandler createServerHandler(HostAndPort remoteAddress) {
     if (sni) {
-      return createSniHandler(remoteAddress);
+      return createSniHandler(remoteAddress, useHybridKeyExchangeProtocol);
     } else {
-      return createServerSslHandler(useAlpn, remoteAddress);
+      return createServerSslHandler(useAlpn, remoteAddress, useHybridKeyExchangeProtocol);
     }
   }
 
-  private SslHandler createServerSslHandler(boolean useAlpn, HostAndPort remoteAddress) {
+  private SslHandler createServerSslHandler(boolean useAlpn, HostAndPort remoteAddress, boolean useHybridKeyExchangeProtocol) {
     SslContext sslContext = sslServerContext(useAlpn);
     Executor delegatedTaskExec = useWorkerPool ? workerPool : ImmediateExecutor.INSTANCE;
     SslHandler sslHandler;
@@ -173,16 +186,33 @@ public class SslChannelProvider {
     } else {
       sslHandler = sslContext.newHandler(ByteBufAllocator.DEFAULT, delegatedTaskExec);
     }
+    if (useHybridKeyExchangeProtocol) {
+      applyHybridCurves(sslHandler);
+    }
     sslHandler.setHandshakeTimeout(sslHandshakeTimeout, sslHandshakeTimeoutUnit);
     return sslHandler;
   }
 
-  private SniHandler createSniHandler(HostAndPort remoteAddress) {
+  private SniHandler createSniHandler(HostAndPort remoteAddress, boolean useHybridKeyExchangeProtocol) {
     Executor delegatedTaskExec = useWorkerPool ? workerPool : ImmediateExecutor.INSTANCE;
-    return new VertxSniHandler(serverNameMapping(), sslHandshakeTimeoutUnit.toMillis(sslHandshakeTimeout), delegatedTaskExec, remoteAddress);
+    return new VertxSniHandler(serverNameMapping(), sslHandshakeTimeoutUnit.toMillis(sslHandshakeTimeout), delegatedTaskExec, useHybridKeyExchangeProtocol, remoteAddress);
   }
 
   private static int idx(boolean useAlpn) {
     return useAlpn ? 0 : 1;
+  }
+
+  static void applyHybridCurves(SslHandler sslHandler) {
+    try {
+      long sslPtr = ((ReferenceCountedOpenSslEngine) sslHandler.engine()).sslPointer();
+      boolean success = SSL.setCurvesList(sslPtr, "X25519MLKEM768");
+      if (!success) {
+        log.error("Failed to set hybrid PQC groups on SSL instance, closing engine to prevent non-PQC fallback");
+        sslHandler.engine().closeOutbound();
+      }
+    } catch (Exception e) {
+      log.error("Unable to apply hybrid PQC curves: " + e.getMessage() + ", closing engine to prevent non-PQC fallback");
+      sslHandler.engine().closeOutbound();
+    }
   }
 }

--- a/src/main/java/io/vertx/core/net/impl/VertxSniHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxSniHandler.java
@@ -28,13 +28,15 @@ import java.util.concurrent.TimeUnit;
 class VertxSniHandler extends SniHandler {
 
   private final Executor delegatedTaskExec;
+  private final boolean useHybridKeyExchangeProtocol;
   private final HostAndPort remoteAddress;
 
   public VertxSniHandler(AsyncMapping<? super String, ? extends SslContext> mapping, long handshakeTimeoutMillis, Executor delegatedTaskExec,
-      HostAndPort remoteAddress) {
+      boolean useHybridKeyExchangeProtocol, HostAndPort remoteAddress) {
     super(mapping, handshakeTimeoutMillis);
 
     this.delegatedTaskExec = delegatedTaskExec;
+    this.useHybridKeyExchangeProtocol = useHybridKeyExchangeProtocol;
     this.remoteAddress = remoteAddress;
   }
 
@@ -45,6 +47,9 @@ class VertxSniHandler extends SniHandler {
       sslHandler = context.newHandler(allocator, remoteAddress.host(), remoteAddress.port(), delegatedTaskExec);
     } else {
       sslHandler = context.newHandler(allocator, delegatedTaskExec);
+    }
+    if (useHybridKeyExchangeProtocol) {
+      SslChannelProvider.applyHybridCurves(sslHandler);
     }
     sslHandler.setHandshakeTimeout(handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
     return sslHandler;

--- a/src/test/java/io/vertx/core/file/FileSystemTest.java
+++ b/src/test/java/io/vertx/core/file/FileSystemTest.java
@@ -510,6 +510,7 @@ public class FileSystemTest extends VertxTestBase {
 
   @Test
   public void testChownToRootFails() throws Exception {
+    Assume.assumeFalse("Running as root, chown to root will succeed", "root".equals(System.getProperty("user.name")));
     testChownFails("root");
   }
 

--- a/src/test/java/io/vertx/it/HybridKeyExchangeTest.java
+++ b/src/test/java/io/vertx/it/HybridKeyExchangeTest.java
@@ -1,0 +1,504 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.it;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.*;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.ssl.*;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.internal.tcnative.SSL;
+import io.vertx.core.Future;
+import io.vertx.core.http.*;
+import io.vertx.core.http.ClientAuth;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.test.tls.Cert;
+import io.vertx.test.tls.Trust;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests hybrid key exchange (X25519MLKEM768) with OpenSSL.
+ */
+public class HybridKeyExchangeTest extends HttpTestBase {
+
+  private static void assumeMlKemAvailable() {
+    boolean available = OpenSsl.isAvailable();
+    if (!available) {
+      System.err.println("OpenSSL is not available: " + OpenSsl.unavailabilityCause());
+      Assume.assumeTrue("OpenSSL is not available", false);
+      return;
+    }
+    System.out.println("OpenSSL available: version=" + OpenSsl.versionString() + " (" + Long.toHexString(OpenSsl.version()) + ")");
+    boolean mlkem;
+    try {
+      SslContext ctx = SslContextBuilder.forClient()
+        .sslProvider(SslProvider.OPENSSL)
+        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+        .build();
+      SslHandler handler = ctx.newHandler(ByteBufAllocator.DEFAULT);
+      try {
+        long sslPtr = ((ReferenceCountedOpenSslEngine) handler.engine()).sslPointer();
+        mlkem = SSL.setCurvesList(sslPtr, "X25519MLKEM768");
+      } finally {
+        handler.engine().closeOutbound();
+      }
+    } catch (Exception e) {
+      System.err.println("Failed to probe X25519MLKEM768 support: " + e.getMessage());
+      mlkem = false;
+    }
+    if (!mlkem) {
+      System.err.println("X25519MLKEM768 is not supported by OpenSSL " + OpenSsl.versionString());
+    }
+    Assume.assumeTrue("X25519MLKEM768 not supported by OpenSSL " + OpenSsl.versionString(), mlkem);
+  }
+
+  @Test
+  public void testHybridKeyExchangeHandshake() throws Exception {
+    assumeMlKemAvailable();
+    server = vertx.createHttpServer(new HttpServerOptions()
+      .setPort(DEFAULT_HTTPS_PORT)
+      .setHost(DEFAULT_HTTPS_HOST)
+      .setSsl(true)
+      .setUseAlpn(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+      .setUseHybridKeyExchangeProtocol(true)
+      .setKeyCertOptions(Cert.SERVER_PEM.get()));
+    server.requestHandler(req -> req.response().end("hybrid-ok"));
+    startServer(server);
+
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+        .setUseAlpn(true)
+      .setUseHybridKeyExchangeProtocol(true)
+      .setTrustAll(true));
+    HttpClient client2 = vertx.createHttpClient(new HttpClientOptions()
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+      .setUseHybridKeyExchangeProtocol(false)
+      .setTrustAll(true));
+
+    CompletableFuture<Boolean> cf1 = new CompletableFuture<>();
+    CompletableFuture<Boolean> cf2 = new CompletableFuture<>();
+
+    Future<HttpClientRequest> reqSuccess = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(onSuccess(req -> {
+      req.send().onComplete(onSuccess(resp -> {
+        assertEquals(200, resp.statusCode());
+        assertEquals("TLSv1.3", req.connection().sslSession().getProtocol());
+        resp.body().onComplete(onSuccess(body -> {
+          assertEquals("hybrid-ok", body.toString());
+          cf1.complete(true);
+        }));
+      }));
+    }));
+
+    Future<HttpClientRequest> reqFail = client2.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(
+      onFailure(req -> {
+        assertTrue(req instanceof javax.net.ssl.SSLHandshakeException);
+        cf2.complete(true);
+      })
+    );
+
+    CompletableFuture.allOf(cf1, cf2).thenAccept((v) -> testComplete()).get();
+  }
+
+  @Test
+  public void testHybridKeyExchangeHandshakeMTLS() throws Exception {
+    assumeMlKemAvailable();
+    server = vertx.createHttpServer(new HttpServerOptions()
+      .setPort(DEFAULT_HTTPS_PORT)
+      .setHost(DEFAULT_HTTPS_HOST)
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+      .setUseHybridKeyExchangeProtocol(true)
+      .setClientAuth(ClientAuth.REQUIRED)
+      .setKeyCertOptions(Cert.SERVER_PEM_ROOT_CA.get())
+      .setTrustOptions(Trust.SERVER_PEM_ROOT_CA.get()));
+    server.requestHandler(req -> {
+      assertTrue(req.isSSL());
+      req.response().end("mtls-hybrid-ok");
+    });
+    startServer(server);
+
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+      .setUseHybridKeyExchangeProtocol(true)
+      .setKeyCertOptions(Cert.CLIENT_PEM_ROOT_CA.get())
+      .setTrustAll(true));
+    HttpClient client2 = vertx.createHttpClient(new HttpClientOptions()
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+      .setUseHybridKeyExchangeProtocol(false)
+      .setKeyCertOptions(Cert.CLIENT_PEM_ROOT_CA.get())
+      .setTrustAll(true));
+
+    CompletableFuture<Boolean> cf1 = new CompletableFuture<>();
+    CompletableFuture<Boolean> cf2 = new CompletableFuture<>();
+
+    Future<HttpClientRequest> reqSuccess = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(onSuccess(req -> {
+      req.send().onComplete(onSuccess(resp -> {
+        assertEquals(200, resp.statusCode());
+        assertEquals("TLSv1.3", req.connection().sslSession().getProtocol());
+        resp.body().onComplete(onSuccess(body -> {
+          assertEquals("mtls-hybrid-ok", body.toString());
+          cf1.complete(true);
+        }));
+      }));
+    }));
+
+    Future<HttpClientRequest> reqFail = client2.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(
+      onFailure(req -> {
+        assertTrue(req instanceof javax.net.ssl.SSLHandshakeException);
+        cf2.complete(true);
+      })
+    );
+
+    CompletableFuture.allOf(cf1, cf2).thenAccept((v) -> testComplete()).get();
+  }
+
+  @Test
+  public void testHybridFailsServerSideWhenPqcNotAvailable() throws Exception {
+    assumeMlKemAvailable();
+    server.close();
+    server = vertx.createHttpServer(new HttpServerOptions()
+      .setPort(DEFAULT_HTTPS_PORT)
+      .setHost(DEFAULT_HTTPS_HOST)
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+      .setUseHybridKeyExchangeProtocol(true)
+      .setKeyCertOptions(Cert.SERVER_PEM.get()));
+    server.requestHandler(req -> req.response().end("should-not-reach"));
+    startServer(server);
+
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setSsl(true)
+      .setTrustAll(true));
+
+    client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(
+      onFailure(err -> {
+        assertTrue(err instanceof javax.net.ssl.SSLHandshakeException);
+        testComplete();
+      })
+    );
+    await();
+  }
+
+  @Test
+  public void testHybridFailsClientSideWhenPqcNotAvailable() throws Exception {
+    assumeMlKemAvailable();
+    server.close();
+    server = vertx.createHttpServer(new HttpServerOptions()
+      .setPort(DEFAULT_HTTPS_PORT)
+      .setHost(DEFAULT_HTTPS_HOST)
+      .setSsl(true)
+      .setKeyCertOptions(Cert.SERVER_PEM.get()));
+    server.requestHandler(req -> req.response().end("should-not-reach"));
+    startServer(server);
+
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+      .setUseHybridKeyExchangeProtocol(true)
+      .setTrustAll(true));
+
+    client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(
+      onFailure(err -> {
+        assertTrue(err instanceof javax.net.ssl.SSLHandshakeException);
+        testComplete();
+      })
+    );
+    await();
+  }
+
+  @Test
+  public void testHybridKeyExchangeWithSNI() throws Exception {
+    assumeMlKemAvailable();
+    server.close();
+    server = vertx.createHttpServer(new HttpServerOptions()
+      .setPort(DEFAULT_HTTPS_PORT)
+      .setHost(DEFAULT_HTTPS_HOST)
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+      .setUseHybridKeyExchangeProtocol(true)
+      .setSni(true)
+      .setKeyCertOptions(Cert.SERVER_PEM.get()));
+    server.requestHandler(req -> req.response().end("sni-hybrid-ok"));
+    startServer(server);
+
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+      .setUseHybridKeyExchangeProtocol(true)
+      .setTrustAll(true));
+
+    client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(onSuccess(req -> {
+      req.send().onComplete(onSuccess(resp -> {
+        assertEquals(200, resp.statusCode());
+        assertEquals("TLSv1.3", req.connection().sslSession().getProtocol());
+        resp.body().onComplete(onSuccess(body -> {
+          assertEquals("sni-hybrid-ok", body.toString());
+          testComplete();
+        }));
+      }));
+    }));
+    await();
+  }
+
+  @Test
+  public void testHybridFailsWithSNIWhenPqcNotAvailable() throws Exception {
+    assumeMlKemAvailable();
+    server.close();
+    server = vertx.createHttpServer(new HttpServerOptions()
+      .setPort(DEFAULT_HTTPS_PORT)
+      .setHost(DEFAULT_HTTPS_HOST)
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+      .setUseHybridKeyExchangeProtocol(true)
+      .setSni(true)
+      .setKeyCertOptions(Cert.SERVER_PEM.get()));
+    server.requestHandler(req -> req.response().end("should-not-reach"));
+    startServer(server);
+
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setSsl(true)
+      .setTrustAll(true));
+
+    client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(
+      onFailure(err -> {
+        assertTrue(err instanceof javax.net.ssl.SSLHandshakeException);
+        testComplete();
+      })
+    );
+    await();
+  }
+
+  @Test
+  public void testHybridWithRawNettySocket() throws Exception {
+    assumeMlKemAvailable();
+    // Start Vert.x server with hybrid
+    server.close();
+    server = vertx.createHttpServer(new HttpServerOptions()
+      .setPort(DEFAULT_HTTPS_PORT)
+      .setHost(DEFAULT_HTTPS_HOST)
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+      .setUseHybridKeyExchangeProtocol(true)
+      .setKeyCertOptions(Cert.SERVER_PEM.get()));
+    server.requestHandler(req -> req.response().end("hybrid-ok"));
+    startServer(server);
+
+    // Raw Netty client
+    SslContext sslContext = SslContextBuilder.forClient()
+      .sslProvider(SslProvider.OPENSSL)
+      .trustManager(InsecureTrustManagerFactory.INSTANCE)
+      .build();
+
+    // Will hold the negotiated group from key_share extension
+    CompletableFuture<Integer> negotiatedGroup = new CompletableFuture<>();
+
+    EventLoopGroup group = new NioEventLoopGroup();
+    try {
+      Bootstrap bootstrap = new Bootstrap()
+        .group(group)
+        .channel(NioSocketChannel.class)
+        .handler(new ChannelInitializer<SocketChannel>() {
+          @Override
+          protected void initChannel(SocketChannel ch) {
+            SslHandler sslHandler = sslContext.newHandler(ch.alloc(),
+              DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT);
+
+            // Set hybrid curves on the OpenSSL engine
+            ReferenceCountedOpenSslEngine engine =
+              (ReferenceCountedOpenSslEngine) sslHandler.engine();
+            SSL.setCurvesList(engine.sslPointer(), "X25519MLKEM768");
+
+            // Interceptor BEFORE SslHandler sees raw TLS records
+            ch.pipeline().addLast("server-hello-interceptor",
+              new ServerHelloGroupExtractor(negotiatedGroup));
+            ch.pipeline().addLast("ssl", sslHandler);
+
+            sslHandler.handshakeFuture().addListener(future -> {
+              if (!future.isSuccess()) {
+                negotiatedGroup.completeExceptionally(future.cause());
+              }
+            });
+          }
+        });
+
+      Channel ch = bootstrap.connect(DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT)
+        .sync().channel();
+
+      int groupId = negotiatedGroup.get(10, TimeUnit.SECONDS);
+      // 0x11ec = 4588 = X25519MLKEM768 see https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml
+      assertEquals(0x11ec, groupId);
+
+      ch.close().sync();
+    } finally {
+      group.shutdownGracefully();
+    }
+  }
+
+  @Test
+  public void testHybridMTLSWithRawNettySocket() throws Exception {
+    assumeMlKemAvailable();
+    // Start Vert.x server with hybrid + mTLS
+    server.close();
+    server = vertx.createHttpServer(new HttpServerOptions()
+      .setPort(DEFAULT_HTTPS_PORT)
+      .setHost(DEFAULT_HTTPS_HOST)
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions())
+      .setUseHybridKeyExchangeProtocol(true)
+      .setClientAuth(ClientAuth.REQUIRED)
+      .setKeyCertOptions(Cert.SERVER_PEM_ROOT_CA.get())
+      .setTrustOptions(Trust.SERVER_PEM_ROOT_CA.get()));
+    server.requestHandler(req -> {
+      assertTrue(req.isSSL());
+      req.response().end("mtls-hybrid-ok");
+    });
+    startServer(server);
+
+    // Raw Netty client with client cert
+    SslContext sslContext = SslContextBuilder.forClient()
+      .sslProvider(SslProvider.OPENSSL)
+      .trustManager(InsecureTrustManagerFactory.INSTANCE)
+      .keyManager(
+        getClass().getClassLoader().getResourceAsStream("tls/client-cert-root-ca.pem"),
+        getClass().getClassLoader().getResourceAsStream("tls/client-key.pem"))
+      .build();
+
+    // Will hold the negotiated group from key_share extension
+    CompletableFuture<Integer> negotiatedGroup = new CompletableFuture<>();
+
+    EventLoopGroup group = new NioEventLoopGroup();
+    try {
+      Bootstrap bootstrap = new Bootstrap()
+        .group(group)
+        .channel(NioSocketChannel.class)
+        .handler(new ChannelInitializer<SocketChannel>() {
+          @Override
+          protected void initChannel(SocketChannel ch) {
+            SslHandler sslHandler = sslContext.newHandler(ch.alloc(),
+              DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT);
+
+            // Set hybrid curves on the OpenSSL engine
+            ReferenceCountedOpenSslEngine engine =
+              (ReferenceCountedOpenSslEngine) sslHandler.engine();
+            SSL.setCurvesList(engine.sslPointer(), "X25519MLKEM768");
+
+            // Interceptor BEFORE SslHandler sees raw TLS records
+            ch.pipeline().addLast("server-hello-interceptor",
+              new ServerHelloGroupExtractor(negotiatedGroup));
+            ch.pipeline().addLast("ssl", sslHandler);
+
+            sslHandler.handshakeFuture().addListener(future -> {
+              if (!future.isSuccess()) {
+                negotiatedGroup.completeExceptionally(future.cause());
+              }
+            });
+          }
+        });
+
+      Channel ch = bootstrap.connect(DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT)
+        .sync().channel();
+
+      int groupId = negotiatedGroup.get(10, TimeUnit.SECONDS);
+      // 0x11ec = 4588 = X25519MLKEM768 see https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml
+      assertEquals(0x11ec, groupId);
+
+      ch.close().sync();
+    } finally {
+      group.shutdownGracefully();
+    }
+  }
+
+
+  static class ServerHelloGroupExtractor extends ChannelInboundHandlerAdapter {
+
+    private static final int HANDSHAKE_CONTENT_TYPE = 0x16;
+    private static final int SERVER_HELLO = 0x02;
+    private static final int KEY_SHARE_EXTENSION = 0x0033;
+
+    private final CompletableFuture<Integer> result;
+
+    ServerHelloGroupExtractor(CompletableFuture<Integer> result) {
+      this.result = result;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+      if (msg instanceof ByteBuf && !result.isDone()) {
+        ByteBuf buf = (ByteBuf) msg;
+        int readerIndex = buf.readerIndex();
+        try {
+          parseServerHello(buf);
+        } catch (Exception e) {
+          // Not a ServerHello or not parseable yet, ignore
+        } finally {
+          buf.readerIndex(readerIndex);
+        }
+      }
+      // Always forward to SslHandler
+      super.channelRead(ctx, msg);
+    }
+
+    private void parseServerHello(ByteBuf buf) {
+      if (buf.readableBytes() < 5) return;
+
+      int contentType = buf.readUnsignedByte();
+      if (contentType != HANDSHAKE_CONTENT_TYPE) return;
+
+      buf.skipBytes(2); // protocol version
+      int recordLength = buf.readUnsignedShort();
+      if (buf.readableBytes() < recordLength) return;
+
+      int handshakeType = buf.readUnsignedByte();
+      if (handshakeType != SERVER_HELLO) return;
+
+      buf.skipBytes(3);  // handshake length
+      buf.skipBytes(2);  // server version (0x0303)
+      buf.skipBytes(32); // random
+
+      int sessionIdLen = buf.readUnsignedByte();
+      buf.skipBytes(sessionIdLen); // session id
+
+      buf.skipBytes(2); // cipher suite
+      buf.skipBytes(1); // compression method
+
+      if (buf.readableBytes() < 2) return;
+      int extensionsLength = buf.readUnsignedShort();
+
+      // Walk extensions
+      int extensionsEnd = buf.readerIndex() + extensionsLength;
+      while (buf.readerIndex() < extensionsEnd && buf.readableBytes() >= 4) {
+        int extType = buf.readUnsignedShort();
+        int extLen = buf.readUnsignedShort();
+
+        if (extType == KEY_SHARE_EXTENSION && extLen >= 2) {
+          int groupId = buf.readUnsignedShort();
+          result.complete(groupId);
+          return;
+        }
+        buf.skipBytes(extLen);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Motivation:
The rise of quantum computers threatens traditional asymmetric key exchange protocol due to their ability to break private keys.
Post-quantum cryptography must use problems that quantum computers can't solve as quickly. Module-lattice-based problems have been found to resist quantum computers. ML-KEM, for module-lattice-based key encapsulation mechanism, is an instance of a key exchange protocol resistant to quantum computers. Due to its relative short existence, it has been recommended to use it alongside traditional Diffie-Hellman with elliptic curve.
Thus, the new hybrid key exchange protocol x25519mlkem768 uses both Diffie-Hellman with elliptic curve 25519 and ML-KEM. Its has been integrated in OpenSsl starting with version 3.5.

Changes:
This features relies on the netty-tcnative-openssl-dynamic bound to version 3.6 of openssl at runtime, and netty-tcnative-classes at build-time.

- Add boolean useHybrid field to io.vertx.core.net.SSLOptions and create getters/setters in io.vertx.core.net.SSLOptions as well as every implementation of io.vertx.core.net.TCPSSLOptions.
- If this value is set to true (default false), the ssl handler will be set to use x25519mlkem768 instead of x25519.
- If key exchange protocol is set to x25519mlkem768 but JdkSsl is used instead of OpenSsl, or the version of openssl used at runtime does not suppot x25519mlkem768, the user is informed that hybrid key exchange is impossible, then channel is closed.