### PR TITLE
Ensure setup of ‎HttpBandwidthLimitingTest is only called once

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpBandwidthLimitingTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpBandwidthLimitingTest.java
@@ -66,9 +66,9 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
     });
   }
 
-  private Function<Vertx, HttpServer> serverFactory;
-  private Function<Vertx, HttpClientAgent> clientFactory;
-  private Function<Vertx, HttpServer> nonTrafficShapedServerFactory;
+  private final Function<Vertx, HttpServer> serverFactory;
+  private final Function<Vertx, HttpClientAgent> clientFactory;
+  private final Function<Vertx, HttpServer> nonTrafficShapedServerFactory;
 
   public HttpBandwidthLimitingTest(double protoVersion, Function<Vertx, HttpServer> serverFactory,
                                    Function<Vertx, HttpClientAgent> clientFactory,
@@ -78,19 +78,14 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
     this.nonTrafficShapedServerFactory = nonTrafficShapedServerFactory;
   }
 
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
-    server = serverFactory.apply(vertx);
-    client = clientFactory.apply(vertx);
+  @Override
+  protected HttpClientAgent createHttpClient() {
+    return clientFactory.apply(vertx);
   }
 
-  @After
-  public void after() throws InterruptedException
-  {
-    CountDownLatch waitForClose = new CountDownLatch(1);
-    vertx.close().onComplete(onSuccess(resp -> waitForClose.countDown()));
-    awaitLatch(waitForClose);
+  @Override
+  protected HttpServer createHttpServer() {
+    return serverFactory.apply(vertx);
   }
 
   @Test


### PR DESCRIPTION
It is called from the AsyncTestBase's `@Before`.
No explicit teardown necessary, as Vert.x instances are closed automatically via AsyncTestBase's `@After`.

Closes #5851

Motivation:

The test case seems unstable, and a first observation was that `setUp()` was called multiple times. Let's see if it is now more stable. 

