### PR TITLE
Stabilize test by keeping reference to NetClient [5.0]

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -11,6 +11,7 @@
 
 package io.vertx.tests.http;
 
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.compression.DecompressionException;
@@ -4979,17 +4980,21 @@ public abstract class HttpTest extends HttpTestBase {
     Buffer buffer = TestUtils.randomBuffer(128);
     Buffer received = Buffer.buffer();
     CompletableFuture<Void> closeSocket = new CompletableFuture<>();
-    vertx.createNetServer(new NetServerOptions().setPort(1235).setHost("localhost")).connectHandler(socket -> {
-      socket.handler(socket::write);
-      closeSocket.thenAccept(v -> {
-        socket.close();
-      });
-    }).listen().onComplete(onSuccess(netServer -> {
-      server.requestHandler(req -> {
-        vertx.createNetClient(new NetClientOptions()).connect(1235, "localhost").onComplete(onSuccess(dst -> {
+    NetServer netServer = vertx.createNetServer(new NetServerOptions().setPort(0).setHost("localhost"))
+      .connectHandler(socket -> {
+        socket.handler(socket::write);
+        closeSocket.thenAccept(v -> {
+          socket.close();
+        });
+      }).listen().await();
+    // Declare netClient in the main thread to avoid having it randomly garbage collected just after it created the connection
+    NetClient netClient = vertx.createNetClient(new NetClientOptions());
 
-          req.response().setStatusCode(sc);
-          req.response().setStatusMessage("Connection established");
+    server.requestHandler(req -> {
+      netClient.connect(netServer.actualPort(), "localhost").onComplete(onSuccess(dst -> {
+
+        req.response().setStatusCode(sc);
+        req.response().setStatusMessage("Connection established");
 
           // Now create a NetSocket
           req.toNetSocket().onComplete(onSuccess(src -> {
@@ -5015,12 +5020,11 @@ public abstract class HttpTest extends HttpTestBase {
                 }
               });
               socket.closeHandler(v -> {
-                assertEquals(buffer, received);
-                testComplete();
-              });
-              socket.write(buffer);
-            }));
-        }));
+                assertEquals(ByteBufUtil.hexDump(buffer.getBytes()), ByteBufUtil.hexDump(received.getBytes()));
+              testComplete();
+            });
+            socket.write(buffer);
+          }));
       }));
     }));
 


### PR DESCRIPTION
Closes #5853

(cherry picked from commit 8c3bc9717f0f4f49fb6a39952d9d5f2158cdbf7e)

Motivation:

Cherry-pick changes to master to also stabilize the release branch. This backports the changes including the refactoring as the API used is available in 5.0
