### PR TITLE
Add Http1xClientTest for HTTP client functionality.

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xClientTest.java
@@ -1,0 +1,53 @@
+package io.vertx.tests.http;
+
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertFalse;
+
+public class Http1xClientTest {
+
+  @Test
+  public void testHttp1xClientLocal() throws TimeoutException {
+    Vertx vertx = Vertx.vertx();
+
+    Promise<String> promise = Promise.promise();
+
+    vertx.createHttpServer().requestHandler(req -> req.response().end("Hello World!")).listen(8080);
+
+    vertx.createHttpClient().request(new RequestOptions().setMethod(HttpMethod.GET).setPort(8080).setURI("/"))
+      .compose(HttpClientRequest::send)
+      .compose(HttpClientResponse::body)
+      .onSuccess(resp -> promise.complete(resp.toString()))
+      .onFailure(promise::fail);
+
+    String body = promise.future().await(10, TimeUnit.SECONDS);
+
+    assertFalse("Response body should not be empty", body.isEmpty());
+  }
+
+  @Test
+  public void testHttp1xClient() throws TimeoutException {
+    Vertx vertx = Vertx.vertx();
+
+    Promise<String> promise = Promise.promise();
+
+    vertx.createHttpClient().request(new RequestOptions().setMethod(HttpMethod.GET).setAbsoluteURI("http://meowfacts.herokuapp.com/"))
+      .compose(HttpClientRequest::send)
+      .compose(HttpClientResponse::body)
+      .onSuccess(resp -> promise.complete(resp.toString()))
+      .onFailure(promise::fail);
+
+    String body = promise.future().await(10, TimeUnit.SECONDS);
+
+    assertFalse("Response body should not be empty", body.isEmpty());
+  }
+}


### PR DESCRIPTION
Add Http1xClientTest for HTTP client functionality.

Motivation:

Introduce unit tests to verify core HTTP client features in HTTP/1.x protocol. This Test class is not using any Vert.x Test Base class as these tests are passing correctly if used. I have found that at the moment using the client can lead to 2 errors one is Pool Closed error and second is:
```
Cannot invoke "io.vertx.core.Promise.complete(Object)" because "promise" is null
	at io.vertx.core.http.impl.http1x.Http1xClientConnection.endRequest(Http1xClientConnection.java:319)
	at io.vertx.core.http.impl.http1x.Http1xClientConnection.beginRequest(Http1xClientConnection.java:272)
	at io.vertx.core.http.impl.http1x.Http1xClientConnection$1.write(Http1xClientConnection.java:355)
	at io.vertx.core.net.impl.VertxConnection$InternalMessageChannel.test(VertxConnection.java:588)
	at io.vertx.core.net.impl.VertxConnection$InternalMessageChannel.test(VertxConnection.java:579)
	at io.vertx.core.streams.impl.MessagePassingQueue.drain(MessagePassingQueue.java:228)
	at io.vertx.core.streams.impl.MessagePassingQueue.drain(MessagePassingQueue.java:210)
	at io.vertx.core.internal.concurrent.OutboundMessageQueue.drainMessageQueue(OutboundMessageQueue.java:105)
```

I'm not able to replicate this one in test suit, maybe it gets swallowed by that pool exception?

Changes:

- Added `Http1xClientTest` class with tests for local server and external HTTP requests.