### PR TITLE
Use shutdown with a duration timeout pattern consistently.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClient.java
@@ -11,9 +11,11 @@
 
 package io.vertx.core.http;
 
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -96,6 +98,13 @@ public interface HttpClient {
   }
 
   /**
+   * Calls {@link #shutdown(Duration)}.
+   */
+  default Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return shutdown(Duration.of(timeout, unit.toChronoUnit()));
+  }
+
+  /**
    * Initiate the client shutdown sequence.
    *
    * <p> Connections are taken out of service and closed when all inflight requests are processed, client connection are
@@ -108,9 +117,9 @@ public interface HttpClient {
    * </ul>
    *
    * @param timeout the amount of time after which all resources are forcibly closed
-   * @param unit the of the timeout
    * @return a future notified when the client is closed
    */
-  Future<Void> shutdown(long timeout, TimeUnit unit);
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Future<Void> shutdown(Duration timeout);
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientConnection.java
@@ -46,7 +46,9 @@ public interface HttpClientConnection extends HttpConnection, HttpClient {
   }
 
   @Override
-  Future<Void> shutdown(long timeout, TimeUnit unit);
+  default Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return HttpConnection.super.shutdown(timeout, unit);
+  }
 
   @Override
   default Future<Void> close() {

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -20,6 +20,7 @@ import io.vertx.core.net.SocketAddress;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import java.security.cert.Certificate;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -133,6 +134,13 @@ public interface HttpConnection {
   }
 
   /**
+   * Calls {@link #shutdown(Duration)}
+   */
+  default Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return shutdown(Duration.of(timeout, unit.toChronoUnit()));
+  }
+
+  /**
    * Initiate a graceful connection shutdown, the connection is taken out of service and closed when all the inflight requests
    * are processed, otherwise after a {@code timeout} the connection will be closed. Client connection are immediately removed
    * from the pool.
@@ -143,10 +151,10 @@ public interface HttpConnection {
    * </ul>
    *
    * @param timeout the amount of time after which all resources are forcibly closed
-   * @param unit the of the timeout
    * @return a future completed when shutdown has completed
    */
-  Future<Void> shutdown(long timeout, TimeUnit unit);
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Future<Void> shutdown(Duration timeout);
 
   /**
    * Set a close handler. The handler will get notified when the connection is closed.

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServer.java
@@ -22,6 +22,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.TrafficShapingOptions;
 import io.vertx.core.net.impl.SocketAddressImpl;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -213,16 +214,23 @@ public interface HttpServer extends Measured {
    * @return a future completed with the result
    */
   default Future<Void> close() {
-    return shutdown(0, TimeUnit.SECONDS);
+    return shutdown(Duration.ZERO);
   }
 
   /**
-   * Shutdown with a 30 seconds timeout ({@code shutdown(30, TimeUnit.SECONDS)}).
+   * Shutdown with a 30 seconds timeout ({@code shutdown(Duration.ofSeconds(30))}).
    *
    * @return a future completed when shutdown has completed
    */
   default Future<Void> shutdown() {
-    return shutdown(30, TimeUnit.SECONDS);
+    return shutdown(Duration.ofSeconds(30));
+  }
+
+  /**
+   * Calls {@link #shutdown(Duration)}.
+   */
+  default Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return shutdown(Duration.of(timeout, unit.toChronoUnit()));
   }
 
   /**
@@ -237,10 +245,10 @@ public interface HttpServer extends Measured {
    * </ul>
    *
    * @param timeout the amount of time after which all resources are forcibly closed
-   * @param unit the of the timeout
    * @return a future notified when the client is closed
    */
