### PR TITLE
Introduce NetServerConfig to configure a NetServer

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -20,9 +20,7 @@ import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.*;
-import io.vertx.core.net.impl.tcp.NetServerImpl;
-import io.vertx.core.net.impl.tcp.NetServerInternal;
-import io.vertx.core.net.impl.tcp.NetSocketImpl;
+import io.vertx.core.net.impl.tcp.*;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 
@@ -187,7 +185,10 @@ public class HttpServerImpl implements HttpServer, MetricsProvider {
         .withThreadingModel(ThreadingModel.EVENT_LOOP)
         .build();
     }
-    NetServerInternal server = vertx.createNetServer(tcpOptions);
+    NetServerInternal server = new NetServerBuilder(vertx, new NetServerConfig(tcpOptions))
+      .fileRegionEnabled(tcpOptions.isFileRegionEnabled())
+      .metricsProvider((metrics, addr) -> metrics.createHttpServerMetrics(options, addr))
+      .build();
     Handler<Throwable> h = exceptionHandler;
     Handler<Throwable> exceptionHandler = h != null ? h : DEFAULT_EXCEPTION_HANDLER;
     server.exceptionHandler(exceptionHandler);

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -48,10 +48,7 @@ import io.vertx.core.internal.threadchecker.BlockedThreadChecker;
 import io.vertx.core.net.*;
 import io.vertx.core.net.impl.*;
 import io.vertx.core.impl.transports.NioTransport;
-import io.vertx.core.net.impl.tcp.CleanableNetClient;
-import io.vertx.core.net.impl.tcp.NetClientBuilder;
-import io.vertx.core.net.impl.tcp.NetServerImpl;
-import io.vertx.core.net.impl.tcp.NetServerInternal;
+import io.vertx.core.net.impl.tcp.*;
 import io.vertx.core.spi.context.executor.EventExecutorProvider;
 import io.vertx.core.spi.context.storage.AccessMode;
 import io.vertx.core.spi.context.storage.ContextLocal;
@@ -353,8 +350,8 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     return so;
   }
 
