### PR TITLE
Restore handling of headers after goaway received [4.x]

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
@@ -202,20 +202,16 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
 
   @Override
   public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endOfStream) throws Http2Exception {
-    if (goAwayStatus == null) {
-      StreamPriority streamPriority = new StreamPriority()
-        .setDependency(streamDependency)
-        .setWeight(weight)
-        .setExclusive(exclusive);
-      onHeadersRead(streamId, headers, streamPriority, endOfStream);
-    }
+    StreamPriority streamPriority = new StreamPriority()
+      .setDependency(streamDependency)
+      .setWeight(weight)
+      .setExclusive(exclusive);
+    onHeadersRead(streamId, headers, streamPriority, endOfStream);
   }
 
   @Override
   public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding, boolean endOfStream) throws Http2Exception {
-    if (goAwayStatus == null) {
-      onHeadersRead(streamId, headers, null, endOfStream);
-    }
+    onHeadersRead(streamId, headers, null, endOfStream);
   }
 
   protected abstract void onHeadersRead(int streamId, Http2Headers headers, StreamPriority streamPriority, boolean endOfStream);

--- a/src/test/java/io/vertx/core/http/Http2ClientTest.java
+++ b/src/test/java/io/vertx/core/http/Http2ClientTest.java
@@ -1039,6 +1039,52 @@ public class Http2ClientTest extends Http2TestBase {
   }
 
   @Test
+  public void testServerGracefulShutdownBeforeHeaderSent() throws Exception {
+    server.requestHandler(req -> {
+      req.connection().shutdown();
+      req.response().end("OK");
+    });
+    startServer(testAddress);
+
+    client.request(requestOptions).compose(req -> req
+        .send()
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::end))
+      .andThen(resp -> {
+        if (resp.succeeded()) {
+          testComplete();
+        } else {
+          fail(resp.cause());
+        }
+      });
+
+    await();
+  }
+
+  @Test
+  public void testGoAwayErrorBeforeHeaderSent() throws Exception {
+    server.requestHandler(req -> {
+      req.connection().goAway(100);
+      req.response().end("OK");
+    });
+    startServer(testAddress);
+
+    client.request(requestOptions).compose(req -> req
+        .send()
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::end))
+      .andThen(resp -> {
+        if (resp.succeeded()) {
+          testComplete();
+        } else {
+          fail(resp.cause());
+        }
+      });
+
+    await();
+  }
+
+  @Test
   public void testReceivingGoAwayDiscardsTheConnection() throws Exception {
     AtomicInteger reqCount = new AtomicInteger();
     Set<HttpConnection> connections = Collections.synchronizedSet(new HashSet<>());


### PR DESCRIPTION
Closes #5693

(cherry picked from commit 9a399e2a26ff56d3bfd44f06ee5ed16068e62d91)

Motivation:

This re-enables a graceful shutdown that was broken after ff78924cff931f275238bac3dfc64bacb27991d1