-  Future<Void> shutdown(long timeout, TimeUnit unit);
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Future<Void> shutdown(Duration timeout);
 
   /**
    * The actual port the server is listening on. This is useful if you bound the server specifying 0 as port number

--- a/vertx-core/src/main/java/io/vertx/core/http/WebSocketBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/WebSocketBase.java
@@ -27,6 +27,7 @@ import io.vertx.core.streams.WriteStream;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import java.security.cert.Certificate;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -339,10 +340,33 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
   }
 
   /**
+   * Calls {@link #shutdown(Duration, short, String)} with the status code {@code 1000} and a {@code null} reason.
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default Future<Void> shutdown(Duration timeout) {
+    return shutdown(timeout, (short)1000);
+  }
+
+  /**
    * Calls {@link #shutdown(long, TimeUnit, short, String)} with a {@code null} reason.
    */
   default Future<Void> shutdown(long timeout, TimeUnit unit, short statusCode) {
     return shutdown(timeout, unit, statusCode, null);
+  }
+
+  /**
+   * Calls {@link #shutdown(Duration, short, String)} with a {@code null} reason.
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  default Future<Void> shutdown(Duration timeout, short statusCode) {
+    return shutdown(timeout, statusCode, null);
+  }
+
+  /**
+   * Calls {@link #shutdown(Duration, short, String)}
+   */
+  default Future<Void> shutdown(long timeout, TimeUnit unit, short statusCode, @Nullable String reason) {
+    return shutdown(Duration.of(timeout, unit.toChronoUnit()), statusCode, reason);
   }
 
   /**
@@ -353,12 +377,12 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
    * here: RFC6455 <a href="https://tools.ietf.org/html/rfc6455#section-7.4.1">section 7.4.1</a>
    *
    * @param timeout the amount of time after which all resources are forcibly closed
-   * @param unit the of the timeout
    * @param statusCode the status code
    * @param reason reason of closure
    * @return a future completed when shutdown has completed
    */
-  Future<Void> shutdown(long timeout, TimeUnit unit, short statusCode, @Nullable String reason);
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Future<Void> shutdown(Duration timeout, short statusCode, @Nullable String reason);
 
   /**
    * @return the remote address for this connection, possibly {@code null} (e.g a server bound on a domain socket).

--- a/vertx-core/src/main/java/io/vertx/core/http/WebSocketClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/WebSocketClient.java
@@ -10,11 +10,13 @@
  */
 package io.vertx.core.http;
 
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.metrics.Measured;
 import io.vertx.core.net.ClientSSLOptions;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -120,12 +122,19 @@ public interface WebSocketClient extends Measured {
   Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force);
 
   /**
+   * Calls {@link #shutdown(Duration)}.
+   */
+  default Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return shutdown(Duration.of(timeout, unit.toChronoUnit()));
+  }
+
+  /**
    * Initiate the client shutdown sequence.
    *
    * @return a future notified when the client is closed
    * @param timeout the amount of time after which all resources are forcibly closed
-   * @param unit the of the timeout
    */
