### PR TITLE
Fix initialization and re-computation of expirationTimestamp in Http2ClientConnectionImpl

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ClientConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ClientConnectionImpl.java
@@ -62,6 +62,8 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
     this.authority = authority;
     this.lifetimeEvictionTimestamp = maxLifetime > 0 ? System.currentTimeMillis() + maxLifetime : Long.MAX_VALUE;
     this.handler = connHandler;
+    // Ensure that the expirationTimestamp is initialized
+    recycle();
   }
 
   @Override
@@ -199,8 +201,9 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
 
   @Override
   void onStreamClosed(Http2Stream s) {
-    super.onStreamClosed(s);
+    // Prepare this connection for returning as onStreamClosed() will return it to the pool.
     recycle();
+    super.onStreamClosed(s);
   }
 
   @Override


### PR DESCRIPTION
Closes #5865

Motivation:

Setting `expirationTimestamp` is required before the connection is recycled to ensure that the background timer executed correctly.

In a [previous attempt](https://github.com/eclipse-vertx/vert.x/compare/e0df732d1d402e7986dafb9b8cca6299bd7069d2..1eb0c76d21d1fdbed66cee40fb254030002f1433) I tried to set the initial value to `Long.MAX_VALUE`, but then `Http2Test.testClientKeepAliveTimeoutNoStreams` started failing. So I'm no setting it a value using `recycle()`. 

