### PR TITLE
Update the Vert.x logging implementation to log better human readable message in absence of a log message.

### DIFF
--- a/src/main/java/io/vertx/core/logging/JULLogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/JULLogDelegate.java
@@ -22,6 +22,39 @@ import java.util.logging.LogRecord;
  * @author <a href="kenny.macleod@kizoom.com">Kenny MacLeod</a>
  */
 public class JULLogDelegate implements LogDelegate {
+
+  private static final String MISSING_LOG_MESSAGE = "<missing-log-message>";
+
+  /**
+   * Best effort to provide a human-readable message from the {@code message} and {@code cause}
+   * @param message the message
+   * @param cause the throwable
+   * @return the log message, never {@code null}
+   */
+  static String logMessage(Object message, Throwable cause) {
+    String msg;
+    if (message != null) {
+      msg = message.toString();
+    } else if (cause != null) {
+      msg = cause.getMessage();
+    } else {
+      msg = null;
+    }
+    if (msg == null) {
+      msg = MISSING_LOG_MESSAGE;
+    }
+    return msg;
+  }
+
+  /**
+   * Best effort to provide a human-readable message from the {@code message}
+   * @param message the message
+   * @return the log message, never {@code null}
+   */
+  static String logMessage(Object message) {
+    return logMessage(message, null);
+  }
+
   private final java.util.logging.Logger logger;
 
   JULLogDelegate(final String name) {
@@ -151,7 +184,7 @@ public class JULLogDelegate implements LogDelegate {
     if (!logger.isLoggable(level)) {
       return;
     }
-    String msg = (message == null) ? "NULL" : message.toString();
+    String msg = logMessage(message, t);
     LogRecord record = new LogRecord(level, msg);
     record.setLoggerName(logger.getName());
     if (t != null) {

--- a/src/main/java/io/vertx/core/logging/Log4j2LogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/Log4j2LogDelegate.java
@@ -17,6 +17,8 @@ import org.apache.logging.log4j.message.FormattedMessage;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.spi.ExtendedLogger;
 
+import static io.vertx.core.logging.JULLogDelegate.logMessage;
+
 /**
  * A {@link LogDelegate} which delegates to Apache Log4j 2
  *
@@ -156,7 +158,7 @@ public class Log4j2LogDelegate implements LogDelegate {
     if (message instanceof Message) {
       logger.logIfEnabled(FQCN, level, null, (Message) message, t);
     } else {
-      logger.logIfEnabled(FQCN, level, null, message, t);
+      logger.logIfEnabled(FQCN, level, null, logMessage(message, t), t);
     }
   }
 

--- a/src/main/java/io/vertx/core/logging/SLF4JLogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/SLF4JLogDelegate.java
@@ -19,6 +19,7 @@ import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
 import org.slf4j.spi.LocationAwareLogger;
 
+import static io.vertx.core.logging.JULLogDelegate.logMessage;
 import static org.slf4j.spi.LocationAwareLogger.*;
 
 /**
@@ -163,7 +164,7 @@ public class SLF4JLogDelegate implements LogDelegate {
   }
 
   private void log(int level, Object message, Throwable t, Object... params) {
-    String msg = (message == null) ? "NULL" : message.toString();
+    String msg = logMessage(message, t);
 
     // We need to compute the right parameters.
     // If we have both parameters and an error, we need to build a new array [params, t]

--- a/src/test/java/io/vertx/it/JULLogDelegateTest.java
+++ b/src/test/java/io/vertx/it/JULLogDelegateTest.java
@@ -211,4 +211,28 @@ public class JULLogDelegateTest {
     assertTrue(result.contains("Luke, an exception has been thrown"));
     assertTrue(result.contains("java.lang.IllegalStateException"));
   }
+
+  @Test
+  public void testNullMessage() {
+    class Exc extends RuntimeException {
+      public Exc(String msg) {
+        super(msg, null, false, false);
+      }
+    }
+    String result = recording.execute(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null);
+    });
+    assertTrue(result.contains("<missing-log-message>"));
+    result = recording.execute(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null, new Exc("the-msg"));
+    });
+    assertTrue(result.contains("the-msg"));
+    result = recording.execute(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null, new Exc(null));
+    });
+    assertTrue(result.contains("<missing-log-message>"));
+  }
 }

--- a/src/test/java/io/vertx/it/Log4J2LogDelegateTest.java
+++ b/src/test/java/io/vertx/it/Log4J2LogDelegateTest.java
@@ -210,4 +210,27 @@ public class Log4J2LogDelegateTest {
     assertTrue(result.contains(".run:"));
   }
 
+  @Test
+  public void testNullMessage() {
+    class Exc extends RuntimeException {
+      public Exc(String msg) {
+        super(msg, null, false, false);
+      }
+    }
+    String result = recording.execute(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null);
+    });
+    assertTrue(result.contains("<missing-log-message>"));
+    result = recording.execute(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null, new Exc("the-msg"));
+    });
+    assertTrue(result.contains("the-msg"));
+    result = recording.execute(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null, new Exc(null));
+    });
+    assertTrue(result.contains("<missing-log-message>"));
+  }
 }

--- a/src/test/java/io/vertx/it/SLF4JLogDelegateTest.java
+++ b/src/test/java/io/vertx/it/SLF4JLogDelegateTest.java
@@ -170,6 +170,30 @@ public class SLF4JLogDelegateTest {
     assertTrue(result.contains("java.lang.IllegalStateException"));
   }
 
+  @Test
+  public void testNullMessage() {
+    class Exc extends RuntimeException {
+      public Exc(String msg) {
+        super(msg, null, false, false);
+      }
+    }
+    String result = record(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null);
+    });
+    assertTrue(result.contains("<missing-log-message>"));
+    result = record(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null, new Exc("the-msg"));
+    });
+    assertTrue(result.contains("the-msg"));
+    result = record(() -> {
+      Logger logger = LoggerFactory.getLogger("my-jul-logger");
+      logger.warn(null, new Exc(null));
+    });
+    assertTrue(result.contains("<missing-log-message>"));
+  }
+
   private void withStream(PrintStream stream, Runnable runnable) {
     PrintStream prev = System.out;
     System.setOut(stream);


### PR DESCRIPTION
Motivation:

Some logging event might arrive with a null message and trigger the logging of the NULL string which is very confusing for human analyzing the a log tail.

We should improve this and provide a better message.

Changes:

Use the <missing-log-message> when no log message is provided instead of NULL.
