### PR TITLE
Ensure setup of ‎HttpBandwidthLimitingTest is only called once [5.0]

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpBandwidthLimitingTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpBandwidthLimitingTest.java
@@ -66,9 +66,9 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
     });
   }
 
-  private Function<Vertx, HttpServer> serverFactory;
-  private Function<Vertx, HttpClientAgent> clientFactory;
-  private Function<Vertx, HttpServer> nonTrafficShapedServerFactory;
+  private final Function<Vertx, HttpServer> serverFactory;
+  private final Function<Vertx, HttpClientAgent> clientFactory;
+  private final Function<Vertx, HttpServer> nonTrafficShapedServerFactory;
 
   public HttpBandwidthLimitingTest(double protoVersion, Function<Vertx, HttpServer> serverFactory,
                                    Function<Vertx, HttpClientAgent> clientFactory,
@@ -78,19 +78,13 @@ public class HttpBandwidthLimitingTest extends Http2TestBase {
     this.nonTrafficShapedServerFactory = nonTrafficShapedServerFactory;
   }
 
-  @Before
+  @Override
   public void setUp() throws Exception {
     super.setUp();
+    server.close().await();
     server = serverFactory.apply(vertx);
+    client.close().await();
     client = clientFactory.apply(vertx);
-  }
-
-  @After
-  public void after() throws InterruptedException
-  {
-    CountDownLatch waitForClose = new CountDownLatch(1);
-    vertx.close().onComplete(onSuccess(resp -> waitForClose.countDown()));
-    awaitLatch(waitForClose);
   }
 
   @Test


### PR DESCRIPTION
It is called from the AsyncTestBase's `@Before`.
No explicit teardown necessary, as Vert.x instances are closed automatically via AsyncTestBase's `@After`.
Also not create more servers and clients than necessary.

Closes #5851

(cherry picked from commit a07b88f62f5e30af2a24e510240db2cd7c390ede)

