### PR TITLE
Move the max lifetime connection pooling implementation to the pool.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -112,4 +112,6 @@ public interface HttpClientConnection extends HttpConnection {
    */
   long lastResponseReceivedTimestamp();
 
+  long creationTimestamp();
+
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -268,7 +268,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     boolean useSSL = ssl != null ? ssl : transport.defaultSsl;
     checkClosed();
     HttpConnectParams params = new HttpConnectParams(protocol, sslOptions, proxyOptions, useSSL);
-    return transport.connector.httpConnect(vertx.getOrCreateContext(), server, authority, params, 0L, clientMetrics)
+    return transport.connector.httpConnect(vertx.getOrCreateContext(), server, authority, params, clientMetrics)
       .map(conn -> new UnpooledHttpClientConnection(conn).init());
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketGroup.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketGroup.java
@@ -93,7 +93,7 @@ class WebSocketGroup extends ManagedResource {
     } else {
       eventLoopContext = ctx.toBuilder().withThreadingModel(ThreadingModel.EVENT_LOOP).build();
     }
-    Future<HttpClientConnection> fut = connector.httpConnect(eventLoopContext, server, authority, connectParams, maxLifetimeMillis, clientMetrics);
+    Future<HttpClientConnection> fut = connector.httpConnect(eventLoopContext, server, authority, connectParams, clientMetrics);
     fut.onComplete(ar -> {
       if (ar.succeeded()) {
         HttpClientConnection c = ar.result();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2ClientChannelInitializer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2ClientChannelInitializer.java
@@ -24,8 +24,8 @@ import io.vertx.core.spi.metrics.ClientMetrics;
  */
 public interface Http2ClientChannelInitializer {
 
-  void http2Connected(ContextInternal context, HostAndPort authority, Object metric, long maxLifetimeMillis, Channel ch, ClientMetrics<?, ?, ?> metrics, PromiseInternal<HttpClientConnection> promise);
+  void http2Connected(ContextInternal context, HostAndPort authority, Object metric, Channel ch, ClientMetrics<?, ?, ?> metrics, PromiseInternal<HttpClientConnection> promise);
 
-  Http2UpgradeClientConnection.Http2ChannelUpgrade channelUpgrade(Http1xClientConnection conn, long maxLifetimeMillis, ClientMetrics<?, ?, ?> clientMetrics);
+  Http2UpgradeClientConnection.Http2ChannelUpgrade channelUpgrade(Http1xClientConnection conn, ClientMetrics<?, ?, ?> clientMetrics);
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpChannelConnector.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpChannelConnector.java
@@ -32,7 +32,6 @@ public interface HttpChannelConnector {
                                            SocketAddress server,
                                            HostAndPort authority,
                                            HttpConnectParams params,
-                                           long maxLifetimeMillis,
                                            ClientMetrics<?, ?, ?> metrics);
 
   Future<Void> shutdown(Duration timeout);


### PR DESCRIPTION
Motivation:

The implementation of max lifetime connection pooling is implemented in the HttpClientConnection#isValid method of each implementation we have.

This feature can actually be implemented by the pool instead of being implemented in HttpClientConnection#isValid as long as the pool can determine the creation timestamp of the connection.

Changes:

- Stop checking the max lifetime validity in each implementation of HttpClientConnection#isValid
- Move the max lifetime validity check in the caller of HttpClientConnection#isValid using the creation timestamp of the connection
