### PR TITLE
Restore handling of headers after goaway received [5.0]

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
@@ -203,20 +203,16 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
 
   @Override
   public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endOfStream) throws Http2Exception {
-    if (goAwayStatus == null || endOfStream) {
-      StreamPriority streamPriority = new StreamPriority()
-        .setDependency(streamDependency)
-        .setWeight(weight)
-        .setExclusive(exclusive);
-      onHeadersRead(streamId, headers, streamPriority, endOfStream);
-    }
+    StreamPriority streamPriority = new StreamPriority()
+      .setDependency(streamDependency)
+      .setWeight(weight)
+      .setExclusive(exclusive);
+    onHeadersRead(streamId, headers, streamPriority, endOfStream);
   }
 
   @Override
   public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding, boolean endOfStream) throws Http2Exception {
-    if (goAwayStatus == null || endOfStream) {
-      onHeadersRead(streamId, headers, null, endOfStream);
-    }
+    onHeadersRead(streamId, headers, null, endOfStream);
   }
 
   protected abstract void onHeadersRead(int streamId, Http2Headers headers, StreamPriority streamPriority, boolean endOfStream);


### PR DESCRIPTION
This re-enables a graceful shutdown that was broken after ff78924cff931f275238bac3dfc64bacb27991d1

Closes #5693

(cherry picked from commit 9a399e2a26ff56d3bfd44f06ee5ed16068e62d91)

Motivation:

This re-enables a graceful shutdown that was broken after ff78924cff931f275238bac3dfc64bacb27991d1