-  public NetServerImpl createNetServer(NetServerOptions options) {
-    return new NetServerImpl(this, options.copy());
+  public NetServerInternal createNetServer(NetServerOptions options) {
+    return new NetServerBuilder(this, options.copy()).build();
   }
 
   public NetClient createNetClient(NetClientOptions options) {

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/NetClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/NetClientConfig.java
@@ -12,6 +12,7 @@ package io.vertx.core.net.impl;
 
 import io.netty.handler.logging.ByteBufFormat;
 import io.vertx.core.net.*;
+import io.vertx.core.net.impl.tcp.NetEndpointConfig;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -22,77 +23,51 @@ import java.util.List;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class NetClientConfig {
+public class NetClientConfig extends NetEndpointConfig {
 
-  private TcpOptions transportOptions;
-  private ClientSSLOptions sslOptions;
-  private SSLEngineOptions sslEngineOptions;
   private Duration connectTimeout;
   private String metricsName;
   private ProxyOptions proxyOptions;
   private List<String> nonProxyHosts;
   private int reconnectAttempts;
   private Duration reconnectInterval;
-  private Duration idleTimeout;
-  private Duration readIdleTimeout;
-  private Duration writeIdleTimeout;
-  private boolean logActivity;
-  private ByteBufFormat activityLogDataFormat;
-  private boolean ssl;
 
   public NetClientConfig() {
-    this.transportOptions = new TcpOptions();
-    this.sslOptions = null;
-    this.sslEngineOptions = TCPSSLOptions.DEFAULT_SSL_ENGINE;
+    super();
     this.connectTimeout = Duration.ofMillis(ClientOptionsBase.DEFAULT_CONNECT_TIMEOUT);
     this.metricsName = ClientOptionsBase.DEFAULT_METRICS_NAME;
     this.proxyOptions = null;
     this.nonProxyHosts = null;
     this.reconnectAttempts = NetClientOptions.DEFAULT_RECONNECT_ATTEMPTS;
     this.reconnectInterval = Duration.ofMillis(NetClientOptions.DEFAULT_RECONNECT_INTERVAL);
-    this.logActivity = NetworkOptions.DEFAULT_LOG_ENABLED;
-    this.activityLogDataFormat = NetworkOptions.DEFAULT_LOG_ACTIVITY_FORMAT;
-    this.ssl = TCPSSLOptions.DEFAULT_SSL;
   }
 
   public NetClientConfig(NetClientConfig other) {
-    this.transportOptions = other.transportOptions != null ? new TcpOptions(other.transportOptions) : null;
-    this.sslOptions = other.sslOptions != null ? new ClientSSLOptions(other.sslOptions) : null;
-    this.sslEngineOptions = other.sslEngineOptions != null ? other.sslEngineOptions.copy() : null;
+    super(other);
     this.connectTimeout = other.connectTimeout;
     this.metricsName = other.metricsName;
     this.proxyOptions = other.proxyOptions != null ? new ProxyOptions(other.proxyOptions) : null;
     this.nonProxyHosts = other.nonProxyHosts != null ? new ArrayList<>(other.nonProxyHosts) : null;
     this.reconnectAttempts = other.reconnectAttempts;
     this.reconnectInterval = other.reconnectInterval;
-    this.logActivity = other.logActivity;
-    this.activityLogDataFormat = other.activityLogDataFormat;
-    this.ssl = other.ssl;
   }
 
-  /**
-   * @return the client TCP transport options
-   */
-  public TcpOptions getTransportOptions() {
-    return transportOptions;
+  public NetClientConfig(NetClientOptions options) {
+    super(options);
+    setConnectTimeout(Duration.ofMillis(options.getConnectTimeout()));
+    setMetricsName(options.getMetricsName());
+    setNonProxyHosts(options.getNonProxyHosts() != null ? new ArrayList<>(options.getNonProxyHosts()) : null);
+    setProxyOptions(options.getProxyOptions() != null ? new ProxyOptions(options.getProxyOptions()) : null);
+    setReconnectAttempts(options.getReconnectAttempts());
+    setReconnectInterval(Duration.ofMillis(options.getReconnectInterval()));
   }
 
-  /**
-   * Set the client TCP transport options.
-   *
-   * @param transportOptions the transport options
-   * @return a reference to this, so the API can be used fluently
-   */
   public NetClientConfig setTransportOptions(TcpOptions transportOptions) {
-    this.transportOptions = transportOptions;
-    return this;
+    return (NetClientConfig)super.setTransportOptions(transportOptions);
   }
 
-  /**
-   * @return the client SSL options.
-   */
   public ClientSSLOptions getSslOptions() {
-    return sslOptions;
+    return (ClientSSLOptions)super.getSslOptions();
   }
 
   /**
@@ -102,26 +77,35 @@ public class NetClientConfig {
    * @return a reference to this, so the API can be used fluently
    */
   public NetClientConfig setSslOptions(ClientSSLOptions sslOptions) {
-    this.sslOptions = sslOptions;
-    return this;
+    return (NetClientConfig)super.setSslOptions(sslOptions);
   }
 
-  /**
-   * @return the SSL engine implementation to use
-   */
-  public SSLEngineOptions getSslEngineOptions() {
-    return sslEngineOptions;
-  }
-
-  /**
-   * Set to use SSL engine implementation to use.
-   *
-   * @param sslEngineOptions the ssl engine to use
-   * @return a reference to this, so the API can be used fluently
-   */
   public NetClientConfig setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
-    this.sslEngineOptions = sslEngineOptions;
-    return this;
+    return (NetClientConfig)super.setSslEngineOptions(sslEngineOptions);
+  }
+
+  public NetClientConfig setIdleTimeout(Duration idleTimeout) {
+    return (NetClientConfig)super.setIdleTimeout(idleTimeout);
+  }
+
+  public NetClientConfig setReadIdleTimeout(Duration idleTimeout) {
+    return (NetClientConfig)super.setReadIdleTimeout(idleTimeout);
+  }
+
+  public NetClientConfig setWriteIdleTimeout(Duration idleTimeout) {
+    return (NetClientConfig)super.setWriteIdleTimeout(idleTimeout);
+  }
+
+  public NetClientConfig setLogActivity(boolean logActivity) {
+    return (NetClientConfig)super.setLogActivity(logActivity);
+  }
+
+  public NetClientConfig setActivityLogDataFormat(ByteBufFormat activityLogDataFormat) {
+    return (NetClientConfig)super.setActivityLogDataFormat(activityLogDataFormat);
+  }
+
+  public NetClientConfig setSsl(boolean ssl) {
+    return (NetClientConfig)super.setSsl(ssl);
   }
 
   /**
@@ -259,127 +243,6 @@ public class NetClientConfig {
       throw new IllegalArgumentException("reconnect interval must be >= 1");
     }
     this.reconnectInterval = interval;
-    return this;
-  }
-
-  /**
-   * @return the idle timeout
-   */
-  public Duration getIdleTimeout() {
-    return idleTimeout;
-  }
-
-  /**
-   * Set the idle timeout, default time unit is seconds. Zero means don't time out.
-   * This determines if a connection will timeout and be closed if no data is received nor sent within the timeout.
-   *
-   * @param idleTimeout  the timeout
-   * @return a reference to this, so the API can be used fluently
-   */
-  public NetClientConfig setIdleTimeout(Duration idleTimeout) {
-    if (idleTimeout != null && idleTimeout.isNegative()) {
-      throw new IllegalArgumentException("idleTimeout must be >= 0");
-    }
-    this.idleTimeout = idleTimeout;
-    return this;
-  }
-
-  /**
-   * Set the read idle timeout. Zero means don't time out.
-   * This determines if a connection will timeout and be closed if no data is received within the timeout.
-   *
-   * @param idleTimeout  the read timeout
-   * @return a reference to this, so the API can be used fluently
-   */
-  public NetClientConfig setReadIdleTimeout(Duration idleTimeout) {
-    if (idleTimeout != null && idleTimeout.isNegative()) {
-      throw new IllegalArgumentException("readIdleTimeout must be >= 0");
-    }
-    this.readIdleTimeout = idleTimeout;
-    return this;
-  }
-
-  /**
-   * @return the read idle timeout
-   */
-  public Duration getReadIdleTimeout() {
-    return readIdleTimeout;
-  }
-
-  /**
-   * Set the write idle timeout, default time unit is seconds. Zero means don't time out.
-   * This determines if a connection will timeout and be closed if no data is sent within the timeout.
-   *
-   * @param idleTimeout  the write timeout
-   * @return a reference to this, so the API can be used fluently
-   */
-  public NetClientConfig setWriteIdleTimeout(Duration idleTimeout) {
-    if (idleTimeout != null && idleTimeout.isNegative()) {
-      throw new IllegalArgumentException("writeIdleTimeout must be >= 0");
-    }
-    this.writeIdleTimeout = idleTimeout;
-    return this;
-  }
-
-  /**
-   * @return the write idle timeout.
-   */
-  public Duration getWriteIdleTimeout() {
-    return writeIdleTimeout;
-  }
-
-  /**
-   * @return true when network activity logging is enabled
-   */
-  public boolean getLogActivity() {
-    return logActivity;
-  }
-
-  /**
-   * Set to true to enabled network activity logging: Netty's pipeline is configured for logging on Netty's logger.
-   *
-   * @param logActivity true for logging the network activity
-   * @return a reference to this, so the API can be used fluently
-   */
-  public NetClientConfig setLogActivity(boolean logActivity) {
-    this.logActivity = logActivity;
-    return this;
-  }
-
-  /**
-   * @return Netty's logging handler's data format.
-   */
-  public ByteBufFormat getActivityLogDataFormat() {
-    return activityLogDataFormat;
-  }
-
-  /**
-   * Set the value of Netty's logging handler's data format: Netty's pipeline is configured for logging on Netty's logger.
-   *
-   * @param activityLogDataFormat the format to use
-   * @return a reference to this, so the API can be used fluently
-   */
-  public NetClientConfig setActivityLogDataFormat(ByteBufFormat activityLogDataFormat) {
-    this.activityLogDataFormat = activityLogDataFormat;
-    return this;
-  }
-
-  /**
-   *
-   * @return is SSL/TLS enabled?
-   */
-  public boolean isSsl() {
-    return ssl;
-  }
-
-  /**
-   * Set whether SSL/TLS is enabled
-   *
-   * @param ssl  true if enabled
-   * @return a reference to this, so the API can be used fluently
-   */
-  public NetClientConfig setSsl(boolean ssl) {
-    this.ssl = ssl;
     return this;
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientBuilder.java
@@ -42,23 +42,7 @@ public class NetClientBuilder {
 
   public NetClientBuilder(VertxInternal vertx, NetClientOptions options) {
 
-    NetClientConfig cfg = new NetClientConfig();
-
-    cfg.setConnectTimeout(Duration.ofMillis(options.getConnectTimeout()));
-    cfg.setMetricsName(options.getMetricsName());
-    cfg.setNonProxyHosts(options.getNonProxyHosts() != null ? new ArrayList<>(options.getNonProxyHosts()) : null);
-    cfg.setProxyOptions(options.getProxyOptions() != null ? new ProxyOptions(options.getProxyOptions()) : null);
-    cfg.setReconnectAttempts(options.getReconnectAttempts());
-    cfg.setReconnectInterval(Duration.ofMillis(options.getReconnectInterval()));
-    cfg.setSslOptions(options.getSslOptions() != null ? new ClientSSLOptions(options.getSslOptions()) : null);
-    cfg.setTransportOptions(new TcpOptions(options.getTransportOptions()));
-    cfg.setIdleTimeout(Duration.of(options.getIdleTimeout(), options.getIdleTimeoutUnit().toChronoUnit()));
-    cfg.setReadIdleTimeout(Duration.of(options.getReadIdleTimeout(), options.getIdleTimeoutUnit().toChronoUnit()));
-    cfg.setWriteIdleTimeout(Duration.of(options.getWriteIdleTimeout(), options.getIdleTimeoutUnit().toChronoUnit()));
-    cfg.setSslEngineOptions(options.getSslEngineOptions() != null ? options.getSslEngineOptions().copy() : null);
-    cfg.setLogActivity(options.getLogActivity());
-    cfg.setActivityLogDataFormat(options.getActivityLogDataFormat());
-    cfg.setSsl(options.isSsl());
+    NetClientConfig cfg = new NetClientConfig(options);
 
     this.vertx = vertx;
     this.config = cfg;

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetEndpointConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetEndpointConfig.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net.impl.tcp;
+
+import io.netty.handler.logging.ByteBufFormat;
+import io.vertx.core.net.*;
+
+import java.time.Duration;
+
+/**
+ * Should this be {@code TcpConfig} instead ?
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public abstract class NetEndpointConfig {
+
+  private TcpOptions transportOptions;
+  private SSLOptions sslOptions;
+  private SSLEngineOptions sslEngineOptions;
+  private Duration idleTimeout;
+  private Duration readIdleTimeout;
+  private Duration writeIdleTimeout;
+  private boolean logActivity;
+  private ByteBufFormat activityLogDataFormat;
+  private boolean ssl;
+
+  public NetEndpointConfig() {
+    this.transportOptions = new TcpOptions();
+    this.sslOptions = null;
+    this.sslEngineOptions = TCPSSLOptions.DEFAULT_SSL_ENGINE;
+    this.idleTimeout = null;
+    this.readIdleTimeout = null;
+    this.writeIdleTimeout = null;
+    this.logActivity = NetworkOptions.DEFAULT_LOG_ENABLED;
+    this.activityLogDataFormat = NetworkOptions.DEFAULT_LOG_ACTIVITY_FORMAT;
+    this.ssl = TCPSSLOptions.DEFAULT_SSL;
+  }
+
+  public NetEndpointConfig(NetEndpointConfig other) {
+    this.transportOptions = other.transportOptions != null ? new TcpOptions(other.transportOptions) : null;
+    this.sslOptions = other.sslOptions != null ? other.sslOptions.copy() : null;
+    this.sslEngineOptions = other.sslEngineOptions != null ? other.sslEngineOptions.copy() : null;
+    this.idleTimeout = other.idleTimeout;
+    this.readIdleTimeout = other.readIdleTimeout;
+    this.writeIdleTimeout = other.writeIdleTimeout;
+    this.logActivity = other.logActivity;
+    this.activityLogDataFormat = other.activityLogDataFormat;
+    this.ssl = other.ssl;
+  }
+
+  public NetEndpointConfig(TCPSSLOptions options) {
+    setTransportOptions(new TcpOptions(options.getTransportOptions()));
+    setSslOptions(options.getSslOptions() != null ? options.getSslOptions().copy() : null);
+    setSslEngineOptions(options.getSslEngineOptions() != null ? options.getSslEngineOptions().copy() : null);
+    setIdleTimeout(Duration.of(options.getIdleTimeout(), options.getIdleTimeoutUnit().toChronoUnit()));
+    setReadIdleTimeout(Duration.of(options.getReadIdleTimeout(), options.getIdleTimeoutUnit().toChronoUnit()));
+    setWriteIdleTimeout(Duration.of(options.getWriteIdleTimeout(), options.getIdleTimeoutUnit().toChronoUnit()));
+    setLogActivity(options.getLogActivity());
+    setActivityLogDataFormat(options.getActivityLogDataFormat());
+    setSsl(options.isSsl());
+  }
+
+  /**
+   * @return the client TCP transport options
+   */
+  public TcpOptions getTransportOptions() {
+    return transportOptions;
+  }
+
+  /**
+   * Set the client TCP transport options.
+   *
+   * @param transportOptions the transport options
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetEndpointConfig setTransportOptions(TcpOptions transportOptions) {
+    this.transportOptions = transportOptions;
+    return this;
+  }
+
+  /**
+   * @return the client SSL options.
+   */
+  public SSLOptions getSslOptions() {
+    return sslOptions;
+  }
+
+  /**
+   * Set the client SSL options.
+   *
+   * @param sslOptions the options
+   * @return a reference to this, so the API can be used fluently
+   */
+  protected NetEndpointConfig setSslOptions(SSLOptions sslOptions) {
+    this.sslOptions = sslOptions;
+    return this;
+  }
+
+  /**
+   * @return the SSL engine implementation to use
+   */
+  public SSLEngineOptions getSslEngineOptions() {
+    return sslEngineOptions;
+  }
+
+  /**
+   * Set to use SSL engine implementation to use.
+   *
+   * @param sslEngineOptions the ssl engine to use
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetEndpointConfig setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
+    this.sslEngineOptions = sslEngineOptions;
+    return this;
+  }
+
+  /**
+   * @return the idle timeout
+   */
+  public Duration getIdleTimeout() {
+    return idleTimeout;
+  }
+
+  /**
+   * Set the idle timeout, default time unit is seconds. Zero means don't time out.
+   * This determines if a connection will timeout and be closed if no data is received nor sent within the timeout.
+   *
+   * @param idleTimeout  the timeout
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetEndpointConfig setIdleTimeout(Duration idleTimeout) {
+    if (idleTimeout != null && idleTimeout.isNegative()) {
+      throw new IllegalArgumentException("idleTimeout must be >= 0");
+    }
+    this.idleTimeout = idleTimeout;
+    return this;
+  }
+
+  /**
+   * Set the read idle timeout. Zero means don't time out.
+   * This determines if a connection will timeout and be closed if no data is received within the timeout.
+   *
+   * @param idleTimeout  the read timeout
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetEndpointConfig setReadIdleTimeout(Duration idleTimeout) {
+    if (idleTimeout != null && idleTimeout.isNegative()) {
+      throw new IllegalArgumentException("readIdleTimeout must be >= 0");
+    }
+    this.readIdleTimeout = idleTimeout;
+    return this;
+  }
+
+  /**
+   * @return the read idle timeout
+   */
+  public Duration getReadIdleTimeout() {
+    return readIdleTimeout;
+  }
+
+  /**
+   * Set the write idle timeout, default time unit is seconds. Zero means don't time out.
+   * This determines if a connection will timeout and be closed if no data is sent within the timeout.
+   *
+   * @param idleTimeout  the write timeout
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetEndpointConfig setWriteIdleTimeout(Duration idleTimeout) {
+    if (idleTimeout != null && idleTimeout.isNegative()) {
+      throw new IllegalArgumentException("writeIdleTimeout must be >= 0");
+    }
+    this.writeIdleTimeout = idleTimeout;
+    return this;
+  }
+
+  /**
+   * @return the write idle timeout.
+   */
+  public Duration getWriteIdleTimeout() {
+    return writeIdleTimeout;
+  }
+
+  /**
+   * @return true when network activity logging is enabled
+   */
+  public boolean getLogActivity() {
+    return logActivity;
+  }
+
+  /**
+   * Set to true to enabled network activity logging: Netty's pipeline is configured for logging on Netty's logger.
+   *
+   * @param logActivity true for logging the network activity
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetEndpointConfig setLogActivity(boolean logActivity) {
+    this.logActivity = logActivity;
+    return this;
+  }
+
+  /**
+   * @return Netty's logging handler's data format.
+   */
+  public ByteBufFormat getActivityLogDataFormat() {
+    return activityLogDataFormat;
+  }
+
+  /**
+   * Set the value of Netty's logging handler's data format: Netty's pipeline is configured for logging on Netty's logger.
+   *
+   * @param activityLogDataFormat the format to use
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetEndpointConfig setActivityLogDataFormat(ByteBufFormat activityLogDataFormat) {
+    this.activityLogDataFormat = activityLogDataFormat;
+    return this;
+  }
+
+  /**
+   *
+   * @return is SSL/TLS enabled?
+   */
+  public boolean isSsl() {
+    return ssl;
+  }
+
+  /**
+   * Set whether SSL/TLS is enabled
+   *
+   * @param ssl  true if enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetEndpointConfig setSsl(boolean ssl) {
+    this.ssl = ssl;
+    return this;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2011-2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net.impl.tcp;
+
+import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.net.NetClientInternal;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.impl.NetClientConfig;
+import io.vertx.core.spi.metrics.TransportMetrics;
+import io.vertx.core.spi.metrics.VertxMetrics;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * A builder to configure NetServer plugins.
+ */
+public class NetServerBuilder {
+
+  private VertxInternal vertx;
+  private NetServerConfig config;
+  private BiFunction<VertxMetrics, SocketAddress, TransportMetrics<?>> metricsProvider;
+  private boolean fileRegionEnabled;
+  private boolean registerWriteHandler;
+
+  public NetServerBuilder(VertxInternal vertx, NetServerConfig config) {
+    this.vertx = vertx;
+    this.config = config;
+    this.fileRegionEnabled = false;
+    this.registerWriteHandler = false;
+  }
+
+  public NetServerBuilder(VertxInternal vertx, NetServerOptions options) {
+
+    NetServerConfig cfg = new NetServerConfig(options);
+
+    this.vertx = vertx;
+    this.config = cfg;
+    this.fileRegionEnabled = options.isFileRegionEnabled();
+    this.registerWriteHandler = options.isRegisterWriteHandler();
+    this.metricsProvider = (metrics,  localAddress) -> metrics.createNetServerMetrics(options, localAddress);
+  }
+
+  public NetServerBuilder fileRegionEnabled(boolean fileRegionEnabled) {
+    this.fileRegionEnabled = fileRegionEnabled;
+    return this;
+  }
+
+  public NetServerBuilder metricsProvider(BiFunction<VertxMetrics, SocketAddress, TransportMetrics<?>> metricsProvider) {
+    this.metricsProvider = metricsProvider;
+    return this;
+  }
+
+  public NetServerInternal build() {
+    return new NetServerImpl(
+      vertx,
+      config,
+      fileRegionEnabled,
+      registerWriteHandler,
+      metricsProvider);
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerConfig.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net.impl.tcp;
+
+import io.netty.handler.logging.ByteBufFormat;
+import io.vertx.core.net.*;
+
+import java.time.Duration;
+
+import static io.vertx.core.net.NetServerOptions.*;
+
+/**
+ * Configuration of a {@link NetServer}
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class NetServerConfig extends NetEndpointConfig {
+
+  private int port;
+  private String host;
+  private int acceptBacklog;
+  private boolean useProxyProtocol;
+  private Duration proxyProtocolTimeout;
+  private TrafficShapingOptions trafficShapingOptions;
+
+  public NetServerConfig() {
+    init();
+  }
+
+  public NetServerConfig(NetServerConfig other) {
+    super(other);
+
+    this.port = other.getPort();
+    this.host = other.getHost();
+    this.acceptBacklog = other.getAcceptBacklog();
+    this.useProxyProtocol = other.isUseProxyProtocol();
+    this.proxyProtocolTimeout = other.proxyProtocolTimeout;
+    this.trafficShapingOptions = other.getTrafficShapingOptions() != null ? new TrafficShapingOptions(other.getTrafficShapingOptions()) : null;
+  }
+
+  public NetServerConfig(NetServerOptions options) {
+    super(options);
+
+    this.port = options.getPort();
+    this.host = options.getHost();
+    this.acceptBacklog = options.getAcceptBacklog();
+    this.useProxyProtocol = options.isUseProxyProtocol();
+    this.proxyProtocolTimeout = Duration.of(options.getProxyProtocolTimeout(), options.getProxyProtocolTimeoutUnit().toChronoUnit());
+    this.trafficShapingOptions = options.getTrafficShapingOptions() != null ? new TrafficShapingOptions(options.getTrafficShapingOptions()) : null;
+  }
+
+
+  private void init() {
+    this.port = DEFAULT_PORT;
+    this.host = DEFAULT_HOST;
+    this.acceptBacklog = DEFAULT_ACCEPT_BACKLOG;
+    this.useProxyProtocol = DEFAULT_USE_PROXY_PROTOCOL;
+    this.proxyProtocolTimeout = Duration.of(DEFAULT_PROXY_PROTOCOL_TIMEOUT, DEFAULT_PROXY_PROTOCOL_TIMEOUT_TIME_UNIT.toChronoUnit());
+    this.trafficShapingOptions = null;
+  }
+
+  public NetServerConfig setTransportOptions(TcpOptions transportOptions) {
+    return (NetServerConfig)super.setTransportOptions(transportOptions);
+  }
+
+  public ServerSSLOptions getSslOptions() {
+    return (ServerSSLOptions)super.getSslOptions();
+  }
+
+  /**
+   * Set the client SSL options.
+   *
+   * @param sslOptions the options
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetServerConfig setSslOptions(ClientSSLOptions sslOptions) {
+    return (NetServerConfig)super.setSslOptions(sslOptions);
+  }
+
+  public NetServerConfig setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
+    return (NetServerConfig)super.setSslEngineOptions(sslEngineOptions);
+  }
+
+  public NetServerConfig setIdleTimeout(Duration idleTimeout) {
+    return (NetServerConfig)super.setIdleTimeout(idleTimeout);
+  }
+
+  public NetServerConfig setReadIdleTimeout(Duration idleTimeout) {
+    return (NetServerConfig)super.setReadIdleTimeout(idleTimeout);
+  }
+
+  public NetServerConfig setWriteIdleTimeout(Duration idleTimeout) {
+    return (NetServerConfig)super.setWriteIdleTimeout(idleTimeout);
+  }
+
+  public NetServerConfig setLogActivity(boolean logActivity) {
+    return (NetServerConfig)super.setLogActivity(logActivity);
+  }
+
+  public NetServerConfig setActivityLogDataFormat(ByteBufFormat activityLogDataFormat) {
+    return (NetServerConfig)super.setActivityLogDataFormat(activityLogDataFormat);
+  }
+
+  public NetServerConfig setSsl(boolean ssl) {
+    return (NetServerConfig)super.setSsl(ssl);
+  }
+
+  /**
+   * @return the port
+   */
+  public int getPort() {
+    return port;
+  }
+
+  /**
+   * Set the port
+   *
+   * @param port  the port
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetServerConfig setPort(int port) {
+    if (port > 65535) {
+      throw new IllegalArgumentException("port must be <= 65535");
+    }
+    this.port = port;
+    return this;
+  }
+
+  /**
+   *
+   * @return the host
+   */
+  public String getHost() {
+    return host;
+  }
+
+  /**
+   * Set the host
+   *
+   * @param host  the host
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetServerConfig setHost(String host) {
+    this.host = host;
+    return this;
+  }
+
+  /**
+   * @return the value of accept backlog
+   */
+  public int getAcceptBacklog() {
+    return acceptBacklog;
+  }
+
+  /**
+   * Set the accept back log
+   *
+   * @param acceptBacklog accept backlog
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetServerConfig setAcceptBacklog(int acceptBacklog) {
+    this.acceptBacklog = acceptBacklog;
+    return this;
+  }
+
+  /**
+   * @return whether the server uses the HA Proxy protocol
+   */
+  public boolean isUseProxyProtocol() { return useProxyProtocol; }
+
+  /**
+   * Set whether the server uses the HA Proxy protocol
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetServerConfig setUseProxyProtocol(boolean useProxyProtocol) {
+    this.useProxyProtocol = useProxyProtocol;
+    return this;
+  }
+
+  /**
+   * @return the Proxy protocol timeout.
+   */
+  public Duration getProxyProtocolTimeout() {
+    return proxyProtocolTimeout;
+  }
+
+  /**
+   * Set the Proxy protocol timeout, default time unit.
+   *
+   * @param proxyProtocolTimeout the Proxy protocol timeout to set
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetServerConfig setProxyProtocolTimeout(Duration proxyProtocolTimeout) {
+    if (proxyProtocolTimeout != null && proxyProtocolTimeout.isNegative()) {
+      throw new IllegalArgumentException("proxyProtocolTimeout must be >= 0");
+    }
+    this.proxyProtocolTimeout = proxyProtocolTimeout;
+    return this;
+  }
+
+  /**
+   * @return traffic shaping options used by Net server.
+   */
+  public TrafficShapingOptions getTrafficShapingOptions() {
+    return this.trafficShapingOptions;
+  }
+
+  /**
+   * Set traffic shaping options. If not specified, traffic is unthrottled.
+   *
+   * @param trafficShapingOptions options used by traffic handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetServerConfig setTrafficShapingOptions(TrafficShapingOptions trafficShapingOptions) {
+    this.trafficShapingOptions = trafficShapingOptions;
+    return this;
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -3962,7 +3962,7 @@ public class Http1xTest extends HttpTest {
     server.close();
     server = vertx.createHttpServer(new HttpServerOptions().setIdleTimeout(1));
     server.requestHandler(req -> {
-      testComplete();
+      fail();
     });
     startServer(testAddress);
     NetClient client = vertx.createNetClient();


### PR DESCRIPTION
and break the `HttpServerOptions`/`NetServerOptions`/`TCPSSLOptions` silo.

For the moment this API remains implementation specific as it is only required internally, this is not needed from the API perspective since QUIC endpoints are created differently.
