### PR TITLE
Internal modularization of HTTP/1.x and HTTP/2 client configuration.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/Http1ClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/Http1ClientConfig.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.core.impl.Arguments;
+
+/**
+ * HTTP/1.x client configuration.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+class Http1ClientConfig {
+
+  private boolean keepAlive;
+  private int keepAliveTimeout;
+  private int pipeliningLimit;
+  private boolean pipelining;
+  private int maxChunkSize;
+  private int maxInitialLineLength;
+  private int maxHeaderSize;
+  private int decoderInitialBufferSize;
+
+  Http1ClientConfig() {
+    keepAlive = HttpClientOptions.DEFAULT_KEEP_ALIVE;
+    keepAliveTimeout = HttpClientOptions.DEFAULT_KEEP_ALIVE_TIMEOUT;
+    pipelining = HttpClientOptions.DEFAULT_PIPELINING;
+    pipeliningLimit = HttpClientOptions.DEFAULT_PIPELINING_LIMIT;
+    maxChunkSize = HttpClientOptions.DEFAULT_MAX_CHUNK_SIZE;
+    maxInitialLineLength = HttpClientOptions.DEFAULT_MAX_INITIAL_LINE_LENGTH;
+    maxHeaderSize = HttpClientOptions.DEFAULT_MAX_HEADER_SIZE;
+    decoderInitialBufferSize = HttpClientOptions.DEFAULT_DECODER_INITIAL_BUFFER_SIZE;
+  }
+
+  Http1ClientConfig(Http1ClientConfig other) {
+    this.keepAlive = other.isKeepAlive();
+    this.keepAliveTimeout = other.getKeepAliveTimeout();
+    this.pipelining = other.isPipelining();
+    this.pipeliningLimit = other.getPipeliningLimit();
+    this.maxChunkSize = other.maxChunkSize;
+    this.maxInitialLineLength = other.getMaxInitialLineLength();
+    this.maxHeaderSize = other.getMaxHeaderSize();
+    this.decoderInitialBufferSize = other.getDecoderInitialBufferSize();
+  }
+
+
+  /**
+   * Is keep alive enabled on the client?
+   *
+   * @return {@code true} if enabled
+   */
+  public boolean isKeepAlive() {
+    return keepAlive;
+  }
+
+  /**
+   * Set whether keep alive is enabled on the client
+   *
+   * @param keepAlive {@code true} if enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http1ClientConfig setKeepAlive(boolean keepAlive) {
+    this.keepAlive = keepAlive;
+    return this;
+  }
+
+  /**
+   * @return the keep alive timeout value in seconds for HTTP/1.x connections
+   */
+  public int getKeepAliveTimeout() {
+    return keepAliveTimeout;
+  }
+
+  /**
+   * Set the keep alive timeout for HTTP/1.x, in seconds.
+   * <p/>
+   * This value determines how long a connection remains unused in the pool before being evicted and closed.
+   * <p/>
+   * A timeout of {@code 0} means there is no timeout.
+   *
+   * @param keepAliveTimeout the timeout, in seconds
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http1ClientConfig setKeepAliveTimeout(int keepAliveTimeout) {
+    if (keepAliveTimeout < 0) {
+      throw new IllegalArgumentException("keepAliveTimeout must be >= 0");
+    }
+    this.keepAliveTimeout = keepAliveTimeout;
+    return this;
+  }
+
+  /**
+   * Is pipe-lining enabled on the client
+   *
+   * @return {@code true} if pipe-lining is enabled
+   */
+  public boolean isPipelining() {
+    return pipelining;
+  }
+
+  /**
+   * Set whether pipe-lining is enabled on the client
+   *
+   * @param pipelining {@code true} if enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http1ClientConfig setPipelining(boolean pipelining) {
+    this.pipelining = pipelining;
+    return this;
+  }
+
+  /**
+   * @return the limit of pending requests a pipe-lined HTTP/1 connection can send
+   */
+  public int getPipeliningLimit() {
+    return pipeliningLimit;
+  }
+
+  /**
+   * Set the limit of pending requests a pipe-lined HTTP/1 connection can send.
+   *
+   * @param limit the limit of pending requests
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http1ClientConfig setPipeliningLimit(int limit) {
+    if (limit < 1) {
+      throw new IllegalArgumentException("pipeliningLimit must be > 0");
+    }
+    this.pipeliningLimit = limit;
+    return this;
+  }
+
+  /**
+   * Set the maximum HTTP chunk size
+   * @param maxChunkSize the maximum chunk size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http1ClientConfig setMaxChunkSize(int maxChunkSize) {
+    this.maxChunkSize = maxChunkSize;
+    return this;
+  }
+
+  /**
+   * Returns the maximum HTTP chunk size
+   * @return the maximum HTTP chunk size
+   */
+  public int getMaxChunkSize() {
+    return maxChunkSize;
+  }
+
+  /**
+   * @return the maximum length of the initial line for HTTP/1.x (e.g. {@code "GET / HTTP/1.0"})
+   */
+  public int getMaxInitialLineLength() {
+    return maxInitialLineLength;
+  }
+
+  /**
+   * Set the maximum length of the initial line for HTTP/1.x (e.g. {@code "HTTP/1.1 200 OK"})
+   *
+   * @param maxInitialLineLength the new maximum initial length
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http1ClientConfig setMaxInitialLineLength(int maxInitialLineLength) {
+    this.maxInitialLineLength = maxInitialLineLength;
+    return this;
+  }
+
+  /**
+   * @return Returns the maximum length of all headers for HTTP/1.x
+   */
+  public int getMaxHeaderSize() {
+    return maxHeaderSize;
+  }
+
+  /**
+   * Set the maximum length of all headers for HTTP/1.x .
+   *
+   * @param maxHeaderSize the new maximum length
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http1ClientConfig setMaxHeaderSize(int maxHeaderSize) {
+    this.maxHeaderSize = maxHeaderSize;
+    return this;
+  }
+
+  /**
+   * @return the initial buffer size for the HTTP decoder
+   */
+  public int getDecoderInitialBufferSize() { return decoderInitialBufferSize; }
+
+  /**
+   * set to {@code initialBufferSizeHttpDecoder} the initial buffer of the HttpDecoder.
+   *
+   * @param decoderInitialBufferSize the initial buffer size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http1ClientConfig setDecoderInitialBufferSize(int decoderInitialBufferSize) {
+    Arguments.require(decoderInitialBufferSize > 0, "initialBufferSizeHttpDecoder must be > 0");
+    this.decoderInitialBufferSize = decoderInitialBufferSize;
+    return this;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/Http2ClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/Http2ClientConfig.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+/**
+ * HTTP/2 client configuration.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class Http2ClientConfig {
+
+  private int multiplexingLimit;
+  private int connectionWindowSize;
+  private int keepAliveTimeout;
+  private int upgradeMaxContentLength;
+  private boolean multiplexImplementation;
+  private Http2Settings initialSettings;
+  private boolean clearTextUpgrade;
+  private boolean clearTextUpgradeWithPreflightRequest;
+
+  public Http2ClientConfig() {
+    multiplexingLimit = HttpClientOptions.DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
+    connectionWindowSize = HttpClientOptions.DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE;
+    keepAliveTimeout = HttpClientOptions.DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT;
+    upgradeMaxContentLength = HttpClientOptions.DEFAULT_HTTP2_UPGRADE_MAX_CONTENT_LENGTH;
+    multiplexImplementation = HttpClientOptions.DEFAULT_HTTP_2_MULTIPLEX_IMPLEMENTATION;
+    initialSettings = new Http2Settings();
+    clearTextUpgrade = HttpClientOptions.DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE;
+    clearTextUpgradeWithPreflightRequest = HttpClientOptions.DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE_WITH_PREFLIGHT_REQUEST;
+  }
+
+  public Http2ClientConfig(Http2ClientConfig other) {
+    this.multiplexingLimit = other.multiplexingLimit;
+    this.connectionWindowSize = other.connectionWindowSize;
+    this.keepAliveTimeout = other.getKeepAliveTimeout();
+    this.upgradeMaxContentLength = other.getUpgradeMaxContentLength();
+    this.multiplexImplementation = other.getMultiplexImplementation();
+    this.initialSettings = other.initialSettings != null ? new Http2Settings(other.initialSettings) : null;
+    this.clearTextUpgrade = other.clearTextUpgrade;
+    this.clearTextUpgradeWithPreflightRequest = other.clearTextUpgradeWithPreflightRequest;
+  }
+
+  /**
+   * @return the maximum number of concurrent streams for an HTTP/2 connection, {@code -1} means
+   * the value sent by the server
+   */
+  public int getMultiplexingLimit() {
+    return multiplexingLimit;
+  }
+
+  /**
+   * Set a client limit of the number concurrent streams for each HTTP/2 connection, this limits the number
+   * of streams the client can create for a connection. The effective number of streams for a
+   * connection is the min of this value and the server's initial settings.
+   * <p/>
+   * Setting the value to {@code -1} means to use the value sent by the server's initial settings.
+   * {@code -1} is the default value.
+   *
+   * @param limit the maximum concurrent for an HTTP/2 connection
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http2ClientConfig setMultiplexingLimit(int limit) {
+    if (limit == 0 || limit < -1) {
+      throw new IllegalArgumentException("maxPoolSize must be > 0 or -1 (disabled)");
+    }
+    this.multiplexingLimit = limit;
+    return this;
+  }
+
+  /**
+   * @return the default HTTP/2 connection window size
+   */
+  public int getConnectionWindowSize() {
+    return connectionWindowSize;
+  }
+
+  /**
+   * Set the default HTTP/2 connection window size. It overrides the initial window
+   * size set by {@link Http2Settings#getInitialWindowSize}, so the connection window size
+   * is greater than for its streams, in order the data throughput.
+   * <p/>
+   * A value of {@code -1} reuses the initial window size setting.
+   *
+   * @param connectionWindowSize the window size applied to the connection
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http2ClientConfig setConnectionWindowSize(int connectionWindowSize) {
+    this.connectionWindowSize = connectionWindowSize;
+    return this;
+  }
+
+  /**
+   * @return the keep alive timeout value in seconds for HTTP/2 connections
+   */
+  public int getKeepAliveTimeout() {
+    return keepAliveTimeout;
+  }
+
+  /**
+   * Set the keep alive timeout for HTTP/2 connections, in seconds.
+   * <p/>
+   * This value determines how long a connection remains unused in the pool before being evicted and closed.
+   * <p/>
+   * A timeout of {@code 0} means there is no timeout.
+   *
+   * @param keepAliveTimeout the timeout, in seconds
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http2ClientConfig setKeepAliveTimeout(int keepAliveTimeout) {
+    if (keepAliveTimeout < 0) {
+      throw new IllegalArgumentException("HTTP/2 keepAliveTimeout must be >= 0");
+    }
+    this.keepAliveTimeout = keepAliveTimeout;
+    return this;
+  }
+
+  /**
+   * @return the HTTP/2 upgrade maximum length of the aggregated content in bytes
+   */
+  public int getUpgradeMaxContentLength() {
+    return upgradeMaxContentLength;
+  }
+
+  /**
+   * Set the HTTP/2 upgrade maximum length of the aggregated content in bytes.
+   * This is only taken into account when {@link Http2ClientConfig#isClearTextUpgradeWithPreflightRequest} is set to {@code false} (which is the default).
+   * When {@link Http2ClientConfig#isClearTextUpgradeWithPreflightRequest} is {@code true}, then the client makes a preflight OPTIONS request
+   * and the upgrade will not send a body, voiding the requirements.
+   *
+   * @param upgradeMaxContentLength the length, in bytes
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http2ClientConfig setUpgradeMaxContentLength(int upgradeMaxContentLength) {
+    this.upgradeMaxContentLength = upgradeMaxContentLength;
+    return this;
+  }
+
+  /**
+   * @return whether to use the HTTP/2 implementation based on multiplexed channel
+   */
+  public boolean getMultiplexImplementation() {
+    return multiplexImplementation;
+  }
+
+  /**
+   * Set which HTTP/2 implementation to use
+   *
+   * @param multiplexImplementation whether to use the HTTP/2 multiplex implementation
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http2ClientConfig setMultiplexImplementation(boolean multiplexImplementation) {
+    this.multiplexImplementation = multiplexImplementation;
+    return this;
+  }
+
+  /**
+   * @return the initial HTTP/2 connection settings
+   */
+  public Http2Settings getInitialSettings() {
+    return initialSettings;
+  }
+
+  /**
+   * Set the HTTP/2 connection settings immediately sent by to the server when the client connects.
+   *
+   * @param settings the settings value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http2ClientConfig setInitialSettings(Http2Settings settings) {
+    this.initialSettings = settings;
+    return this;
+  }
+
+  /**
+   * @return {@code true} when an <i>h2c</i> connection is established using an HTTP/1.1 upgrade request, {@code false} when directly
+   */
+  public boolean isClearTextUpgrade() {
+    return clearTextUpgrade;
+  }
+
+  /**
+   * Set to {@code true} when an <i>h2c</i> connection is established using an HTTP/1.1 upgrade request, and {@code false}
+   * when an <i>h2c</i> connection is established directly (with prior knowledge).
+   *
+   * @param value the upgrade value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http2ClientConfig setClearTextUpgrade(boolean value) {
+    this.clearTextUpgrade = value;
+    return this;
+  }
+
+  /**
+   * @return {@code true} when an <i>h2c</i> connection established using an HTTP/1.1 upgrade request should perform
+   *         a preflight {@code OPTIONS} request to the origin server to establish the <i>h2c</i> connection
+   */
+  public boolean isClearTextUpgradeWithPreflightRequest() {
+    return clearTextUpgradeWithPreflightRequest;
+  }
+
+  /**
+   * Set to {@code true} when an <i>h2c</i> connection established using an HTTP/1.1 upgrade request should perform
+   * a preflight {@code OPTIONS} request to the origin server to establish the <i>h2c</i> connection.
+   *
+   * @param value the upgrade value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http2ClientConfig setClearTextUpgradeWithPreflightRequest(boolean value) {
+    this.clearTextUpgradeWithPreflightRequest = value;
+    return this;
+  }
+}


### PR DESCRIPTION
Motivation:

HttpClientOptions defines a portion of its state for HTTP/1.x protocol as well as HTTP/2 protocol.

Protocol level configuration should have its own class container.

This might be helpful when HTTP/3 configuration will be a concern.

Changes:

Move the HTTP protocol level configuration state in configuration classes.

For the moment such configuration classes are package private and not visible (yet).

Existing property names are maintaining, except the http2 prefixed properties for which the prefix has been stripped, e.g. http2MultiplexingLimit becomes multiplexingLimit.
