### PR TITLE
Ensure setup is only called once in VirtualThreadEventBusTest, VirtualThreadContextTest and NetBandwidthLimitingTest

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/VirtualThreadEventBusTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/VirtualThreadEventBusTest.java
@@ -22,7 +22,7 @@ public class VirtualThreadEventBusTest extends VertxTestBase {
 
   VertxInternal vertx;
 
-  @Before
+  @Override
   public void setUp() throws Exception {
     super.setUp();
     vertx = (VertxInternal) super.vertx;

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetBandwidthLimitingTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetBandwidthLimitingTest.java
@@ -51,7 +51,7 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
   private NetClient client = null;
   private final List<NetServer> servers = Collections.synchronizedList(new ArrayList<>());
 
-  @Before
+  @Override
   public void setUp() throws Exception {
     super.setUp();
     if (USE_DOMAIN_SOCKETS) {

--- a/vertx-core/src/test/java/io/vertx/tests/virtualthread/VirtualThreadContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/virtualthread/VirtualThreadContextTest.java
@@ -37,7 +37,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   VertxInternal vertx;
 
-  @Before
+  @Override
   public void setUp() throws Exception {
     super.setUp();
     vertx = (VertxInternal) super.vertx;


### PR DESCRIPTION
Closes #5857

Motivation:

Ensure setup is only called once. Otherwise there are multiple methods annotated with `@Before`.  


