### PR TITLE
Change QUIC config with sensible defaults according to the intended usage.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
@@ -53,12 +53,12 @@ public class HttpClientConfig {
   }
 
   public static final List<HttpVersion> DEFAULT_SUPPORTED_VERSIONS = List.of(HttpVersion.HTTP_1_1, HttpVersion.HTTP_2);
-  public static final long DEFAULT_QUIC_INITIAL_MAX_DATA = 10000000L;
-  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL = 1000000L;
-  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE = 1000000L;
-  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_UNI = 1000000L;
-  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_BIDI = 100L;
-  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_UNI = 100L;
+  public static final long DEFAULT_QUIC_INITIAL_MAX_DATA = 10_485_760L;
+  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL = 1_048_576L;
+  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE = 0L;
+  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_UNI = 1_048_576L;
+  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_BIDI = 0L;
+  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_UNI = 1L;
 
   private TcpClientConfig tcpConfig;
   private QuicClientConfig quicConfig;

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerConfig.java
@@ -33,12 +33,12 @@ public class HttpServerConfig {
    */
   public static final int DEFAULT_HTTP3_PORT = 443;
 
-  public static final long DEFAULT_QUIC_INITIAL_MAX_DATA = 10000000L;
-  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL = 1000000L;
-  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE = 1000000L;
-  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_UNI = 1000000L;
-  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_BIDI = 100L;
-  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_UNI = 100L;
+  public static final long DEFAULT_QUIC_INITIAL_MAX_DATA = 10_485_760L;
+  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL = 0L;
+  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE = 1_048_576L;
+  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_UNI = 1_048_576L;
+  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_BIDI = 256L;
+  public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_UNI = 1L;
 
   private static QuicServerConfig defaultQuicConfig() {
     QuicServerConfig config = new QuicServerConfig();

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicClient.java
@@ -60,6 +60,13 @@ public interface QuicClient extends QuicEndpoint {
   }
 
   /**
+   * Like {@link #create(Vertx, QuicClientConfig, ServerSSLOptions)}, with the default client configuration.
+   */
+  static QuicClient create(Vertx vertx, ClientSSLOptions defaultSslOptions) {
+    return create(vertx, new QuicClientConfig(), defaultSslOptions);
+  }
+
+  /**
    * Connect to a Quic server.
    *
    * @param address the server address

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicClientConfig.java
@@ -15,7 +15,10 @@ import io.vertx.codegen.annotations.DataObject;
 import java.time.Duration;
 
 /**
- * Configuration of a Quic client.
+ * <p>Configuration of a Quic client.</p>
+ *
+ * <p>The default transport configuration, allows the client to open bidi streams to a server with sensitive defaults values,
+ * it does not allow to open uni streams nor allows the server to open streams toward the client.</p>
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -31,6 +34,9 @@ public class QuicClientConfig extends QuicEndpointConfig {
   private SocketAddress localAddress;
 
   public QuicClientConfig() {
+
+    configureClient(getTransportConfig());
+
     this.connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     this.localAddress = null;
   }
@@ -40,6 +46,16 @@ public class QuicClientConfig extends QuicEndpointConfig {
 
     this.connectTimeout = other.connectTimeout;
     this.localAddress = other.localAddress;
+  }
+
+  private static void configureClient(QuicConfig cfg) {
+    cfg.setInitialMaxData(QuicConfig.DEFAULT_CLIENT_MAX_INITIAL_DATA);
+    cfg.setInitialMaxStreamDataBidiLocal(QuicConfig.DEFAULT_CLIENT_MAX_STREAM_DATA_BIDI_LOCAL);
+    cfg.setInitialMaxStreamDataBidiRemote(QuicConfig.DEFAULT_CLIENT_MAX_STREAM_DATA_BIDI_REMOTE);
+    cfg.setInitialMaxStreamDataUni(QuicConfig.DEFAULT_CLIENT_MAX_STREAMS_DATA_UNI);
+    cfg.setInitialMaxStreamsBidi(QuicConfig.DEFAULT_CLIENT_MAX_STREAMS_DATA_BIDI);
+    cfg.setInitialMaxStreamsUni(QuicConfig.DEFAULT_CLIENT_MAX_STREAM_DATA_UNI);
+    cfg.setDisableActiveMigration(QuicConfig.DEFAULT_CLIENT_DISABLE_ACTIVE_MIGRATION);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicConfig.java
@@ -19,6 +19,22 @@ import java.time.Duration;
  */
 public class QuicConfig extends TransportConfig {
 
+  public static final long DEFAULT_CLIENT_MAX_INITIAL_DATA = 10_485_760L;
+  public static final long DEFAULT_CLIENT_MAX_STREAM_DATA_BIDI_LOCAL = 1_048_576L;
+  public static final long DEFAULT_CLIENT_MAX_STREAM_DATA_BIDI_REMOTE = 0L;
+  public static final long DEFAULT_CLIENT_MAX_STREAMS_DATA_UNI = 0L;
+  public static final long DEFAULT_CLIENT_MAX_STREAMS_DATA_BIDI = 0L;
+  public static final long DEFAULT_CLIENT_MAX_STREAM_DATA_UNI = 0L;
+  public static final boolean DEFAULT_CLIENT_DISABLE_ACTIVE_MIGRATION = true;
+
+  public static final long DEFAULT_SERVER_MAX_INITIAL_DATA = 10_485_760L;
+  public static final long DEFAULT_SERVER_MAX_STREAM_DATA_BIDI_LOCAL = 0L;
+  public static final long DEFAULT_SERVER_MAX_STREAM_DATA_BIDI_REMOTE = 1_048_576L;
+  public static final long DEFAULT_SERVER_MAX_STREAMS_DATA_UNI = 0L;
+  public static final long DEFAULT_SERVER_MAX_STREAMS_DATA_BIDI = 256L;
+  public static final long DEFAULT_SERVER_MAX_STREAM_DATA_UNI = 0L;
+  public static final boolean DEFAULT_SERVER_DISABLE_ACTIVE_MIGRATION = true;
+
   public static final long DEFAULT_MAX_INITIAL_DATA = 0L;
   public static final long DEFAULT_MAX_STREAM_DATA_BIDI_LOCAL = 0L;
   public static final long DEFAULT_MAX_STREAM_DATA_BIDI_REMOTE = 0L;

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicServer.java
@@ -52,6 +52,13 @@ public interface QuicServer extends QuicEndpoint {
   }
 
   /**
+   * Like {@link #create(Vertx, QuicServerConfig, ServerSSLOptions)}, with the default server configuration.
+   */
+  static QuicServer create(Vertx vertx, ServerSSLOptions sslOptions) {
+    return create(vertx, new QuicServerConfig(), sslOptions);
+  }
+
+  /**
    * Set the handler processing {@link QuicConnection}, the handler must be set before the server is bound.
    * @param handler the connection handler
    * @return this object instance

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicServerConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicServerConfig.java
@@ -19,7 +19,10 @@ import static io.vertx.core.net.NetServerOptions.DEFAULT_HOST;
 import static io.vertx.core.net.NetServerOptions.DEFAULT_PORT;
 
 /**
- * Configuration of a Quic client.
+ * <p>Configuration of a Quic server.</p>
+ *
+ * <p>The default transport configuration, allows the server to accept bidi streams from a client with sensitive defaults values,
+ * it does not allow to accept uni streams nor allows the open streams toward the client.</p>
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -39,6 +42,9 @@ public class QuicServerConfig extends QuicEndpointConfig {
   private KeyCertOptions clientAddressValidationKey;
 
   public QuicServerConfig() {
+
+    configureServer(getTransportConfig());
+
     port = DEFAULT_PORT;
     host = DEFAULT_HOST;
     loadBalanced = DEFAULT_LOAD_BALANCED;
@@ -58,6 +64,16 @@ public class QuicServerConfig extends QuicEndpointConfig {
     this.clientAddressValidation = other.clientAddressValidation;
     this.clientAddressValidationTimeWindow = other.clientAddressValidationTimeWindow;
     this.clientAddressValidationKey = tokenValidationKey != null ? tokenValidationKey.copy() : null;
+  }
+
+  private static void configureServer(QuicConfig cfg) {
+    cfg.setInitialMaxData(QuicConfig.DEFAULT_SERVER_MAX_INITIAL_DATA);
+    cfg.setInitialMaxStreamDataBidiLocal(QuicConfig.DEFAULT_SERVER_MAX_STREAM_DATA_BIDI_LOCAL);
+    cfg.setInitialMaxStreamDataBidiRemote(QuicConfig.DEFAULT_SERVER_MAX_STREAM_DATA_BIDI_REMOTE);
+    cfg.setInitialMaxStreamDataUni(QuicConfig.DEFAULT_SERVER_MAX_STREAMS_DATA_UNI);
+    cfg.setInitialMaxStreamsBidi(QuicConfig.DEFAULT_SERVER_MAX_STREAMS_DATA_BIDI);
+    cfg.setInitialMaxStreamsUni(QuicConfig.DEFAULT_SERVER_MAX_STREAM_DATA_UNI);
+    cfg.setDisableActiveMigration(QuicConfig.DEFAULT_SERVER_DISABLE_ACTIVE_MIGRATION);
   }
 
   @Override

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QLogTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QLogTest.java
@@ -25,9 +25,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static io.vertx.tests.net.quic.QuicClientTest.clientOptions;
-import static io.vertx.tests.net.quic.QuicServerTest.serverOptions;
-
 @RunWith(LinuxOrOsx.class)
 public class QLogTest extends VertxTestBase {
 
@@ -37,8 +34,8 @@ public class QLogTest extends VertxTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    server = QuicServer.create(vertx, serverOptions(), QuicServerTest.SSL_OPTIONS);
-    client = QuicClient.create(vertx, clientOptions(), QuicClientTest.SSL_OPTIONS);
+    server = QuicServer.create(vertx, QuicServerTest.SSL_OPTIONS);
+    client = QuicClient.create(vertx, QuicClientTest.SSL_OPTIONS);
   }
 
   @Override
@@ -94,7 +91,7 @@ public class QLogTest extends VertxTestBase {
     File qlogDir = File.createTempFile("vertx", "qlog");
     assertTrue(qlogDir.delete());
     assertTrue(qlogDir.mkdirs());
-    server = QuicServer.create(vertx, serverOptions().setQLogConfig(qlogConfig(qlogDir, "the title", "the description")), QuicServerTest.SSL_OPTIONS);
+    server = QuicServer.create(vertx, new QuicServerConfig().setQLogConfig(qlogConfig(qlogDir, "the title", "the description")), QuicServerTest.SSL_OPTIONS);
     server.handler(conn -> {
     });
     server.bind(SocketAddress.inetSocketAddress(9999, "localhost")).await();

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicApplicationTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicApplicationTest.java
@@ -57,7 +57,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import static io.vertx.tests.net.quic.QuicClientTest.clientOptions;
-import static io.vertx.tests.net.quic.QuicServerTest.serverOptions;
 
 @RunWith(LinuxOrOsx.class)
 public class QuicApplicationTest extends VertxTestBase {
@@ -68,9 +67,9 @@ public class QuicApplicationTest extends VertxTestBase {
     // HTTP/3
     byte[] content = "Hello World!\r\n".getBytes(CharsetUtil.US_ASCII);
 
-    QuicServerConfig serverOptions = serverOptions();
     ServerSSLOptions serverSslOptions = QuicServerTest.SSL_OPTIONS.copy();
     serverSslOptions.setApplicationLayerProtocols(Arrays.asList(Http3.supportedApplicationProtocols()));
+    QuicServerConfig serverOptions = new QuicServerConfig();
     serverOptions.getTransportConfig().setInitialMaxStreamsUni(3L);
     serverOptions.getTransportConfig().setInitialMaxStreamDataUni(1024L);
     QuicServer server = QuicServer.create(vertx, serverOptions, serverSslOptions);
@@ -166,7 +165,7 @@ public class QuicApplicationTest extends VertxTestBase {
   @Test
   public void testStreamLevel() {
     // HTTP/1.1
-    QuicServerConfig serverOptions = serverOptions();
+    QuicServerConfig serverOptions = new QuicServerConfig();
     ServerSSLOptions serverSslOptions = QuicServerTest.SSL_OPTIONS.copy();
     serverSslOptions.setApplicationLayerProtocols(Arrays.asList(Http3.supportedApplicationProtocols()));
     serverOptions.getTransportConfig().setInitialMaxStreamsUni(3L);

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicContextTest.java
@@ -25,9 +25,6 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.vertx.tests.net.quic.QuicClientTest.clientOptions;
-import static io.vertx.tests.net.quic.QuicServerTest.serverOptions;
-
 @RunWith(LinuxOrOsx.class)
 public class QuicContextTest extends VertxTestBase {
 
@@ -38,8 +35,8 @@ public class QuicContextTest extends VertxTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    QuicServerConfig serverOptions = serverOptions();
-    QuicClientConfig clientOptions = clientOptions();
+    QuicServerConfig serverOptions = new QuicServerConfig();
+    QuicClientConfig clientOptions = new QuicClientConfig();
     serverOptions.getTransportConfig().setEnableDatagrams(true);
     clientOptions.getTransportConfig().setEnableDatagrams(true);
     server = QuicServer.create(vertx, serverOptions, QuicServerTest.SSL_OPTIONS);

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicFlowControlTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicFlowControlTest.java
@@ -25,9 +25,6 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.CompletableFuture;
 
-import static io.vertx.tests.net.quic.QuicClientTest.clientOptions;
-import static io.vertx.tests.net.quic.QuicServerTest.serverOptions;
-
 @RunWith(LinuxOrOsx.class)
 public class QuicFlowControlTest extends VertxTestBase {
 
@@ -37,8 +34,8 @@ public class QuicFlowControlTest extends VertxTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    server = QuicServer.create(vertx, serverOptions(), QuicServerTest.SSL_OPTIONS);
-    client = QuicClient.create(vertx, clientOptions(), QuicClientTest.SSL_OPTIONS);
+    server = QuicServer.create(vertx, QuicServerTest.SSL_OPTIONS);
+    client = QuicClient.create(vertx, QuicClientTest.SSL_OPTIONS);
   }
 
   @Override

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicMetricsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicMetricsTest.java
@@ -11,11 +11,7 @@
 package io.vertx.tests.net.quic;
 
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.net.SocketAddress;
-import io.vertx.core.net.QuicClient;
-import io.vertx.core.net.QuicConnection;
-import io.vertx.core.net.QuicServer;
-import io.vertx.core.net.QuicStream;
+import io.vertx.core.net.*;
 import io.vertx.core.spi.VertxMetricsFactory;
 import io.vertx.test.core.LinuxOrOsx;
 import io.vertx.test.core.VertxTestBase;
@@ -31,9 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static io.vertx.tests.net.quic.QuicClientTest.clientOptions;
-import static io.vertx.tests.net.quic.QuicServerTest.serverOptions;
 
 @RunWith(LinuxOrOsx.class)
 public class QuicMetricsTest extends VertxTestBase {
@@ -68,10 +61,10 @@ public class QuicMetricsTest extends VertxTestBase {
   }
 
   private void testMetrics(int numberOfServers) throws Exception {
-    client = QuicClient.create(vertx, clientOptions().setMetricsName("the-metrics"), QuicClientTest.SSL_OPTIONS);
+    client = QuicClient.create(vertx, new QuicClientConfig().setMetricsName("the-metrics"), QuicClientTest.SSL_OPTIONS);
     AtomicReference<SocketMetric> serverConnectionMetric = new AtomicReference<>();
     for (int i = 0;i < numberOfServers;i++) {
-      QuicServer server = QuicServer.create(vertx, serverOptions().setLoadBalanced(numberOfServers > 1), QuicServerTest.SSL_OPTIONS);
+      QuicServer server = QuicServer.create(vertx, new QuicServerConfig().setLoadBalanced(numberOfServers > 1), QuicServerTest.SSL_OPTIONS);
       server.handler(conn -> {
         FakeQuicEndpointMetrics serverMetrics = FakeTransportMetrics.getMetrics(server);
         assertEquals(1, serverMetrics.connectionCount());
@@ -97,6 +90,9 @@ public class QuicMetricsTest extends VertxTestBase {
     clientStream.endHandler(v -> {
       latch.countDown();
     });
+
+    // TODO stream close metrics
+
     clientStream.end(Buffer.buffer("ping"));
     awaitLatch(latch);
     assertEquals(List.of(Buffer.buffer("ping")), received);

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicServerLoadBalancingTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicServerLoadBalancingTest.java
@@ -12,10 +12,7 @@ package io.vertx.tests.net.quic;
 
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
-import io.vertx.core.net.SocketAddress;
-import io.vertx.core.net.QuicClient;
-import io.vertx.core.net.QuicConnection;
-import io.vertx.core.net.QuicServer;
+import io.vertx.core.net.*;
 import io.vertx.core.net.impl.quic.QuicServerImpl;
 import io.vertx.core.shareddata.LocalMap;
 import io.vertx.test.core.LinuxOrOsx;
@@ -32,9 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.vertx.test.core.AsyncTestBase.assertWaitUntil;
 import static io.vertx.tests.net.quic.QuicClientTest.clientOptions;
-import static io.vertx.tests.net.quic.QuicServerTest.serverOptions;
 
 @RunWith(LinuxOrOsx.class)
 public class QuicServerLoadBalancingTest extends VertxTestBase {
@@ -59,7 +54,7 @@ public class QuicServerLoadBalancingTest extends VertxTestBase {
   }
 
   private QuicServer server() {
-    QuicServer server = QuicServer.create(vertx, serverOptions().setLoadBalanced(true), QuicServerTest.SSL_OPTIONS);
+    QuicServer server = QuicServer.create(vertx, new QuicServerConfig().setLoadBalanced(true), QuicServerTest.SSL_OPTIONS);
     servers.add(server);
     return server;
   }


### PR DESCRIPTION
Motivation:

The default QUIC config is restrictive, each usage should have its own default configuration according to the intended usage.

Changes:

Apply specific QUIC configuration according to the usage:

- Quic client/server
- HTTP/3 client/server
