### PR TITLE
HttpClient implementation should stop using HttpClientOptions

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -17,6 +17,8 @@ import io.vertx.codegen.annotations.Unstable;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.impl.HttpUtils;
+import io.vertx.core.http.impl.config.Http1ClientConfig;
+import io.vertx.core.http.impl.config.Http2ClientConfig;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
 import io.vertx.core.tracing.TracingPolicy;
@@ -260,6 +262,14 @@ public class HttpClientOptions extends ClientOptionsBase {
     shared = DEFAULT_SHARED;
     name = DEFAULT_NAME;
     followAlternativeServices = DEFAULT_FOLLOW_ALTERNATIVE_SERVICES;
+  }
+
+  public Http1ClientConfig getHttp1Config() {
+    return http1Config;
+  }
+
+  public Http2ClientConfig getHttp2Config() {
+    return http2Config;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -107,7 +107,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
                                               PoolOptions po) {
     HttpClientMetrics<?, ?, ?> metrics = vertx.metrics() != null ? vertx.metrics().createHttpClientMetrics(co) : null;
     NetClientInternal tcpClient = new NetClientBuilder(vertx, new NetClientOptions(co).setProxyOptions(null)).metrics(metrics).build();
-    HttpChannelConnector channelConnector = new Http1xOrH2ChannelConnector(tcpClient, co, metrics);
+    HttpChannelConnector channelConnector = Http1xOrH2ChannelConnector.create(tcpClient, co, metrics);
     HttpClientImpl.Transport transport = new HttpClientImpl.Transport(
       connectionHandler,
       channelConnector,

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/config/Http1ClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/config/Http1ClientConfig.java
@@ -8,8 +8,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.core.http;
+package io.vertx.core.http.impl.config;
 
+import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.impl.Arguments;
 
 /**
@@ -17,7 +18,7 @@ import io.vertx.core.impl.Arguments;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-class Http1ClientConfig {
+public class Http1ClientConfig {
 
   private boolean keepAlive;
   private int keepAliveTimeout;
@@ -28,7 +29,7 @@ class Http1ClientConfig {
   private int maxHeaderSize;
   private int decoderInitialBufferSize;
 
-  Http1ClientConfig() {
+  public Http1ClientConfig() {
     keepAlive = HttpClientOptions.DEFAULT_KEEP_ALIVE;
     keepAliveTimeout = HttpClientOptions.DEFAULT_KEEP_ALIVE_TIMEOUT;
     pipelining = HttpClientOptions.DEFAULT_PIPELINING;
@@ -39,7 +40,7 @@ class Http1ClientConfig {
     decoderInitialBufferSize = HttpClientOptions.DEFAULT_DECODER_INITIAL_BUFFER_SIZE;
   }
 
-  Http1ClientConfig(Http1ClientConfig other) {
+  public Http1ClientConfig(Http1ClientConfig other) {
     this.keepAlive = other.isKeepAlive();
     this.keepAliveTimeout = other.getKeepAliveTimeout();
     this.pipelining = other.isPipelining();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/config/Http2ClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/config/Http2ClientConfig.java
@@ -8,7 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.core.http;
+package io.vertx.core.http.impl.config;
+
+import io.vertx.core.http.Http2Settings;
+import io.vertx.core.http.HttpClientOptions;
 
 /**
  * HTTP/2 client configuration.

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1x/Http1xClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1x/Http1xClientConnection.java
@@ -39,6 +39,7 @@ import io.vertx.core.http.WebSocketVersion;
 import io.vertx.core.http.impl.*;
 import io.vertx.core.http.impl.HttpClientConnection;
 import io.vertx.core.http.impl.HttpRequestHead;
+import io.vertx.core.http.impl.config.Http1ClientConfig;
 import io.vertx.core.http.impl.headers.HeadersAdaptor;
 import io.vertx.core.http.impl.headers.Http1xHeaders;
 import io.vertx.core.http.impl.websocket.WebSocketConnectionImpl;
@@ -59,6 +60,7 @@ import io.vertx.core.spi.metrics.HttpClientMetrics;
 import io.vertx.core.spi.tracing.SpanKind;
 import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingPolicy;
 
 import java.net.URI;
 import java.time.Duration;
@@ -77,7 +79,9 @@ public class Http1xClientConnection extends Http1xConnection implements io.vertx
   private static final Handler<Object> INVALID_MSG_HANDLER = ReferenceCountUtil::release;
 
   private final HttpClientMetrics clientMetrics;
-  private final HttpClientOptions options;
+  private final Http1ClientConfig config;
+  private final TracingPolicy tracingPolicy;
+  private final boolean useDecompression;
   private final boolean ssl;
   private final SocketAddress server;
   private final HostAndPort authority;
@@ -104,7 +108,9 @@ public class Http1xClientConnection extends Http1xConnection implements io.vertx
 
   public Http1xClientConnection(HttpVersion version,
                          HttpClientMetrics clientMetrics,
-                         HttpClientOptions options,
+                         Http1ClientConfig config,
+                         TracingPolicy tracingPolicy,
+                         boolean useDecompression,
                          ChannelHandlerContext chctx,
                          boolean ssl,
                          SocketAddress server,
@@ -114,14 +120,16 @@ public class Http1xClientConnection extends Http1xConnection implements io.vertx
                          long maxLifetime) {
     super(context, chctx);
     this.clientMetrics = clientMetrics;
-    this.options = options;
+    this.config = config;
+    this.tracingPolicy = tracingPolicy;
+    this.useDecompression = useDecompression;
     this.ssl = ssl;
     this.server = server;
     this.authority = authority;
     this.metrics = metrics;
     this.version = version;
     this.lifetimeEvictionTimestamp = maxLifetime > 0 ? System.currentTimeMillis() + maxLifetime : Long.MAX_VALUE;
-    this.keepAliveTimeout = options.getKeepAliveTimeout();
+    this.keepAliveTimeout = config.getKeepAliveTimeout();
     this.expirationTimestamp = expirationTimestampOf(keepAliveTimeout);
     this.pending = new ArrayDeque<>();
     this.inflight = new ArrayDeque<>();
@@ -163,7 +171,7 @@ public class Http1xClientConnection extends Http1xConnection implements io.vertx
 
   @Override
   public long concurrency() {
-    return options.isPipelining() ? options.getPipeliningLimit() : 1;
+    return config.isPipelining() ? config.getPipeliningLimit() : 1;
   }
 
   @Override
@@ -210,14 +218,14 @@ public class Http1xClientConnection extends Http1xConnection implements io.vertx
     if (chunked) {
       HttpUtil.setTransferEncodingChunked(request, true);
     }
-    if (options.isDecompressionSupported() && request.headers().get(ACCEPT_ENCODING) == null) {
+    if (useDecompression && request.headers().get(ACCEPT_ENCODING) == null) {
       // if compression should be used but nothing is specified by the user support deflate and gzip.
       CharSequence acceptEncoding = determineCompressionAcceptEncoding();
       request.headers().set(ACCEPT_ENCODING, acceptEncoding);
     }
-    if (!options.isKeepAlive() && options.getProtocolVersion() == io.vertx.core.http.HttpVersion.HTTP_1_1) {
+    if (!config.isKeepAlive() && version == io.vertx.core.http.HttpVersion.HTTP_1_1) {
       request.headers().set(CONNECTION, CLOSE);
-    } else if (options.isKeepAlive() && options.getProtocolVersion() == io.vertx.core.http.HttpVersion.HTTP_1_0) {
+    } else if (config.isKeepAlive() && version == io.vertx.core.http.HttpVersion.HTTP_1_0) {
       request.headers().set(CONNECTION, KEEP_ALIVE);
     }
     if (end) {
@@ -279,7 +287,7 @@ public class Http1xClientConnection extends Http1xConnection implements io.vertx
         if (operation == null) {
           operation = request.method.name();
         }
-        stream.trace = tracer.sendRequest(stream.context, SpanKind.RPC, options.getTracingPolicy(), new ObservableRequest(request), operation, headers, HttpUtils.CLIENT_HTTP_REQUEST_TAG_EXTRACTOR);
+        stream.trace = tracer.sendRequest(stream.context, SpanKind.RPC, tracingPolicy, new ObservableRequest(request), operation, headers, HttpUtils.CLIENT_HTTP_REQUEST_TAG_EXTRACTOR);
       }
     }
     write(nettyRequest, false, promise);
@@ -966,7 +974,7 @@ public class Http1xClientConnection extends Http1xConnection implements io.vertx
         String responseConnectionHeader = response.headers.get(HttpHeaderNames.CONNECTION);
         String requestConnectionHeader = request.headers != null ? request.headers.get(HttpHeaderNames.CONNECTION) : null;
         // We don't need to protect against concurrent changes on forceClose as it only goes from false -> true
-        boolean close = !options.isKeepAlive();
+        boolean close = !config.isKeepAlive();
         if (HttpHeaderValues.CLOSE.contentEqualsIgnoreCase(responseConnectionHeader) || HttpHeaderValues.CLOSE.contentEqualsIgnoreCase(requestConnectionHeader)) {
           // In all cases, if we have a close connection option then we SHOULD NOT treat the connection as persistent
           close = true;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ClientConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ClientConnectionImpl.java
@@ -19,6 +19,7 @@ import io.vertx.core.*;
 import io.vertx.core.http.*;
 import io.vertx.core.http.impl.*;
 import io.vertx.core.http.impl.HttpClientConnection;
+import io.vertx.core.http.impl.config.Http2ClientConfig;
 import io.vertx.core.http.impl.headers.HttpRequestHeaders;
 import io.vertx.core.http.impl.headers.HttpResponseHeaders;
 import io.vertx.core.http.impl.http2.Http2ClientConnection;
@@ -28,6 +29,7 @@ import io.vertx.core.net.HostAndPort;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
 import io.vertx.core.spi.metrics.TransportMetrics;
+import io.vertx.core.tracing.TracingPolicy;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -35,7 +37,9 @@ import io.vertx.core.spi.metrics.TransportMetrics;
 public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements HttpClientConnection, Http2ClientConnection {
 
   private final TransportMetrics<?> transportMetrics;
-  private final HttpClientOptions options;
+  private final Http2ClientConfig config;
+  private final TracingPolicy tracingPolicy;
+  private final boolean useDecompression;
   private final ClientMetrics clientMetrics;
   private final HostAndPort authority;
   private final long lifetimeEvictionTimestamp;
@@ -51,12 +55,16 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
                             VertxHttp2ConnectionHandler connHandler,
                             HttpClientMetrics transportMetrics,
                             ClientMetrics clientMetrics,
-                            HttpClientOptions options,
+                            Http2ClientConfig config,
+                            TracingPolicy tracingPolicy,
+                            boolean useDecompression,
                             long maxLifetime) {
     super(context, connHandler);
     this.clientMetrics = clientMetrics;
     this.transportMetrics = transportMetrics;
-    this.options = options;
+    this.config = config;
+    this.tracingPolicy = tracingPolicy;
+    this.useDecompression = useDecompression;
     this.authority = authority;
     this.lifetimeEvictionTimestamp = maxLifetime > 0 ? System.currentTimeMillis() + maxLifetime : Long.MAX_VALUE;
     this.handler = connHandler;
@@ -97,7 +105,7 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
 
   public long concurrency() {
     long concurrency = remoteSettings().getMaxConcurrentStreams();
-    long http2MaxConcurrency = options.getHttp2MultiplexingLimit() <= 0 ? Long.MAX_VALUE : options.getHttp2MultiplexingLimit();
+    long http2MaxConcurrency = config.getMultiplexingLimit() <= 0 ? Long.MAX_VALUE : config.getMultiplexingLimit();
     if (http2MaxConcurrency > 0) {
       concurrency = Math.min(concurrency, http2MaxConcurrency);
     }
@@ -143,7 +151,7 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
 
   @Override
   protected void concurrencyChanged(long concurrency) {
-    int limit = options.getHttp2MultiplexingLimit();
+    int limit = config.getMultiplexingLimit();
     if (limit > 0) {
       concurrency = Math.min(concurrency, limit);
     }
@@ -161,8 +169,8 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
 
   public HttpClientStream upgradeStream(Object metric, Object trace, ContextInternal context) {
     Http2Stream nettyStream = handler.connection().stream(1);
-    Http2ClientStream s = Http2ClientStream.create(nettyStream.id(), this, context, options.getTracingPolicy(),
-      options.isDecompressionSupported(), transportMetrics, clientMetrics, isWritable(1));
+    Http2ClientStream s = Http2ClientStream.create(nettyStream.id(), this, context, tracingPolicy,
+      useDecompression, transportMetrics, clientMetrics, isWritable(1));
     s.upgrade(metric, trace);
     nettyStream.setProperty(streamKey, s);
     return s.unwrap();
@@ -184,14 +192,14 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
     return Http2ClientStream.create(
       this,
       context,
-      options.getTracingPolicy(),
-      options.isDecompressionSupported(),
+      tracingPolicy,
+      useDecompression,
       transportMetrics,
       clientMetrics());
   }
 
   private void recycle() {
-    int timeout = options.getHttp2KeepAliveTimeout();
+    int timeout = config.getKeepAliveTimeout();
     expirationTimestamp = timeout > 0 ? System.currentTimeMillis() + timeout * 1000L : Long.MAX_VALUE;
   }
 
@@ -240,7 +248,7 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
     if (stream != null) {
       Http2Stream promisedStream = handler.connection().stream(promisedStreamId);
 //      Http2ClientStreamImpl pushStream = new Http2ClientStreamImpl(this, context, client.options.getTracingPolicy(), client.options.isDecompressionSupported(), clientMetrics());
-      Http2ClientStream s = Http2ClientStream.create(this, context, options.getTracingPolicy(), options.isDecompressionSupported(), transportMetrics, clientMetrics);
+      Http2ClientStream s = Http2ClientStream.create(this, context, tracingPolicy, useDecompression, transportMetrics, clientMetrics);
 //      pushStream.init(s);
 //      pushStream.stream = s;
       promisedStream.setProperty(streamKey, s);
@@ -293,7 +301,10 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
   }
 
   public static VertxHttp2ConnectionHandler<Http2ClientConnectionImpl> createHttp2ConnectionHandler(
-    HttpClientOptions options,
+    Http2ClientConfig config,
+    TracingPolicy tracingPolicy,
+    boolean useDecompression,
+    boolean logActivity,
     HttpClientMetrics clientMetrics,
     ClientMetrics metrics,
     ContextInternal context,
@@ -303,18 +314,18 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
     long maxLifetime) {
     VertxHttp2ConnectionHandler<Http2ClientConnectionImpl> handler = new VertxHttp2ConnectionHandlerBuilder<Http2ClientConnectionImpl>()
       .server(false)
-      .useDecompression(options.isDecompressionSupported())
+      .useDecompression(useDecompression)
       .gracefulShutdownTimeoutMillis(0) // So client close tests don't hang 30 seconds - make this configurable later but requires HTTP/1 impl
-      .initialSettings(options.getInitialSettings())
+      .initialSettings(config.getInitialSettings())
       .connectionFactory(connHandler -> {
-        Http2ClientConnectionImpl conn = new Http2ClientConnectionImpl(context, authority, connHandler, clientMetrics, metrics, options, maxLifetime);
+        Http2ClientConnectionImpl conn = new Http2ClientConnectionImpl(context, authority, connHandler, clientMetrics, metrics, config, tracingPolicy, useDecompression, maxLifetime);
         if (metrics != null) {
           Object m = socketMetric;
           conn.metric(m);
         }
         return conn;
       })
-      .logEnabled(options.getLogActivity())
+      .logEnabled(logActivity)
       .build();
     handler.addHandler(conn -> {
       if (metrics != null) {

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -433,7 +433,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   private WebSocketClientImpl createWebSocketClientImpl(HttpClientOptions o, WebSocketClientOptions options) {
     HttpClientMetrics<?, ?, ?> metrics = metrics() != null ? metrics().createHttpClientMetrics(o) : null;
     NetClientInternal tcpClient = new NetClientBuilder(this, new NetClientOptions(o).setProxyOptions(null)).metrics(metrics).build();
-    Http1xOrH2ChannelConnector channelConnector = new Http1xOrH2ChannelConnector(tcpClient, o, metrics);
+    Http1xOrH2ChannelConnector channelConnector = Http1xOrH2ChannelConnector.create(tcpClient, o, metrics);
     return new WebSocketClientImpl(this, o, options, channelConnector, metrics);
   }
 

--- a/vertx-core/src/main/java/module-info.java
+++ b/vertx-core/src/main/java/module-info.java
@@ -128,6 +128,7 @@ module io.vertx.core {
   exports io.vertx.core.net.impl.quic to io.vertx.core.tests;
   exports io.vertx.core.http.impl.http1x to io.vertx.core.tests;
   exports io.vertx.core.http.impl.observability to io.vertx.core.tests;
-  exports io.vertx.core.net.endpoint.impl;
+  exports io.vertx.core.http.impl.config to io.vertx.core.tests;
+  exports io.vertx.core.net.endpoint.impl to io.vertx.core.tests;
 
 }


### PR DESCRIPTION
Motivation:

Further more decoupling step toward a unified HttpClient configuration for any protocol version.
