### PR TITLE
Enable the io_uring sendfile implementations.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/VertxHttpResponseEncoder.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/VertxHttpResponseEncoder.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.vertx.core.http.impl.headers.Http1xHeaders;
 import io.vertx.core.impl.SysProps;
+import io.vertx.core.net.impl.UncloseableFileRegion;
 
 /**
  * {@link io.netty.handler.codec.http.HttpResponseEncoder} which forces the usage of direct buffers for max performance.
@@ -60,7 +61,7 @@ public final class VertxHttpResponseEncoder extends HttpResponseEncoder {
       msgClazz == VertxAssembledHttpResponse.class ||
       msgClazz == DefaultHttpContent.class ||
       msgClazz == VertxLastHttpContent.class ||
-      msgClazz == DefaultFileRegion.class) {
+      msgClazz == UncloseableFileRegion.class) {
       return true;
     }
     // Netty slow-path

--- a/vertx-core/src/main/java/io/vertx/core/impl/SysProps.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/SysProps.java
@@ -116,6 +116,17 @@ public enum SysProps {
   JACKSON_DEFAULT_READ_MAX_NAME_LEN("vertx.jackson.defaultReadMaxNameLength"),
   JACKSON_DEFAULT_READ_MAX_TOKEN_COUNT("vertx.jackson.defaultMaxTokenCount"),
 
+  /**
+   * Disable {@code sendfile} support for the io_uring transport.
+   * <p>
+   * When this system property is set to {@code true}, Vert.x will avoid using the
+   * io_uring splice path.
+   * <p>
+   * This is useful because io_uring splice can be slower than the
+   * epoll {@code sendfile} in some workloads.
+   * See <a href="https://github.com/netty/netty/issues/15747">Netty issue 15747</a>.
+   */
+  DISABLE_IO_URING_SENDFILE("vertx.disableIoUringSendfile"),
   ;
 
   public final String name;

