### PR TITLE
Ensure setup is only called once in VirtualThreadEventBusTest, VirtualThreadContextTest and NetBandwidthLimitingTest [5.0]

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/VirtualThreadEventBusTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/VirtualThreadEventBusTest.java
@@ -22,7 +22,7 @@ public class VirtualThreadEventBusTest extends VertxTestBase {
 
   VertxInternal vertx;
 
-  @Before
+  @Override
   public void setUp() throws Exception {
     super.setUp();
     vertx = (VertxInternal) super.vertx;

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetBandwidthLimitingTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetBandwidthLimitingTest.java
@@ -51,7 +51,7 @@ public class NetBandwidthLimitingTest extends VertxTestBase {
   private NetClient client = null;
   private final List<NetServer> servers = Collections.synchronizedList(new ArrayList<>());
 
-  @Before
+  @Override
   public void setUp() throws Exception {
     super.setUp();
     if (USE_DOMAIN_SOCKETS) {

--- a/vertx-core/src/test/java/io/vertx/tests/virtualthread/VirtualThreadContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/virtualthread/VirtualThreadContextTest.java
@@ -37,7 +37,7 @@ public class VirtualThreadContextTest extends VertxTestBase {
 
   VertxInternal vertx;
 
-  @Before
+  @Override
   public void setUp() throws Exception {
     super.setUp();
     vertx = (VertxInternal) super.vertx;


### PR DESCRIPTION
Closes #5857

(cherry picked from commit 57b9c68db77307b5bab89e61a7d6bc2af20e25af)

Motivation:

Setup should not be called twice due to the `@Before` annotation.
