### PR TITLE
Stabilize test by keeping reference to NetClient [4.x]

### DIFF
--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.http;
 
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.handler.codec.compression.DecompressionException;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -5179,14 +5180,17 @@ public abstract class HttpTest extends HttpTestBase {
     Buffer buffer = TestUtils.randomBuffer(128);
     Buffer received = Buffer.buffer();
     CompletableFuture<Void> closeSocket = new CompletableFuture<>();
-    vertx.createNetServer(new NetServerOptions().setPort(1235).setHost("localhost")).connectHandler(socket -> {
+    // Declare netClient in the main thread to avoid having it randomly garbage collected just after it created the connection
+    NetClient netClient = vertx.createNetClient(new NetClientOptions());
+
+    vertx.createNetServer(new NetServerOptions().setPort(0).setHost("localhost")).connectHandler(socket -> {
       socket.handler(socket::write);
       closeSocket.thenAccept(v -> {
         socket.close();
       });
     }).listen(onSuccess(netServer -> {
       server.requestHandler(req -> {
-        vertx.createNetClient(new NetClientOptions()).connect(1235, "localhost", onSuccess(dst -> {
+        netClient.connect(netServer.actualPort(), "localhost", onSuccess(dst -> {
 
           req.response().setStatusCode(sc);
           req.response().setStatusMessage("Connection established");
@@ -5217,7 +5221,7 @@ public abstract class HttpTest extends HttpTestBase {
                 }
               });
               socket.closeHandler(v -> {
-                assertEquals(buffer, received);
+                assertEquals(ByteBufUtil.hexDump(buffer.getBytes()), ByteBufUtil.hexDump(received.getBytes()));
                 testComplete();
               });
               socket.write(buffer);


### PR DESCRIPTION
Closes #5853

(cherry picked from commit 8c3bc9717f0f4f49fb6a39952d9d5f2158cdbf7e)

Motivation:

Stabilizing the test as outlined in the referenced issue. This is a minimized variant that doesn't do the refactoring done in the master branch to keep it minimal. 
