### PR TITLE
Add defaultServer to HttpClientOptions

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -13,7 +13,6 @@ package io.vertx.core.http;
 
 import io.netty.handler.logging.ByteBufFormat;
 import io.vertx.codegen.annotations.DataObject;
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.impl.HttpUtils;
@@ -22,7 +21,10 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
 import io.vertx.core.tracing.TracingPolicy;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -178,6 +180,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   private boolean decompressionSupported;
   private String defaultHost;
   private int defaultPort;
+  private Address defaultAddress;
   private HttpVersion protocolVersion;
   private int maxChunkSize;
   private int maxInitialLineLength;
@@ -232,6 +235,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.decompressionSupported = other.decompressionSupported;
     this.defaultHost = other.defaultHost;
     this.defaultPort = other.defaultPort;
+    this.defaultAddress = other.defaultAddress;
     this.protocolVersion = other.protocolVersion;
     this.maxChunkSize = other.maxChunkSize;
     this.maxInitialLineLength = other.getMaxInitialLineLength();
@@ -283,6 +287,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     decompressionSupported = DEFAULT_DECOMPRESSION_SUPPORTED;
     defaultHost = DEFAULT_DEFAULT_HOST;
     defaultPort = DEFAULT_DEFAULT_PORT;
+    defaultAddress = null;
     protocolVersion = DEFAULT_PROTOCOL_VERSION;
     maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
     maxInitialLineLength = DEFAULT_MAX_INITIAL_LINE_LENGTH;
@@ -748,6 +753,27 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public HttpClientOptions setDefaultPort(int defaultPort) {
     this.defaultPort = defaultPort;
+    return this;
+  }
+
+  /**
+   * Get the default service {@link Address} to be used by this client in requests if none is provided when making the request.
+   * It's not set by default. If set, it takes precedence over {@link #setDefaultHost(String)} and {@link #setDefaultPort(int)}.
+   *
+   * @return the default address
+   */
+  public Address getDefaultAddress() {
+    return defaultAddress;
+  }
+
+  /**
+   * Set the default service {@link Address} to be used by this client in requests if none is provided when making the request.
+   * It's not set by default. If set, it takes precedence over {@link #setDefaultHost(String)} and {@link #setDefaultPort(int)}.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientOptions setDefaultAddress(Address defaultAddress) {
+    this.defaultAddress = defaultAddress;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -11,11 +11,11 @@ import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.http.HttpChannelConnector;
 import io.vertx.core.internal.http.HttpClientInternal;
 import io.vertx.core.internal.net.NetClientInternal;
-import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.endpoint.LoadBalancer;
 import io.vertx.core.net.AddressResolver;
-import io.vertx.core.net.endpoint.impl.EndpointResolverImpl;
+import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.endpoint.EndpointResolver;
+import io.vertx.core.net.endpoint.LoadBalancer;
+import io.vertx.core.net.endpoint.impl.EndpointResolverImpl;
 import io.vertx.core.net.impl.tcp.NetClientBuilder;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
 
@@ -110,6 +110,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       co.isSsl(),
       co.getDefaultHost(),
       co.getDefaultPort(),
+      co.getDefaultAddress(),
       co.getMaxRedirects(),
       co.getProtocolVersion(),
       co.getSslOptions()

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -11,7 +11,10 @@
 
 package io.vertx.core.http.impl;
 
-import io.vertx.core.*;
+import io.vertx.core.Completable;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
@@ -197,6 +200,9 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     String host = connect.getHost();
     SocketAddress server;
     if (addr == null) {
+      addr = transport.defaultAddress;
+    }
+    if (addr == null) {
       if (port == null) {
         port = transport.defaultPort;
       }
@@ -241,6 +247,9 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     Address addr = request.getServer();
     Integer port = request.getPort();
     String host = request.getHost();
+    if (addr == null) {
+      addr = transport.defaultAddress;
+    }
     if (addr == null) {
       if (port == null) {
         port = transport.defaultPort;
@@ -443,12 +452,13 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     private final boolean defaultSsl;
     private final String defaultHost;
     private final int defaultPort;
+    private final Address defaultAddress;
     private final int maxRedirects;
     private final HttpVersion protocol;
     private volatile ClientSSLOptions sslOptions;
 
     Transport(EndpointResolver resolver, Handler<HttpConnection> connectHandler, HttpChannelConnector connector,
-              boolean verifyHost, boolean defaultSsl, String defaultHost, int defaultPort, int maxRedirects,
+              boolean verifyHost, boolean defaultSsl, String defaultHost, int defaultPort, Address defaultAddress, int maxRedirects,
               HttpVersion protocol, ClientSSLOptions sslOptions) {
 
       if (sslOptions != null) {
@@ -462,6 +472,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
       this.defaultSsl = defaultSsl;
       this.defaultHost = defaultHost;
       this.defaultPort = defaultPort;
+      this.defaultAddress = defaultAddress;
       this.maxRedirects = maxRedirects;
       this.protocol = protocol;
       this.sslOptions = sslOptions;


### PR DESCRIPTION
Closes #5102

`HttpClientOptions` allows to set a default port and a default host.

It can also be convenient to set a default address (in particular, when using a domain socket address or a service address from the Vert.x service resolver).