### PR TITLE
Proper implementation of QuicStream reset handling

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/QuicStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicStream.java
@@ -55,7 +55,7 @@ public interface QuicStream extends Socket {
    * @param handler the handler
    * @return this instance of a stream
    */
-  QuicStream resetHandler(@Nullable Handler<Integer> handler);
+  QuicStream resetHandler(@Nullable Handler<Long> handler);
 
   /**
    * Abruptly terminate the sending part of the stream with the specified application protocol {@code error} code


### PR DESCRIPTION
Motivation:

Previously proper implementation of `QuicStream` reset handling could not be implemented since Netty was not propagating the stream reset application code.

Changes:

When processing a quic stream reset, unwrap the application code and provide it to the stream reset handler.
