### PR TITLE
Fix leaking creation of vertx instances during tests

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/ClientMultipartFormUpload.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/ClientMultipartFormUpload.java
@@ -146,7 +146,9 @@ public class ClientMultipartFormUpload implements ReadStream<Buffer> {
         return;
       }
     }
-    handler.handle(item);
+    if (handler != null) {
+      handler.handle(item);
+    }
   }
 
   public void pump() {

--- a/vertx-core/src/test/java/io/vertx/tests/file/FileResolverTestBase.java
+++ b/vertx-core/src/test/java/io/vertx/tests/file/FileResolverTestBase.java
@@ -348,7 +348,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   }
 
   private void testCaching(boolean enabled) throws Exception {
-    VertxInternal vertx = (VertxInternal) Vertx.vertx(new VertxOptions().setFileSystemOptions(new FileSystemOptions().setFileCachingEnabled(enabled)));
+    VertxInternal vertx = (VertxInternal) vertx(new VertxOptions().setFileSystemOptions(new FileSystemOptions().setFileCachingEnabled(enabled)));
     File tmp = File.createTempFile("vertx", ".bin");
     tmp.deleteOnExit();
     URL url = tmp.toURI().toURL();

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpDomainSocketTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpDomainSocketTest.java
@@ -32,14 +32,14 @@ public class HttpDomainSocketTest extends HttpTestBase {
 
   @Test
   public void testListenDomainSocketAddressNative() throws Exception {
-    VertxInternal vx = (VertxInternal) Vertx.vertx(new VertxOptions().setPreferNativeTransport(true));
+    VertxInternal vx = (VertxInternal) vertx(() -> Vertx.vertx(new VertxOptions().setPreferNativeTransport(true)));
     assumeTrue("Native transport must be enabled", vx.isNativeTransportEnabled());
     testListenDomainSocketAddress(vx);
   }
 
   @Test
   public void testListenDomainSocketAddressJdk() throws Exception {
-    VertxInternal vx = (VertxInternal) Vertx.vertx(new VertxOptions().setPreferNativeTransport(false));
+    VertxInternal vx = (VertxInternal) vertx(() -> Vertx.vertx(new VertxOptions().setPreferNativeTransport(false)));
     assumeFalse("Native transport must not be enabled", vx.isNativeTransportEnabled());
     testListenDomainSocketAddress(vx);
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/MultipartFormUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/MultipartFormUploadTest.java
@@ -52,7 +52,7 @@ public class MultipartFormUploadTest extends HttpTestBase {
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    vertx = (VertxInternal) Vertx.vertx();
+    vertx = (VertxInternal) super.vertx;
   }
 
   @Test
@@ -136,5 +136,6 @@ public class MultipartFormUploadTest extends HttpTestBase {
         fail(e);
       }
     });
+    await();
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsOptionsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsOptionsTest.java
@@ -66,8 +66,7 @@ public class MetricsOptionsTest extends VertxTestBase {
 
   @Test
   public void testMetricsEnabledWithoutConfig() {
-    vertx.close();
-    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    Vertx vertx = vertx(() -> Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true))));
     VertxMetrics metrics = ((VertxInternal) vertx).metrics();
     assertNull(metrics);
   }
