### PR TITLE
Add a few handfull and missing methods on VertxInternal that are shortcut for methods on ContextInternal

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxInternal.java
@@ -15,6 +15,8 @@ package io.vertx.core.internal;
 import io.netty.channel.EventLoopGroup;
 import io.vertx.core.*;
 import io.vertx.core.impl.*;
+import io.vertx.core.impl.future.FailedFuture;
+import io.vertx.core.impl.future.SucceededFuture;
 import io.vertx.core.internal.deployment.DeploymentManager;
 import io.vertx.core.internal.resolver.NameResolver;
 import io.vertx.core.internal.threadchecker.BlockedThreadChecker;
@@ -77,20 +79,39 @@ public interface VertxInternal extends Vertx {
    *         if that handler is already an instance of {@code PromiseInternal}
    */
   default <T> PromiseInternal<T> promise(Completable<T> p) {
-    if (p instanceof PromiseInternal) {
-      PromiseInternal<T> promise = (PromiseInternal<T>) p;
-      if (promise.context() != null) {
-        return promise;
-      }
-    }
-    PromiseInternal<T> promise = promise();
-    promise.future().onComplete(p);
-    return promise;
+    return getOrCreateContext().promise(p);
+  }
+
+  /**
+   * @return an empty succeeded {@link Future} associated with this context
+   */
+  default <T> Future<T> succeededFuture() {
+    return getOrCreateContext().succeededFuture();
+  }
+
+  /**
+   * @return a succeeded {@link Future} of the {@code result} associated with this context
+   */
+  default <T> Future<T> succeededFuture(T result) {
+    return getOrCreateContext().succeededFuture(result);
+  }
+
+  /**
+   * @return a {@link Future} failed with the {@code failure} associated with this context
+   */
+  default <T> Future<T> failedFuture(Throwable failure) {
+    return getOrCreateContext().failedFuture(failure);
+  }
+
+  /**
+   * @return a {@link Future} failed with the {@code message} associated with this context
+   */
+  default <T> Future<T> failedFuture(String message) {
+    return getOrCreateContext().failedFuture(message);
   }
 
   default void runOnContext(Handler<Void> task) {
-    ContextInternal context = getOrCreateContext();
-    context.runOnContext(task);
+    getOrCreateContext().runOnContext(task);
   }
 
   NetServerInternal createNetServer(NetServerOptions options);


### PR DESCRIPTION
- `succeededFuture`
- `failedFuture`

Replacing `vertx.getOrCreateContext().succeededFuture(T)` by `vertx.succeededFuture(T)`.
