### PR TITLE
Restore handling of headers after goaway received

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
@@ -194,20 +194,16 @@ abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameL
 
   @Override
   public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endOfStream) throws Http2Exception {
-    if (goAwayStatus == null || endOfStream) {
-      StreamPriority streamPriority = new StreamPriority()
-        .setDependency(streamDependency)
-        .setWeight(weight)
-        .setExclusive(exclusive);
-      onHeadersRead(streamId, headers, streamPriority, endOfStream);
-    }
+    StreamPriority streamPriority = new StreamPriority()
+      .setDependency(streamDependency)
+      .setWeight(weight)
+      .setExclusive(exclusive);
+    onHeadersRead(streamId, headers, streamPriority, endOfStream);
   }
 
   @Override
   public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding, boolean endOfStream) throws Http2Exception {
-    if (goAwayStatus == null || endOfStream) {
-      onHeadersRead(streamId, headers, null, endOfStream);
-    }
+    onHeadersRead(streamId, headers, null, endOfStream);
   }
 
   protected abstract void onHeadersRead(int streamId, Http2Headers headers, StreamPriority streamPriority, boolean endOfStream);

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
@@ -1070,6 +1070,52 @@ public class Http2ClientTest extends Http2TestBase {
   }
 
   @Test
+  public void testServerGracefulShutdownBeforeHeaderSent() throws Exception {
+    server.requestHandler(req -> {
+      req.connection().shutdown();
+      req.response().end("OK");
+    });
+    startServer(testAddress);
+
+    client.request(requestOptions).compose(req -> req
+        .send()
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::end))
+      .andThen(resp -> {
+        if (resp.succeeded()) {
+          testComplete();
+        } else {
+          fail(resp.cause());
+        }
+      });
+
+    await();
+  }
+
+  @Test
+  public void testGoAwayErrorBeforeHeaderSent() throws Exception {
+    server.requestHandler(req -> {
+      req.connection().goAway(100);
+      req.response().end("OK");
+    });
+    startServer(testAddress);
+
+    client.request(requestOptions).compose(req -> req
+        .send()
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::end))
+      .andThen(resp -> {
+        if (resp.succeeded()) {
+          testComplete();
+        } else {
+          fail(resp.cause());
+        }
+      });
+
+    await();
+  }
+
+  @Test
   public void testReceivingGoAwayDiscardsTheConnection() throws Exception {
     AtomicInteger connCount = new AtomicInteger();
     List<HttpConnection> connections = Collections.synchronizedList(new ArrayList<>());


### PR DESCRIPTION
Closes #5693

Motivation:

This re-enables a graceful shutdown that was broken after ff78924cff931f275238bac3dfc64bacb27991d1

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
