### PR TITLE
Account for stream in transport connections.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicConnectionHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicConnectionHandler.java
@@ -160,17 +160,17 @@ public class QuicConnectionHandler extends ChannelDuplexHandler implements Netwo
   }
 
   @Override
-  public void bytesRead(Object socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
-    NetworkMetrics.super.bytesRead(socketMetric, remoteAddress, numberOfBytes);
+  public void bytesRead(Object connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
+    NetworkMetrics.super.bytesRead(connectionMetric, remoteAddress, numberOfBytes);
   }
 
   @Override
-  public void bytesWritten(Object socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
-    NetworkMetrics.super.bytesWritten(socketMetric, remoteAddress, numberOfBytes);
+  public void bytesWritten(Object connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
+    NetworkMetrics.super.bytesWritten(connectionMetric, remoteAddress, numberOfBytes);
   }
 
   @Override
-  public void exceptionOccurred(Object socketMetric, SocketAddress remoteAddress, Throwable t) {
-    NetworkMetrics.super.exceptionOccurred(socketMetric, remoteAddress, t);
+  public void exceptionOccurred(Object connectionMetric, SocketAddress remoteAddress, Throwable err) {
+    NetworkMetrics.super.exceptionOccurred(connectionMetric, remoteAddress, err);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
@@ -35,7 +35,7 @@ import io.vertx.core.spi.observability.HttpResponse;
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
-public interface HttpClientMetrics<R, W, S> extends TransportMetrics<S> {
+public interface HttpClientMetrics<R, W, C> extends TransportMetrics<C> {
 
   /**
    * Provides metrics for a particular endpoint

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpServerMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpServerMetrics.java
@@ -35,17 +35,17 @@ import io.vertx.core.spi.observability.HttpResponse;
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
-public interface HttpServerMetrics<R, W, S> extends TransportMetrics<S> {
+public interface HttpServerMetrics<R, W, C> extends TransportMetrics<C> {
 
   /**
    * Called when an http server request begins. Vert.x will invoke {@link #responseEnd} when the response has ended
    * or {@link #requestReset} if the request/response has failed before.
    *
-   * @param socketMetric the socket metric
-   * @param request the http server reuqest
+   * @param connectionMetric the connection metric
+   * @param request the http server request
    * @return the request metric
    */
-  default R requestBegin(S socketMetric, HttpRequest request) {
+  default R requestBegin(C connectionMetric, HttpRequest request) {
     return null;
   }
 
@@ -79,12 +79,12 @@ public interface HttpServerMetrics<R, W, S> extends TransportMetrics<S> {
   /**
    * Called when an http server response is pushed.
    *
-   * @param socketMetric the socket metric
+   * @param connectionMetric the connection metric
    * @param method the pushed response method
    * @param uri the pushed response uri
    * @param response the http server response  @return the request metric
    */
-  default R responsePushed(S socketMetric, HttpMethod method, String uri, HttpResponse response) {
+  default R responsePushed(C connectionMetric, HttpMethod method, String uri, HttpResponse response) {
     return null;
   }
 
@@ -100,21 +100,21 @@ public interface HttpServerMetrics<R, W, S> extends TransportMetrics<S> {
   /**
    * Called when a server web socket connects.
    *
-   * @param socketMetric the socket metric
+   * @param connectionMetric the socket metric
    * @param requestMetric the request metric
-   * @param serverWebSocket the server web socket
+   * @param webSocket the server web socket
    * @return the server web socket metric
    */
-  default W connected(S socketMetric, R requestMetric, ServerWebSocket serverWebSocket) {
+  default W connected(C connectionMetric, R requestMetric, ServerWebSocket webSocket) {
     return null;
   }
 
   /**
    * Called when the server web socket has disconnected.
    *
-   * @param serverWebSocketMetric the server web socket metric
+   * @param webSocketMetric the server web socket metric
    */
-  default void disconnected(W serverWebSocketMetric) {
+  default void disconnected(W webSocketMetric) {
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/NetworkMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/NetworkMetrics.java
@@ -15,39 +15,39 @@ import io.vertx.core.net.SocketAddress;
 
 /**
  * An SPI used internally by Vert.x to gather metrics on a net socket which serves
- * as a base class for TCP or UDP.<p/>
+ * as a base class for TCP, UDP or QUIC.<p/>
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
-public interface NetworkMetrics<S> extends Metrics {
+public interface NetworkMetrics<C> extends Metrics {
 
   /**
    * Called when bytes have been read
    *
-   * @param socketMetric the socket metric, null for UDP
+   * @param connectionMetric the connection metric, {@code null} for UDP
    * @param remoteAddress the remote address which this socket received bytes from
    * @param numberOfBytes the number of bytes read
    */
-  default void bytesRead(S socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+  default void bytesRead(C connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
   }
 
   /**
    * Called when bytes have been written
    *
-   * @param socketMetric the socket metric, null for UDP
+   * @param connectionMetric the connection metric,  {@code null} for UDP
    * @param remoteAddress the remote address which bytes are being written to
    * @param numberOfBytes the number of bytes written
    */
-  default void bytesWritten(S socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+  default void bytesWritten(C connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
   }
 
   /**
    * Called when exceptions occur for a specific connection.
    *
-   * @param socketMetric the socket metric, null for UDP
-   * @param remoteAddress the remote address of the connection or null if it's datagram/udp
-   * @param t the exception that occurred
+   * @param connectionMetric the connection metric,  {@code null} for UDP
+   * @param remoteAddress the remote address of the connection or  {@code null} if it's datagram/udp
+   * @param err the exception that occurred
    */
-  default void exceptionOccurred(S socketMetric, SocketAddress remoteAddress, Throwable t) {
+  default void exceptionOccurred(C connectionMetric, SocketAddress remoteAddress, Throwable err) {
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/TCPMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/TCPMetrics.java
@@ -18,5 +18,5 @@ package io.vertx.core.spi.metrics;
  * @deprecated instead use {@link TransportMetrics}
  */
 @Deprecated(forRemoval = true)
-public interface TCPMetrics<S> extends TransportMetrics<S> {
+public interface TCPMetrics<C> extends TransportMetrics<C> {
 }

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/TransportMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/TransportMetrics.java
@@ -21,7 +21,7 @@ import io.vertx.core.net.SocketAddress;
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
-public interface TransportMetrics<S> extends NetworkMetrics<S> {
+public interface TransportMetrics<C> extends NetworkMetrics<C> {
 
   /**
    * Called when a client has connected, which is applicable for connections.<p/>
@@ -31,18 +31,32 @@ public interface TransportMetrics<S> extends NetworkMetrics<S> {
    *
    * @param remoteAddress the remote address of the client
    * @param remoteName the remote name of the client
-   * @return the socket metric
+   * @return the connection metric
    */
-  default S connected(SocketAddress remoteAddress, String remoteName) {
+  default C connected(SocketAddress remoteAddress, String remoteName) {
     return null;
   }
 
   /**
    * Called when a client has disconnected, which is applicable for connections.
    *
-   * @param socketMetric the socket metric
+   * @param connectionMetric the connection metric
    * @param remoteAddress the remote address of the client
    */
-  default void disconnected(S socketMetric, SocketAddress remoteAddress) {
+  default void disconnected(C connectionMetric, SocketAddress remoteAddress) {
+  }
+
+  /**
+   * Called when a connection has opened a stream, only applicable for Quic connections
+   * @param connectionMetric the connection metric
+   */
+  default void streamOpened(C connectionMetric) {
+  }
+
+  /**
+   * Called when a connection has closed a stream, only applicable for Quic connections
+   * @param connectionMetric the connection metric
+   */
+  default void streamClosed(C connectionMetric) {
   }
 }

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/ConnectionMetric.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/ConnectionMetric.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class SocketMetric {
+public class ConnectionMetric {
 
   public final SocketAddress remoteAddress;
   public final String remoteName;
@@ -31,8 +31,9 @@ public class SocketMetric {
   public final List<Long> bytesReadEvents = Collections.synchronizedList(new ArrayList<>());
   public final AtomicLong bytesWritten = new AtomicLong();
   public final List<Long> bytesWrittenEvents = Collections.synchronizedList(new ArrayList<>());
+  public final AtomicLong openStreams = new AtomicLong();
 
-  public SocketMetric(SocketAddress remoteAddress, String remoteName) {
+  public ConnectionMetric(SocketAddress remoteAddress, String remoteName) {
     this.remoteAddress = remoteAddress;
     this.remoteName = remoteName;
   }

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeDatagramSocketMetrics.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeDatagramSocketMetrics.java
@@ -51,12 +51,12 @@ public class FakeDatagramSocketMetrics extends FakeMetricsBase implements Datagr
   }
 
   @Override
-  public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+  public void bytesRead(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
     reads.add(new PacketMetric(remoteAddress, numberOfBytes));
   }
 
   @Override
-  public void bytesWritten(Void socketMetric, SocketAddress remoteAddress,long numberOfBytes) {
+  public void bytesWritten(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
     writes.add(new PacketMetric(remoteAddress, numberOfBytes));
   }
 }

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeHttpClientMetrics.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeHttpClientMetrics.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class FakeHttpClientMetrics extends FakeTCPMetrics implements HttpClientMetrics<HttpClientMetric, WebSocketMetric, SocketMetric> {
+public class FakeHttpClientMetrics extends FakeTCPMetrics implements HttpClientMetrics<HttpClientMetric, WebSocketMetric, ConnectionMetric> {
 
   private final ConcurrentMap<WebSocketBase, WebSocketMetric> webSockets = new ConcurrentHashMap<>();
   private final ConcurrentMap<SocketAddress, EndpointMetric> endpoints = new ConcurrentHashMap<>();

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeQuicEndpointMetrics.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeQuicEndpointMetrics.java
@@ -10,7 +10,7 @@
  */
 package io.vertx.test.fakemetrics;
 
-public class FakeQuicEndpointMetrics extends FakeTransportMetrics implements io.vertx.core.spi.metrics.TransportMetrics<SocketMetric> {
+public class FakeQuicEndpointMetrics extends FakeTransportMetrics implements io.vertx.core.spi.metrics.TransportMetrics<ConnectionMetric> {
 
   public FakeQuicEndpointMetrics(String name) {
     super(name);

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeTCPMetrics.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeTCPMetrics.java
@@ -1,8 +1,8 @@
 package io.vertx.test.fakemetrics;
 
-import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 
-public class FakeTCPMetrics extends FakeTransportMetrics implements TCPMetrics<SocketMetric> {
+public class FakeTCPMetrics extends FakeTransportMetrics implements TransportMetrics<ConnectionMetric> {
 
   public FakeTCPMetrics(String name) {
     super(name);

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
@@ -64,11 +64,11 @@ public class FakeVertxMetrics extends FakeMetricsBase implements VertxMetrics {
     return new FakeHttpClientMetrics(options.getMetricsName());
   }
 
-  public TCPMetrics<?> createTcpServerMetrics(TcpServerConfig config, SocketAddress localAddress) {
+  public TransportMetrics<?> createTcpServerMetrics(TcpServerConfig config, SocketAddress localAddress) {
     return new FakeTCPMetrics(null);
   }
 
-  public TCPMetrics<?> createTcpClientMetrics(TcpClientConfig config) {
+  public TransportMetrics<?> createTcpClientMetrics(TcpClientConfig config) {
     return new FakeTCPMetrics(config.getMetricsName());
   }
 

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/HttpServerMetric.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/HttpServerMetric.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class HttpServerMetric {
 
   public final String uri;
-  public final SocketMetric socket;
+  public final ConnectionMetric socket;
   public final AtomicBoolean failed = new AtomicBoolean();
   public final AtomicReference<String> route = new AtomicReference<>();
   public final HttpRequest request;
@@ -34,13 +34,13 @@ public class HttpServerMetric {
   public final AtomicBoolean responseEnded = new AtomicBoolean();
   public final AtomicLong bytesWritten = new AtomicLong();
 
-  public HttpServerMetric(String uri, SocketMetric socket) {
+  public HttpServerMetric(String uri, ConnectionMetric socket) {
     this.uri = uri;
     this.request = null;
     this.socket = socket;
   }
 
-  public HttpServerMetric(HttpRequest request, SocketMetric socket) {
+  public HttpServerMetric(HttpRequest request, ConnectionMetric socket) {
     this.uri = request.uri();
     this.request = request;
     this.socket = socket;

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTest.java
@@ -20,7 +20,7 @@ import io.vertx.core.net.TcpClientConfig;
 import io.vertx.core.net.TcpServerConfig;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
-import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.fakecluster.FakeClusterManager;
@@ -716,29 +716,29 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
       .withClusterManager(getClusterManager())
       .withMetrics(options -> new VertxMetrics() {
         @Override
-        public TCPMetrics<?> createTcpClientMetrics(TcpClientConfig config) {
-          return new TCPMetrics<>() {
+        public TransportMetrics<?> createTcpClientMetrics(TcpClientConfig config) {
+          return new TransportMetrics<>() {
             @Override
             public Object connected(SocketAddress remoteAddress, String remoteName) {
               numberOfOutboundConnections.incrementAndGet();
               return null;
             }
             @Override
-            public void disconnected(Object socketMetric, SocketAddress remoteAddress) {
+            public void disconnected(Object connectionMetric, SocketAddress remoteAddress) {
               numberOfOutboundConnections.decrementAndGet();
             }
           };
         }
         @Override
-        public TCPMetrics<?> createTcpServerMetrics(TcpServerConfig config, SocketAddress localAddress) {
-          return new TCPMetrics<>() {
+        public TransportMetrics<?> createTcpServerMetrics(TcpServerConfig config, SocketAddress localAddress) {
+          return new TransportMetrics<>() {
             @Override
             public Object connected(SocketAddress remoteAddress, String remoteName) {
               numberOfInboundConnections.incrementAndGet();
               return null;
             }
             @Override
-            public void disconnected(Object socketMetric, SocketAddress remoteAddress) {
+            public void disconnected(Object connectionMetric, SocketAddress remoteAddress) {
               numberOfInboundConnections.decrementAndGet();
             }
           };

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/HttpMetricsTestBase.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/HttpMetricsTestBase.java
@@ -128,7 +128,7 @@ public abstract class HttpMetricsTestBase extends SimpleHttpTest {
     startServer(testAddress);
     CountDownLatch latch = new CountDownLatch(1);
     AtomicReference<HttpClientMetric> clientMetric = new AtomicReference<>();
-    AtomicReference<SocketMetric> clientSocketMetric = new AtomicReference<>();
+    AtomicReference<ConnectionMetric> clientSocketMetric = new AtomicReference<>();
     FakeHttpClientMetrics metrics = FakeMetricsBase.getMetrics(client);
 
 

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsContextTest.java
@@ -115,7 +115,7 @@ public class MetricsContextTest extends VertxTestBase {
       public HttpServerMetrics createHttpServerMetrics(HttpServerConfig config, SocketAddress localAddress) {
         return new HttpServerMetrics<Void, Void, Void>() {
           @Override
-          public Void requestBegin(Void socketMetric, HttpRequest request) {
+          public Void requestBegin(Void connectionMetric, HttpRequest request) {
             requestBeginCalled.set(true);
             return null;
           }
@@ -129,15 +129,15 @@ public class MetricsContextTest extends VertxTestBase {
             return null;
           }
           @Override
-          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+          public void disconnected(Void connectionMetric, SocketAddress remoteAddress) {
             socketDisconnectedCalled.set(true);
           }
           @Override
-          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesRead(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesReadCalled.set(true);
           }
           @Override
-          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesWritten(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesWrittenCalled.set(true);
           }
           @Override
@@ -199,7 +199,7 @@ public class MetricsContextTest extends VertxTestBase {
       public HttpServerMetrics createHttpServerMetrics(HttpServerConfig config, SocketAddress localAddress) {
         return new HttpServerMetrics<Void, Void, Void>() {
           @Override
-          public Void requestBegin(Void socketMetric, HttpRequest request) {
+          public Void requestBegin(Void connectionMetric, HttpRequest request) {
             switch (request.uri()) {
               case "/1":
                 assertEquals(0, count.get());
@@ -229,13 +229,13 @@ public class MetricsContextTest extends VertxTestBase {
             return null;
           }
           @Override
-          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+          public void disconnected(Void connectionMetric, SocketAddress remoteAddress) {
           }
           @Override
-          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesRead(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
           }
           @Override
-          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesWritten(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
           }
           @Override
           public void close() {
@@ -299,7 +299,7 @@ public class MetricsContextTest extends VertxTestBase {
       public HttpServerMetrics createHttpServerMetrics(HttpServerConfig config, SocketAddress localAddress) {
         return new HttpServerMetrics<Void, Void, Void>() {
           @Override
-          public Void requestBegin(Void socketMetric, HttpRequest request) {
+          public Void requestBegin(Void connectionMetric, HttpRequest request) {
             assertEquals(0, httpLifecycle.getAndIncrement());
             return null;
           }
@@ -316,13 +316,13 @@ public class MetricsContextTest extends VertxTestBase {
             assertEquals(3, httpLifecycle.getAndIncrement());
           }
           @Override
-          public Void connected(Void socketMetric, Void requestMetric, ServerWebSocket serverWebSocket) {
+          public Void connected(Void connectionMetric, Void requestMetric, ServerWebSocket webSocket) {
             assertEquals(4, httpLifecycle.get());
             webSocketConnected.set(true);
             return null;
           }
           @Override
-          public void disconnected(Void serverWebSocketMetric) {
+          public void disconnected(Void webSocketMetric) {
             assertEquals(4, httpLifecycle.get());
             webSocketDisconnected.set(true);
           }
@@ -332,15 +332,15 @@ public class MetricsContextTest extends VertxTestBase {
             return null;
           }
           @Override
-          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+          public void disconnected(Void connectionMetric, SocketAddress remoteAddress) {
             socketDisconnectedCalled.set(true);
           }
           @Override
-          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesRead(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesReadCalled.set(true);
           }
           @Override
-          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesWritten(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesWrittenCalled.set(true);
           }
           @Override
@@ -435,15 +435,15 @@ public class MetricsContextTest extends VertxTestBase {
             return null;
           }
           @Override
-          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+          public void disconnected(Void connectionMetric, SocketAddress remoteAddress) {
             socketDisconnectedCalled.set(true);
           }
           @Override
-          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesRead(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesReadCalled.set(true);
           }
           @Override
-          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesWritten(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesWrittenCalled.set(true);
           }
           @Override
@@ -537,15 +537,15 @@ public class MetricsContextTest extends VertxTestBase {
             return null;
           }
           @Override
-          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+          public void disconnected(Void connectionMetric, SocketAddress remoteAddress) {
             socketDisconnectedCalled.set(true);
           }
           @Override
-          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesRead(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesReadCalled.set(true);
           }
           @Override
-          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesWritten(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesWrittenCalled.set(true);
           }
           @Override
@@ -614,23 +614,23 @@ public class MetricsContextTest extends VertxTestBase {
     AtomicBoolean closeCalled = new AtomicBoolean();
     VertxMetricsFactory factory = (options) -> new VertxMetrics() {
       @Override
-      public TCPMetrics createTcpServerMetrics(TcpServerConfig config, SocketAddress localAddress) {
-        return new TCPMetrics<Void>() {
+      public TransportMetrics createTcpServerMetrics(TcpServerConfig config, SocketAddress localAddress) {
+        return new TransportMetrics<Void>() {
           @Override
           public Void connected(SocketAddress remoteAddress, String remoteName) {
             socketConnectedCalled.set(true);
             return null;
           }
           @Override
-          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+          public void disconnected(Void connectionMetric, SocketAddress remoteAddress) {
             socketDisconnectedCalled.set(true);
           }
           @Override
-          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesRead(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesReadCalled.set(true);
           }
           @Override
-          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesWritten(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesWrittenCalled.set(true);
           }
           @Override
@@ -702,23 +702,23 @@ public class MetricsContextTest extends VertxTestBase {
     AtomicBoolean closeCalled = new AtomicBoolean();
     VertxMetricsFactory factory = (options) -> new VertxMetrics() {
       @Override
-      public TCPMetrics createTcpClientMetrics(TcpClientConfig config) {
-        return new TCPMetrics<Void>() {
+      public TransportMetrics createTcpClientMetrics(TcpClientConfig config) {
+        return new TransportMetrics<Void>() {
           @Override
           public Void connected(SocketAddress remoteAddress, String remoteName) {
             socketConnectedCalled.set(remoteAddress);
             return null;
           }
           @Override
-          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+          public void disconnected(Void connectionMetric, SocketAddress remoteAddress) {
             socketDisconnectedCalled.set(true);
           }
           @Override
-          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesRead(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesReadCalled.set(true);
           }
           @Override
-          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesWritten(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesWrittenCalled.set(true);
           }
           @Override
@@ -792,11 +792,11 @@ public class MetricsContextTest extends VertxTestBase {
             listening.set(true);
           }
           @Override
-          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesRead(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesReadCalled.set(true);
           }
           @Override
-          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+          public void bytesWritten(Void connectionMetric, SocketAddress remoteAddress, long numberOfBytes) {
             bytesWrittenCalled.set(true);
           }
           @Override

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsTest.java
@@ -565,14 +565,14 @@ public class MetricsTest extends VertxTestBase {
       wsRef.set(ws);
       FakeHttpServerMetrics metrics = FakeMetricsBase.getMetrics(server);
       WebSocketMetric webSocketMetric = metrics.getWebSocketMetric(ws);
-      SocketMetric socketMetric = metrics.firstMetric(ws.remoteAddress());
-      long bytesWritten = socketMetric.bytesRead.get();
-      long bytesRead = socketMetric.bytesRead.get();
+      ConnectionMetric connectionMetric = metrics.firstMetric(ws.remoteAddress());
+      long bytesWritten = connectionMetric.bytesRead.get();
+      long bytesRead = connectionMetric.bytesRead.get();
       assertNotNull(webSocketMetric);
       ws.handler(ws::write);
       ws.closeHandler(closed -> {
         vertx.runOnContext(v -> {
-          assertTrue(socketMetric.bytesRead.get() > bytesRead || socketMetric.bytesWritten.get() > bytesWritten);
+          assertTrue(connectionMetric.bytesRead.get() > bytesRead || connectionMetric.bytesWritten.get() > bytesWritten);
           latch.countDown();
         });
       });
@@ -600,14 +600,14 @@ public class MetricsTest extends VertxTestBase {
         .onComplete(onSuccess(ws -> {
           assertNull(metrics.getRequestMetric(req));
           WebSocketMetric wsMetric = metrics.getWebSocketMetric(ws);
-          SocketMetric socketMetric = metrics.firstMetric(ws.remoteAddress());
-          long bytesWritten = socketMetric.bytesRead.get();
-          long bytesRead = socketMetric.bytesRead.get();
+          ConnectionMetric connectionMetric = metrics.firstMetric(ws.remoteAddress());
+          long bytesWritten = connectionMetric.bytesRead.get();
+          long bytesRead = connectionMetric.bytesRead.get();
           assertNotNull(wsMetric);
           ws.handler(ws::write);
           ws.closeHandler(closed -> {
             vertx.runOnContext(v -> {
-              assertTrue(socketMetric.bytesRead.get() > bytesRead || socketMetric.bytesWritten.get() > bytesWritten);
+              assertTrue(connectionMetric.bytesRead.get() > bytesRead || connectionMetric.bytesWritten.get() > bytesWritten);
               ref.set(ws);
             });
           });
@@ -831,7 +831,7 @@ public class MetricsTest extends VertxTestBase {
     testHttpConnect(TestUtils.loopbackAddress(), socketMetric -> assertEquals(socketMetric.remoteAddress.host(), socketMetric.remoteName));
   }
 
-  private void testHttpConnect(String host, Consumer<SocketMetric> checker) throws InterruptedException {
+  private void testHttpConnect(String host, Consumer<ConnectionMetric> checker) throws InterruptedException {
     waitFor(2);
     server = vertx.createHttpServer();
     AtomicReference<HttpClientMetric> clientMetric = new AtomicReference<>();


### PR DESCRIPTION
Motivation:

With the advent of QUIC, we need to raffine further more the contract of TransportMetrics which has historically used the notion of socket and connection interchangeably. We should clarify these meanings and provide minimal support for QUIC metrics.

Changes:

In TransportMetrics:

- Remove occurences of socket, replaced by connection which is the common concepts defined by TCP and QUIC
- Propagate the change above in the hierarchy (which is a mere renaming of type argument / parameter name)
- Support basic stream event for QUIC : streamOpended / streamClosed