-  Future<Void> shutdown(long timeout, TimeUnit unit);
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Future<Void> shutdown(Duration timeout);
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpServer.java
@@ -23,6 +23,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.TrafficShapingOptions;
 import io.vertx.core.spi.metrics.Metrics;
 
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -89,7 +90,7 @@ public class CleanableHttpServer implements HttpServerInternal, Closeable {
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+  public Future<Void> shutdown(Duration timeout) {
     ContextInternal context;
     synchronized (this) {
       if (listenContext == null) {
@@ -99,7 +100,7 @@ public class CleanableHttpServer implements HttpServerInternal, Closeable {
       listenContext = null;
     }
     context.removeCloseHook(this);
-    return server.shutdown(timeout, unit);
+    return server.shutdown(timeout);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
@@ -19,8 +19,10 @@ import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 
 import java.lang.ref.Cleaner;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * A lightweight proxy of Vert.x {@link HttpClient} that can be collected by the garbage collector and release
@@ -31,16 +33,15 @@ import java.util.function.BiFunction;
 public class CleanableWebSocketClient implements WebSocketClient, MetricsProvider, Closeable {
 
   static class Action implements Runnable {
-    private final BiFunction<Long, TimeUnit, Future<Void>> dispose;
-    private long timeout = 30L;
-    private TimeUnit timeUnit = TimeUnit.SECONDS;
+    private final Function<Duration, Future<Void>> dispose;
+    private Duration timeout = Duration.ofSeconds(30);
     private Future<Void> closeFuture;
-    private Action(BiFunction<Long, TimeUnit, Future<Void>> dispose) {
+    private Action(Function<Duration, Future<Void>> dispose) {
       this.dispose = dispose;
     }
     @Override
     public void run() {
-      closeFuture = dispose.apply(timeout, timeUnit);
+      closeFuture = dispose.apply(timeout);
     }
   }
 
@@ -48,7 +49,7 @@ public class CleanableWebSocketClient implements WebSocketClient, MetricsProvide
   private final Cleaner.Cleanable cleanable;
   private final Action action;
 
-  public CleanableWebSocketClient(WebSocketClient delegate, Cleaner cleaner, BiFunction<Long, TimeUnit, Future<Void>> dispose) {
+  public CleanableWebSocketClient(WebSocketClient delegate, Cleaner cleaner, Function<Duration, Future<Void>> dispose) {
     this.action = new Action(dispose);
     this.delegate = delegate;
     this.cleanable = cleaner.register(this, action);
@@ -69,15 +70,11 @@ public class CleanableWebSocketClient implements WebSocketClient, MetricsProvide
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
-    if (timeout < 0L) {
-      throw new IllegalArgumentException();
-    }
-    if (unit == null) {
+  public Future<Void> shutdown(Duration timeout) {
+    if (timeout.isNegative()) {
       throw new IllegalArgumentException();
     }
     action.timeout = timeout;
-    action.timeUnit = unit;
     cleanable.clean();
     return action.closeFuture;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/CompositeHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/CompositeHttpServer.java
@@ -23,6 +23,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.TrafficShapingOptions;
 import io.vertx.core.spi.metrics.Metrics;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -151,9 +152,9 @@ public class CompositeHttpServer implements HttpServerInternal {
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+  public Future<Void> shutdown(Duration timeout) {
     return Future
-      .join(tcpServer.shutdown(timeout, unit), quicServer.shutdown(timeout, unit))
+      .join(tcpServer.shutdown(timeout), quicServer.shutdown(timeout))
       .mapEmpty();
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -35,8 +35,7 @@ public abstract class HttpClientBase implements MetricsProvider, Closeable {
   protected final ProxyOptions defaultProxyOptions;
   protected final HttpClientMetrics<?, ?, ?> metrics;
   protected final CloseSequence closeSequence;
-  private long closeTimeout = 0L;
-  private TimeUnit closeTimeoutUnit = TimeUnit.SECONDS;
+  private Duration closeTimeout = Duration.ZERO;
   private Predicate<SocketAddress> proxyFilter;
 
   public HttpClientBase(VertxInternal vertx,
@@ -46,7 +45,7 @@ public abstract class HttpClientBase implements MetricsProvider, Closeable {
     this.vertx = vertx;
     this.metrics = metrics;
     this.defaultProxyOptions = defaultProxyOptions;
-    this.closeSequence = new CloseSequence(p -> doClose(p), p1 -> doShutdown(Duration.ofMillis(closeTimeoutUnit.toMillis(closeTimeout)), p1));
+    this.closeSequence = new CloseSequence(p -> doClose(p), p1 -> doShutdown(closeTimeout, p1));
     this.proxyFilter = nonProxyHosts != null ? ProxyFilter.nonProxyHosts(nonProxyHosts) : ProxyFilter.DEFAULT_PROXY_FILTER;
   }
 
@@ -100,9 +99,8 @@ public abstract class HttpClientBase implements MetricsProvider, Closeable {
 
   protected abstract void doClose(Completable<Void> p);
 
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+  public Future<Void> shutdown(Duration timeout) {
     this.closeTimeout = timeout;
-    this.closeTimeoutUnit = unit;
     return closeSequence.close();
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -271,7 +271,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
         cf_.add(completion -> impl.close().onComplete(completion));
         return impl;
       });
-      client = new CleanableHttpClient((HttpClientInternal) client, vertx.cleaner(), (timeout, timeunit) -> closeFuture.close());
+      client = new CleanableHttpClient((HttpClientInternal) client, vertx.cleaner(), (timeout) -> closeFuture.close());
       closeable = closeFuture;
     } else {
       HttpClientImpl impl = createHttpClientImpl(co2, metrics, resolver, redirectHandler, transport, quicTransport);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
@@ -23,6 +23,7 @@ import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.net.SocketAddress;
 
 import javax.net.ssl.SSLSession;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.concurrent.TimeUnit;
@@ -74,8 +75,8 @@ public class UnpooledHttpClientConnection implements io.vertx.core.http.HttpClie
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
-    return actual.shutdown(timeout, unit);
+  public Future<Void> shutdown(Duration timeout) {
+    return actual.shutdown(timeout);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
@@ -40,6 +40,7 @@ import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.impl.ConnectionBase;
 
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Map;
@@ -361,22 +362,18 @@ abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameL
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+  public Future<Void> shutdown(Duration timeout) {
     PromiseInternal<Void> promise = vertx.promise();
-    shutdown(timeout, unit, promise);
+    shutdown(timeout, promise);
     return promise.future();
   }
 
-  private void shutdown(long timeout, TimeUnit unit, PromiseInternal<Void> promise) {
-    if (unit == null) {
-      promise.fail("Null time unit");
-      return;
-    }
-    if (timeout < 0) {
+  private void shutdown(Duration timeout, PromiseInternal<Void> promise) {
+    if (timeout.isNegative()) {
       promise.fail("Invalid timeout value " + timeout);
       return;
     }
-    handler.gracefulShutdownTimeoutMillis(unit.toMillis(timeout));
+    handler.gracefulShutdownTimeoutMillis(timeout.toMillis());
     ChannelFuture fut = channel.close();
     fut.addListener(promise);
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
@@ -52,6 +52,7 @@ import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.spi.metrics.NetworkMetrics;
 import io.vertx.core.spi.metrics.TransportMetrics;
 
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Objects;
@@ -267,10 +268,10 @@ public abstract class Http2MultiplexConnection<S extends Http2Stream> extends Co
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+  public Future<Void> shutdown(Duration timeout) {
     PromiseInternal<Void> promise = context.promise();
     Http2FrameCodec frameCodec = channel.pipeline().get(Http2FrameCodec.class);
-    frameCodec.gracefulShutdownTimeoutMillis(unit.toMillis(timeout));
+    frameCodec.gracefulShutdownTimeoutMillis(timeout.toMillis());
     ChannelFuture closeFuture = channel.close();
     closeFuture.addListener(promise);
     return promise.future();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Connection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Connection.java
@@ -237,11 +237,11 @@ public abstract class Http3Connection implements HttpConnection {
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
-    if (timeout < 0) {
+  public Future<Void> shutdown(Duration timeout) {
+    if (timeout.isNegative()) {
       throw new IllegalArgumentException("Timeout must be >= 0");
     }
-    return connection.shutdown(Duration.ofMillis(unit.toMillis(timeout)));
+    return connection.shutdown(timeout);
   }
 
   private void handleShutdown(QuicStreamChannel localControlStream, Duration timeout) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpServer.java
@@ -245,7 +245,7 @@ public class QuicHttpServer implements HttpServerInternal {
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+  public Future<Void> shutdown(Duration timeout) {
     io.vertx.core.net.QuicServer s;
     synchronized (this) {
       s = quicServer;
@@ -254,7 +254,7 @@ public class QuicHttpServer implements HttpServerInternal {
       }
       quicServer = null;
     }
-    return s.shutdown(Duration.ofMillis(unit.toMillis(timeout)));
+    return s.shutdown(timeout);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
@@ -36,6 +36,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.ClientMetrics;
 
 import javax.net.ssl.SSLSession;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -833,8 +834,8 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
-    return current.shutdown(timeout, unit);
+  public Future<Void> shutdown(Duration timeout) {
+    return current.shutdown(timeout);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/ClientWebSocketImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/ClientWebSocketImpl.java
@@ -24,6 +24,7 @@ import io.vertx.core.net.SocketAddress;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import java.security.cert.Certificate;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -282,8 +283,8 @@ public class ClientWebSocketImpl implements ClientWebSocketInternal {
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit, short statusCode, @Nullable String reason) {
-    return delegate().close(statusCode, reason);
+  public Future<Void> shutdown(Duration timeout, short statusCode, @Nullable String reason) {
+    return delegate().shutdown(timeout, statusCode, reason);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/ServerWebSocketHandshaker.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/ServerWebSocketHandshaker.java
@@ -34,6 +34,7 @@ import io.vertx.core.net.impl.VertxHandler;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import java.security.cert.Certificate;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -349,7 +350,7 @@ public class ServerWebSocketHandshaker extends FutureImpl<ServerWebSocket> imple
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit, short statusCode, @Nullable String reason) {
+  public Future<Void> shutdown(Duration timeout, short statusCode, @Nullable String reason) {
     throw new UnsupportedOperationException();
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/WebSocketConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/WebSocketConnectionImpl.java
@@ -78,12 +78,12 @@ public final class WebSocketConnectionImpl extends VertxConnection {
   private Object reason;
 
   public Future<Void> close(Object reason) {
-    return shutdown(reason, 0L, TimeUnit.SECONDS);
+    return shutdown(reason, Duration.ZERO);
   }
 
-  public Future<Void> shutdown(Object reason, long timeout, TimeUnit unit) {
+  public Future<Void> shutdown(Object reason, Duration timeout) {
     this.reason = reason;
-    return shutdown(timeout, unit);
+    return shutdown(timeout);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/WebSocketImplBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/WebSocketImplBase.java
@@ -38,6 +38,7 @@ import io.vertx.core.internal.concurrent.InboundMessageQueue;
 
 import javax.net.ssl.SSLSession;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -146,11 +147,11 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit, short statusCode, @Nullable String reason) {
+  public Future<Void> shutdown(Duration timeout, short statusCode, @Nullable String reason) {
     // Close the WebSocket by sending a close frame with specified payload
     ByteBuf byteBuf = HttpUtils.generateWSCloseFrameByteBuf(statusCode, reason);
     CloseWebSocketFrame frame = new CloseWebSocketFrame(true, 0, byteBuf);
-    return conn.shutdown(frame, timeout, unit);
+    return conn.shutdown(frame, timeout);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -443,7 +443,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
         cf_.add(completion -> impl.close().onComplete(completion));
         return impl;
       });
-      client = new CleanableWebSocketClient(client, cleaner, (timeout, timeunit) -> closeFuture.close());
+      client = new CleanableWebSocketClient(client, cleaner, (timeout) -> closeFuture.close());
       closeable = closeFuture;
     } else {
       WebSocketClientImpl impl = createWebSocketClientImpl(options);

--- a/vertx-core/src/main/java/io/vertx/core/net/NetClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/NetClient.java
@@ -11,11 +11,13 @@
 
 package io.vertx.core.net;
 
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.Future;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Handler;
 import io.vertx.core.metrics.Measured;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -106,6 +108,13 @@ public interface NetClient extends Measured {
   }
 
   /**
+   * Calls {@link #shutdown(Duration)}.
+   */
+  default Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return shutdown(Duration.of(timeout, unit.toChronoUnit()));
+  }
+
+  /**
    * Initiate the client shutdown sequence.
    * <p>
    * Connections are taken out of service and notified the close sequence has started through {@link NetSocket#shutdownHandler(Handler)}.
@@ -113,9 +122,9 @@ public interface NetClient extends Measured {
    *
    * @return a future notified when the client is closed
    * @param timeout the amount of time after which all resources are forcibly closed
-   * @param unit the of the timeout
    */
-  Future<Void> shutdown(long timeout, TimeUnit unit);
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Future<Void> shutdown(Duration timeout);
 
   /**
    * <p>Update the client with new SSL {@code options}, the update happens if the options object is valid and different

--- a/vertx-core/src/main/java/io/vertx/core/net/NetServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/NetServer.java
@@ -20,6 +20,7 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.metrics.Measured;
 import io.vertx.core.net.impl.SocketAddressImpl;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -124,6 +125,13 @@ public interface NetServer extends Measured {
   }
 
   /**
+   * Calls {@link #shutdown(Duration)}.
+   */
+  default Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return shutdown(Duration.of(timeout, unit.toChronoUnit()));
+  }
+
+  /**
    * Initiate the server shutdown sequence.
    * <p>
    * Connections are taken out of service and notified the close sequence has started through {@link NetSocket#shutdownHandler(Handler)}.
@@ -131,9 +139,9 @@ public interface NetServer extends Measured {
    *
    * @return a future notified when the client is closed
    * @param timeout the amount of time after which all resources are forcibly closed
-   * @param unit the of the timeout
    */
-  Future<Void> shutdown(long timeout, TimeUnit unit);
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Future<Void> shutdown(Duration timeout);
 
   /**
    * The actual port the server is listening on. This is useful if you bound the server specifying 0 as port number

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionGroup.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionGroup.java
@@ -54,9 +54,13 @@ public class ConnectionGroup extends DefaultChannelGroup {
     return closeSequence.started();
   }
 
-  public final Future<Void> shutdown(long timeout, TimeUnit unit) {
-    shutdown = new ShutdownEvent(timeout, unit);
+  public final Future<Void> shutdown(Duration timeout) {
+    shutdown = new ShutdownEvent(timeout);
     return closeSequence.close();
+  }
+
+  public final Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return shutdown(Duration.of(timeout, unit.toChronoUnit()));
   }
 
   private void shutdown(Completable<Void> completion) {

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -165,22 +165,28 @@ public class VertxConnection extends ConnectionBase {
   }
 
   /**
+   * Calls {@link #shutdown(Duration)}
+   */
+  public final Future<Void> shutdown(long timeout, TimeUnit unit) {
+    return shutdown(Duration.of(timeout, unit.toChronoUnit()));
+  }
+
+  /**
    * Initiate the connection shutdown sequence.
    *
    * @param timeout the shutdown timeout
-   * @param unit the shutdown timeout unit
    * @return the future completed after the channel's closure
    */
-  public final Future<Void> shutdown(long timeout, TimeUnit unit) {
-    if (timeout < 0L) {
+  public final Future<Void> shutdown(Duration timeout) {
+    if (timeout.isNegative()) {
       throw new IllegalArgumentException("Timeout must be >= 0");
     }
     ChannelPromise promise = channel.newPromise();
     EventExecutor exec = chctx.executor();
     if (exec.inEventLoop()) {
-      shutdown(Duration.ofMillis(unit.toMillis(timeout)), promise);
+      shutdown(timeout, promise);
     } else {
-      exec.execute(() -> shutdown(Duration.ofMillis(unit.toMillis(timeout)), promise));
+      exec.execute(() -> shutdown(timeout, promise));
     }
     PromiseInternal<Void> p = context.promise();
     promise.addListener(p);

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetServer.java
@@ -11,6 +11,7 @@ import io.vertx.core.net.*;
 import io.vertx.core.spi.metrics.TransportMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 
@@ -30,7 +31,7 @@ public class CleanableNetServer extends NetServerImpl implements Closeable {
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+  public Future<Void> shutdown(Duration timeout) {
     ContextInternal context;
     synchronized (this) {
       if (listenContext == null) {
@@ -40,7 +41,7 @@ public class CleanableNetServer extends NetServerImpl implements Closeable {
       listenContext = null;
     }
     context.removeCloseHook(this);
-    return super.shutdown(timeout, unit);
+    return super.shutdown(timeout);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
@@ -181,8 +181,8 @@ class NetClientImpl implements NetClientInternal {
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit timeUnit) {
-    return channelGroup.shutdown(timeout, timeUnit);
+  public Future<Void> shutdown(Duration timeout) {
+    return channelGroup.shutdown(timeout);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerImpl.java
@@ -144,12 +144,12 @@ public class NetServerImpl implements NetServerInternal {
   }
 
   @Override
-  public Future<Void> shutdown(long timeout, TimeUnit unit) {
+  public Future<Void> shutdown(Duration timeout) {
     ConnectionGroup group = channelGroup;
     if (group == null) {
       return vertx.getOrCreateContext().succeededFuture();
     }
-    return group.shutdown(timeout, unit);
+    return group.shutdown(timeout);
   }
 
   @Override


### PR DESCRIPTION
Motivation:

Shutdown has historically used the (amount of time, time unit) pattern to describe the timeout of a shutdown operation.

Since Vert.x 5 we started to use the java type Duration for that in new APIs.

We should provide the opportunity to always use this overloading when the couple exists in existing APIs.

Changes:

Overload shutdown with (amount of time, time unit) with Duration in API.
