### PR TITLE
Add AsyncLogic interface and related implementations

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/Vertx.java
+++ b/vertx-core/src/main/java/io/vertx/core/Vertx.java
@@ -16,14 +16,14 @@ import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.dns.DnsClient;
 import io.vertx.core.dns.DnsClientOptions;
+import io.vertx.core.dns.impl.DnsAddressResolverProvider;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.*;
 import io.vertx.core.impl.VertxImpl;
-import io.vertx.core.impl.transports.TransportInternal;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.dns.impl.DnsAddressResolverProvider;
 import io.vertx.core.internal.VertxBootstrap;
+import io.vertx.core.logic.AsyncLogic;
 import io.vertx.core.metrics.Measured;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
@@ -82,31 +82,37 @@ public interface Vertx extends Measured {
       private VertxMetricsFactory metricsFactory;
       private VertxTracerFactory tracerFactory;
       private Transport transport;
+
       @Override
       public io.vertx.core.VertxBuilder with(VertxOptions options) {
         this.options = options;
         return this;
       }
+
       @Override
       public io.vertx.core.VertxBuilder withMetrics(VertxMetricsFactory factory) {
         this.metricsFactory = factory;
         return this;
       }
+
       @Override
       public io.vertx.core.VertxBuilder withTracer(VertxTracerFactory factory) {
         this.tracerFactory = factory;
         return this;
       }
+
       @Override
       public io.vertx.core.VertxBuilder withClusterManager(ClusterManager clusterManager) {
         this.clusterManager = clusterManager;
         return this;
       }
+
       @Override
       public VertxBuilder withTransport(Transport transport) {
         this.transport = transport;
         return this;
       }
+
       private VertxBootstrap bootstrap() {
         VertxBootstrap bootstrap = VertxBootstrap.create();
         if (options != null) {
@@ -124,12 +130,14 @@ public interface Vertx extends Measured {
         bootstrap.transport(tr.implementation());
         return bootstrap;
       }
+
       @Override
       public Vertx build() {
         return bootstrap()
           .init()
           .vertx();
       }
+
       @Override
       public Future<Vertx> buildClustered() {
         return bootstrap()
@@ -152,7 +160,7 @@ public interface Vertx extends Measured {
   /**
    * Creates a non clustered instance using the specified options
    *
-   * @param options  the options to use
+   * @param options the options to use
    * @return the instance
    */
   static Vertx vertx(VertxOptions options) {
@@ -164,7 +172,7 @@ public interface Vertx extends Measured {
    * <p>
    * The instance is created asynchronously and the returned future is completed with the result when it is ready.
    *
-   * @param options  the options to use
+   * @param options the options to use
    * @return a future completed with the clustered vertx
    */
   static Future<Vertx> clusteredVertx(VertxOptions options) {
@@ -190,7 +198,7 @@ public interface Vertx extends Measured {
   /**
    * Create a TCP/SSL server using the specified options
    *
-   * @param options  the options to use
+   * @param options the options to use
    * @return the server
    */
   NetServer createNetServer(NetServerOptions options);
@@ -207,7 +215,7 @@ public interface Vertx extends Measured {
   /**
    * Create a TCP/SSL client using the specified options
    *
-   * @param options  the options to use
+   * @param options the options to use
    * @return the client
    */
   NetClient createNetClient(NetClientOptions options);
@@ -224,7 +232,7 @@ public interface Vertx extends Measured {
   /**
    * Create an HTTP/HTTPS server using the specified options
    *
-   * @param options  the options to use
+   * @param options the options to use
    * @return the server
    */
   HttpServer createHttpServer(HttpServerOptions options);
@@ -232,7 +240,7 @@ public interface Vertx extends Measured {
   /**
    * Create an HTTP3 client using the specified options
    *
-   * @param options  the options to use
+   * @param options the options to use
    * @return the server
    */
   default HttpClientAgent createHttpClient(Http3ClientOptions options) {
@@ -242,7 +250,7 @@ public interface Vertx extends Measured {
   /**
    * Create an HTTP3 server using the specified options
    *
-   * @param options  the options to use
+   * @param options the options to use
    * @return the server
    */
   HttpServer createHttpServer(Http3ServerOptions options);
@@ -268,7 +276,7 @@ public interface Vertx extends Measured {
   /**
    * Create a WebSocket client using the specified options
    *
-   * @param options  the options to use
+   * @param options the options to use
    * @return the client
    */
   WebSocketClient createWebSocketClient(WebSocketClientOptions options);
@@ -277,15 +285,16 @@ public interface Vertx extends Measured {
    * Provide a builder for {@link HttpClient}, it can be used to configure advanced
    * HTTP client settings like a redirect handler or a connection handler.
    * <p>
-   * Example usage: {@code HttpClient client = vertx.httpClientBuilder().with(options).withConnectHandler(conn -> ...).build()}
+   * Example usage:
+   * {@code HttpClient client = vertx.httpClientBuilder().with(options).withConnectHandler(conn -> ...).build()}
    */
   HttpClientBuilder httpClientBuilder();
 
   /**
    * Create a HTTP/HTTPS client using the specified client and pool options
    *
-   * @param clientOptions  the client options to use
-   * @param poolOptions  the pool options to use
+   * @param clientOptions the client options to use
+   * @param poolOptions   the pool options to use
    * @return the client
    */
   default HttpClientAgent createHttpClient(HttpClientOptions clientOptions, PoolOptions poolOptions) {
@@ -295,7 +304,7 @@ public interface Vertx extends Measured {
   /**
    * Create a HTTP/HTTPS client using the specified client options
    *
-   * @param clientOptions  the options to use
+   * @param clientOptions the options to use
    * @return the client
    */
   default HttpClientAgent createHttpClient(HttpClientOptions clientOptions) {
@@ -305,7 +314,7 @@ public interface Vertx extends Measured {
   /**
    * Create a HTTP/HTTPS client using the specified pool options
    *
-   * @param poolOptions  the pool options to use
+   * @param poolOptions the pool options to use
    * @return the client
    */
   default HttpClientAgent createHttpClient(PoolOptions poolOptions) {
@@ -324,7 +333,7 @@ public interface Vertx extends Measured {
   /**
    * Create a datagram socket using the specified options
    *
-   * @param options  the options to use
+   * @param options the options to use
    * @return the socket
    */
   DatagramSocket createDatagramSocket(DatagramSocketOptions options);
@@ -355,11 +364,12 @@ public interface Vertx extends Measured {
   EventBus eventBus();
 
   /**
-   * Create a DNS client to connect to a DNS server at the specified host and port, with the default query timeout (5 seconds)
+   * Create a DNS client to connect to a DNS server at the specified host and port, with the default query timeout (5
+   * seconds)
    * <p/>
    *
-   * @param port  the port
-   * @param host  the host
+   * @param port the port
+   * @param host the host
    * @return the DNS client
    */
   DnsClient createDnsClient(int port, String host);
@@ -367,7 +377,8 @@ public interface Vertx extends Measured {
   /**
    * Create a DNS client to connect to the DNS server configured by {@link VertxOptions#getAddressResolverOptions()}
    * <p>
-   * DNS client takes the first configured resolver address provided by {@link DnsAddressResolverProvider#nameServerAddresses()}}
+   * DNS client takes the first configured resolver address provided by
+   * {@link DnsAddressResolverProvider#nameServerAddresses()}}
    *
    * @return the DNS client
    */
@@ -398,11 +409,12 @@ public interface Vertx extends Measured {
 
   /**
    * Create a timer task configured with the specified {@code delay}, when the timeout fires the timer future
-   * is succeeded, when the timeout is cancelled the timer future is failed with a {@link java.util.concurrent.CancellationException}
+   * is succeeded, when the timeout is cancelled the timer future is failed with a
+   * {@link java.util.concurrent.CancellationException}
    * instance.
    *
    * @param delay the delay
-   * @param unit the delay unit
+   * @param unit  the delay unit
    * @return the timer object
    */
   default Timer timer(long delay, TimeUnit unit) {
@@ -414,8 +426,8 @@ public interface Vertx extends Measured {
    * Set a one-shot timer to fire after {@code delay} milliseconds, at which point {@code handler} will be called with
    * the id of the timer.
    *
-   * @param delay  the delay in milliseconds, after which the timer will fire
-   * @param handler  the handler that will be called with the timer ID when the timer fires
+   * @param delay   the delay in milliseconds, after which the timer will fire
+   * @param handler the handler that will be called with the timer ID when the timer fires
    * @return the unique ID of the timer
    */
   long setTimer(long delay, Handler<Long> handler);
@@ -424,8 +436,8 @@ public interface Vertx extends Measured {
    * Set a periodic timer to fire every {@code delay} milliseconds, at which point {@code handler} will be called with
    * the id of the timer.
    *
-   * @param delay  the delay in milliseconds, after which the timer will fire
-   * @param handler  the handler that will be called with the timer ID when the timer fires
+   * @param delay   the delay in milliseconds, after which the timer will fire
+   * @param handler the handler that will be called with the timer ID when the timer fires
    * @return the unique ID of the timer
    */
   default long setPeriodic(long delay, Handler<Long> handler) {
@@ -433,12 +445,13 @@ public interface Vertx extends Measured {
   }
 
   /**
-   * Set a periodic timer to fire every {@code delay} milliseconds with initial delay, at which point {@code handler} will be called with
+   * Set a periodic timer to fire every {@code delay} milliseconds with initial delay, at which point {@code handler}
+   * will be called with
    * the id of the timer.
    *
    * @param initialDelay the initial delay in milliseconds
-   * @param delay the delay in milliseconds, after which the timer will fire
-   * @param handler the handler that will be called with the timer ID when the timer fires
+   * @param delay        the delay in milliseconds, after which the timer will fire
+   * @param handler      the handler that will be called with the timer ID when the timer fires
    * @return the unique ID of the timer
    */
   long setPeriodic(long initialDelay, long delay, Handler<Long> handler);
@@ -446,7 +459,7 @@ public interface Vertx extends Measured {
   /**
    * Cancels the timer with the specified {@code id}.
    *
-   * @param id  The id of the timer to cancel
+   * @param id The id of the timer to cancel
    * @return true if the timer was successfully cancelled, or false if the timer does not exist.
    */
   boolean cancelTimer(long id);
@@ -482,7 +495,7 @@ public interface Vertx extends Measured {
    * <p>
    * This deployment ID can subsequently be used to undeploy the verticle.
    *
-   * @param verticle  the verticle instance to deploy.
+   * @param verticle the verticle instance to deploy.
    * @return a future completed with the result
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
@@ -494,7 +507,7 @@ public interface Vertx extends Measured {
    * Like {@link #deployVerticle(Deployable)} but {@link io.vertx.core.DeploymentOptions} are provided to configure the
    * deployment.
    *
-   * @param verticle  the verticle instance to deploy
+   * @param verticle the verticle instance to deploy
    * @param options  the deployment options.
    * @return a future completed with the result
    */
@@ -504,7 +517,8 @@ public interface Vertx extends Measured {
   }
 
   /**
-   * Like {@link #deployVerticle(Deployable, DeploymentOptions)} but {@link Deployable} instance is created by invoking the
+   * Like {@link #deployVerticle(Deployable, DeploymentOptions)} but {@link Deployable} instance is created by invoking
+   * the
    * {@code verticleSupplier}.
    * <p>
    * The supplier will be invoked as many times as {@link DeploymentOptions#getInstances()}.
@@ -518,8 +532,10 @@ public interface Vertx extends Measured {
   Future<String> deployVerticle(Supplier<? extends Deployable> supplier, DeploymentOptions options);
 
   /**
-   * Like {@link #deployVerticle(Deployable, DeploymentOptions)} but {@link Deployable} instance is created by invoking the
+   * Like {@link #deployVerticle(Deployable, DeploymentOptions)} but {@link Deployable} instance is created by invoking
+   * the
    * default constructor of {@code verticleClass}.
+   *
    * @return a future completed with the result
    */
   @GenIgnore
@@ -537,7 +553,7 @@ public interface Vertx extends Measured {
    * <p>
    * This deployment ID can subsequently be used to undeploy the verticle.
    *
-   * @param name  the name.
+   * @param name the name.
    * @return a future completed with the result
    */
   default Future<String> deployVerticle(String name) {
@@ -548,8 +564,8 @@ public interface Vertx extends Measured {
    * Like {@link #deployVerticle(Deployable)} but {@link io.vertx.core.DeploymentOptions} are provided to configure the
    * deployment.
    *
-   * @param name  the name
-   * @param options  the deployment options.
+   * @param name    the name
+   * @param options the deployment options.
    * @return a future completed with the result
    */
   Future<String> deployVerticle(String name, DeploymentOptions options);
@@ -559,7 +575,7 @@ public interface Vertx extends Measured {
    * <p>
    * The actual undeployment happens asynchronously and may not complete until after the method has returned.
    *
-   * @param deploymentID  the deployment ID
+   * @param deploymentID the deployment ID
    * @return a future completed with the result
    */
   Future<Void> undeploy(String deploymentID);
@@ -607,13 +623,15 @@ public interface Vertx extends Measured {
    * <p>
    * Executes the blocking code in the handler {@code blockingCodeHandler} using a thread from the worker pool.
    * <p>
-   * The returned future will be completed with the result on the original context (i.e. on the original event loop of the caller)
+   * The returned future will be completed with the result on the original context (i.e. on the original event loop of
+   * the caller)
    * or failed when the handler throws an exception.
    * <p>
    * In the {@code blockingCodeHandler} the current context remains the original context and therefore any task
    * scheduled in the {@code blockingCodeHandler} will be executed on this context and not on the worker thread.
    * <p>
-   * The blocking code should block for a reasonable amount of time (i.e no more than a few seconds). Long blocking operations
+   * The blocking code should block for a reasonable amount of time (i.e no more than a few seconds). Long blocking
+   * operations
    * or polling operations (i.e a thread that spin in a loop polling events in a blocking fashion) are precluded.
    * <p>
    * When the blocking operation lasts more than the 10 seconds, a message will be printed on the console by the
@@ -622,11 +640,13 @@ public interface Vertx extends Measured {
    * Long blocking operations should use a dedicated thread managed by the application, which can interact with
    * verticles using the event-bus or {@link Context#runOnContext(Handler)}
    *
-   * @param blockingCodeHandler  handler representing the blocking code to run
-   * @param ordered  if true then if executeBlocking is called several times on the same context, the executions
-   *                 for that context will be executed serially, not in parallel. if false then they will be no ordering
-   *                 guarantees
-   * @param <T> the type of the result
+   * @param blockingCodeHandler handler representing the blocking code to run
+   * @param ordered             if true then if executeBlocking is called several times on the same context, the
+   *                            executions
+   *                            for that context will be executed serially, not in parallel. if false then they will be
+   *                            no ordering
+   *                            guarantees
+   * @param <T>                 the type of the result
    * @return a future completed when the blocking code is complete
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
@@ -644,33 +664,37 @@ public interface Vertx extends Measured {
   }
 
   /**
-   * Like {@link #createSharedWorkerExecutor(String, int)} but with the {@link VertxOptions#setWorkerPoolSize} {@code poolSize}.
+   * Like {@link #createSharedWorkerExecutor(String, int)} but with the {@link VertxOptions#setWorkerPoolSize}
+   * {@code poolSize}.
    */
   WorkerExecutor createSharedWorkerExecutor(String name);
 
   /**
-   * Like {@link #createSharedWorkerExecutor(String, int, long)} but with the {@link VertxOptions#setMaxWorkerExecuteTime} {@code maxExecuteTime}.
+   * Like {@link #createSharedWorkerExecutor(String, int, long)} but with the
+   * {@link VertxOptions#setMaxWorkerExecuteTime} {@code maxExecuteTime}.
    */
   WorkerExecutor createSharedWorkerExecutor(String name, int poolSize);
 
   /**
-   * Like {@link #createSharedWorkerExecutor(String, int, long, TimeUnit)} but with the {@link VertxOptions#setMaxWorkerExecuteTimeUnit(TimeUnit)} {@code maxExecuteTimeUnit}.
+   * Like {@link #createSharedWorkerExecutor(String, int, long, TimeUnit)} but with the
+   * {@link VertxOptions#setMaxWorkerExecuteTimeUnit(TimeUnit)} {@code maxExecuteTimeUnit}.
    */
   WorkerExecutor createSharedWorkerExecutor(String name, int poolSize, long maxExecuteTime);
 
   /**
    * Create a named worker executor, the executor should be closed when it's not needed anymore to release
    * resources.<p/>
-   *
+   * <p>
    * This method can be called mutiple times with the same {@code name}. Executors with the same name will share
-   * the same worker pool. The worker pool size , max execute time and unit of max execute time are set when the worker pool is created and
+   * the same worker pool. The worker pool size , max execute time and unit of max execute time are set when the worker
+   * pool is created and
    * won't change after.<p>
-   *
+   * <p>
    * The worker pool is released when all the {@link WorkerExecutor} sharing the same name are closed.
    *
-   * @param name the name of the worker executor
-   * @param poolSize the size of the pool
-   * @param maxExecuteTime the value of max worker execute time
+   * @param name               the name of the worker executor
+   * @param poolSize           the size of the pool
+   * @param maxExecuteTime     the value of max worker execute time
    * @param maxExecuteTimeUnit the value of unit of max worker execute time
    * @return the named worker executor
    */
@@ -683,7 +707,8 @@ public interface Vertx extends Measured {
   boolean isNativeTransportEnabled();
 
   /**
-   * @return the error (if any) that cause the unavailability of native transport when {@link #isNativeTransportEnabled()}  returns {@code false}.
+   * @return the error (if any) that cause the unavailability of native transport when
+   *   {@link #isNativeTransportEnabled()}  returns {@code false}.
    */
   @CacheReturn
   Throwable unavailableNativeTransportCause();
@@ -701,5 +726,8 @@ public interface Vertx extends Measured {
    * @return the current default exception handler
    */
   @GenIgnore
-  @Nullable Handler<Throwable> exceptionHandler();
+  @Nullable
+  Handler<Throwable> exceptionHandler();
+
+  AsyncLogic asyncLogic();
 }

--- a/vertx-core/src/main/java/io/vertx/core/impl/logic/AsyncLogicImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/logic/AsyncLogicImpl.java
@@ -1,0 +1,17 @@
+package io.vertx.core.impl.logic;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.logic.AsyncLogic;
+
+public class AsyncLogicImpl implements AsyncLogic {
+  private final Vertx vertx;
+
+  public AsyncLogicImpl(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  @Override
+  public Vertx vertx() {
+    return vertx;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxInternal.java
@@ -15,21 +15,21 @@ package io.vertx.core.internal;
 import io.netty.channel.EventLoopGroup;
 import io.vertx.core.*;
 import io.vertx.core.http.impl.HttpClientBuilderInternal;
-import io.vertx.core.impl.*;
-import io.vertx.core.impl.future.FailedFuture;
-import io.vertx.core.impl.future.SucceededFuture;
+import io.vertx.core.impl.VertxImpl;
+import io.vertx.core.impl.logic.AsyncLogicImpl;
 import io.vertx.core.internal.deployment.DeploymentManager;
 import io.vertx.core.internal.resolver.NameResolver;
 import io.vertx.core.internal.threadchecker.BlockedThreadChecker;
+import io.vertx.core.logic.AsyncLogic;
 import io.vertx.core.net.NetServerOptions;
-import io.vertx.core.net.impl.tcp.NetServerInternal;
 import io.vertx.core.net.impl.ServerID;
-import io.vertx.core.spi.context.storage.ContextLocal;
-import io.vertx.core.spi.transport.Transport;
+import io.vertx.core.net.impl.tcp.NetServerInternal;
 import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.core.spi.context.storage.ContextLocal;
 import io.vertx.core.spi.file.FileResolver;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.spi.transport.Transport;
 
 import java.lang.ref.Cleaner;
 import java.util.List;
@@ -77,7 +77,7 @@ public interface VertxInternal extends Vertx {
 
   /**
    * @return a promise associated with the context returned by {@link #getOrCreateContext()} or the {@code handler}
-   *         if that handler is already an instance of {@code PromiseInternal}
+   *   if that handler is already an instance of {@code PromiseInternal}
    */
   default <T> PromiseInternal<T> promise(Completable<T> p) {
     return getOrCreateContext().promise(p);
@@ -146,6 +146,7 @@ public interface VertxInternal extends Vertx {
 
   /**
    * Get the current context
+   *
    * @return the context
    */
   ContextInternal getContext();

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxWrapper.java
@@ -20,22 +20,24 @@ import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.*;
 import io.vertx.core.http.impl.HttpClientBuilderInternal;
+import io.vertx.core.impl.logic.AsyncLogicImpl;
 import io.vertx.core.internal.deployment.DeploymentManager;
 import io.vertx.core.internal.resolver.NameResolver;
 import io.vertx.core.internal.threadchecker.BlockedThreadChecker;
+import io.vertx.core.logic.AsyncLogic;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServerOptions;
-import io.vertx.core.net.impl.tcp.NetServerInternal;
 import io.vertx.core.net.impl.ServerID;
-import io.vertx.core.spi.context.storage.ContextLocal;
-import io.vertx.core.spi.transport.Transport;
+import io.vertx.core.net.impl.tcp.NetServerInternal;
 import io.vertx.core.shareddata.SharedData;
 import io.vertx.core.spi.VerticleFactory;
 import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.core.spi.context.storage.ContextLocal;
 import io.vertx.core.spi.file.FileResolver;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.spi.transport.Transport;
 
 import java.lang.ref.Cleaner;
 import java.util.List;
@@ -48,16 +50,17 @@ import java.util.function.Supplier;
 
 /**
  * A wrapper class that delegates all method calls to the {@link #delegate} instance.
- *
+ * <p>
  * Implementing the {@link Vertx} interface is not encouraged however if that is necessary, implementations
  * should favor extending this class to ensure minimum breakage when new methods are added to the interace.
- *
+ * <p>
  * The delegate instance can be accessed using protected final {@link #delegate} field, any method of the {@code Vertx}
  * interface can be overridden.
  */
 public abstract class VertxWrapper implements VertxInternal {
 
   protected final VertxInternal delegate;
+  private final AsyncLogic asyncLogicInstance = new AsyncLogicImpl(this);
 
   protected VertxWrapper(VertxInternal delegate) {
     if (delegate == null) {
@@ -369,5 +372,10 @@ public abstract class VertxWrapper implements VertxInternal {
   @Override
   public boolean isMetricsEnabled() {
     return delegate.isMetricsEnabled();
+  }
+
+  @Override
+  public final AsyncLogic asyncLogic() {
+    return asyncLogicInstance;
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/logic/AsyncLogic.java
+++ b/vertx-core/src/main/java/io/vertx/core/logic/AsyncLogic.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.logic;
+
+/**
+ * Main interface for asynchronous logic operations in Vert.x.
+ * <p>
+ * This interface combines three core capabilities:
+ * <ul>
+ *   <li>{@link AsyncLogicParallel} - Parallel execution of async operations</li>
+ *   <li>{@link AsyncLogicLock} - Exclusive execution with lock mechanisms</li>
+ *   <li>{@link AsyncLogicBlock} - Transformation of blocking operations to async</li>
+ * </ul>
+ * <p>
+ * Instances of this interface can be obtained via {@link io.vertx.core.Vertx#asyncLogic()}.
+ *
+ * @author Sinri Edogawa
+ */
+public interface AsyncLogic extends AsyncLogicParallel, AsyncLogicLock, AsyncLogicBlock {
+}

--- a/vertx-core/src/main/java/io/vertx/core/logic/AsyncLogicBlock.java
+++ b/vertx-core/src/main/java/io/vertx/core/logic/AsyncLogicBlock.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.logic;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.ThreadingModel;
+import io.vertx.core.Vertx;
+
+/**
+ * Interface containing method definitions for converting synchronous blocking calls
+ * to asynchronous operations.
+ *
+ * @author Sinri Edogawa
+ */
+interface AsyncLogicBlock extends AsyncLogicCore {
+  private boolean isInNonBlockContext() {
+    Context currentContext = Vertx.currentContext();
+    return currentContext != null && currentContext.isEventLoopContext();
+  }
+
+  /**
+   * Converts a {@link CompletableFuture} to a Vert.x {@link Future}.
+   * <p>
+   * The conversion ensures proper context handling, executing completion callbacks
+   * on the appropriate event loop thread when available.
+   *
+   * @param <R>               the type of the asynchronous return value
+   * @param completableFuture the given {@link CompletableFuture}
+   * @return the converted {@link Future}
+   */
+  default <R> Future<R> asyncTransformCompletableFuture(CompletableFuture<R> completableFuture) {
+    Promise<R> promise = Promise.promise();
+    Context currentContext = Vertx.currentContext();
+
+      completableFuture.whenComplete((r, t) -> {
+      Runnable completeAction = () -> {
+        try {
+          if (t != null) {
+            promise.fail(t);
+          } else {
+            promise.complete(r);
+          }
+        } catch (Exception e) {
+          promise.tryFail(e);
+        }
+      };
+
+      // If there is no context or already on the correct event loop thread, execute directly
+      if (currentContext == null) {
+        completeAction.run();
+      } else if (currentContext.isEventLoopContext()) {
+        currentContext.runOnContext(v -> completeAction.run());
+      } else {
+        // In a worker thread, execute directly
+        completeAction.run();
+      }
+    });
+
+    return promise.future();
+  }
+
+  /**
+   * Converts a {@link java.util.concurrent.Future} to a Vert.x {@link Future}.
+   * <p>
+   * If called from a non-blocking context (event loop), the conversion uses
+   * {@code executeBlocking} to avoid blocking the event loop. Otherwise, it
+   * blocks the current thread to get the result.
+   *
+   * @param <R>       the type of the asynchronous return value
+   * @param rawFuture the given {@link java.util.concurrent.Future}
+   * @return the converted {@link Future}
+   */
+  default <R> Future<R> asyncTransformRawFuture(java.util.concurrent.Future<R> rawFuture) {
+    if (isInNonBlockContext()) {
+      return vertx().executeBlocking(rawFuture::get);
+    } else {
+      try {
+        var r = rawFuture.get();
+        return Future.succeededFuture(r);
+      } catch (InterruptedException | ExecutionException e) {
+        return Future.failedFuture(e);
+      }
+    }
+  }
+
+  /**
+   * Converts a {@link java.util.concurrent.Future} to a Vert.x {@link Future}
+   * using polling with a specified sleep interval.
+   * <p>
+   * This method repeatedly checks if the future is done, sleeping for the specified
+   * duration between checks. Once the future is done, it retrieves the result.
+   *
+   * @param <R>       the type of the asynchronous return value
+   * @param rawFuture the given {@link java.util.concurrent.Future}
+   * @param sleepTime the wait time between checks in milliseconds
+   * @return the converted {@link Future}
+   */
+  default <R> Future<R> asyncTransformRawFuture(java.util.concurrent.Future<R> rawFuture, long sleepTime) {
+    return asyncCallRepeatedly(repeatedlyCallTask -> {
+      if (rawFuture.isDone()) {
+        repeatedlyCallTask.stop();
+        return Future.succeededFuture();
+      }
+      return this.asyncSleep(sleepTime);
+    })
+      .compose(over -> {
+        if (rawFuture.isCancelled()) {
+          return Future
+            .failedFuture(new java.util.concurrent.CancellationException("Raw Future Cancelled"));
+        }
+        try {
+          var r = rawFuture.get();
+          return Future.succeededFuture(r);
+        } catch (InterruptedException | ExecutionException e) {
+          return Future.failedFuture(e);
+        }
+      });
+  }
+
+  /**
+   * Blocks and waits for an asynchronous task to complete, then returns its result.
+   * <p>
+   * This method uses {@link CountDownLatch} to implement blocking wait, avoiding CPU
+   * spinning. The method blocks the current thread until the asynchronous task completes
+   * (successfully or with failure).
+   * <p>
+   * <strong>Important restrictions:</strong>
+   * <ul>
+   *   <li>This method <strong>must not</strong> be called from an EventLoop thread,
+   *       otherwise it will throw {@link IllegalThreadStateException}</li>
+   *   <li>This method can only be called from Worker threads, virtual threads, or
+   *       regular threads</li>
+   *   <li>It is recommended to use this method in Verticles with
+   *       {@link ThreadingModel#WORKER} or {@link ThreadingModel#VIRTUAL_THREAD}</li>
+   * </ul>
+   * <p>
+   * <strong>Exception handling:</strong>
+   * <ul>
+   *   <li>If the asynchronous task fails, this method throws {@link RuntimeException},
+   *       with the original exception wrapped or thrown directly (if it is already a
+   *       RuntimeException)</li>
+   *   <li>If the current thread is interrupted during waiting, it throws
+   *       {@link RuntimeException} and restores the thread's interrupt status</li>
+   *   <li>If called from an EventLoop thread, it immediately throws
+   *       {@link IllegalThreadStateException}</li>
+   * </ul>
+   * <p>
+   * <strong>Return value:</strong>
+   * <ul>
+   *   <li>If the asynchronous task completes successfully, returns the task's result
+   *       (which may be {@code null})</li>
+   *   <li>If the asynchronous task fails, throws an exception instead of returning
+   *       {@code null}</li>
+   * </ul>
+   * <p>
+   * Use this method only when necessary, and ensure it fits your use case before using it.
+   *
+   * @param <T>                         the type of the value returned by the asynchronous task
+   * @param longTermAsyncProcessFuture  a {@link Future} returned by a long-running
+   *                                    asynchronous task, must not be {@code null}
+   * @return the value returned by the asynchronous task; if the task completes successfully
+   *         but the result is {@code null}, returns {@code null}
+   * @throws IllegalThreadStateException if this method is called from an EventLoop thread
+   * @throws RuntimeException            if the asynchronous task fails, or the current
+   *                                     thread is interrupted during waiting
+   */
+  @Nullable
+  default <T> T blockAwait(Future<T> longTermAsyncProcessFuture) {
+    if (isInNonBlockContext()) {
+      throw new IllegalThreadStateException("Cannot call blockAwait in event loop context");
+    }
+
+    // 使用 CountDownLatch 替代忙等待，避免 CPU 空转
+    CountDownLatch latch = new CountDownLatch(1);
+    longTermAsyncProcessFuture.onComplete(ar -> latch.countDown());
+
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while waiting for async task", e);
+    }
+
+    // 检查任务是否失败，如果有异常则抛出，而不是返回 null
+    if (longTermAsyncProcessFuture.failed()) {
+      Throwable cause = longTermAsyncProcessFuture.cause();
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      throw new RuntimeException(cause);
+    }
+
+    return longTermAsyncProcessFuture.result();
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/logic/AsyncLogicCore.java
+++ b/vertx-core/src/main/java/io/vertx/core/logic/AsyncLogicCore.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.logic;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+/**
+ * Core interface for asynchronous logic operations.
+ * <p>
+ * This interface provides the fundamental building blocks for asynchronous operations
+ * including non-blocking sleep, repeated calls, iterations, and stepwise loops.
+ *
+ * @author Sinri Edogawa
+ */
+interface AsyncLogicCore {
+  /**
+   * Returns the Vert.x instance associated with this async logic.
+   *
+   * @return the Vert.x instance
+   */
+  Vertx vertx();
+
+  /**
+   * Non-blocking sleep for a specified duration.
+   * <p>
+   * Note that this is not a true thread sleep, but rather implemented through a timer
+   * callback mechanism. Therefore, it does not block the thread and will not prevent
+   * process exit.
+   *
+   * @param time the duration in milliseconds, minimum valid value is 1 millisecond;
+   *             invalid values will be forced to 1 millisecond
+   * @return a {@link Future} that completes when the specified time has elapsed
+   */
+  default Future<Void> asyncSleep(long time) {
+    return asyncSleep(time, null);
+  }
+
+  /**
+   * Non-blocking sleep for a specified duration with optional interrupt capability.
+   * <p>
+   * The sleep can be interrupted early by completing the provided interrupter promise.
+   *
+   * @param time        the duration in milliseconds, minimum valid value is 1 millisecond;
+   *                    invalid values will be forced to 1 millisecond
+   * @param interrupter an optional {@link Promise} for asynchronous interruption
+   * @return a {@link Future} that completes when the specified time has elapsed,
+   *         or when the interrupt is triggered
+   */
+  default Future<Void> asyncSleep(long time, @Nullable Promise<Void> interrupter) {
+    Promise<Void> promise = Promise.promise();
+    time = Math.max(1, time);
+    long timer_id = vertx().setTimer(time, timerID -> {
+      promise.complete();
+    });
+    if (interrupter != null) {
+      interrupter.future().onSuccess(interrupted -> {
+        vertx().cancelTimer(timer_id);
+        promise.tryComplete();
+      });
+    }
+    return promise.future();
+  }
+
+  /**
+   * Executes an asynchronous loop based on the given repeatedly call task.
+   *
+   * @param repeatedlyCallTask the given asynchronous repeatedly call task
+   * @return the result of the asynchronous loop execution
+   */
+  private Future<Void> asyncCallRepeatedly(RepeatedlyCallTask repeatedlyCallTask) {
+    Promise<Void> promise = Promise.promise();
+    RepeatedlyCallTask.start(vertx(), repeatedlyCallTask, promise);
+    return promise.future();
+  }
+
+  /**
+   * Executes an asynchronous loop based on the given processor function.
+   * <p>
+   * The processor function is called repeatedly until the task is stopped via
+   * {@link RepeatedlyCallTask#stop()}.
+   *
+   * @param processor the loop logic function used to build the asynchronous repeatedly call task
+   * @return the result of the asynchronous loop execution
+   */
+  default Future<Void> asyncCallRepeatedly(Function<RepeatedlyCallTask, Future<Void>> processor) {
+    return asyncCallRepeatedly(new RepeatedlyCallTask(processor));
+  }
+
+  /**
+   * Performs asynchronous batch iteration over an iterator using asynchronous loop calls,
+   * with the ability to interrupt the task early within the iteration body if needed.
+   *
+   * @param <T>            the type of objects in the iterator
+   * @param iterator       the iterator
+   * @param itemsProcessor the batch iteration execution logic
+   * @param batchSize      the batch size for execution
+   * @return the result of the asynchronous loop execution
+   */
+  default <T extends @Nullable Object> Future<Void> asyncCallIteratively(
+    Iterator<T> iterator,
+    BiFunction<List<T>, RepeatedlyCallTask, Future<Void>> itemsProcessor,
+    int batchSize
+  ) {
+    if (batchSize <= 0)
+      throw new IllegalArgumentException("batchSize must be greater than 0");
+
+    return asyncCallRepeatedly(repeatedlyCallTask -> {
+      List<T> buffer = new ArrayList<>();
+
+      while (buffer.size() < batchSize) {
+        if (iterator.hasNext()) {
+          buffer.add(iterator.next());
+        } else {
+          break;
+        }
+      }
+
+      if (buffer.isEmpty()) {
+        repeatedlyCallTask.stop();
+        return Future.succeededFuture();
+      }
+
+      return itemsProcessor.apply(buffer, repeatedlyCallTask);
+    });
+  }
+
+  /**
+   * Performs asynchronous batch iteration over an iterator using asynchronous loop calls.
+   *
+   * @param <T>            the type of objects in the iterator
+   * @param iterator       the iterator
+   * @param itemsProcessor the batch iteration execution logic
+   * @param batchSize      the batch size for execution
+   * @return the result of the asynchronous loop execution
+   */
+  default <T extends @Nullable Object> Future<Void> asyncCallIteratively(
+    Iterator<T> iterator,
+    Function<List<T>, Future<Void>> itemsProcessor,
+    int batchSize
+  ) {
+    return asyncCallIteratively(
+      iterator,
+      (ts, repeatedlyCallTask) -> itemsProcessor.apply(ts),
+      batchSize);
+  }
+
+  /**
+   * Performs asynchronous batch iteration over an iterable using asynchronous loop calls.
+   *
+   * @param <T>            the type of objects in the iterable
+   * @param iterable       the iterable
+   * @param itemsProcessor the batch iteration execution logic
+   * @param batchSize      the batch size for execution
+   * @return the result of the asynchronous loop execution
+   */
+  default <T extends @Nullable Object> Future<Void> asyncCallIteratively(
+    Iterable<T> iterable,
+    BiFunction<List<T>, RepeatedlyCallTask, Future<Void>> itemsProcessor,
+    int batchSize
+  ) {
+    return asyncCallIteratively(iterable.iterator(), itemsProcessor, batchSize);
+  }
+
+  /**
+   * Performs asynchronous iteration over an iterator using asynchronous loop calls,
+   * with the ability to interrupt the task early within the iteration body if needed.
+   *
+   * @param <T>           the type of objects in the iterator
+   * @param iterator      the iterator
+   * @param itemProcessor the iteration execution logic
+   * @return the result of the asynchronous loop execution
+   */
+  default <T extends @Nullable Object> Future<Void> asyncCallIteratively(
+    Iterator<T> iterator,
+    BiFunction<T, RepeatedlyCallTask, Future<Void>> itemProcessor
+  ) {
+    return asyncCallRepeatedly(routineResult -> Future
+      .succeededFuture()
+      .compose(v -> {
+        if (iterator.hasNext()) {
+          return itemProcessor.apply(iterator.next(), routineResult);
+        } else {
+          routineResult.stop();
+          return Future.succeededFuture();
+        }
+      }));
+  }
+
+  /**
+   * Performs asynchronous iteration over an iterator using asynchronous loop calls.
+   *
+   * @param <T>           the type of objects in the iterator
+   * @param iterator      the iterator
+   * @param itemProcessor the iteration execution logic
+   * @return the result of the asynchronous loop execution
+   */
+  default <T extends @Nullable Object> Future<Void> asyncCallIteratively(
+    Iterator<T> iterator,
+    Function<T, Future<Void>> itemProcessor) {
+    return asyncCallIteratively(
+      iterator,
+      (t, repeatedlyCallTask) -> itemProcessor.apply(t)
+    );
+  }
+
+  /**
+   * Performs asynchronous iteration over an iterable using asynchronous loop calls.
+   *
+   * @param <T>           the type of objects in the iterable
+   * @param iterable      the iterable
+   * @param itemProcessor the iteration execution logic
+   * @return the result of the asynchronous loop execution
+   */
+  default <T extends @Nullable Object> Future<Void> asyncCallIteratively(
+    Iterable<T> iterable,
+    Function<T, Future<Void>> itemProcessor) {
+    return asyncCallIteratively(iterable.iterator(), itemProcessor);
+  }
+
+  /**
+   * Performs asynchronous iteration over an iterable using asynchronous loop calls,
+   * with the ability to interrupt the task early within the iteration body if needed.
+   *
+   * @param <T>           the type of objects in the iterable
+   * @param iterable      the iterable
+   * @param itemProcessor the iteration execution logic
+   * @return the result of the asynchronous loop execution
+   */
+  default <T extends @Nullable Object> Future<Void> asyncCallIteratively(
+    Iterable<T> iterable,
+    BiFunction<T, RepeatedlyCallTask, Future<Void>> itemProcessor) {
+    return asyncCallIteratively(iterable.iterator(), itemProcessor);
+  }
+
+  /**
+   * Performs an asynchronous stepwise loop based on given start, end, and step values
+   * using asynchronous loop calls.
+   * <p>
+   * The step direction must be incremental and reachable. Therefore, if the start value
+   * is greater than the end value, or the step value is less than or equal to 0,
+   * an exception will be thrown.
+   *
+   * @param start     the start value
+   * @param end       the end value
+   * @param step      the step value
+   * @param processor the asynchronous stepwise loop logic
+   * @return the result of the asynchronous loop execution
+   * @throws IllegalArgumentException if the step is not incremental and reachable
+   */
+  default Future<Void> asyncCallStepwise(
+    long start, long end, long step,
+    BiFunction<Long, RepeatedlyCallTask, Future<Void>> processor) {
+    if (step <= 0)
+      throw new IllegalArgumentException("step must be greater than 0");
+    if (start > end)
+      throw new IllegalArgumentException("start must not be greater than end");
+    AtomicLong ptr = new AtomicLong(start);
+    return asyncCallRepeatedly(task -> Future
+      .succeededFuture()
+      .compose(vv -> processor.apply(ptr.get(), task)
+                              .compose(v -> {
+                                long y = ptr.addAndGet(step);
+                                if (y >= end) {
+                                  task.stop();
+                                }
+                                return Future.succeededFuture();
+                              })));
+  }
+
+  /**
+   * Performs an asynchronous stepwise loop for a specified number of times using
+   * asynchronous loop calls, with the ability to interrupt early.
+   * <p>
+   * Based on {@link #asyncCallStepwise(long, long, long, BiFunction)}, with the start
+   * value set to 0 and the step value set to 1.
+   *
+   * @param times     the number of iterations (i.e., the end value). When the number
+   *                  of iterations is less than or equal to 0, a successful result
+   *                  will be returned directly.
+   * @param processor the asynchronous stepwise loop logic
+   * @return the result of the asynchronous loop execution
+   */
+  default Future<Void> asyncCallStepwise(
+    long times,
+    BiFunction<Long, RepeatedlyCallTask, Future<Void>> processor
+  ) {
+    if (times <= 0) {
+      return Future.succeededFuture();
+    }
+    return asyncCallStepwise(0, times, 1, processor);
+  }
+
+  /**
+   * Performs an asynchronous stepwise loop for a specified number of times using
+   * asynchronous loop calls.
+   *
+   * @param times     the number of iterations (i.e., the end value). When the number
+   *                  of iterations is less than or equal to 0, a successful result
+   *                  will be returned directly.
+   * @param processor the asynchronous stepwise loop logic
+   * @return the result of the asynchronous loop execution
+   */
+  default Future<Void> asyncCallStepwise(
+    long times,
+    Function<Long, Future<Void>> processor
+  ) {
+    if (times <= 0) {
+      return Future.succeededFuture();
+    }
+    return asyncCallStepwise(0, times, 1, (aLong, repeatedlyCallTask) -> processor.apply(aLong));
+  }
+
+  /**
+   * Executes an asynchronous logic in an infinite loop, continuing even if the loop
+   * body throws an exception.
+   * <p>
+   * Before using this method, ensure that the logic meets the requirements and has
+   * no side effects.
+   *
+   * @param supplier the asynchronous loop logic
+   */
+  default void asyncCallEndlessly(Supplier<Future<Void>> supplier) {
+    asyncCallRepeatedly(routineResult -> Future
+      .succeededFuture()
+      .compose(v -> supplier.get())
+      .eventually(Future::succeededFuture));
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/logic/AsyncLogicLock.java
+++ b/vertx-core/src/main/java/io/vertx/core/logic/AsyncLogicLock.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.logic;
+
+import java.util.function.Supplier;
+
+import io.vertx.core.Future;
+
+
+/**
+ * Interface for exclusive execution mechanism using locks.
+ * <p>
+ * This interface provides methods for executing asynchronous logic exclusively
+ * using Vert.x's lock mechanism.
+ *
+ * @author Sinri Edogawa
+ */
+interface AsyncLogicLock extends AsyncLogicCore {
+  /**
+   * Executes an asynchronous logic exclusively under Vert.x's lock mechanism.
+   * <p>
+   * Attempts to acquire the lock within the specified time limit, runs the
+   * asynchronous logic, and releases the lock after execution completes.
+   *
+   * @param <T>               the return type of the asynchronous logic
+   * @param lockName          the lock name
+   * @param waitTimeForLock   the maximum lock wait time in milliseconds
+   * @param exclusiveSupplier the asynchronous logic that needs to run exclusively
+   * @return the result of the asynchronous logic; if lock acquisition fails,
+   *         returns a failed future asynchronously
+   */
+  default <T> Future<T> asyncCallExclusively(String lockName, long waitTimeForLock,
+                                             Supplier<Future<T>> exclusiveSupplier) {
+    return vertx().sharedData()
+    .getLockWithTimeout(lockName, waitTimeForLock)
+                       .compose(lock -> Future.succeededFuture()
+                                              .compose(v -> exclusiveSupplier.get())
+                                              .andThen(ar -> lock.release()));
+  }
+
+  /**
+   * Executes an asynchronous logic exclusively under Vert.x's lock mechanism.
+   * <p>
+   * This method has the same logic as
+   * {@link AsyncLogicLock#asyncCallExclusively(String, long, Supplier)},
+   * with a default lock wait time of 1 second.
+   *
+   * @param <T>               the return type of the asynchronous logic
+   * @param lockName          the lock name
+   * @param exclusiveSupplier the asynchronous logic that needs to run exclusively
+   * @return the result of the asynchronous logic; if lock acquisition fails,
+   *         returns a failed future asynchronously
+   */
+  default <T> Future<T> asyncCallExclusively(String lockName, Supplier<Future<T>> exclusiveSupplier) {
+    return asyncCallExclusively(lockName, 1_000L, exclusiveSupplier);
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/logic/AsyncLogicParallel.java
+++ b/vertx-core/src/main/java/io/vertx/core/logic/AsyncLogicParallel.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.logic;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Future;
+
+/**
+ * Interface for asynchronous parallel execution logic.
+ * <p>
+ * This interface provides methods for executing asynchronous operations in parallel
+ * over collections, with different completion strategies (all success, any success,
+ * or all complete).
+ *
+ * @author Sinri Edogawa
+ */
+interface AsyncLogicParallel extends AsyncLogicCore {
+  private <T extends @Nullable Object> List<Future<Void>> buildFutures(
+    Iterator<T> iterator,
+    Function<T, Future<Void>> itemProcessor
+  ) {
+    List<Future<Void>> futures = new ArrayList<>();
+    while (iterator.hasNext()) {
+      Future<Void> f = itemProcessor.apply(iterator.next());
+      futures.add(f);
+    }
+    return futures;
+  }
+
+
+  /**
+   * Iterates over an iterable and triggers asynchronous logic for parallel execution;
+   * all asynchronous tasks must succeed for this call to be considered successful.
+   *
+   * @param <T>           the type of objects in the iterable
+   * @param collection    the iterable
+   * @param itemProcessor the asynchronous processing logic for each object
+   * @return an asynchronous result that succeeds only if all asynchronous tasks succeed,
+   *         otherwise returns failure
+   */
+  default <T extends @Nullable Object> Future<Void> parallelForAllSuccess(
+    Iterable<T> collection,
+    Function<T, Future<Void>> itemProcessor
+  ) {
+    return parallelForAllSuccess(collection.iterator(), itemProcessor);
+  }
+
+  /**
+   * Iterates over an iterator and triggers asynchronous logic for parallel execution;
+   * all asynchronous tasks must succeed for this call to be considered successful.
+   *
+   * @param <T>           the type of objects in the iterator
+   * @param iterator      the iterator
+   * @param itemProcessor the asynchronous processing logic for each object
+   * @return an asynchronous result that succeeds only if all asynchronous tasks succeed,
+   *         otherwise returns failure
+   */
+  default <T extends @Nullable Object> Future<Void> parallelForAllSuccess(
+    Iterator<T> iterator,
+    Function<T, Future<Void>> itemProcessor
+  ) {
+    List<Future<Void>> futures = buildFutures(iterator, itemProcessor);
+    if (futures.isEmpty()) {
+      return Future.succeededFuture();
+    }
+    return Future.all(futures)
+                 .mapEmpty();
+  }
+
+  /**
+   * Iterates over an iterable and triggers asynchronous logic for parallel execution;
+   * the call is considered successful if any asynchronous task succeeds.
+   *
+   * @param <T>           the type of objects in the iterable
+   * @param collection    the iterable
+   * @param itemProcessor the asynchronous processing logic for each object
+   * @return an asynchronous result that succeeds if any asynchronous task succeeds,
+   *         otherwise returns failure
+   */
+  default <T extends @Nullable Object> Future<Void> parallelForAnySuccess(
+    Iterable<T> collection,
+    Function<T, Future<Void>> itemProcessor
+  ) {
+    return parallelForAnySuccess(collection.iterator(), itemProcessor);
+  }
+
+  /**
+   * Iterates over an iterator and triggers asynchronous logic for parallel execution;
+   * the call is considered successful if any asynchronous task succeeds.
+   *
+   * @param <T>           the type of objects in the iterator
+   * @param iterator      the iterator
+   * @param itemProcessor the asynchronous processing logic for each object
+   * @return an asynchronous result that succeeds if any asynchronous task succeeds,
+   *         otherwise returns failure
+   */
+  default <T extends @Nullable Object> Future<Void> parallelForAnySuccess(
+    Iterator<T> iterator,
+    Function<T, Future<Void>> itemProcessor
+  ) {
+    List<Future<Void>> futures = buildFutures(iterator, itemProcessor);
+    if (futures.isEmpty()) {
+      return Future.succeededFuture();
+    }
+    return Future.any(futures)
+                 .mapEmpty();
+  }
+
+  /**
+   * Iterates over an iterable and triggers asynchronous logic for parallel execution;
+   * the call is considered successful when all asynchronous tasks have completed execution.
+   *
+   * @param <T>           the type of objects in the iterable
+   * @param collection    the iterable
+   * @param itemProcessor the asynchronous processing logic for each object
+   * @return an asynchronous result that succeeds when all asynchronous tasks have completed,
+   *         otherwise returns failure
+   */
+  default <T extends @Nullable Object> Future<Void> parallelForAllComplete(
+    Iterable<T> collection,
+    Function<T, Future<Void>> itemProcessor
+  ) {
+    return parallelForAllComplete(collection.iterator(), itemProcessor);
+  }
+
+  /**
+   * Iterates over an iterator and triggers asynchronous logic for parallel execution;
+   * the call is considered successful when all asynchronous tasks have completed execution.
+   *
+   * @param <T>           the type of objects in the iterator
+   * @param iterator      the iterator
+   * @param itemProcessor the asynchronous processing logic for each object
+   * @return an asynchronous result that succeeds when all asynchronous tasks have completed,
+   *         otherwise returns failure
+   */
+  default <T extends @Nullable Object> Future<Void> parallelForAllComplete(
+    Iterator<T> iterator,
+    Function<T, Future<Void>> itemProcessor
+  ) {
+    List<Future<Void>> futures = buildFutures(iterator, itemProcessor);
+    if (futures.isEmpty()) {
+      return Future.succeededFuture();
+    }
+    return Future.join(futures).mapEmpty();
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/logic/RepeatedlyCallTask.java
+++ b/vertx-core/src/main/java/io/vertx/core/logic/RepeatedlyCallTask.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.logic;
+
+import java.util.function.Function;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+
+/**
+ * Asynchronous repeatedly call task.
+ * <p>
+ * Contains an asynchronous loop body that executes repeatedly at 1 millisecond intervals.
+ * At the end of each task loop iteration, the task stop flag is checked to determine
+ * whether to end the loop. If an exception is thrown during loop execution causing
+ * an asynchronous failure, the loop is forcibly terminated and the root cause exception
+ * is propagated.
+ *
+ * @see #start(Vertx, RepeatedlyCallTask, Promise)
+ * @see #stop()
+ * @author Sinri Edogawa
+ */
+public final class RepeatedlyCallTask {
+  private final Function<RepeatedlyCallTask, Future<Void>> processor;
+  private volatile boolean toStop = false;
+
+  /**
+   * Creates a new repeatedly call task with the given processor function.
+   *
+   * @param processor the function that will be called repeatedly until the task is stopped
+   */
+  public RepeatedlyCallTask(Function<RepeatedlyCallTask, Future<Void>> processor) {
+    this.processor = processor;
+  }
+
+  /**
+   * Starts the repeatedly call task execution.
+   * <p>
+   * This static method initiates the asynchronous loop, calling the task's processor
+   * function repeatedly at 1 millisecond intervals until the task is stopped or
+   * an error occurs.
+   *
+   * @param vertx        the Vert.x instance
+   * @param thisTask     the repeatedly call task to start
+   * @param finalPromise the promise that will be completed when the task finishes
+   *                     (either successfully or with failure)
+   */
+  public static void start(Vertx vertx, RepeatedlyCallTask thisTask, Promise<Void> finalPromise) {
+    Future.succeededFuture()
+          .compose(v -> {
+            if (thisTask.toStop) {
+              return Future.succeededFuture();
+            }
+            return thisTask.processor.apply(thisTask);
+          })
+          .andThen(shouldStopAR -> {
+            if (shouldStopAR.succeeded()) {
+              if (thisTask.toStop) {
+                finalPromise.complete();
+              } else {
+                vertx.setTimer(1L, x -> start(vertx, thisTask, finalPromise));
+              }
+            } else {
+              finalPromise.fail(shouldStopAR.cause());
+            }
+          });
+  }
+
+  /**
+   * Stops the repeatedly call task.
+   * <p>
+   * Sets the stop flag, which will cause the loop to terminate after the current
+   * iteration completes. The task will not execute further iterations after this
+   * method is called.
+   */
+  public void stop() {
+    toStop = true;
+  }
+}

--- a/vertx-core/src/main/java/module-info.java
+++ b/vertx-core/src/main/java/module-info.java
@@ -67,6 +67,7 @@ module io.vertx.core {
   exports io.vertx.core.spi;
   exports io.vertx.core.file;
   exports io.vertx.core.transport;
+  exports io.vertx.core.logic;
 
   // SPI
 


### PR DESCRIPTION
Add AsyncLogic interface and related implementations for async operations directly.

This commit introduces the AsyncLogic interface along with its supporting classes, enabling advanced asynchronous operations in Vert.x. The new functionality includes parallel execution, exclusive execution with locks, and transformation of blocking operations to asynchronous ones. Key components added are AsyncLogic, AsyncLogicImpl, AsyncLogicBlock, AsyncLogicLock, AsyncLogicParallel, and RepeatedlyCallTask, enhancing the framework's capabilities for handling asynchronous logic efficiently.

Motivation:

Encapsulate commonly used asynchronous logic in Vert.x application development to enable rapid implementation of business logic.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
