### PR TITLE
Update the Vert.x logging implementation to log better human readable message in absence of a log message.

### DIFF
--- a/vertx-core-logging/src/main/java/io/vertx/core/logging/JULLogDelegate.java
+++ b/vertx-core-logging/src/main/java/io/vertx/core/logging/JULLogDelegate.java
@@ -16,12 +16,47 @@ import io.vertx.core.spi.logging.LogDelegate;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
+import static io.vertx.core.logging.JULLogDelegate.logMessage;
+
 /**
  * A {@link io.vertx.core.spi.logging.LogDelegate} which delegates to java.util.logging
  *
  * @author <a href="kenny.macleod@kizoom.com">Kenny MacLeod</a>
  */
 public class JULLogDelegate implements LogDelegate {
+
+  private static final String MISSING_LOG_MESSAGE = "<missing-log-message>";
+
+  /**
+   * Best effort to provide a human-readable message from the {@code message} and {@code cause}
+   * @param message the message
+   * @param cause the throwable
+   * @return the log message, never {@code null}
+   */
+  static String logMessage(Object message, Throwable cause) {
+    String msg;
+    if (message != null) {
+      msg = message.toString();
+    } else if (cause != null) {
+      msg = cause.getMessage();
+    } else {
+      msg = null;
+    }
+    if (msg == null) {
+      msg = MISSING_LOG_MESSAGE;
+    }
+    return msg;
+  }
+
+  /**
+   * Best effort to provide a human-readable message from the {@code message}
+   * @param message the message
+   * @return the log message, never {@code null}
+   */
+  static String logMessage(Object message) {
+    return logMessage(message, null);
+  }
+
   private final java.util.logging.Logger logger;
 
   JULLogDelegate(final String name) {
@@ -98,7 +133,7 @@ public class JULLogDelegate implements LogDelegate {
     if (!logger.isLoggable(level)) {
       return;
     }
-    String msg = (message == null) ? "NULL" : message.toString();
+    String msg = logMessage(message, t);
     LogRecord record = new LogRecord(level, msg);
     record.setLoggerName(logger.getName());
     if (t != null) {

--- a/vertx-core-logging/src/main/java/io/vertx/core/logging/Log4j2LogDelegate.java
+++ b/vertx-core-logging/src/main/java/io/vertx/core/logging/Log4j2LogDelegate.java
@@ -17,6 +17,8 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.spi.ExtendedLogger;
 
+import static io.vertx.core.logging.JULLogDelegate.logMessage;
+
 /**
  * A {@link LogDelegate} which delegates to Apache Log4j 2
  *
@@ -104,7 +106,7 @@ public class Log4j2LogDelegate implements LogDelegate {
 
   @Override
   public void trace(final Object message, final Throwable t) {
-    log(Level.TRACE, message.toString(), t);
+    log(Level.TRACE, logMessage(message), t);
   }
 
   private void log(Level level, Object message) {
@@ -115,7 +117,7 @@ public class Log4j2LogDelegate implements LogDelegate {
     if (message instanceof Message) {
       logger.logIfEnabled(FQCN, level, null, (Message) message, t);
     } else {
-      logger.logIfEnabled(FQCN, level, null, message, t);
+      logger.logIfEnabled(FQCN, level, null, logMessage(message, t), t);
     }
   }
 

--- a/vertx-core-logging/src/main/java/io/vertx/core/logging/SLF4JLogDelegate.java
+++ b/vertx-core-logging/src/main/java/io/vertx/core/logging/SLF4JLogDelegate.java
@@ -16,6 +16,8 @@ import io.vertx.core.spi.logging.LogDelegate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.vertx.core.logging.JULLogDelegate.logMessage;
+
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -59,56 +61,52 @@ public class SLF4JLogDelegate implements LogDelegate {
 
   @Override
   public void error(final Object message) {
-    logger.error(valueOf(message));
+    logger.error(logMessage(message));
   }
 
   @Override
   public void error(final Object message, final Throwable t) {
-    logger.error(valueOf(message), t);
+    logger.error(logMessage(message, t), t);
   }
 
   @Override
   public void warn(final Object message) {
-    logger.warn(valueOf(message));
+    logger.warn(logMessage(message));
   }
 
   @Override
   public void warn(final Object message, final Throwable t) {
-    logger.warn(valueOf(message), t);
+    logger.warn(logMessage(message, t), t);
   }
 
   @Override
   public void info(final Object message) {
-    logger.info(valueOf(message));
+    logger.info(logMessage(message));
   }
 
   @Override
   public void info(final Object message, final Throwable t) {
-    logger.info(valueOf(message), t);
+    logger.info(logMessage(message, t), t);
   }
 
   @Override
   public void debug(final Object message) {
-    logger.debug(valueOf(message));
+    logger.debug(logMessage(message));
   }
 
   @Override
   public void debug(final Object message, final Throwable t) {
-    logger.debug(valueOf(message), t);
+    logger.debug(logMessage(message), t);
   }
 
   @Override
   public void trace(final Object message) {
-    logger.trace(valueOf(message));
+    logger.trace(logMessage(message));
   }
 
   @Override
   public void trace(final Object message, final Throwable t) {
-    logger.trace(valueOf(message), t);
-  }
-
-  private static String valueOf(Object message) {
-    return message == null ? "NULL" : message.toString();
+    logger.trace(logMessage(message), t);
   }
 
   @Override

--- a/vertx-core-logging/src/test/java/io/vertx/it/JULLogDelegateTest.java
+++ b/vertx-core-logging/src/test/java/io/vertx/it/JULLogDelegateTest.java
@@ -97,4 +97,28 @@ public class JULLogDelegateTest {
     assertTrue(result.contains("exception"));
     assertTrue(result.contains("java.lang.NullPointerException"));
   }
+
+  @Test
+  public void testNullMessage() {
+    class Exc extends RuntimeException {
+      public Exc(String msg) {
+        super(msg, null, false, false);
+      }
+    }
+    String result = recording.execute(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null);
+    });
+    assertTrue(result.contains("<missing-log-message>"));
+    result = recording.execute(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null, new Exc("the-msg"));
+    });
+    assertTrue(result.contains("the-msg"));
+    result = recording.execute(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null, new Exc(null));
+    });
+    assertTrue(result.contains("<missing-log-message>"));
+  }
 }

--- a/vertx-core-logging/src/test/java/io/vertx/it/Log4J2LogDelegateTest.java
+++ b/vertx-core-logging/src/test/java/io/vertx/it/Log4J2LogDelegateTest.java
@@ -111,4 +111,27 @@ public class Log4J2LogDelegateTest {
     assertTrue(result.contains(".run:"));
   }
 
+  @Test
+  public void testNullMessage() {
+    class Exc extends RuntimeException {
+      public Exc(String msg) {
+        super(msg, null, false, false);
+      }
+    }
+    String result = recording.execute(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null);
+    });
+    assertTrue(result.contains("<missing-log-message>"));
+    result = recording.execute(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null, new Exc("the-msg"));
+    });
+    assertTrue(result.contains("the-msg"));
+    result = recording.execute(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null, new Exc(null));
+    });
+    assertTrue(result.contains("<missing-log-message>"));
+  }
 }

--- a/vertx-core-logging/src/test/java/io/vertx/it/SLF4JLogDelegateTest.java
+++ b/vertx-core-logging/src/test/java/io/vertx/it/SLF4JLogDelegateTest.java
@@ -481,4 +481,28 @@ public class SLF4JLogDelegateTest {
       actual.error(marker, msg, t);
     }
   }
+
+  @Test
+  public void testNullMessage() {
+    class Exc extends RuntimeException {
+      public Exc(String msg) {
+        super(msg, null, false, false);
+      }
+    }
+    String result = record(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null);
+    });
+    assertTrue(result.contains("<missing-log-message>"));
+    result = record(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null, new Exc("the-msg"));
+    });
+    assertTrue(result.contains("the-msg"));
+    result = record(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null, new Exc(null));
+    });
+    assertTrue(result.contains("<missing-log-message>"));
+  }
 }


### PR DESCRIPTION
Motivation:

Some logging event might arrive with a null message and trigger the logging of the NULL string which is very confusing for human analyzing the a log tail.

We should improve this and provide a better message.

Changes:

Use the <missing-log-message> when no log message is provided instead of NULL.
