### PR TITLE
Vert.x CodeGen will always use LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Those files are auto-generated, and will always have LF line endings when re-generated locally
+**/generated/**/*.java text=auto eol=lf


### PR DESCRIPTION
Closes #5849

Motivation:

This aligns the Git settings with the behavior of CodeGen.

An alternative approach would be to teach CodeGen to use the platform specific line endings. Let me know if that is preferred instead, or any other solution. 