### PR TITLE
Specify the protocol when building a transport metrics.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -235,6 +235,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       TcpClientConfig clientConfig = netClientConfig(co)
         .setProxyOptions(null);
       NetClientInternal tcpClient = new NetClientBuilder(vertx, clientConfig)
+        .protocol("http")
         .sslOptions(co.getSslOptions())
         .build();
       transport = new TcpHttpClientTransport(

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpClientTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpClientTransport.java
@@ -47,7 +47,7 @@ public class QuicHttpClientTransport implements HttpClientTransport {
       localSettings = new Http3Settings();
     }
 
-    QuicClient client = new QuicClientImpl(vertx, quicConfig, null);
+    QuicClient client = new QuicClientImpl(vertx, quicConfig, "http", null);
 
     this.vertx = vertx;
     this.keepAliveTimeoutMillis = config.getHttp3Config().getKeepAliveTimeout() == null ? 0L : config.getHttp3Config().getKeepAliveTimeout().toMillis();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpServer.java
@@ -212,7 +212,7 @@ public class QuicHttpServer implements HttpServerInternal {
       }
       requestHandler = this.requestHandler;
       connectionHandler = this.connectionHandler;
-      quicServer = new QuicServerImpl(vertx, quicConfig, sslOptions);
+      quicServer = new QuicServerImpl(vertx, quicConfig, "http", sslOptions);
       httpMetrics = vertx.metrics() != null ? vertx.metrics().createHttpServerMetrics(config, address) : null;
     }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpServer.java
