### PR TITLE
Ensure setup is only called once in VirtualThreadEventBusTest, VirtualThreadContextTest and NetBandwidthLimitingTest [4.x]

### DIFF
--- a/src/test/java/io/vertx/core/VirtualThreadContextTest.java
+++ b/src/test/java/io/vertx/core/VirtualThreadContextTest.java
@@ -33,7 +33,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   VertxInternal vertx;
 
-  @Before
+  @Override
   public void setUp() throws Exception {
     super.setUp();
     vertx = (VertxInternal) super.vertx;

--- a/src/test/java/io/vertx/core/eventbus/VirtualThreadEventBusTest.java
+++ b/src/test/java/io/vertx/core/eventbus/VirtualThreadEventBusTest.java
@@ -21,7 +21,7 @@ public class VirtualThreadEventBusTest extends VertxTestBase {
 
   VertxInternal vertx;
 
-  @Before
+  @Override
   public void setUp() throws Exception {
     super.setUp();
     vertx = (VertxInternal) super.vertx;

--- a/src/test/java/io/vertx/core/net/NetBandwidthLimitingTest.java
+++ b/src/test/java/io/vertx/core/net/NetBandwidthLimitingTest.java
@@ -49,7 +49,7 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
   private SocketAddress testAddress;
   private NetClient client = null;
 
-  @Before
+  @Override
   public void setUp() throws Exception {
     super.setUp();
     if (USE_DOMAIN_SOCKETS) {


### PR DESCRIPTION
Closes #5857

(cherry picked from commit 57b9c68db77307b5bab89e61a7d6bc2af20e25af)

Motivation:

Setup should not be called twice due to the `@Before` anotation