@@ -76,12 +75,11 @@ public class MetricsOptionsTest extends VertxTestBase {
   public void testSetMetricsInstance() {
     VertxMetrics metrics = new VertxMetrics() {
     };
-    vertx.close();
-    vertx = Vertx
+    Vertx vertx = vertx(() -> Vertx
       .builder()
       .with(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)))
       .withMetrics(new SimpleVertxMetricsFactory<>(metrics))
-      .build();
+      .build());
     assertSame(metrics, ((VertxInternal) vertx).metrics());
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -1960,14 +1960,14 @@ public class NetTest extends VertxTestBase {
 
   @Test
   public void testListenDomainSocketAddressNative() throws Exception {
-    VertxInternal vx = (VertxInternal) Vertx.vertx(new VertxOptions().setPreferNativeTransport(true));
+    VertxInternal vx = (VertxInternal)vertx(() -> Vertx.vertx(new VertxOptions().setPreferNativeTransport(true)));
     assumeTrue("Native transport must be enabled", vx.isNativeTransportEnabled());
     testListenDomainSocketAddress(vx);
   }
 
   @Test
   public void testListenDomainSocketAddressJdk() throws Exception {
-    VertxInternal vx = (VertxInternal) Vertx.vertx(new VertxOptions().setPreferNativeTransport(false));
+    VertxInternal vx = (VertxInternal)vertx(() -> Vertx.vertx(new VertxOptions().setPreferNativeTransport(false)));
     assumeFalse("Native transport must not be enabled", vx.isNativeTransportEnabled());
     testListenDomainSocketAddress(vx);
   }

--- a/vertx-core/src/test/java/io/vertx/tests/security/PrivateKeyParserTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/security/PrivateKeyParserTest.java
@@ -24,6 +24,7 @@ import java.security.spec.ECPrivateKeySpec;
 import java.util.Base64;
 
 import io.vertx.core.net.impl.pkcs1.PrivateKeyParser;
+import io.vertx.test.core.VertxTestBase;
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -35,7 +36,7 @@ import io.vertx.test.core.TestUtils;
  * Verifies behavior of {@link PrivateKeyParser}.
  *
  */
-public class PrivateKeyParserTest {
+public class PrivateKeyParserTest extends VertxTestBase {
 
   /**
    * Verifies that the parser correctly identifies a
@@ -92,7 +93,6 @@ public class PrivateKeyParserTest {
   public void testGetECKeySpecSucceedsForDEREncodedECPrivateKey() throws GeneralSecurityException {
 
     Assume.assumeTrue("ECC is not supported by VM's security providers", TestUtils.isECCSupportedByVM());
-    Vertx vertx = Vertx.vertx();
     String b = vertx.fileSystem().readFileBlocking("tls/server-key-ec-pkcs1.pem")
         .toString(StandardCharsets.US_ASCII)
         .replaceAll("-----BEGIN EC PRIVATE KEY-----", "")

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxBootstrapTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxBootstrapTest.java
@@ -55,7 +55,11 @@ public class VertxBootstrapTest {
   public void testCreate() {
     VertxBootstrap factory = VertxBootstrap.create().init();
     Vertx vertx = factory.init().vertx();
-    assertNotNull(vertx);
+    try {
+      assertNotNull(vertx);
+    } finally {
+      vertx.close().await();
+    }
   }
 
   @Test
@@ -72,8 +76,12 @@ public class VertxBootstrapTest {
       }
     });
     Vertx vertx = fut.get(10, TimeUnit.SECONDS);
-    assertNotNull(vertx);
-    assertNotNull(((VertxInternal)vertx).clusterManager());
+    try {
+      assertNotNull(vertx);
+      assertNotNull(((VertxInternal)vertx).clusterManager());
+    } finally {
+      vertx.close().await();
+    }
   }
 
   @Test
@@ -85,7 +93,11 @@ public class VertxBootstrapTest {
       factory.metricsFactory(options -> metrics);
       factory.init();
       Vertx vertx = factory.vertx();
-      assertSame(metrics, ((VertxInternal)vertx).metrics());
+      try {
+        assertSame(metrics, ((VertxInternal)vertx).metrics());
+      } finally {
+        vertx.close().await();
+      }
     });
   }
 
@@ -113,7 +125,11 @@ public class VertxBootstrapTest {
       factory.tracerFactory(options -> tracer);
       factory.init();
       Vertx vertx = factory.vertx();
-      assertSame(tracer, ((VertxInternal)vertx).getOrCreateContext().tracer());
+      try {
+        assertSame(tracer, ((VertxInternal)vertx).getOrCreateContext().tracer());
+      } finally {
+        vertx.close().await();
+      }
     });
   }
 
@@ -149,7 +165,11 @@ public class VertxBootstrapTest {
       });
     });
     Vertx vertx = res.get(10, TimeUnit.SECONDS);
-    assertSame(clusterManager, ((VertxInternal)vertx).clusterManager());
+    try {
+      assertSame(clusterManager, ((VertxInternal)vertx).clusterManager());
+    } finally {
+      vertx.close().await();
+    }
   }
 
   @Test
@@ -161,7 +181,11 @@ public class VertxBootstrapTest {
     factory.transport(override);
     factory.init();
     Vertx vertx = factory.vertx();
-    assertSame(override, ((VertxInternal)vertx).transport());
+    try {
+      assertSame(override, ((VertxInternal)vertx).transport());
+    } finally {
+      vertx.close().await();
+    }
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxBuilderTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxBuilderTest.java
@@ -13,23 +13,24 @@ package io.vertx.tests.vertx;
 import io.vertx.core.Vertx;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.test.core.AsyncTestBase;
+import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakemetrics.FakeVertxMetrics;
 import io.vertx.test.faketracer.FakeTracer;
 import org.junit.Test;
 
-public class VertxBuilderTest  extends AsyncTestBase {
+public class VertxBuilderTest extends VertxTestBase {
 
   @Test
   public void testTracerFactoryDoesNotRequireOptions() {
     FakeTracer tracer = new FakeTracer();
-    Vertx vertx = Vertx.builder().withTracer(options -> tracer).build();
+    Vertx vertx = vertx(() -> Vertx.builder().withTracer(options -> tracer).build());
     assertEquals(tracer, ((VertxInternal)vertx).tracer());
   }
 
   @Test
   public void testMetricsFactoryDoesNotRequireOptions() {
     FakeVertxMetrics metrics = new FakeVertxMetrics();
-    Vertx vertx = Vertx.builder().withMetrics(options -> metrics).build();
+    Vertx vertx = vertx(() -> Vertx.builder().withMetrics(options -> metrics).build());
     assertEquals(metrics, ((VertxInternal)vertx).metrics());
   }
 }


### PR DESCRIPTION
Motivation:

A few tests are incorrectly written and create vertx instances that are never closed and create file descriptor leaks.

Changes:

Fix incorrect tests.