### PR TITLE
QUIC server name identification support.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/QuicConnectOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicConnectOptions.java
@@ -25,6 +25,7 @@ public class QuicConnectOptions {
   private ClientSSLOptions sslOptions;
   private QLogConfig qlogConfig;
   private Duration timeout;
+  private String serverName;
 
   public QuicConnectOptions() {
   }
@@ -100,6 +101,24 @@ public class QuicConnectOptions {
       throw new IllegalArgumentException("Timeout must be >= 0");
     }
     this.timeout = timeout;
+    return this;
+  }
+
+  /**
+   * @return the server name presented during the TLS handshake by the SNI extension
+   */
+  public String getServerName() {
+    return serverName;
+  }
+
+  /**
+   * Set the server name presented during the TLS handshake by the SNI extension.
+   *
+   * @param serverName the server name to indicate
+   * @return a reference to this, so the API can be used fluently
+   */
+  public QuicConnectOptions setServerName(String serverName) {
+    this.serverName = serverName;
     return this;
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicConnection.java
@@ -144,6 +144,11 @@ public interface QuicConnection {
   String applicationLayerProtocol();
 
   /**
+   * @return the server name indicated during the TLS handshake
+   */
+  String indicatedServerName();
+
+  /**
    * @return SSLSession associated with the underlying socket. Returns null if connection is
    *         not SSL.
    * @see javax.net.ssl.SSLSession


### PR DESCRIPTION
Motivation:

A QUIC client should be capable to configuration the indicated server name by the SNI extension, the indicated server name identifying the server should be made available by the QUIC connection.