@@ -199,6 +199,7 @@ public class TcpHttpServer implements HttpServerInternal {
     NetServerInternal server = new NetServerBuilder(vertx, config.getTcpConfig(), config.getSslOptions())
       .fileRegionEnabled(!compression.isCompressionEnabled())
       .cleanable(false)
+      .protocol("http")
       .build();
     Handler<Throwable> h = exceptionHandler;
     Handler<Throwable> exceptionHandler = h != null ? h : DEFAULT_EXCEPTION_HANDLER;

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -465,6 +465,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     HttpClientConfig config = new HttpClientConfig(o);
     HttpClientMetrics<?, ?> httpMetrics = metrics() != null ? metrics().createHttpClientMetrics(config) : null;
     NetClientInternal tcpClient = new NetClientBuilder(this, config.getTcpConfig())
+      .protocol("http")
       .sslOptions(options.getSslOptions())
       .build();
     TcpHttpClientTransport channelConnector = TcpHttpClientTransport.create(tcpClient, config, httpMetrics);

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/CleanableQuicClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/CleanableQuicClient.java
@@ -32,7 +32,7 @@ public class CleanableQuicClient extends QuicClientImpl implements Closeable {
   public CleanableQuicClient(VertxInternal vertx,
                              QuicClientConfig config,
                              ClientSSLOptions sslOptions) {
-    super(vertx, config, sslOptions);
+    super(vertx, config, null, sslOptions);
     this.vertx = vertx;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/CleanableQuicServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/CleanableQuicServer.java
@@ -35,7 +35,7 @@ public class CleanableQuicServer extends QuicServerImpl implements Closeable {
   public CleanableQuicServer(VertxInternal vertx,
                              QuicServerConfig config,
                              ServerSSLOptions sslOptions) {
-    super(vertx, config, sslOptions);
+    super(vertx, config, null, sslOptions);
     this.vertx = vertx;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicClientImpl.java
@@ -60,8 +60,8 @@ public class QuicClientImpl extends QuicEndpointImpl implements QuicClient {
   private Future<Integer> clientFuture;
   private volatile Channel channel;
 
-  public QuicClientImpl(VertxInternal vertx, QuicClientConfig config, ClientSSLOptions sslOptions) {
-    super(vertx, config);
+  public QuicClientImpl(VertxInternal vertx, QuicClientConfig config, String protocol, ClientSSLOptions sslOptions) {
+    super(vertx, config, protocol);
     this.config = config;
     this.sslOptions = sslOptions;
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicServerImpl.java
@@ -68,8 +68,8 @@ public class QuicServerImpl extends QuicEndpointImpl implements QuicServerIntern
   private Handler<QuicConnection> handler;
   private QuicTokenHandler tokenHandler;
 
-  public QuicServerImpl(VertxInternal vertx, QuicServerConfig config, ServerSSLOptions sslOptions) {
-    super(vertx, config);
+  public QuicServerImpl(VertxInternal vertx, QuicServerConfig config, String protocol, ServerSSLOptions sslOptions) {
+    super(vertx, config, protocol);
     this.config = config;
     this.sslOptions = sslOptions;
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetServer.java
@@ -18,10 +18,11 @@ public class CleanableNetServer extends NetServerImpl implements Closeable {
 
   public CleanableNetServer(VertxInternal vertx,
                             TcpServerConfig config,
+                            String protocol,
                             ServerSSLOptions sslOptions,
                             boolean fileRegionEnabled,
                             boolean registerWriteHandler) {
-    super(vertx, config, sslOptions, fileRegionEnabled, registerWriteHandler);
+    super(vertx, config, protocol, sslOptions, fileRegionEnabled, registerWriteHandler);
     this.vertx = vertx;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientBuilder.java
@@ -24,6 +24,7 @@ public class NetClientBuilder {
 
   private VertxInternal vertx;
   private TcpClientConfig config;
+  private String protocol;
   private ClientSSLOptions sslOptions;
   private boolean registerWriteHandler;
 
@@ -31,6 +32,7 @@ public class NetClientBuilder {
     this.vertx = vertx;
     this.config = config;
     this.registerWriteHandler = false;
+    this.protocol = null;
   }
 
   public NetClientBuilder sslOptions(ClientSSLOptions sslOptions) {
@@ -43,7 +45,12 @@ public class NetClientBuilder {
     return this;
   }
 
+  public NetClientBuilder protocol(String protocol) {
+    this.protocol = protocol;
+    return this;
+  }
+
   public NetClientInternal build() {
-    return new NetClientImpl(vertx, config, sslOptions, registerWriteHandler);
+    return new NetClientImpl(vertx, config, protocol, sslOptions, registerWriteHandler);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
@@ -59,6 +59,7 @@ class NetClientImpl implements NetClientInternal {
   private final VertxInternal vertx;
   private final TcpClientConfig config;
   private final TcpConfig transportOptions;
+  private final String protocol;
   private final boolean registerWriteHandler;
   private final SslContextManager sslContextManager;
   private volatile ClientSSLOptions sslOptions;
@@ -68,6 +69,7 @@ class NetClientImpl implements NetClientInternal {
 
   public NetClientImpl(VertxInternal vertx,
                        TcpClientConfig config,
+                       String protocol,
                        ClientSSLOptions sslOptions,
                        boolean registerWriteHandler) {
 
@@ -81,7 +83,7 @@ class NetClientImpl implements NetClientInternal {
     this.config = config;
     this.registerWriteHandler = registerWriteHandler;
     this.sslContextManager = new SslContextManager(SslContextManager.resolveEngineOptions(config.getSslEngineOptions(), sslOptions != null && sslOptions.isUseAlpn()));
-    this.metrics = vertx.metrics() != null ? vertx.metrics().createTcpClientMetrics(config) : null;
+    this.metrics = vertx.metrics() != null ? vertx.metrics().createTcpClientMetrics(config, protocol) : null;
     this.logging = config.getNetworkLogging() != null ? config.getNetworkLogging().getDataFormat() : null;
     this.idleTimeout = config.getIdleTimeout() != null ? config.getIdleTimeout() : Duration.ofMillis(0L);
     this.readIdleTimeout = config.getReadIdleTimeout() != null ? config.getReadIdleTimeout() : Duration.ofMillis(0L);
@@ -89,6 +91,7 @@ class NetClientImpl implements NetClientInternal {
     this.proxyFilter = config.getNonProxyHosts() != null ? ProxyFilter.nonProxyHosts(config.getNonProxyHosts()) : ProxyFilter.DEFAULT_PROXY_FILTER;
     this.sslOptions = sslOptions;
     this.transportOptions = config.getTransportConfig();
+    this.protocol = protocol;
   }
 
   protected void initChannel(ChannelPipeline pipeline, boolean ssl) {

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerBuilder.java
@@ -26,6 +26,7 @@ public class NetServerBuilder {
   private VertxInternal vertx;
   private TcpServerConfig config;
   private ServerSSLOptions sslOptions;
+  private String protocol;
   private boolean fileRegionEnabled;
   private boolean registerWriteHandler;
   private boolean cleanable;
@@ -34,6 +35,7 @@ public class NetServerBuilder {
     this.vertx = vertx;
     this.config = config;
     this.sslOptions = sslOptions;
+    this.protocol = null;
     this.fileRegionEnabled = false;
     this.registerWriteHandler = false;
     this.cleanable = false;
@@ -61,11 +63,17 @@ public class NetServerBuilder {
     return this;
   }
 
+  public NetServerBuilder protocol(String protocol) {
+    this.protocol = protocol;
+    return this;
+  }
+
   public NetServerInternal build() {
     NetServerInternal server;
     if (cleanable) {
       server = new CleanableNetServer(vertx,
         config,
+        protocol,
         sslOptions,
         fileRegionEnabled,
         registerWriteHandler);
@@ -73,6 +81,7 @@ public class NetServerBuilder {
       server = new NetServerImpl(
         vertx,
         config,
+        protocol,
         sslOptions,
         fileRegionEnabled,
         registerWriteHandler

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerImpl.java
@@ -68,6 +68,7 @@ public class NetServerImpl implements NetServerInternal {
   private final ServerSSLOptions sslOptions;
   private final boolean fileRegionEnabled;
   private final boolean registerWriteHandler;
+  private final String protocol;
   private Handler<NetSocket> handler;
   private Handler<Throwable> exceptionHandler;
 
@@ -91,6 +92,7 @@ public class NetServerImpl implements NetServerInternal {
 
   public NetServerImpl(VertxInternal vertx,
                        TcpServerConfig config,
+                       String protocol,
                        ServerSSLOptions sslOptions,
                        boolean fileRegionEnabled,
                        boolean registerWriteHandler) {
@@ -101,6 +103,7 @@ public class NetServerImpl implements NetServerInternal {
 
     this.vertx = vertx;
     this.config = config;
+    this.protocol = protocol;
     this.fileRegionEnabled = fileRegionEnabled;
     this.registerWriteHandler = registerWriteHandler;
     this.sslOptions = sslOptions;
@@ -572,7 +575,7 @@ public class NetServerImpl implements NetServerInternal {
   }
 
   private TransportMetrics<?> createMetrics(VertxMetrics metrics,  SocketAddress localAddress) {
-    return metrics != null ? metrics.createTcpServerMetrics(config, localAddress) : null;
+    return metrics != null ? metrics.createTcpServerMetrics(config, protocol, localAddress) : null;
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
@@ -97,10 +97,11 @@ public interface VertxMetrics extends Metrics, Measured {
    * instances.
    *
    * @param config       the options used to create the {@link NetServer}
+   * @param protocol     the protocol type, e.g. {@code http}, {@code null} when unknown
    * @param localAddress localAddress the local address the net socket is listening on
    * @return the net server metrics SPI or {@code null} when metrics are disabled
    */
-    default TransportMetrics<?> createTcpServerMetrics(TcpServerConfig config, SocketAddress localAddress) {
+    default TransportMetrics<?> createTcpServerMetrics(TcpServerConfig config, String protocol, SocketAddress localAddress) {
     return null;
   }
 
@@ -109,10 +110,11 @@ public interface VertxMetrics extends Metrics, Measured {
    * <p>
    * No specific thread and context can be expected when this method is called.
    *
-   * @param config the options used to create the {@link NetClient}
+   * @param config   the options used to create the {@link NetClient}
+   * @param protocol the protocol type, e.g. {@code http}, {@code null} when unknown
    * @return the net client metrics SPI or {@code null} when metrics are disabled
    */
-  default TransportMetrics<?> createTcpClientMetrics(TcpClientConfig config) {
+  default TransportMetrics<?> createTcpClientMetrics(TcpClientConfig config, String protocol) {
     return null;
   }
 
@@ -122,11 +124,12 @@ public interface VertxMetrics extends Metrics, Measured {
    * scaled, it is the responsibility of the metrics implementation to eventually merge metrics. In this case
    * the provided {@code server} argument can be used to distinguish the different metrics instances.</p>
    *
-   * @param config      the config used to create the {@link NetServer}
+   * @param config       the config used to create the {@link NetServer}
+   * @param protocol     the protocol type, e.g. {@code http}, {@code null} when unknown
    * @param localAddress localAddress the local address of the UDP socket the endpoint is listening on
    * @return the net server metrics SPI or {@code null} when metrics are disabled
    */
-  default TransportMetrics<?> createQuicEndpointMetrics(QuicEndpointConfig config, SocketAddress localAddress) {
+  default TransportMetrics<?> createQuicEndpointMetrics(QuicEndpointConfig config, String protocol, SocketAddress localAddress) {
     return null;
   }
 

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
@@ -64,16 +64,16 @@ public class FakeVertxMetrics extends FakeMetricsBase implements VertxMetrics {
     return new FakeHttpClientMetrics(options.getMetricsName());
   }
 
-  public TransportMetrics<?> createTcpServerMetrics(TcpServerConfig config, SocketAddress localAddress) {
+  public TransportMetrics<?> createTcpServerMetrics(TcpServerConfig config, String protocol, SocketAddress localAddress) {
     return new FakeTCPMetrics(null);
   }
 
-  public TransportMetrics<?> createTcpClientMetrics(TcpClientConfig config) {
+  public TransportMetrics<?> createTcpClientMetrics(TcpClientConfig config, String protocol) {
     return new FakeTCPMetrics(config.getMetricsName());
   }
 
   @Override
-  public TransportMetrics<?> createQuicEndpointMetrics(QuicEndpointConfig config, SocketAddress localAddress) {
+  public TransportMetrics<?> createQuicEndpointMetrics(QuicEndpointConfig config, String protocol, SocketAddress localAddress) {
     return new FakeQuicEndpointMetrics(config.getMetricsName());
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/ClusteredEventBusTest.java
@@ -716,7 +716,7 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
       .withClusterManager(getClusterManager())
       .withMetrics(options -> new VertxMetrics() {
         @Override
-        public TransportMetrics<?> createTcpClientMetrics(TcpClientConfig config) {
+        public TransportMetrics<?> createTcpClientMetrics(TcpClientConfig config, String protocol) {
           return new TransportMetrics<>() {
             @Override
             public Object connected(SocketAddress remoteAddress, String remoteName) {
@@ -730,7 +730,7 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
           };
         }
         @Override
-        public TransportMetrics<?> createTcpServerMetrics(TcpServerConfig config, SocketAddress localAddress) {
+        public TransportMetrics<?> createTcpServerMetrics(TcpServerConfig config, String protocol, SocketAddress localAddress) {
           return new TransportMetrics<>() {
             @Override
             public Object connected(SocketAddress remoteAddress, String remoteName) {

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsContextTest.java
@@ -112,7 +112,7 @@ public class MetricsContextTest extends VertxTestBase {
     AtomicBoolean closeCalled = new AtomicBoolean();
     VertxMetricsFactory factory = (options) -> new VertxMetrics() {
       @Override
-      public TransportMetrics<Void> createTcpServerMetrics(TcpServerConfig config, SocketAddress localAddress) {
+      public TransportMetrics<Void> createTcpServerMetrics(TcpServerConfig config, String protocol, SocketAddress localAddress) {
         return new TransportMetrics<>() {
           @Override
           public Void connected(SocketAddress remoteAddress, String remoteName) {
@@ -389,7 +389,7 @@ public class MetricsContextTest extends VertxTestBase {
     AtomicBoolean closeCalled = new AtomicBoolean();
     VertxMetricsFactory factory = (options) -> new VertxMetrics() {
       @Override
-      public TransportMetrics<?> createTcpClientMetrics(TcpClientConfig config) {
+      public TransportMetrics<?> createTcpClientMetrics(TcpClientConfig config, String protocol) {
         return new TransportMetrics<Void>() {
           @Override
           public Void connected(SocketAddress remoteAddress, String remoteName) {
@@ -496,7 +496,7 @@ public class MetricsContextTest extends VertxTestBase {
     AtomicBoolean closeCalled = new AtomicBoolean();
     VertxMetricsFactory factory = (options) -> new VertxMetrics() {
       @Override
-      public TransportMetrics<Void> createTcpClientMetrics(TcpClientConfig config) {
+      public TransportMetrics<Void> createTcpClientMetrics(TcpClientConfig config, String protocol) {
         return new TransportMetrics<>() {
           @Override
           public Void connected(SocketAddress remoteAddress, String remoteName) {
@@ -600,7 +600,7 @@ public class MetricsContextTest extends VertxTestBase {
     AtomicBoolean closeCalled = new AtomicBoolean();
     VertxMetricsFactory factory = (options) -> new VertxMetrics() {
       @Override
-      public TransportMetrics createTcpServerMetrics(TcpServerConfig config, SocketAddress localAddress) {
+      public TransportMetrics createTcpServerMetrics(TcpServerConfig config, String protocol, SocketAddress localAddress) {
         return new TransportMetrics<Void>() {
           @Override
           public Void connected(SocketAddress remoteAddress, String remoteName) {
@@ -688,7 +688,7 @@ public class MetricsContextTest extends VertxTestBase {
     AtomicBoolean closeCalled = new AtomicBoolean();
     VertxMetricsFactory factory = (options) -> new VertxMetrics() {
       @Override
-      public TransportMetrics createTcpClientMetrics(TcpClientConfig config) {
+      public TransportMetrics createTcpClientMetrics(TcpClientConfig config, String protocol) {
         return new TransportMetrics<Void>() {
           @Override
           public Void connected(SocketAddress remoteAddress, String remoteName) {


### PR DESCRIPTION
Motivation:

Make the metrics implementation aware of the protocol used by the transport.
