### PR TITLE
NetworkOptions does not declare anymore its state (besides activity logging).

### DIFF
--- a/vertx-core/src/main/generated/io/vertx/core/datagram/DatagramSocketOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/datagram/DatagramSocketOptionsConverter.java
@@ -12,11 +12,6 @@ public class DatagramSocketOptionsConverter {
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DatagramSocketOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "reuseAddress":
-          if (member.getValue() instanceof Boolean) {
-            obj.setReuseAddress((Boolean)member.getValue());
-          }
-          break;
         case "logActivity":
           if (member.getValue() instanceof Boolean) {
             obj.setLogActivity((Boolean)member.getValue());
@@ -40,6 +35,11 @@ public class DatagramSocketOptionsConverter {
         case "receiveBufferSize":
           if (member.getValue() instanceof Number) {
             obj.setReceiveBufferSize(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "reuseAddress":
+          if (member.getValue() instanceof Boolean) {
+            obj.setReuseAddress((Boolean)member.getValue());
           }
           break;
         case "trafficClass":
@@ -81,7 +81,6 @@ public class DatagramSocketOptionsConverter {
   }
 
    static void toJson(DatagramSocketOptions obj, java.util.Map<String, Object> json) {
-    json.put("reuseAddress", obj.isReuseAddress());
     json.put("logActivity", obj.getLogActivity());
     if (obj.getActivityLogDataFormat() != null) {
       json.put("activityLogDataFormat", obj.getActivityLogDataFormat().name());
@@ -89,6 +88,7 @@ public class DatagramSocketOptionsConverter {
     json.put("reusePort", obj.isReusePort());
     json.put("sendBufferSize", obj.getSendBufferSize());
     json.put("receiveBufferSize", obj.getReceiveBufferSize());
+    json.put("reuseAddress", obj.isReuseAddress());
     json.put("trafficClass", obj.getTrafficClass());
     json.put("broadcast", obj.isBroadcast());
     json.put("loopbackModeDisabled", obj.isLoopbackModeDisabled());

--- a/vertx-core/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
@@ -12,6 +12,16 @@ public class TCPSSLOptionsConverter {
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, TCPSSLOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "logActivity":
+          if (member.getValue() instanceof Boolean) {
+            obj.setLogActivity((Boolean)member.getValue());
+          }
+          break;
+        case "activityLogDataFormat":
+          if (member.getValue() instanceof String) {
+            obj.setActivityLogDataFormat(io.netty.handler.logging.ByteBufFormat.valueOf((String)member.getValue()));
+          }
+          break;
         case "sendBufferSize":
           if (member.getValue() instanceof Number) {
             obj.setSendBufferSize(((Number)member.getValue()).intValue());
@@ -30,16 +40,6 @@ public class TCPSSLOptionsConverter {
         case "trafficClass":
           if (member.getValue() instanceof Number) {
             obj.setTrafficClass(((Number)member.getValue()).intValue());
-          }
-          break;
-        case "logActivity":
-          if (member.getValue() instanceof Boolean) {
-            obj.setLogActivity((Boolean)member.getValue());
-          }
-          break;
-        case "activityLogDataFormat":
-          if (member.getValue() instanceof String) {
-            obj.setActivityLogDataFormat(io.netty.handler.logging.ByteBufFormat.valueOf((String)member.getValue()));
           }
           break;
         case "reusePort":
@@ -165,14 +165,14 @@ public class TCPSSLOptionsConverter {
   }
 
    static void toJson(TCPSSLOptions obj, java.util.Map<String, Object> json) {
-    json.put("sendBufferSize", obj.getSendBufferSize());
-    json.put("receiveBufferSize", obj.getReceiveBufferSize());
-    json.put("reuseAddress", obj.isReuseAddress());
-    json.put("trafficClass", obj.getTrafficClass());
     json.put("logActivity", obj.getLogActivity());
     if (obj.getActivityLogDataFormat() != null) {
       json.put("activityLogDataFormat", obj.getActivityLogDataFormat().name());
     }
+    json.put("sendBufferSize", obj.getSendBufferSize());
+    json.put("receiveBufferSize", obj.getReceiveBufferSize());
+    json.put("reuseAddress", obj.isReuseAddress());
+    json.put("trafficClass", obj.getTrafficClass());
     json.put("reusePort", obj.isReusePort());
     json.put("tcpNoDelay", obj.isTcpNoDelay());
     json.put("tcpKeepAlive", obj.isTcpKeepAlive());

--- a/vertx-core/src/main/java/io/vertx/core/datagram/DatagramSocketOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/datagram/DatagramSocketOptions.java
@@ -57,6 +57,10 @@ public class DatagramSocketOptions extends NetworkOptions {
    */
   public static final boolean DEFAULT_IPV6 = false;
 
+  private int sendBufferSize;
+  private int receiveBufferSize;
+  private int trafficClass;
+  private boolean reuseAddress;
   private boolean reusePort;
   private boolean broadcast;
   private boolean loopbackModeDisabled;
@@ -80,6 +84,10 @@ public class DatagramSocketOptions extends NetworkOptions {
    */
   public DatagramSocketOptions(DatagramSocketOptions other) {
     super(other);
+    this.sendBufferSize = other.getSendBufferSize();
+    this.receiveBufferSize = other.getReceiveBufferSize();
+    this.reuseAddress = other.isReuseAddress();
+    this.trafficClass = other.getTrafficClass();
     this.reusePort = other.reusePort;
     this.broadcast = other.isBroadcast();
     this.loopbackModeDisabled = other.isLoopbackModeDisabled();
@@ -100,6 +108,10 @@ public class DatagramSocketOptions extends NetworkOptions {
   }
 
   private void init() {
+    sendBufferSize = DEFAULT_SEND_BUFFER_SIZE;
+    receiveBufferSize = DEFAULT_RECEIVE_BUFFER_SIZE;
+    reuseAddress = DEFAULT_REUSE_ADDRESS;
+    trafficClass = DEFAULT_TRAFFIC_CLASS;
     reusePort = DEFAULT_REUSE_PORT;
     broadcast = DEFAULT_BROADCAST;
     loopbackModeDisabled = DEFAULT_LOOPBACK_MODE_DISABLED;
@@ -121,40 +133,48 @@ public class DatagramSocketOptions extends NetworkOptions {
 
   @Override
   public int getSendBufferSize() {
-    return super.getSendBufferSize();
+    return sendBufferSize;
   }
 
   @Override
   public DatagramSocketOptions setSendBufferSize(int sendBufferSize) {
-    super.setSendBufferSize(sendBufferSize);
+    Arguments.require(sendBufferSize > 0  || sendBufferSize == DEFAULT_SEND_BUFFER_SIZE, "sendBufferSize must be > 0");
+    this.sendBufferSize = sendBufferSize;
     return this;
   }
 
   @Override
   public int getReceiveBufferSize() {
-    return super.getReceiveBufferSize();
+    return receiveBufferSize;
   }
 
   @Override
   public DatagramSocketOptions setReceiveBufferSize(int receiveBufferSize) {
-    super.setReceiveBufferSize(receiveBufferSize);
+    Arguments.require(receiveBufferSize > 0 || receiveBufferSize == DEFAULT_RECEIVE_BUFFER_SIZE, "receiveBufferSize must be > 0");
+    this.receiveBufferSize = receiveBufferSize;
     return this;
   }
 
   @Override
+  public boolean isReuseAddress() {
+    return reuseAddress;
+  }
+
+  @Override
   public DatagramSocketOptions setReuseAddress(boolean reuseAddress) {
-    super.setReuseAddress(reuseAddress);
+    this.reuseAddress = reuseAddress;
     return this;
   }
 
   @Override
   public int getTrafficClass() {
-    return super.getTrafficClass();
+    return trafficClass;
   }
 
   @Override
   public DatagramSocketOptions setTrafficClass(int trafficClass) {
-    super.setTrafficClass(trafficClass);
+    Arguments.requireInRange(trafficClass, NetworkOptions.DEFAULT_TRAFFIC_CLASS, 255, "trafficClass tc must be 0 <= tc <= 255");
+    this.trafficClass = trafficClass;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/NetworkOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/NetworkOptions.java
@@ -12,8 +12,6 @@
 package io.vertx.core.net;
 
 import io.vertx.codegen.annotations.DataObject;
-import io.vertx.codegen.json.annotations.JsonGen;
-import io.vertx.core.impl.Arguments;
 import io.vertx.core.json.JsonObject;
 import io.netty.handler.logging.ByteBufFormat;
 
@@ -59,10 +57,6 @@ public abstract class NetworkOptions {
    */
   public static final ByteBufFormat DEFAULT_LOG_ACTIVITY_FORMAT = ByteBufFormat.HEX_DUMP;
 
-  private int sendBufferSize;
-  private int receiveBufferSize;
-  private int trafficClass;
-  private boolean reuseAddress;
   private boolean logActivity;
   private ByteBufFormat activityLogDataFormat;
 
@@ -70,10 +64,6 @@ public abstract class NetworkOptions {
    * Default constructor
    */
   public NetworkOptions() {
-    sendBufferSize = DEFAULT_SEND_BUFFER_SIZE;
-    receiveBufferSize = DEFAULT_RECEIVE_BUFFER_SIZE;
-    reuseAddress = DEFAULT_REUSE_ADDRESS;
-    trafficClass = DEFAULT_TRAFFIC_CLASS;
     logActivity = DEFAULT_LOG_ENABLED;
     activityLogDataFormat = DEFAULT_LOG_ACTIVITY_FORMAT;
   }
@@ -84,10 +74,6 @@ public abstract class NetworkOptions {
    * @param other  the options to copy
    */
   public NetworkOptions(NetworkOptions other) {
-    this.sendBufferSize = other.getSendBufferSize();
-    this.receiveBufferSize = other.getReceiveBufferSize();
-    this.reuseAddress = other.isReuseAddress();
-    this.trafficClass = other.getTrafficClass();
     this.logActivity = other.logActivity;
     this.activityLogDataFormat = other.activityLogDataFormat;
   }
@@ -113,9 +99,7 @@ public abstract class NetworkOptions {
    *
    * @return the send buffer size
    */
-  public int getSendBufferSize() {
-    return sendBufferSize;
-  }
+  public abstract int getSendBufferSize();
 
   /**
    * Set the TCP send buffer size
@@ -123,20 +107,14 @@ public abstract class NetworkOptions {
    * @param sendBufferSize  the buffers size, in bytes
    * @return a reference to this, so the API can be used fluently
    */
-  public NetworkOptions setSendBufferSize(int sendBufferSize) {
-    Arguments.require(sendBufferSize > 0  || sendBufferSize == DEFAULT_SEND_BUFFER_SIZE, "sendBufferSize must be > 0");
-    this.sendBufferSize = sendBufferSize;
-    return this;
-  }
+  public abstract NetworkOptions setSendBufferSize(int sendBufferSize);
 
   /**
    * Return the TCP receive buffer size, in bytes
    *
    * @return the receive buffer size
    */
-  public int getReceiveBufferSize() {
-    return receiveBufferSize;
-  }
+  public abstract int getReceiveBufferSize();
 
   /**
    * Set the TCP receive buffer size
@@ -144,35 +122,24 @@ public abstract class NetworkOptions {
    * @param receiveBufferSize  the buffers size, in bytes
    * @return a reference to this, so the API can be used fluently
    */
-  public NetworkOptions setReceiveBufferSize(int receiveBufferSize) {
-    Arguments.require(receiveBufferSize > 0 || receiveBufferSize == DEFAULT_RECEIVE_BUFFER_SIZE, "receiveBufferSize must be > 0");
-    this.receiveBufferSize = receiveBufferSize;
-    return this;
-  }
+  public abstract NetworkOptions setReceiveBufferSize(int receiveBufferSize);
 
   /**
    * @return  the value of reuse address
    */
-  public boolean isReuseAddress() {
-    return reuseAddress;
-  }
+  public abstract boolean isReuseAddress();
 
   /**
    * Set the value of reuse address
    * @param reuseAddress  the value of reuse address
    * @return a reference to this, so the API can be used fluently
    */
-  public NetworkOptions setReuseAddress(boolean reuseAddress) {
-    this.reuseAddress = reuseAddress;
-    return this;
-  }
+  public abstract NetworkOptions setReuseAddress(boolean reuseAddress);
 
   /**
    * @return  the value of traffic class
    */
-  public int getTrafficClass() {
-    return trafficClass;
-  }
+  public abstract int getTrafficClass();
 
   /**
    * Set the value of traffic class
@@ -180,11 +147,7 @@ public abstract class NetworkOptions {
    * @param trafficClass  the value of traffic class
    * @return a reference to this, so the API can be used fluently
    */
-  public NetworkOptions setTrafficClass(int trafficClass) {
-    Arguments.requireInRange(trafficClass, DEFAULT_TRAFFIC_CLASS, 255, "trafficClass tc must be 0 <= tc <= 255");
-    this.trafficClass = trafficClass;
-    return this;
-  }
+  public abstract NetworkOptions setTrafficClass(int trafficClass);
 
   /**
    * @return true when network activity logging is enabled

--- a/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -263,6 +263,50 @@ public abstract class TCPSSLOptions extends NetworkOptions {
   }
 
   @Override
+  public int getSendBufferSize() {
+    return transportOptions.getSendBufferSize();
+  }
+
+  @Override
+  public TCPSSLOptions setSendBufferSize(int sendBufferSize) {
+    transportOptions.setSendBufferSize(sendBufferSize);
+    return this;
+  }
+
+  @Override
+  public int getReceiveBufferSize() {
+    return transportOptions.getReceiveBufferSize();
+  }
+
+  @Override
+  public TCPSSLOptions setReceiveBufferSize(int receiveBufferSize) {
+    transportOptions.setReceiveBufferSize(receiveBufferSize);
+    return this;
+  }
+
+  @Override
+  public boolean isReuseAddress() {
+    return transportOptions.isReuseAddress();
+  }
+
+  @Override
+  public TCPSSLOptions setReuseAddress(boolean reuseAddress) {
+    transportOptions.setReuseAddress(reuseAddress);
+    return this;
+  }
+
+  @Override
+  public int getTrafficClass() {
+    return transportOptions.getTrafficClass();
+  }
+
+  @Override
+  public TCPSSLOptions setTrafficClass(int trafficClass) {
+    transportOptions.setTrafficClass(trafficClass);
+    return this;
+  }
+
+  @Override
   public boolean isReusePort() {
     return transportOptions.isReusePort();
   }
@@ -753,31 +797,6 @@ public abstract class TCPSSLOptions extends NetworkOptions {
   @Override
   public TCPSSLOptions setLogActivity(boolean logEnabled) {
     return (TCPSSLOptions) super.setLogActivity(logEnabled);
-  }
-
-  @Override
-  public TCPSSLOptions setActivityLogDataFormat(ByteBufFormat activityLogDataFormat) {
-    return (TCPSSLOptions) super.setActivityLogDataFormat(activityLogDataFormat);
-  }
-
-  @Override
-  public TCPSSLOptions setSendBufferSize(int sendBufferSize) {
-    return (TCPSSLOptions) super.setSendBufferSize(sendBufferSize);
-  }
-
-  @Override
-  public TCPSSLOptions setReceiveBufferSize(int receiveBufferSize) {
-    return (TCPSSLOptions) super.setReceiveBufferSize(receiveBufferSize);
-  }
-
-  @Override
-  public TCPSSLOptions setReuseAddress(boolean reuseAddress) {
-    return (TCPSSLOptions) super.setReuseAddress(reuseAddress);
-  }
-
-  @Override
-  public TCPSSLOptions setTrafficClass(int trafficClass) {
-    return (TCPSSLOptions) super.setTrafficClass(trafficClass);
   }
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/TcpOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TcpOptions.java
@@ -10,6 +10,8 @@
  */
 package io.vertx.core.net;
 
+import io.vertx.core.impl.Arguments;
+
 import static io.vertx.core.net.TCPSSLOptions.DEFAULT_SO_LINGER;
 
 /**
@@ -17,6 +19,10 @@ import static io.vertx.core.net.TCPSSLOptions.DEFAULT_SO_LINGER;
  */
 public class TcpOptions extends TransportOptions {
 
+  private int sendBufferSize;
+  private int receiveBufferSize;
+  private int trafficClass;
+  private boolean reuseAddress;
   private boolean reusePort;
   private boolean tcpNoDelay;
   private boolean tcpKeepAlive;
@@ -32,6 +38,10 @@ public class TcpOptions extends TransportOptions {
 
   public TcpOptions(TcpOptions other) {
     init();
+    this.sendBufferSize = other.getSendBufferSize();
+    this.receiveBufferSize = other.getReceiveBufferSize();
+    this.reuseAddress = other.isReuseAddress();
+    this.trafficClass = other.getTrafficClass();
     this.reusePort = other.isReusePort();
     this.tcpNoDelay = other.isTcpNoDelay();
     this.tcpKeepAlive = other.isTcpKeepAlive();
@@ -43,6 +53,10 @@ public class TcpOptions extends TransportOptions {
   }
 
   void init() {
+    sendBufferSize = NetworkOptions.DEFAULT_SEND_BUFFER_SIZE;
+    receiveBufferSize = NetworkOptions.DEFAULT_RECEIVE_BUFFER_SIZE;
+    reuseAddress = NetworkOptions.DEFAULT_REUSE_ADDRESS;
+    trafficClass = NetworkOptions.DEFAULT_TRAFFIC_CLASS;
     reusePort = NetworkOptions.DEFAULT_REUSE_PORT;
     tcpNoDelay = TCPSSLOptions.DEFAULT_TCP_NO_DELAY;
     tcpKeepAlive = TCPSSLOptions.DEFAULT_TCP_KEEP_ALIVE;
@@ -56,6 +70,84 @@ public class TcpOptions extends TransportOptions {
   @Override
   protected TcpOptions copy() {
     return new TcpOptions(this);
+  }
+
+  /**
+   * Return the TCP send buffer size, in bytes.
+   *
+   * @return the send buffer size
+   */
+  public int getSendBufferSize() {
+    return sendBufferSize;
+  }
+
+  /**
+   * Set the TCP send buffer size
+   *
+   * @param sendBufferSize  the buffers size, in bytes
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TcpOptions setSendBufferSize(int sendBufferSize) {
+    Arguments.require(sendBufferSize > 0  || sendBufferSize == NetworkOptions.DEFAULT_SEND_BUFFER_SIZE, "sendBufferSize must be > 0");
+    this.sendBufferSize = sendBufferSize;
+    return this;
+  }
+
+  /**
+   * Return the TCP receive buffer size, in bytes
+   *
+   * @return the receive buffer size
+   */
+  public int getReceiveBufferSize() {
+    return receiveBufferSize;
+  }
+
+  /**
+   * Set the TCP receive buffer size
+   *
+   * @param receiveBufferSize  the buffers size, in bytes
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TcpOptions setReceiveBufferSize(int receiveBufferSize) {
+    Arguments.require(receiveBufferSize > 0 || receiveBufferSize == NetworkOptions.DEFAULT_RECEIVE_BUFFER_SIZE, "receiveBufferSize must be > 0");
+    this.receiveBufferSize = receiveBufferSize;
+    return this;
+  }
+
+  /**
+   * @return  the value of reuse address
+   */
+  public boolean isReuseAddress() {
+    return reuseAddress;
+  }
+
+  /**
+   * Set the value of reuse address
+   * @param reuseAddress  the value of reuse address
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TcpOptions setReuseAddress(boolean reuseAddress) {
+    this.reuseAddress = reuseAddress;
+    return this;
+  }
+
+  /**
+   * @return  the value of traffic class
+   */
+  public int getTrafficClass() {
+    return trafficClass;
+  }
+
+  /**
+   * Set the value of traffic class
+   *
+   * @param trafficClass  the value of traffic class
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TcpOptions setTrafficClass(int trafficClass) {
+    Arguments.requireInRange(trafficClass, NetworkOptions.DEFAULT_TRAFFIC_CLASS, 255, "trafficClass tc must be 0 <= tc <= 255");
+    this.trafficClass = trafficClass;
+    return this;
   }
 
   /**


### PR DESCRIPTION
Motivation:

TCP related configuration started to be encapsulated into TcpOptions but only the TCPSSLOptions portion was moved to this class.

In order to be fully reusable, the NetworkOptions portion should be declared as well.

Changes:

- NetworkOptions does not declare anymore state, related property accessors have been made abstract
- TcpOptions declares the NetworkOptions state as well as its property accessors
- TCPSSLOptions implements the property accessors defined by NetworkOptions by delegating to TcpOptions
- DatagramSocketOptions declares the NetworkOptions state and implements the property accessors defined by NetworkOptions
