### PR TITLE
Improve the support of alternative services event.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/AltSvc.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/AltSvc.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+/**
+ * An event signalling an <a href="https://datatracker.ietf.org/doc/html/rfc7838">alternative service</a> of an origin.
+ */
+public class AltSvc {
+
+  public final Origin origin;
+  public final String value;
+
+  public AltSvc(Origin origin, String value) {
+    this.origin = origin;
+    this.value = value;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -81,7 +81,7 @@ public interface HttpClientConnection extends HttpConnection {
    * @param handler
    * @return
    */
-  default HttpClientConnection alternativeServicesHandler(Handler<String> handler) {
+  default HttpClientConnection alternativeServicesHandler(Handler<AltSvc> handler) {
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Origin.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Origin.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.HostAndPort;
+
+import java.nio.charset.StandardCharsets;
+
+public class Origin {
+
+  public static Origin fromASCII(String s) {
+    int idx = s.indexOf("://");
+    if (idx == -1) {
+      return null;
+    }
+    String scheme = s.substring(0, idx);
+    int schemePort;
+    switch (scheme) {
+      case "http":
+        schemePort = 80;
+        break;
+      case "https":
+        schemePort = 443;
+        break;
+      default:
+        return null;
+    }
+    HostAndPort hostAndPort = HostAndPort.parseAuthority(s.substring(idx + 3), schemePort);
+    if (hostAndPort == null) {
+      return null;
+    }
+    return new Origin(scheme, hostAndPort.host(), hostAndPort.port());
+  }
+
+  public final String scheme;
+  public final String host;
+  public final int port;
+
+  public Origin(String scheme, String host, int port) {
+    this.scheme = scheme;
+    this.host = host;
+    this.port = port;
+  }
+
+  /**
+   * ASCII <a href="https://datatracker.ietf.org/doc/html/rfc6454#section-6.2">serialization</a> of an origin.
+   */
+  public Buffer toASCII() {
+    Buffer buffer = Buffer.buffer();
+    buffer.appendString(scheme);
+    buffer.appendString("://");
+    buffer.appendString(host, StandardCharsets.US_ASCII.name());
+    int defaultPort;
+    switch (scheme) {
+      case "http":
+        defaultPort = 80;
+        break;
+      case "https":
+        defaultPort = 443;
+        break;
+      default:
+        defaultPort = -1;
+        break;
+    }
+    if (port != defaultPort) {
+      buffer.appendByte((byte)':');
+      buffer.appendString(Integer.toString(port));
+    }
+    return buffer;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1x/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1x/Http2UpgradeClientConnection.java
@@ -22,9 +22,8 @@ import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.impl.*;
 import io.vertx.core.http.impl.HttpClientConnection;
-import io.vertx.core.http.impl.HttpClientPush;
-import io.vertx.core.http.impl.HttpClientStream;
 import io.vertx.core.http.impl.HttpRequestHead;
 import io.vertx.core.http.impl.headers.Http1xHeaders;
 import io.vertx.core.internal.ContextInternal;
@@ -63,7 +62,7 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
   private Handler<Void> evictionHandler;
   private Handler<Object> invalidMessageHandler;
   private Handler<Long> concurrencyChangeHandler;
-  private Handler<String> alternativeServicesHandler;
+  private Handler<AltSvc> alternativeServicesHandler;
   private Handler<Http2Settings> remoteSettingsHandler;
 
   public Http2UpgradeClientConnection(Http1xClientConnection connection, long maxLifetimeMillis, ClientMetrics<?, ?, ?> metrics, Http2ChannelUpgrade upgrade) {
@@ -813,7 +812,7 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
   }
 
   @Override
-  public HttpClientConnection alternativeServicesHandler(Handler<String> handler) {
+  public HttpClientConnection alternativeServicesHandler(Handler<AltSvc> handler) {
     if (current instanceof Http1xClientConnection) {
       alternativeServicesHandler = handler;
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2ClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2ClientStream.java
@@ -33,6 +33,7 @@ import io.vertx.core.http.impl.observability.StreamObserver;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.buffer.BufferInternal;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.impl.MessageWrite;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.TransportMetrics;
@@ -55,6 +56,8 @@ class DefaultHttp2ClientStream extends DefaultHttp2Stream<DefaultHttp2ClientStre
   private final Http2ClientConnection connection;
   private final boolean decompressionSupported;
   private final ClientStreamObserver observable;
+  private String scheme;
+  private HostAndPort authority;
 
   // Handlers
   private Handler<HttpResponseHead> headersHandler;
@@ -80,6 +83,16 @@ class DefaultHttp2ClientStream extends DefaultHttp2Stream<DefaultHttp2ClientStre
   }
 
   @Override
+  public String scheme() {
+    return scheme;
+  }
+
+  @Override
+  public HostAndPort authority() {
+    return authority;
+  }
+
+  @Override
   StreamObserver observer() {
     return observable;
   }
@@ -94,6 +107,8 @@ class DefaultHttp2ClientStream extends DefaultHttp2Stream<DefaultHttp2ClientStre
   public Future<Void> writeHead(HttpRequestHead request, boolean chunked, Buffer buf, boolean end, StreamPriority priority, boolean connect) {
     PromiseInternal<Void> promise = context.promise();
     priority(priority);
+    scheme = request.scheme;
+    authority = request.authority;
     write(new HeadersWrite(request, buf != null ? ((BufferInternal)buf).getByteBuf() : null, end, promise));
     return promise.future();
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2Stream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2Stream.java
@@ -15,6 +15,7 @@ import io.vertx.core.http.GoAway;
 import io.vertx.core.http.StreamPriority;
 import io.vertx.core.http.impl.headers.HttpHeaders;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.net.HostAndPort;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -22,6 +23,8 @@ import io.vertx.core.internal.ContextInternal;
 public interface Http2Stream {
 
   int id();
+  String scheme();
+  HostAndPort authority();
 
   ContextInternal context();
 

--- a/vertx-core/src/test/java/io/vertx/tests/http/connection/Http2ClientConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/connection/Http2ClientConnectionTest.java
@@ -13,7 +13,9 @@ package io.vertx.tests.http.connection;
 import io.vertx.core.http.Http2Settings;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.impl.Origin;
 import io.vertx.tests.http.Http2TestBase;
+import org.junit.Test;
 
 public class Http2ClientConnectionTest extends HttpClientConnectionTest {
 
@@ -26,5 +28,10 @@ public class Http2ClientConnectionTest extends HttpClientConnectionTest {
   @Override
   protected HttpClientOptions createBaseClientOptions() {
     return Http2TestBase.createHttp2ClientOptions();
+  }
+
+  @Test
+  public void testAlternateServiceHandlerConnectionStream() throws Exception {
+    testAlternateServiceHandler(new Origin("https", "example.com", 334));
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/connection/Http2MultiplexClientConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/connection/Http2MultiplexClientConnectionTest.java
@@ -12,6 +12,7 @@ package io.vertx.tests.http.connection;
 
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServerOptions;
+import org.junit.Ignore;
 
 public class Http2MultiplexClientConnectionTest extends Http2ClientConnectionTest {
 
@@ -23,5 +24,11 @@ public class Http2MultiplexClientConnectionTest extends Http2ClientConnectionTes
   @Override
   protected HttpClientOptions createBaseClientOptions() {
     return super.createBaseClientOptions().setHttp2MultiplexImplementation(true);
+  }
+
+  @Ignore
+  @Override
+  public void testAlternateServiceHandlerConnectionStream() throws Exception {
+    // The multiplex API does not allow to send custom frames on in the connection stream
   }
 }


### PR DESCRIPTION
Motivation:

HTTP/2 uses a custom frame to signal an alternative services for the origin server.
