### PR TITLE
Fix a bug in the removeDotSegments implementation.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/internal/net/RFC3986.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/net/RFC3986.java
@@ -157,16 +157,12 @@ public final class RFC3986 {
         // preserve last slash
         i += 3;
         int pos = obuf.lastIndexOf("/");
-        if (pos != -1) {
-          obuf.delete(pos, obuf.length());
-        }
+        obuf.setLength(pos == -1 ? 0 : pos);
       } else if (matches(path, i, "/..", true)) {
         path = "/";
         i = 0;
         int pos = obuf.lastIndexOf("/");
-        if (pos != -1) {
-          obuf.delete(pos, obuf.length());
-        }
+        obuf.setLength(pos == -1 ? 0 : pos);
       } else if (matches(path, i, ".", true) || matches(path, i, "..", true)) {
         break;
       } else {

--- a/vertx-core/src/test/java/io/vertx/tests/net/RFC3986Test.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/RFC3986Test.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.net;
+
+import io.vertx.core.internal.net.RFC3986;
+import org.junit.ComparisonFailure;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RFC3986Test {
+
+  @Test
+  public void testRemoveDotSegmentsRuleA() {
+    assertDotSegments("", "../");
+    assertDotSegments("", "./");
+
+    assertDotSegments("foo", "../foo");
+    assertDotSegments("foo", "./foo");
+  }
+
+  @Test
+  public void testRemoveDotSegmentsRuleB() {
+    assertDotSegments("/", "/./");
+    assertDotSegments("/", "/.");
+
+    assertDotSegments("/foo", "/./foo");
+  }
+
+  @Test
+  public void testRemoveDotSegmentsRuleC() {
+    assertDotSegments("/", "/../");
+    assertDotSegments("/foo", "/../foo");
+    assertDotSegments("/", "/..");
+    assertDotSegments("/", "/foo/../");
+    assertDotSegments("/", "/foo/..");
+    assertDotSegments("/", "foo/../");
+    assertDotSegments("/", "foo/..");
+    assertDotSegments("/foo/", "/foo/bar/../");
+    assertDotSegments("/foo/", "/foo/bar/..");
+    assertDotSegments("foo/", "foo/bar/../");
+    assertDotSegments("foo/", "foo/bar/..");
+  }
+
+  @Test
+  public void testRemoveDotSegmentsRuleD() {
+    assertDotSegments("", ".");
+    assertDotSegments("", "..");
+  }
+
+  @Test
+  public void testRemoveDotSegmentsRuleE() {
+    assertDotSegments("/foo", "/foo");
+    assertDotSegments("foo", "foo");
+  }
+
+  private static void assertDotSegments(String expected, String test) {
+    String actual = RFC3986.removeDotSegments(test);
+    assertEquals(expected, actual);
+  }
+}


### PR DESCRIPTION
Motivation:

`RFC3986#removeDotSegments` does not properly handle the C. rule of section 5.2.4 of RFC3986. When the output buffer
does not contain a / it should discard the entire content of the buffer.

Changes:

When handling rule C in `RFC3986#removeDotSegments`, discard the output buffer when no / is present.