--- a/vertx-core/src/main/java/io/vertx/core/impl/SysProps.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/SysProps.java
@@ -116,17 +116,6 @@ public enum SysProps {
   JACKSON_DEFAULT_READ_MAX_NAME_LEN("vertx.jackson.defaultReadMaxNameLength"),
   JACKSON_DEFAULT_READ_MAX_TOKEN_COUNT("vertx.jackson.defaultMaxTokenCount"),
 
-  /**
-   * Disable {@code sendfile} support for the io_uring transport.
-   * <p>
-   * When this system property is set to {@code true}, Vert.x will avoid using the
-   * io_uring splice path.
-   * <p>
-   * This is useful because io_uring splice can be slower than the
-   * epoll {@code sendfile} in some workloads.
-   * See <a href="https://github.com/netty/netty/issues/15747">Netty issue 15747</a>.
-   */
-  DISABLE_IO_URING_SENDFILE("vertx.disableIoUringSendfile"),
   ;
 
   public final String name;

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
@@ -20,6 +20,7 @@ import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.UnixChannelOption;
 import io.netty.channel.uring.*;
 import io.vertx.core.datagram.DatagramSocketOptions;
+import io.vertx.core.impl.SysProps;
 import io.vertx.core.net.TcpConfig;
 import io.vertx.core.net.TcpOption;
 import io.vertx.core.net.impl.SocketAddressImpl;
@@ -34,6 +35,8 @@ import static io.vertx.core.impl.transports.NioTransport.configOption;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class IoUringTransport implements Transport {
+
+  private static final boolean DISABLE_SENDFILE = SysProps.DISABLE_IO_URING_SENDFILE.getBoolean();
 
   private static volatile int pendingFastOpenRequestsThreshold = 256;
 
@@ -68,7 +71,7 @@ public class IoUringTransport implements Transport {
 
   @Override
   public boolean supportFileRegion() {
-    return IoUring.isSpliceSupported();
+    return IoUring.isSpliceSupported() && !DISABLE_SENDFILE;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
@@ -71,7 +71,7 @@ public class IoUringTransport implements Transport {
 
   @Override
   public boolean supportFileRegion() {
-    return IoUring.isSpliceSupported() && !DISABLE_SENDFILE;
+    return !DISABLE_SENDFILE && IoUring.isSpliceSupported();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
@@ -20,7 +20,6 @@ import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.UnixChannelOption;
 import io.netty.channel.uring.*;
 import io.vertx.core.datagram.DatagramSocketOptions;
-import io.vertx.core.impl.SysProps;
 import io.vertx.core.net.TcpConfig;
 import io.vertx.core.net.TcpOption;
 import io.vertx.core.net.impl.SocketAddressImpl;
@@ -35,8 +34,6 @@ import static io.vertx.core.impl.transports.NioTransport.configOption;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class IoUringTransport implements Transport {
-
-  private static final boolean DISABLE_SENDFILE = SysProps.DISABLE_IO_URING_SENDFILE.getBoolean();
 
   private static volatile int pendingFastOpenRequestsThreshold = 256;
 
@@ -67,11 +64,6 @@ public class IoUringTransport implements Transport {
   @Override
   public boolean supportsDomainSockets() {
     return true;
-  }
-
-  @Override
-  public boolean supportFileRegion() {
-    return !DISABLE_SENDFILE;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
@@ -68,7 +68,7 @@ public class IoUringTransport implements Transport {
 
   @Override
   public boolean supportFileRegion() {
-    return false;
+    return IoUring.isSpliceSupported();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
@@ -71,7 +71,7 @@ public class IoUringTransport implements Transport {
 
   @Override
   public boolean supportFileRegion() {
-    return !DISABLE_SENDFILE && IoUring.isSpliceSupported();
+    return !DISABLE_SENDFILE;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/UncloseableFileRegion.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/UncloseableFileRegion.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net.impl;
+
+import io.netty.channel.DefaultFileRegion;
+
+import java.io.File;
+import java.nio.channels.FileChannel;
+
+/**
+ * A file region that does close the underlying resource, letting the file user control the lifecycle of
+ * the file descriptor.
+ *
+ * @author <a href="mailto:dreamlike.vertx@gmail.com">MengYang Li</a>
+ */
+public class UncloseableFileRegion extends DefaultFileRegion {
+  public UncloseableFileRegion(FileChannel fileChannel, long position, long count) {
+    super(fileChannel, position, count);
+  }
+
+  public UncloseableFileRegion(File file, long position, long count) {
+    super(file, position, count);
+  }
+
+  @Override
+  protected void deallocate() {
+
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/UncloseableFileRegion.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/UncloseableFileRegion.java
@@ -26,10 +26,6 @@ public class UncloseableFileRegion extends DefaultFileRegion {
     super(fileChannel, position, count);
   }
 
-  public UncloseableFileRegion(File file, long position, long count) {
-    super(file, position, count);
-  }
-
   @Override
   protected void deallocate() {
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -512,17 +512,11 @@ public class VertxConnection extends ConnectionBase {
    */
   private void sendFileRegion(FileChannel fc, long offset, long length, ChannelPromise writeFuture) {
     if (length < MAX_REGION_SIZE) {
-      FileRegion region = new DefaultFileRegion(fc, offset, length);
-      // Retain explicitly this file region so the underlying channel is not closed by the NIO channel when it
-      // as been sent as the caller can need it again
-      region.retain();
+      FileRegion region = new UncloseableFileRegion(fc, offset, length);
       writeToChannel(region, writeFuture);
     } else {
       ChannelPromise promise = chctx.newPromise();
-      FileRegion region = new DefaultFileRegion(fc, offset, MAX_REGION_SIZE);
-      // Retain explicitly this file region so the underlying channel is not closed by the NIO channel when it
-      // as been sent as we need it again
-      region.retain();
+      FileRegion region = new UncloseableFileRegion(fc, offset, MAX_REGION_SIZE);
       writeToChannel(region, promise);
       promise.addListener(future -> {
         if (future.isSuccess()) {


### PR DESCRIPTION
Motivation:

Enable the io_uring UDS and sendfile implementations

Current Netty io_uring transport already fully provides sendfile and Unix domain socket functionality. This PR enables Vert.x support for these features.
	1.	`io.vertx.core.impl.transports.IoUringTransport#supportsDomainSockets` will always return true, and  `io.vertx.core.impl.transports.IoUringTransport#configure(io.vertx.core.net.TcpOptions, boolean, io.netty.bootstrap.ServerBootstrap)` and `io.vertx.core.impl.transports.IoUringTransport#configure(io.vertx.core.net.TcpOptions, boolean, io.netty.bootstrap.Bootstrap)` are adjusted to support Unix domain sockets.
	2.	`io.vertx.core.impl.transports.IoUringTransport#supportFileRegion`: if the current Linux kernel supports IORING_OP_SPLICE and it is not disabled by system parameters, sendfile support is enabled.
	3.	Due to performance issues with io_uring splice (see https://github.com/netty/netty/issues/15747), support is added to forcibly disable io_uring sendfile via a system parameter.
	4.	Introduce UncloseableFileRegion to replace the current DefaultFileRegion in Vert.x code, preventing resource leaks caused by non-zero reference counts. fix #5743
	
Conformance:

I have signed the Eclipse Contributor Agreement
