### PR TITLE
Stabilize test HttpBandwidthLimitingTest.testDynamicOutboundRateUpdateSharedServers [4.x]

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/TCPServerBase.java
+++ b/src/main/java/io/vertx/core/net/impl/TCPServerBase.java
@@ -148,6 +148,9 @@ public abstract class TCPServerBase implements Closeable, MetricsProvider {
     if (options == null) {
       throw new IllegalArgumentException("Invalid null value passed for traffic shaping options update");
     }
+    if (!listening) {
+      throw new IllegalStateException("Listening initialization not completed yet");
+    }
     TCPServerBase server = actualServer;
     // Update the traffic shaping options only for the actual/main server
     if (server != null && server != this) {
@@ -189,7 +192,6 @@ public abstract class TCPServerBase implements Closeable, MetricsProvider {
     }
 
     this.listenContext = context;
-    this.listening = true;
     this.eventLoop = context.nettyEventLoop();
 
     SocketAddress bindAddress;
@@ -285,7 +287,7 @@ public abstract class TCPServerBase implements Closeable, MetricsProvider {
           }
           listening = false;
         });
-
+        this.listening = true;
         return bindFuture;
       } else {
         // Server already exists with that host/port - we will use that
@@ -298,6 +300,7 @@ public abstract class TCPServerBase implements Closeable, MetricsProvider {
         actualServer.channelBalancer.addWorker(eventLoop, worker);
         listenContext.addCloseHook(this);
         main.bindFuture.onComplete(promise);
+        this.listening = true;
         return promise.future();
       }
     }


### PR DESCRIPTION
Only a server that has completed the listening is ready to update the traffic shaping.

Closes #5863

Motivation:

This both fixes the test that now only acts on fully initialized server instances, as well as adds additional safety measures on `TCPServerBase.java`. 

As 4.x is AFAIK in maintenance mode, I'm happy to discuss if those changes to `TCPServerBase` should change some behavior people might depend on. Looking at the `TCPServerBase.listen()` code, it was a bit surprising to me that a failing bind-future on the actual server will reset the listening flag ...

https://github.com/eclipse-vertx/vert.x/blob/8e06aa8e371ae7e2e80e04c460793420ec44f7e5/src/main/java/io/vertx/core/net/impl/TCPServerBase.java#L280-L287

... while it will not do the same on the other servers ....

https://github.com/eclipse-vertx/vert.x/blob/8e06aa8e371ae7e2e80e04c460793420ec44f7e5/src/main/java/io/vertx/core/net/impl/TCPServerBase.java#L300

Happy to discuss how to shape this PR, and what should be handled in follow-up issues.