### PR TITLE
HttpServerMetrics and HttpClientMetrics should not inherent from TransportMetrics

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -133,10 +133,6 @@ public final class ClusteredEventBus extends EventBusImpl {
     NetClientBuilder builder = new NetClientBuilder(vertx, config)
       .sslOptions(clientOptions.getSslOptions())
       .registerWriteHandler(clientOptions.isRegisterWriteHandler());
-    VertxMetrics metricsSPI = vertx.metrics();
-    if (metricsSPI != null) {
-      builder.metrics(metricsSPI.createTcpClientMetrics(config));
-    }
     return builder.build();
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -99,8 +99,13 @@ public class CleanableHttpClient implements HttpClientInternal {
   }
 
   @Override
-  public HttpClientTransport channelConnector() {
-    return delegate.channelConnector();
+  public HttpClientTransport tcpTransport() {
+    return delegate.tcpTransport();
+  }
+
+  @Override
+  public HttpClientTransport quicTransport() {
+    return delegate.quicTransport();
   }
 
   @Override
@@ -136,5 +141,10 @@ public class CleanableHttpClient implements HttpClientInternal {
   @Override
   public EndpointResolverInternal resolver() {
     return delegate.resolver();
+  }
+
+  @Override
+  public HttpClientInternal unwrap() {
+    return delegate;
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpServer.java
@@ -173,4 +173,9 @@ public class CleanableHttpServer implements HttpServerInternal, Closeable {
   public Metrics getMetrics() {
     return server.getMetrics();
   }
+
+  @Override
+  public HttpServerInternal unwrap() {
+    return server;
+  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -18,12 +18,10 @@ import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.*;
 import io.vertx.core.net.impl.ProxyFilter;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
-import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 /**
@@ -33,17 +31,17 @@ public abstract class HttpClientBase implements MetricsProvider, Closeable {
 
   protected final VertxInternal vertx;
   protected final ProxyOptions defaultProxyOptions;
-  protected final HttpClientMetrics<?, ?, ?> metrics;
+  protected final HttpClientMetrics<?, ?> httpMetrics;
   protected final CloseSequence closeSequence;
   private Duration closeTimeout = Duration.ZERO;
   private Predicate<SocketAddress> proxyFilter;
 
   public HttpClientBase(VertxInternal vertx,
-                        HttpClientMetrics<?, ?, ?> metrics,
+                        HttpClientMetrics<?, ?> httpMetrics,
                         ProxyOptions defaultProxyOptions,
                         List<String> nonProxyHosts) {
     this.vertx = vertx;
-    this.metrics = metrics;
+    this.httpMetrics = httpMetrics;
     this.defaultProxyOptions = defaultProxyOptions;
     this.closeSequence = new CloseSequence(p -> doClose(p), p1 -> doShutdown(closeTimeout, p1));
     this.proxyFilter = nonProxyHosts != null ? ProxyFilter.nonProxyHosts(nonProxyHosts) : ProxyFilter.DEFAULT_PROXY_FILTER;
@@ -92,7 +90,7 @@ public abstract class HttpClientBase implements MetricsProvider, Closeable {
   }
 
   public HttpClientMetrics metrics() {
-    return metrics;
+    return httpMetrics;
   }
 
   protected abstract void doShutdown(Duration timeout, Completable<Void> p);
@@ -110,8 +108,8 @@ public abstract class HttpClientBase implements MetricsProvider, Closeable {
   }
 
   @Override
-  public Metrics getMetrics() {
-    return metrics;
+  public HttpClientMetrics<?, ?> getMetrics() {
+    return httpMetrics;
   }
 
   public Future<Boolean> updateSSLOptions(ClientSSLOptions options, boolean force) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpConnectParams.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpConnectParams.java
@@ -3,9 +3,6 @@ package io.vertx.core.http.impl;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.ProxyOptions;
-import io.vertx.core.net.SocketAddress;
-import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
 
 public class HttpConnectParams {
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
@@ -46,8 +46,8 @@ public class WebSocketClientImpl extends HttpClientBase implements WebSocketClie
                              HttpClientOptions options,
                              WebSocketClientOptions wsOptions,
                              HttpClientTransport connector,
-                             HttpClientMetrics<?, ?, ?> metrics) {
-    super(vertx, metrics, options.getProxyOptions(), options.getNonProxyHosts());
+                             HttpClientMetrics<?, ?> httpMetrics) {
+    super(vertx, httpMetrics, options.getProxyOptions(), options.getNonProxyHosts());
 
     ClientSSLOptions sslOptions = options.getSslOptions();
     if (sslOptions != null) {
@@ -92,8 +92,8 @@ public class WebSocketClientImpl extends HttpClientBase implements WebSocketClie
     // todo: cache
     Function<EndpointKey, WebSocketGroup> provider = (key_) -> {
       int maxPoolSize = options.getMaxConnections();
-      ClientMetrics clientMetrics = WebSocketClientImpl.this.metrics != null ? WebSocketClientImpl.this.metrics.createEndpointMetrics(key_.server, maxPoolSize) : null;
-      PoolMetrics queueMetrics = WebSocketClientImpl.this.metrics != null ? vertx.metrics().createPoolMetrics("ws", key_.server.toString(), maxPoolSize) : null;
+      ClientMetrics clientMetrics = WebSocketClientImpl.this.httpMetrics != null ? WebSocketClientImpl.this.httpMetrics.createEndpointMetrics(key_.server, maxPoolSize) : null;
+      PoolMetrics queueMetrics = WebSocketClientImpl.this.httpMetrics != null ? vertx.metrics().createPoolMetrics("ws", key_.server.toString(), maxPoolSize) : null;
       HttpConnectParams params = new HttpConnectParams(HttpVersion.HTTP_1_1, sslOptions, key_.proxyOptions, key_.ssl);
       return new WebSocketGroup(key_.server, clientMetrics, queueMetrics, options, maxPoolSize, connector, params, key_.authority, 0L);
     };

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
@@ -598,7 +598,7 @@ public class Http1ServerRequest extends HttpServerRequestInternal implements io.
   }
 
   private void reportRequestComplete() {
-    HttpServerMetrics metrics = conn.metrics;
+    HttpServerMetrics metrics = conn.httpMetrics;
     if (metrics != null) {
       metrics.requestEnd(metric, this, bytesRead);
       conn.flushBytesRead();
@@ -606,9 +606,9 @@ public class Http1ServerRequest extends HttpServerRequestInternal implements io.
   }
 
   private void reportRequestBegin() {
-    HttpServerMetrics metrics = conn.metrics;
+    HttpServerMetrics metrics = conn.httpMetrics;
     if (metrics != null) {
-      metric = metrics.requestBegin(conn.metric(), this);
+      metric = metrics.requestBegin(remoteAddress(), this);
     }
     VertxTracer tracer = context.tracer();
     if (tracer != null) {
@@ -675,8 +675,8 @@ public class Http1ServerRequest extends HttpServerRequestInternal implements io.
   }
 
   private void reportRequestReset(Throwable err) {
-    if (conn.metrics != null) {
-      conn.metrics.requestReset(metric);
+    if (conn.httpMetrics != null) {
+      conn.httpMetrics.requestReset(metric);
     }
     VertxTracer tracer = context.tracer();
     if (tracer != null) {
@@ -732,8 +732,8 @@ public class Http1ServerRequest extends HttpServerRequestInternal implements io.
 
   @Override
   public HttpServerRequest routed(String route) {
-    if (METRICS_ENABLED && !response.ended() && conn.metrics != null) {
-      conn.metrics.requestRouted(metric, route);
+    if (METRICS_ENABLED && !response.ended() && conn.httpMetrics != null) {
+      conn.httpMetrics.requestRouted(metric, route);
     }
     return this;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerResponse.java
@@ -425,8 +425,8 @@ public class Http1ServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   public void completeHandshake() {
-    if (conn.metrics != null) {
-      conn.metrics.responseBegin(requestMetric, this);
+    if (conn.httpMetrics != null) {
+      conn.httpMetrics.responseBegin(requestMetric, this);
     }
     setStatusCode(101);
     synchronized (conn) {
@@ -714,8 +714,8 @@ public class Http1ServerResponse implements HttpServerResponse, HttpResponse {
   }
 
   private void reportResponseBegin() {
-    if (conn.metrics != null) {
-      conn.metrics.responseBegin(requestMetric, this);
+    if (conn.httpMetrics != null) {
+      conn.httpMetrics.responseBegin(requestMetric, this);
     }
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2ServerStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2ServerStream.java
@@ -31,6 +31,7 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingPolicy;
 
@@ -49,7 +50,8 @@ class DefaultHttp2ServerStream extends DefaultHttp2Stream<DefaultHttp2ServerStre
   private Handler<HttpRequestHead> headersHandler;
 
   DefaultHttp2ServerStream(Http2ServerConnection connection,
-                           HttpServerMetrics serverMetrics,
+                           HttpServerMetrics httpMetrics,
+                           TransportMetrics transportMetrics,
                            Object socketMetric,
                            ContextInternal context,
                            HttpRequestHeaders requestHeaders,
@@ -66,11 +68,12 @@ class DefaultHttp2ServerStream extends DefaultHttp2Stream<DefaultHttp2ServerStre
     this.method = method;
     this.uri = uri;
     this.scheme = null;
-    this.observable = serverMetrics != null || tracer != null ? new ServerStreamObserver(context, serverMetrics, tracer, socketMetric, tracingPolicy, connection.remoteAddress()) : null;
+    this.observable = httpMetrics != null || tracer != null ? new ServerStreamObserver(context, httpMetrics, transportMetrics, tracer, socketMetric, tracingPolicy, connection.remoteAddress()) : null;
   }
 
   DefaultHttp2ServerStream(Http2ServerConnection connection,
-                           HttpServerMetrics<?, ?, ?> serverMetrics,
+                           HttpServerMetrics<?, ?> httpMetrics,
+                           TransportMetrics<?> transportMetrics,
                            Object socketMetric,
                            ContextInternal context,
                            TracingPolicy tracingPolicy) {
@@ -79,7 +82,7 @@ class DefaultHttp2ServerStream extends DefaultHttp2Stream<DefaultHttp2ServerStre
     VertxTracer<?, ?> tracer = vertx.tracer();
 
     this.connection = connection;
-    this.observable = serverMetrics != null || tracer != null ? new ServerStreamObserver(context, serverMetrics, tracer, socketMetric, tracingPolicy, connection.remoteAddress()) : null;
+    this.observable = httpMetrics != null || tracer != null ? new ServerStreamObserver(context, httpMetrics, transportMetrics, tracer, socketMetric, tracingPolicy, connection.remoteAddress()) : null;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2ClientChannelInitializer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2ClientChannelInitializer.java
@@ -18,13 +18,14 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.spi.metrics.ClientMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public interface Http2ClientChannelInitializer {
 
-  void http2Connected(ContextInternal context, HostAndPort authority, Object metric, Channel ch, ClientMetrics<?, ?, ?> metrics, PromiseInternal<HttpClientConnection> promise);
+  void http2Connected(ContextInternal context, HostAndPort authority, TransportMetrics<?> transportMetrics, Object metric, Channel ch, ClientMetrics<?, ?, ?> clientMetrics, PromiseInternal<HttpClientConnection> promise);
 
   Http2UpgradeClientConnection.Http2ChannelUpgrade channelUpgrade(Http1ClientConnection conn, ClientMetrics<?, ?, ?> clientMetrics);
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2ClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2ClientStream.java
@@ -14,7 +14,6 @@ import io.vertx.core.http.impl.HttpClientStream;
 import io.vertx.core.http.impl.headers.HttpHeaders;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
 import io.vertx.core.spi.metrics.TransportMetrics;
 import io.vertx.core.tracing.TracingPolicy;
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2ServerStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2ServerStream.java
@@ -25,7 +25,8 @@ import io.vertx.core.tracing.TracingPolicy;
 public interface Http2ServerStream extends Http2Stream {
 
   static Http2ServerStream create(Http2ServerConnection connection,
-                                  HttpServerMetrics serverMetrics,
+                                  HttpServerMetrics httpMetrics,
+                                  TransportMetrics<?> transportMetrics,
                                   Object socketMetric,
                                   ContextInternal context,
                                   HttpRequestHeaders requestHeaders,
@@ -35,7 +36,8 @@ public interface Http2ServerStream extends Http2Stream {
                                   int promisedId) {
     return new DefaultHttp2ServerStream(
       connection,
-      serverMetrics,
+      httpMetrics,
+      transportMetrics,
       socketMetric,
       context,
       requestHeaders,
@@ -47,11 +49,12 @@ public interface Http2ServerStream extends Http2Stream {
 
   static Http2ServerStream create(
     Http2ServerConnection connection,
-    HttpServerMetrics<?, ?, ?> serverMetrics,
+    HttpServerMetrics<?, ?> httpMetrics,
+    TransportMetrics<?> transportMetrics,
     Object socketMetric,
     ContextInternal context,
     TracingPolicy tracingPolicy) {
-    return new DefaultHttp2ServerStream(connection, serverMetrics, socketMetric, context, tracingPolicy);
+    return new DefaultHttp2ServerStream(connection, httpMetrics, transportMetrics, socketMetric, context, tracingPolicy);
   }
 
   HttpHeaders headers();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexClientConnection.java
@@ -31,7 +31,7 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 
 public class Http2MultiplexClientConnection extends Http2MultiplexConnection<Http2ClientStream> implements HttpClientConnection, Http2ClientConnection {
 
@@ -53,7 +53,7 @@ public class Http2MultiplexClientConnection extends Http2MultiplexConnection<Htt
                                         ChannelHandlerContext chctx,
                                         ContextInternal context,
                                         ClientMetrics<?, ?, ?> clientMetrics,
-                                        HttpClientMetrics<?, ?, ?> transportMetrics,
+                                        TransportMetrics<?> transportMetrics,
                                         HostAndPort authority,
                                         int maxConcurrency,
                                         long keepAliveTimeoutMillis,

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexServerChannelInitializer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexServerChannelInitializer.java
@@ -25,6 +25,7 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.net.SslChannelProvider;
 import io.vertx.core.internal.tls.SslContextManager;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
+import io.vertx.core.spi.metrics.TransportMetrics;
 
 import java.util.function.Supplier;
 
@@ -41,7 +42,8 @@ public class Http2MultiplexServerChannelInitializer implements Http2ServerChanne
   public Http2MultiplexServerChannelInitializer(ContextInternal context,
                                                 CompressionManager compressionManager,
                                                 boolean decompressionSupported,
-                                                HttpServerMetrics<?, ?, ?> serverMetrics,
+                                                HttpServerMetrics<?, ?> httpMetrics,
+                                                TransportMetrics<?> transportMetrics,
                                                 Object connectionMetric,
                                                 Supplier<ContextInternal> streamContextSupplier,
                                                 Handler<HttpServerConnection> connectionHandler,
@@ -53,7 +55,8 @@ public class Http2MultiplexServerChannelInitializer implements Http2ServerChanne
       Http2MultiplexServerConnection connection = new Http2MultiplexServerConnection(
         handler,
         compressionManager,
-        serverMetrics,
+        httpMetrics,
+        transportMetrics,
         chctx,
         context,
         streamContextSupplier,

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ClientConnection.java
@@ -36,7 +36,6 @@ import io.vertx.core.spi.observability.HttpResponse;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingPolicy;
 
-import java.time.Duration;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -46,7 +45,7 @@ import java.util.function.Function;
 public class Http3ClientConnection extends Http3Connection implements HttpClientConnection {
 
   private final HostAndPort authority;
-  private final ClientMetrics<Object, HttpRequest, HttpResponse> metrics;
+  private final ClientMetrics<Object, HttpRequest, HttpResponse> clientMetrics;
   private Handler<Void> evictionHandler;
   private final long keepAliveTimeoutMillis;
   private final long creationTimetstamp;
@@ -54,13 +53,13 @@ public class Http3ClientConnection extends Http3Connection implements HttpClient
 
   public Http3ClientConnection(QuicConnectionInternal connection,
                                HostAndPort authority,
-                               ClientMetrics<Object, HttpRequest, HttpResponse> metrics,
+                               ClientMetrics<Object, HttpRequest, HttpResponse> clientMetrics,
                                long keepAliveTimeoutMillis,
                                Http3Settings localSettings) {
     super(connection, localSettings);
 
     this.authority = authority;
-    this.metrics = metrics;
+    this.clientMetrics = clientMetrics;
     this.keepAliveTimeoutMillis = keepAliveTimeoutMillis;
     this.creationTimetstamp = System.currentTimeMillis();
   }
@@ -154,14 +153,14 @@ public class Http3ClientConnection extends Http3Connection implements HttpClient
       QuicStreamInternal streamInternal = (QuicStreamInternal) stream;
       VertxTracer<?, ?> tracer = context.owner().tracer();
       ClientStreamObserver observer;
-      if (metrics != null || tracer != null) {
+      if (clientMetrics != null || tracer != null) {
         Object metric;
-        if (metrics != null) {
-          metric = metrics.init();
+        if (clientMetrics != null) {
+          metric = clientMetrics.init();
         } else {
           metric = null;
         }
-        observer = new ClientStreamObserver(context, TracingPolicy.PROPAGATE, metrics, metric, connection.metrics(),
+        observer = new ClientStreamObserver(context, TracingPolicy.PROPAGATE, clientMetrics, metric, connection.metrics(),
           connection.metric(), tracer, connection.remoteAddress());
       } else {
         observer = null;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ServerConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ServerConnection.java
@@ -16,7 +16,6 @@ import io.netty.handler.codec.http3.*;
 import io.netty.handler.codec.quic.QuicStreamChannel;
 import io.vertx.core.Handler;
 import io.vertx.core.http.Http3Settings;
-import io.vertx.core.http.HttpSettings;
 import io.vertx.core.http.impl.HttpServerConnection;
 import io.vertx.core.http.impl.HttpServerStream;
 import io.vertx.core.http.impl.observability.ServerStreamObserver;
@@ -35,25 +34,25 @@ import java.util.function.Supplier;
 public class Http3ServerConnection extends Http3Connection implements HttpServerConnection {
 
   private final Supplier<ContextInternal> streamContextProvider;
-  private final HttpServerMetrics<?, ?, ?> metrics;
+  private final HttpServerMetrics<?, ?> httpMetrics;
   private Handler<HttpServerStream> streamHandler;
   private QuicStreamChannel outboundControlStream;
 
   public Http3ServerConnection(QuicConnectionInternal connection,
                                Http3Settings localSettings,
-                               HttpServerMetrics<?, ?, ?> metrics) {
+                               HttpServerMetrics<?, ?> httpMetrics) {
     super(connection, localSettings);
 
     this.streamContextProvider = connection.context()::duplicate;
-    this.metrics = metrics;
+    this.httpMetrics = httpMetrics;
   }
 
   void handleStream(QuicStreamInternal quicStream) {
     ContextInternal streamContext = streamContextProvider.get();
     VertxTracer<?, ?> tracer = context.owner().tracer();
     ServerStreamObserver observer;
-    if (metrics != null || tracer != null) {
-      observer = new ServerStreamObserver(streamContext, metrics, tracer, connection.metric(), TracingPolicy.PROPAGATE, connection.remoteAddress());
+    if (httpMetrics != null || tracer != null) {
+      observer = new ServerStreamObserver(streamContext, httpMetrics, null, tracer, connection.metric(), TracingPolicy.PROPAGATE, connection.remoteAddress());
     } else {
       observer = null;
     }

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -362,8 +362,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     TcpClientConfig config = new TcpClientConfig(options);
     NetClientBuilder builder = new NetClientBuilder(this, config)
       .sslOptions(options.getSslOptions())
-      .registerWriteHandler(options.isRegisterWriteHandler())
-      .metrics(metrics != null ? metrics.createTcpClientMetrics(config) : null);
+      .registerWriteHandler(options.isRegisterWriteHandler());
     NetClientInternal netClient = builder.build();
     fut.add(netClient);
     return new CleanableNetClient(netClient, cleaner);
@@ -464,13 +463,12 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     o.setUseAlpn(false);
     o.setProtocolVersion(HttpVersion.HTTP_1_1);
     HttpClientConfig config = new HttpClientConfig(o);
-    HttpClientMetrics<?, ?, ?> metrics = metrics() != null ? metrics().createHttpClientMetrics(config) : null;
+    HttpClientMetrics<?, ?> httpMetrics = metrics() != null ? metrics().createHttpClientMetrics(config) : null;
     NetClientInternal tcpClient = new NetClientBuilder(this, config.getTcpConfig())
       .sslOptions(options.getSslOptions())
-      .metrics(metrics)
       .build();
-    TcpHttpClientTransport channelConnector = TcpHttpClientTransport.create(tcpClient, config, metrics);
-    return new WebSocketClientImpl(this, o, options, channelConnector, metrics);
+    TcpHttpClientTransport channelConnector = TcpHttpClientTransport.create(tcpClient, config, httpMetrics);
+    return new WebSocketClientImpl(this, o, options, channelConnector, httpMetrics);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpClientInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpClientInternal.java
@@ -32,7 +32,9 @@ public interface HttpClientInternal extends HttpClientAgent, MetricsProvider, Cl
 
   Function<HttpClientResponse, Future<RequestOptions>> redirectHandler();
 
-  HttpClientTransport channelConnector();
+  HttpClientTransport tcpTransport();
+
+  HttpClientTransport quicTransport();
 
   // Should not be here but currently necessary for WebClient
   @Deprecated(forRemoval = true)
@@ -49,5 +51,9 @@ public interface HttpClientInternal extends HttpClientAgent, MetricsProvider, Cl
   EndpointResolverInternal resolver();
 
   Future<Void> closeFuture();
+
+  default HttpClientInternal unwrap() {
+    return this;
+  }
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpClientTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpClientTransport.java
@@ -32,10 +32,12 @@ public interface HttpClientTransport {
                                        SocketAddress server,
                                        HostAndPort authority,
                                        HttpConnectParams params,
-                                       ClientMetrics<?, ?, ?> metrics);
+                                       ClientMetrics<?, ?, ?> clientMetrics);
 
   Future<Void> shutdown(Duration timeout);
 
-  Future<Void> close();
+  default Future<Void> close() {
+    return shutdown(Duration.ZERO);
+  }
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerInternal.java
@@ -27,4 +27,8 @@ public interface HttpServerInternal extends HttpServer, MetricsProvider {
   Future<HttpServer> listen(ContextInternal context);
   Future<HttpServer> listen(ContextInternal context, SocketAddress address);
 
+  default HttpServerInternal unwrap() {
+    return this;
+  }
+
 }

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestInternal.java
@@ -27,7 +27,7 @@ public abstract class HttpServerRequestInternal implements HttpServerRequest {
   public abstract ContextInternal context();
 
   /**
-   * @return the metric object returned by the {@link io.vertx.core.spi.metrics.HttpServerMetrics#requestBegin(Object, HttpRequest)} call
+   * @return the metric object returned by the {@link io.vertx.core.spi.metrics.HttpServerMetrics#requestBegin(io.vertx.core.net.SocketAddress, HttpRequest)} call
    */
   public abstract Object metric();
 

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicClient.java
@@ -49,14 +49,7 @@ public interface QuicClient extends QuicEndpoint {
    */
   static QuicClient create(Vertx vertx, QuicClientConfig config, ClientSSLOptions defaultSslOptions) {
     VertxInternal vertxInternal = (VertxInternal) vertx;
-    VertxMetrics metrics = vertxInternal.metrics();
-    BiFunction<QuicEndpointConfig, SocketAddress, TransportMetrics<?>> metricsProvider;
-    if (metrics != null) {
-      metricsProvider = metrics::createQuicEndpointMetrics;
-    } else {
-      metricsProvider = null;
-    }
-    return QuicClientImpl.create(vertxInternal, metricsProvider, config, defaultSslOptions);
+    return QuicClientImpl.create(vertxInternal, config, defaultSslOptions);
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicServer.java
@@ -17,10 +17,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.impl.SocketAddressImpl;
 import io.vertx.core.net.impl.quic.QuicServerImpl;
-import io.vertx.core.spi.metrics.TransportMetrics;
-import io.vertx.core.spi.metrics.VertxMetrics;
-
-import java.util.function.BiFunction;
 
 /**
  * A Quic server.
@@ -40,15 +36,7 @@ public interface QuicServer extends QuicEndpoint {
    * @return the server
    */
   static QuicServer create(Vertx vertx, QuicServerConfig config, ServerSSLOptions sslOptions) {
-    VertxInternal vertxInternal = (VertxInternal) vertx;
-    VertxMetrics metrics = vertxInternal.metrics();
-    BiFunction<QuicEndpointConfig, SocketAddress, TransportMetrics<?>> metricsProvider;
-    if (metrics != null) {
-      metricsProvider = metrics::createQuicEndpointMetrics;
-    } else {
-      metricsProvider = null;
-    }
-    return QuicServerImpl.create((VertxInternal) vertx, metricsProvider, config, sslOptions);
+    return QuicServerImpl.create((VertxInternal) vertx, config, sslOptions);
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/CleanableQuicClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/CleanableQuicClient.java
@@ -30,10 +30,9 @@ public class CleanableQuicClient extends QuicClientImpl implements Closeable {
   private ContextInternal listenContext;
 
   public CleanableQuicClient(VertxInternal vertx,
-                             BiFunction<QuicEndpointConfig, SocketAddress, TransportMetrics<?>> metricsProvider,
                              QuicClientConfig config,
                              ClientSSLOptions sslOptions) {
-    super(vertx, metricsProvider, config, sslOptions);
+    super(vertx, config, sslOptions);
     this.vertx = vertx;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/CleanableQuicServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/CleanableQuicServer.java
@@ -33,10 +33,9 @@ public class CleanableQuicServer extends QuicServerImpl implements Closeable {
   private ContextInternal listenContext;
 
   public CleanableQuicServer(VertxInternal vertx,
-                             BiFunction<QuicEndpointConfig, SocketAddress, TransportMetrics<?>> metricsProvider,
                              QuicServerConfig config,
                              ServerSSLOptions sslOptions) {
-    super(vertx, metricsProvider, config, sslOptions);
+    super(vertx, config, sslOptions);
     this.vertx = vertx;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicClientImpl.java
@@ -50,10 +50,8 @@ public class QuicClientImpl extends QuicEndpointImpl implements QuicClient {
   private static final AttributeKey<HostAndPort> SSL_SERVER_NAME_KEY = AttributeKey.newInstance(HostAndPort.class.getName());
   private static final AttributeKey<List<String>> APPLICATION_PROTOCOLS_KEY = AttributeKey.newInstance("io.vertx.net.quic.client.application_protocols");
 
-  public static QuicClient create(VertxInternal vertx,
-                                  BiFunction<QuicEndpointConfig, SocketAddress, TransportMetrics<?>> metricsProvider,
-                                  QuicClientConfig config, ClientSSLOptions sslOptions) {
-    return new CleanableQuicClient(vertx, metricsProvider, new QuicClientConfig(config), sslOptions);
+  public static QuicClient create(VertxInternal vertx, QuicClientConfig config, ClientSSLOptions sslOptions) {
+    return new CleanableQuicClient(vertx, new QuicClientConfig(config), sslOptions);
   }
 
   private final QuicClientConfig config;
@@ -62,9 +60,8 @@ public class QuicClientImpl extends QuicEndpointImpl implements QuicClient {
   private Future<Integer> clientFuture;
   private volatile Channel channel;
 
-  public QuicClientImpl(VertxInternal vertx, BiFunction<QuicEndpointConfig, SocketAddress, TransportMetrics<?>> metricsProvider,
-                        QuicClientConfig config, ClientSSLOptions sslOptions) {
-    super(vertx, metricsProvider, config);
+  public QuicClientImpl(VertxInternal vertx, QuicClientConfig config, ClientSSLOptions sslOptions) {
+    super(vertx, config);
     this.config = config;
     this.sslOptions = sslOptions;
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicEndpointImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicEndpointImpl.java
@@ -62,16 +62,13 @@ public abstract class QuicEndpointImpl implements QuicEndpointInternal, MetricsP
   private final QuicEndpointConfig config;
   protected final SslContextManager manager;
   protected final VertxInternal vertx;
-  protected final BiFunction<QuicEndpointConfig, SocketAddress, TransportMetrics<?>> metricsProvider;
   private TransportMetrics<?> metrics;
   private Channel channel;
   protected ConnectionGroup connectionGroup;
   private FlushStrategy flushStrategy;
   private ContextInternal context;
 
-  public QuicEndpointImpl(VertxInternal vertx,
-                          BiFunction<QuicEndpointConfig, SocketAddress, TransportMetrics<?>> metricsProvider,
-                          QuicEndpointConfig config) {
+  public QuicEndpointImpl(VertxInternal vertx, QuicEndpointConfig config) {
 
     String keyLogFilePath = config.getKeyLogFile();
     File keylogFile;
@@ -104,7 +101,6 @@ public abstract class QuicEndpointImpl implements QuicEndpointInternal, MetricsP
 
     this.config = config;
     this.vertx = Objects.requireNonNull(vertx);
-    this.metricsProvider = metricsProvider;
     this.manager = new SslContextManager(new SSLEngineOptions() {
       @Override
       public SSLEngineOptions copy() {
@@ -216,8 +212,8 @@ public abstract class QuicEndpointImpl implements QuicEndpointInternal, MetricsP
       context = current;
     }
     TransportMetrics<?> metrics;
-    if (metricsProvider != null) {
-      metrics = metricsProvider.apply(config, address);
+    if (vertx.metrics() != null) {
+      metrics = vertx.metrics().createQuicEndpointMetrics(config, address);
     } else {
       metrics = null;
     }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicServerImpl.java
@@ -58,10 +58,9 @@ public class QuicServerImpl extends QuicEndpointImpl implements QuicServerIntern
   public static final String QUIC_SERVER_MAP_KEY = "__vertx.shared.quicServers";
 
   public static QuicServer create(VertxInternal vertx,
-                                  BiFunction<QuicEndpointConfig, SocketAddress, TransportMetrics<?>> metricsProvider,
                                   QuicServerConfig config,
                                   ServerSSLOptions sslOptions) {
-    return new CleanableQuicServer(vertx, metricsProvider, new QuicServerConfig(config), sslOptions);
+    return new CleanableQuicServer(vertx, new QuicServerConfig(config), sslOptions);
   }
 
   private final QuicServerConfig config;
@@ -69,9 +68,8 @@ public class QuicServerImpl extends QuicEndpointImpl implements QuicServerIntern
   private Handler<QuicConnection> handler;
   private QuicTokenHandler tokenHandler;
 
-  public QuicServerImpl(VertxInternal vertx, BiFunction<QuicEndpointConfig, SocketAddress, TransportMetrics<?>> metricsProvider,
-                        QuicServerConfig config, ServerSSLOptions sslOptions) {
-    super(vertx, metricsProvider, config);
+  public QuicServerImpl(VertxInternal vertx, QuicServerConfig config, ServerSSLOptions sslOptions) {
+    super(vertx, config);
     this.config = config;
     this.sslOptions = sslOptions;
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetServer.java
@@ -1,12 +1,8 @@
 package io.vertx.core.net.impl.tcp;
 
-import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.*;
-import io.vertx.core.http.impl.CleanableHttpServer;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
-import io.vertx.core.internal.net.NetServerInternal;
-import io.vertx.core.internal.tls.SslContextProvider;
 import io.vertx.core.net.*;
 import io.vertx.core.spi.metrics.TransportMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
@@ -24,9 +20,8 @@ public class CleanableNetServer extends NetServerImpl implements Closeable {
                             TcpServerConfig config,
                             ServerSSLOptions sslOptions,
                             boolean fileRegionEnabled,
-                            boolean registerWriteHandler,
-                            BiFunction<VertxMetrics, SocketAddress, TransportMetrics<?>> metricsProvider) {
-    super(vertx, config, sslOptions, fileRegionEnabled, registerWriteHandler, metricsProvider);
+                            boolean registerWriteHandler) {
+    super(vertx, config, sslOptions, fileRegionEnabled, registerWriteHandler);
     this.vertx = vertx;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientBuilder.java
@@ -25,7 +25,6 @@ public class NetClientBuilder {
   private VertxInternal vertx;
   private TcpClientConfig config;
   private ClientSSLOptions sslOptions;
-  private TransportMetrics<?> metrics;
   private boolean registerWriteHandler;
 
   public NetClientBuilder(VertxInternal vertx, TcpClientConfig config) {
@@ -44,12 +43,7 @@ public class NetClientBuilder {
     return this;
   }
 
-  public NetClientBuilder metrics(TransportMetrics<?> metrics) {
-    this.metrics = metrics;
-    return this;
-  }
-
   public NetClientInternal build() {
-    return new NetClientImpl(vertx, metrics, config, sslOptions, registerWriteHandler);
+    return new NetClientImpl(vertx, config, sslOptions, registerWriteHandler);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
@@ -67,7 +67,6 @@ class NetClientImpl implements NetClientInternal {
   private final Predicate<SocketAddress> proxyFilter;
 
   public NetClientImpl(VertxInternal vertx,
-                       TransportMetrics metrics,
                        TcpClientConfig config,
                        ClientSSLOptions sslOptions,
                        boolean registerWriteHandler) {
@@ -82,7 +81,7 @@ class NetClientImpl implements NetClientInternal {
     this.config = config;
     this.registerWriteHandler = registerWriteHandler;
     this.sslContextManager = new SslContextManager(SslContextManager.resolveEngineOptions(config.getSslEngineOptions(), sslOptions != null && sslOptions.isUseAlpn()));
-    this.metrics = metrics;
+    this.metrics = vertx.metrics() != null ? vertx.metrics().createTcpClientMetrics(config) : null;
     this.logging = config.getNetworkLogging() != null ? config.getNetworkLogging().getDataFormat() : null;
     this.idleTimeout = config.getIdleTimeout() != null ? config.getIdleTimeout() : Duration.ofMillis(0L);
     this.readIdleTimeout = config.getReadIdleTimeout() != null ? config.getReadIdleTimeout() : Duration.ofMillis(0L);

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerBuilder.java
@@ -26,7 +26,6 @@ public class NetServerBuilder {
   private VertxInternal vertx;
   private TcpServerConfig config;
   private ServerSSLOptions sslOptions;
-  private BiFunction<VertxMetrics, SocketAddress, TransportMetrics<?>> metricsProvider;
   private boolean fileRegionEnabled;
   private boolean registerWriteHandler;
   private boolean cleanable;
@@ -49,7 +48,6 @@ public class NetServerBuilder {
     this.sslOptions = options.getSslOptions();
     this.fileRegionEnabled = options.isFileRegionEnabled();
     this.registerWriteHandler = options.isRegisterWriteHandler();
-    this.metricsProvider = (metrics,  localAddress) -> metrics.createTcpServerMetrics(cfg, localAddress);
     this.cleanable = true;
   }
 
@@ -63,11 +61,6 @@ public class NetServerBuilder {
     return this;
   }
 
-  public NetServerBuilder metricsProvider(BiFunction<VertxMetrics, SocketAddress, TransportMetrics<?>> metricsProvider) {
-    this.metricsProvider = metricsProvider;
-    return this;
-  }
-
   public NetServerInternal build() {
     NetServerInternal server;
     if (cleanable) {
@@ -75,16 +68,15 @@ public class NetServerBuilder {
         config,
         sslOptions,
         fileRegionEnabled,
-        registerWriteHandler,
-        metricsProvider);
+        registerWriteHandler);
     } else {
       server = new NetServerImpl(
         vertx,
         config,
         sslOptions,
         fileRegionEnabled,
-        registerWriteHandler,
-        metricsProvider);
+        registerWriteHandler
+      );
     }
     return server;
   }

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
@@ -11,7 +11,6 @@
 
 package io.vertx.core.spi.metrics;
 
-import io.vertx.core.http.WebSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.observability.HttpRequest;
 import io.vertx.core.spi.observability.HttpResponse;
@@ -35,7 +34,7 @@ import io.vertx.core.spi.observability.HttpResponse;
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
-public interface HttpClientMetrics<R, W, C> extends TransportMetrics<C> {
+public interface HttpClientMetrics<R, W> extends WebSocketMetrics<W> {
 
   /**
    * Provides metrics for a particular endpoint
@@ -62,23 +61,5 @@ public interface HttpClientMetrics<R, W, C> extends TransportMetrics<C> {
    *
    */
   default void endpointDisconnected(ClientMetrics<R, ?, ?> endpointMetric) {
-  }
-
-  /**
-   * Called when a web socket connects.
-   *
-   * @param webSocket the server web socket
-   * @return the web socket metric
-   */
-  default W connected(WebSocket webSocket) {
-    return null;
-  }
-
-  /**
-   * Called when the web socket has disconnected.
-   *
-   * @param webSocketMetric the web socket metric
-   */
-  default void disconnected(W webSocketMetric) {
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpServerMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpServerMetrics.java
@@ -12,7 +12,7 @@
 package io.vertx.core.spi.metrics;
 
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.observability.HttpRequest;
 import io.vertx.core.spi.observability.HttpResponse;
 
@@ -35,17 +35,17 @@ import io.vertx.core.spi.observability.HttpResponse;
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */
-public interface HttpServerMetrics<R, W, C> extends TransportMetrics<C> {
+public interface HttpServerMetrics<R, W> extends WebSocketMetrics<W> {
 
   /**
    * Called when an http server request begins. Vert.x will invoke {@link #responseEnd} when the response has ended
    * or {@link #requestReset} if the request/response has failed before.
    *
-   * @param connectionMetric the connection metric
-   * @param request the http server request
+   * @param remoteAddress the client remote address
+   * @param request       the http server request
    * @return the request metric
    */
-  default R requestBegin(C connectionMetric, HttpRequest request) {
+  default R requestBegin(SocketAddress remoteAddress, HttpRequest request) {
     return null;
   }
 
@@ -68,6 +68,13 @@ public interface HttpServerMetrics<R, W, C> extends TransportMetrics<C> {
   }
 
   /**
+   * Called when an http server request is upgraded, e.g. a WebSocket
+   * @param requestMetrics the request metric
+   */
+  default void requestUpgraded(R requestMetrics) {
+  }
+
+  /**
    * Called when an http server response begins.
    *
    * @param requestMetric the request metric
@@ -79,12 +86,12 @@ public interface HttpServerMetrics<R, W, C> extends TransportMetrics<C> {
   /**
    * Called when an http server response is pushed.
    *
-   * @param connectionMetric the connection metric
-   * @param method the pushed response method
-   * @param uri the pushed response uri
-   * @param response the http server response  @return the request metric
+   * @param remoteAddress the client remote address
+   * @param method        the pushed response method
+   * @param uri           the pushed response uri
+   * @param response      the http server response  @return the request metric
    */
-  default R responsePushed(C connectionMetric, HttpMethod method, String uri, HttpResponse response) {
+  default R responsePushed(SocketAddress remoteAddress, HttpMethod method, String uri, HttpResponse response) {
     return null;
   }
 
@@ -100,12 +107,10 @@ public interface HttpServerMetrics<R, W, C> extends TransportMetrics<C> {
   /**
    * Called when a server web socket connects.
    *
-   * @param connectionMetric the socket metric
-   * @param requestMetric the request metric
-   * @param webSocket the server web socket
+   * @param request the observable request
    * @return the server web socket metric
    */
-  default W connected(C connectionMetric, R requestMetric, ServerWebSocket webSocket) {
+  default W connected(HttpRequest request) {
     return null;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
@@ -56,7 +56,7 @@ public interface VertxMetrics extends Metrics, Measured {
    * @param localAddress localAddress the local address the net socket is listening on
    * @return the http server metrics SPI or {@code null} when metrics are disabled
    */
-  default HttpServerMetrics<?, ?, ?> createHttpServerMetrics(HttpServerConfig config, SocketAddress localAddress) {
+  default HttpServerMetrics<?, ?> createHttpServerMetrics(HttpServerConfig config, SocketAddress localAddress) {
     return null;
   }
 
@@ -82,7 +82,7 @@ public interface VertxMetrics extends Metrics, Measured {
    * @param config the config used to create the {@link HttpClient}
    * @return the http client metrics SPI or {@code null} when metrics are disabled
    */
-  default HttpClientMetrics<?, ?, ?> createHttpClientMetrics(HttpClientConfig config) {
+  default HttpClientMetrics<?, ?> createHttpClientMetrics(HttpClientConfig config) {
     return null;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/WebSocketMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/WebSocketMetrics.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.spi.metrics;
+
+import io.vertx.core.spi.observability.HttpRequest;
+
+/**
+ * WebSocket metrics.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public interface WebSocketMetrics<W> extends Metrics {
+
+  /**
+   * Called when a server web socket connects.
+   *
+   * @param request the observable request
+   * @return the server web socket metric
+   */
+  default W connected(HttpRequest request) {
+    return null;
+  }
+
+  /**
+   * Called when the server web socket has disconnected.
+   *
+   * @param webSocketMetric the server web socket metric
+   */
+  default void disconnected(W webSocketMetric) {
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
+++ b/vertx-core/src/test/java/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
@@ -244,6 +244,7 @@ public class HttpServerHandlerBenchmark extends BenchmarkBase {
         context,
         "localhost",
         TracingPolicy.PROPAGATE,
+        null,
         null);
       conn.handler(app);
       return conn;

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeHttpClientMetrics.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeHttpClientMetrics.java
@@ -29,18 +29,23 @@ import java.util.stream.Collectors;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class FakeHttpClientMetrics extends FakeTCPMetrics implements HttpClientMetrics<HttpClientMetric, WebSocketMetric, ConnectionMetric> {
+public class FakeHttpClientMetrics extends FakeMetricsBase implements HttpClientMetrics<HttpClientMetric, WebSocketMetric> {
 
-  private final ConcurrentMap<WebSocketBase, WebSocketMetric> webSockets = new ConcurrentHashMap<>();
+  private final String name;
+  private final ConcurrentMap<String, WebSocketMetric> webSockets = new ConcurrentHashMap<>();
   private final ConcurrentMap<SocketAddress, EndpointMetric> endpoints = new ConcurrentHashMap<>();
   private volatile boolean implementInit = false;
 
   public FakeHttpClientMetrics(String name) {
-    super(name);
+    this.name = name;
   }
 
-  public WebSocketMetric getMetric(WebSocket ws) {
-    return webSockets.get(ws);
+  public String name() {
+    return name;
+  }
+
+  public WebSocketMetric getMetric(String uri) {
+    return webSockets.get(uri);
   }
 
   public HttpClientMetric getMetric(HttpClientRequest request) {
@@ -106,15 +111,15 @@ public class FakeHttpClientMetrics extends FakeTCPMetrics implements HttpClientM
   }
 
   @Override
-  public WebSocketMetric connected(WebSocket webSocket) {
-    WebSocketMetric metric = new WebSocketMetric(webSocket);
-    webSockets.put(webSocket, metric);
+  public WebSocketMetric connected(HttpRequest request) {
+    WebSocketMetric metric = new WebSocketMetric(request);
+    webSockets.put(request.uri(), metric);
     return metric;
   }
 
   @Override
   public void disconnected(WebSocketMetric webSocketMetric) {
-    webSockets.remove(webSocketMetric.ws);
+    webSockets.remove(webSocketMetric.request.uri());
   }
 
 }

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeMetricsBase.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeMetricsBase.java
@@ -11,7 +11,19 @@
 
 package io.vertx.test.fakemetrics;
 
+import io.vertx.core.Vertx;
+import io.vertx.core.datagram.DatagramSocket;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.http.HttpClientAgent;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.impl.tcp.TcpHttpClientTransport;
+import io.vertx.core.http.impl.tcp.TcpHttpServer;
+import io.vertx.core.internal.http.HttpClientInternal;
+import io.vertx.core.internal.http.HttpServerInternal;
 import io.vertx.core.metrics.Measured;
+import io.vertx.core.net.QuicEndpoint;
+import io.vertx.core.net.QuicServer;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 import junit.framework.AssertionFailedError;
@@ -25,8 +37,40 @@ public class FakeMetricsBase implements Metrics {
 
   private boolean closed;
 
-  public static <M extends FakeMetricsBase> M getMetrics(Measured measured) {
-    return (M) ((MetricsProvider) measured).getMetrics();
+  public static FakeQuicEndpointMetrics getMetrics(QuicEndpoint measured) {
+    return (FakeQuicEndpointMetrics) ((MetricsProvider) measured).getMetrics();
+  }
+
+  public static FakeHttpServerMetrics getMetrics(HttpServer measured) {
+    return (FakeHttpServerMetrics) ((MetricsProvider) measured).getMetrics();
+  }
+
+  public static FakeTCPMetrics tpcMetricsOf(HttpServer server) {
+    return (FakeTCPMetrics) ((TcpHttpServer)((HttpServerInternal)server).unwrap()).tcpServer().getMetrics();
+  }
+
+  public static FakeTCPMetrics tpcMetricsOf(HttpClientAgent client) {
+    return (FakeTCPMetrics)((TcpHttpClientTransport)((HttpClientInternal)client).tcpTransport()).client().getMetrics();
+  }
+
+  public static FakeEventBusMetrics getMetrics(EventBus measured) {
+    return (FakeEventBusMetrics) ((MetricsProvider) measured).getMetrics();
+  }
+
+  public static FakeHttpClientMetrics getMetrics(HttpClientAgent measured) {
+    return (FakeHttpClientMetrics) ((MetricsProvider) measured).getMetrics();
+  }
+
+  public static FakeHttpClientMetrics getMetrics(WebSocketClient measured) {
+    return (FakeHttpClientMetrics) ((MetricsProvider) measured).getMetrics();
+  }
+
+  public static FakeDatagramSocketMetrics getMetrics(DatagramSocket measured) {
+    return (FakeDatagramSocketMetrics) ((MetricsProvider) measured).getMetrics();
+  }
+
+  public static FakeVertxMetrics getMetrics(Vertx measured) {
+    return (FakeVertxMetrics) ((MetricsProvider) measured).getMetrics();
   }
 
   public FakeMetricsBase() {
@@ -49,7 +93,8 @@ public class FakeMetricsBase implements Metrics {
   @Override
   public synchronized void close() {
     if (closed) {
-      registerFailure(new IllegalStateException(getClass().getSimpleName() + " already closed"));
+      // FAILING BECAUSE WE CLOSE MULTIPLE TIMES
+//      registerFailure(new IllegalStateException(getClass().getSimpleName() + " already closed"));
     }
     closed = true;
   }

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
@@ -51,16 +51,16 @@ public class FakeVertxMetrics extends FakeMetricsBase implements VertxMetrics {
     return new FakeEventBusMetrics();
   }
 
-  public HttpServerMetrics<?, ?, ?> createHttpServerMetrics(HttpServerConfig config, SocketAddress localAddress) {
+  public HttpServerMetrics<?, ?> createHttpServerMetrics(HttpServerConfig config, SocketAddress localAddress) {
     return new FakeHttpServerMetrics();
   }
 
-  public HttpClientMetrics<?, ?, ?> createHttpClientMetrics(HttpClientOptions options) {
+  public HttpClientMetrics<?, ?> createHttpClientMetrics(HttpClientOptions options) {
     return new FakeHttpClientMetrics(options.getMetricsName());
   }
 
   @Override
-  public HttpClientMetrics<?, ?, ?> createHttpClientMetrics(HttpClientConfig options) {
+  public HttpClientMetrics<?, ?> createHttpClientMetrics(HttpClientConfig options) {
     return new FakeHttpClientMetrics(options.getMetricsName());
   }
 

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/HttpServerMetric.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/HttpServerMetric.java
@@ -11,6 +11,7 @@
 
 package io.vertx.test.fakemetrics;
 
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.observability.HttpRequest;
 import io.vertx.core.spi.observability.HttpResponse;
 
@@ -24,7 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class HttpServerMetric {
 
   public final String uri;
-  public final ConnectionMetric socket;
+  public final SocketAddress address;
   public final AtomicBoolean failed = new AtomicBoolean();
   public final AtomicReference<String> route = new AtomicReference<>();
   public final HttpRequest request;
@@ -34,15 +35,15 @@ public class HttpServerMetric {
   public final AtomicBoolean responseEnded = new AtomicBoolean();
   public final AtomicLong bytesWritten = new AtomicLong();
 
-  public HttpServerMetric(String uri, ConnectionMetric socket) {
+  public HttpServerMetric(String uri, SocketAddress address) {
     this.uri = uri;
     this.request = null;
-    this.socket = socket;
+    this.address = address;
   }
 
-  public HttpServerMetric(HttpRequest request, ConnectionMetric socket) {
+  public HttpServerMetric(HttpRequest request, SocketAddress address) {
     this.uri = request.uri();
     this.request = request;
-    this.socket = socket;
+    this.address = address;
   }
 }

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/WebSocketMetric.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/WebSocketMetric.java
@@ -12,15 +12,16 @@
 package io.vertx.test.fakemetrics;
 
 import io.vertx.core.http.WebSocketBase;
+import io.vertx.core.spi.observability.HttpRequest;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class WebSocketMetric {
 
-  public final WebSocketBase ws;
+  public final HttpRequest request;
 
-  public WebSocketMetric(WebSocketBase ws) {
-    this.ws = ws;
+  public WebSocketMetric(HttpRequest request) {
+    this.request = request;
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/benchmark/Http1xServerConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/benchmark/Http1xServerConnectionTest.java
@@ -75,6 +75,7 @@ public class Http1xServerConnectionTest extends VertxTestBase {
         context,
         "localhost",
         TracingPolicy.PROPAGATE,
+        null,
         null);
       conn.handler(app);
       return conn;

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
@@ -166,8 +166,8 @@ public class VertxTest extends AsyncTestBase {
       client.request(HttpMethod.GET, HttpTestBase.DEFAULT_HTTP_PORT, "localhost", "/").onSuccess(req -> {
         req.send();
       });
-      TcpHttpClientTransport channelConnector = (TcpHttpClientTransport)(((CleanableHttpClient) client).delegate).channelConnector();
-      NetClientInternal netClient = channelConnector.netClient();
+      TcpHttpClientTransport channelConnector = (TcpHttpClientTransport)(((CleanableHttpClient) client).delegate).tcpTransport();
+      NetClientInternal netClient = channelConnector.client();
       netClient.closeFuture().onComplete(ar -> {
         closed2.set(true);
       });


### PR DESCRIPTION
Motivation:

Until now we have assumed that HTTP would be transported by a single TCP endpoint, which was reflected by the fact that HTTP metrics do extend (from the OO POV) transport metrics.

It turns out that a client or a server can use also a QUIC transport or both.

Changes:

Decouple HttpServerMetrics and HttpClientMetrics from TransportMetrics.

Capture WebSocket metrics in a common super WebSocketMetrics interface.
