### PR TITLE
Simplify HttpClientMetrics.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -220,7 +220,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
 
     HttpClientTransport quicTransport;
     if (co.getVersions().contains(HttpVersion.HTTP_3)) {
-      quicTransport = new QuicHttpClientTransport(vertx, co, httpMetrics);
+      quicTransport = new QuicHttpClientTransport(vertx, co);
     } else {
       quicTransport = null;
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -334,7 +334,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     boolean useSSL = ssl != null ? ssl : defaultSsl;
     checkClosed();
     HttpConnectParams params = new HttpConnectParams(protocol, sslOptions, proxyOptions, useSSL);
-    return transport.connect(vertx.getOrCreateContext(), server, authority, params, clientMetrics, httpMetrics)
+    return transport.connect(vertx.getOrCreateContext(), server, authority, params, clientMetrics)
       .map(conn -> new UnpooledHttpClientConnection(conn).init());
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/SharedHttpClientConnectionGroup.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/SharedHttpClientConnectionGroup.java
@@ -210,7 +210,7 @@ class SharedHttpClientConnectionGroup extends ManagedResource {
     @Override
     public Future<ConnectResult<HttpClientConnection>> connect(ContextInternal context, Listener listener) {
       return connector
-        .connect(context, owner.server, owner.authority, connectParams, owner.clientMetrics, owner.httpMetrics)
+        .connect(context, owner.server, owner.authority, connectParams, owner.clientMetrics)
         .map(connection -> {
           connection.evictionHandler(v -> {
             owner.dispose(connection);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketGroup.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketGroup.java
@@ -96,7 +96,7 @@ class WebSocketGroup extends ManagedResource {
     } else {
       eventLoopContext = ctx.toBuilder().withThreadingModel(ThreadingModel.EVENT_LOOP).build();
     }
-    Future<HttpClientConnection> fut = connector.connect(eventLoopContext, server, authority, connectParams, clientMetrics, httpMetrics);
+    Future<HttpClientConnection> fut = connector.connect(eventLoopContext, server, authority, connectParams, clientMetrics);
     fut.onComplete(ar -> {
       if (ar.succeeded()) {
         HttpClientConnection c = ar.result();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2ClientChannelInitializer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2ClientChannelInitializer.java
@@ -18,7 +18,6 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
 import io.vertx.core.spi.metrics.TransportMetrics;
 
 /**
@@ -26,7 +25,7 @@ import io.vertx.core.spi.metrics.TransportMetrics;
  */
 public interface Http2ClientChannelInitializer {
 
-  void http2Connected(ContextInternal context, HostAndPort authority, TransportMetrics<?> transportMetrics, Object metric, Channel ch, ClientMetrics<?, ?, ?> clientMetrics, HttpClientMetrics<?, ?> httpMetrics, PromiseInternal<HttpClientConnection> promise);
+  void http2Connected(ContextInternal context, HostAndPort authority, TransportMetrics<?> transportMetrics, Object metric, Channel ch, ClientMetrics<?, ?, ?> clientMetrics, PromiseInternal<HttpClientConnection> promise);
 
   Http2UpgradeClientConnection.Http2ChannelUpgrade channelUpgrade(Http1ClientConnection conn, ClientMetrics<?, ?, ?> clientMetrics);
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ClientConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ClientConnectionImpl.java
@@ -42,7 +42,6 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
   private final boolean useDecompression;
   private final TransportMetrics<?> transportMetrics;
   private final ClientMetrics<?, ?, ?> clientMetrics;
-  private final HttpClientMetrics<?, ?> httpMetrics;
   private final HostAndPort authority;
   private final long creationTimestamp;
   private Handler<Void> evictionHandler = DEFAULT_EVICTION_HANDLER;
@@ -57,13 +56,11 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
                             VertxHttp2ConnectionHandler connHandler,
                             TransportMetrics<?> transportMetrics,
                             ClientMetrics<?, ?, ?> clientMetrics,
-                            HttpClientMetrics<?, ?> httpMetrics,
                             Http2ClientConfig config,
                             TracingPolicy tracingPolicy,
                             boolean useDecompression) {
     super(context, connHandler);
     this.clientMetrics = clientMetrics;
-    this.httpMetrics = httpMetrics;
     this.transportMetrics = transportMetrics;
     this.config = config;
     this.tracingPolicy = tracingPolicy;
@@ -312,7 +309,6 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
     TracingPolicy tracingPolicy,
     boolean useDecompression,
     boolean logActivity,
-    HttpClientMetrics<?, ?> httpMetrics,
     TransportMetrics<?> transportMetrics,
     ClientMetrics clientMetrics,
     ContextInternal context,
@@ -326,7 +322,7 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
       .initialSettings(config.getInitialSettings())
       .connectionFactory(connHandler -> {
         Http2ClientConnectionImpl conn = new Http2ClientConnectionImpl(context, authority, connHandler, transportMetrics,
-          clientMetrics, httpMetrics, config, tracingPolicy, useDecompression);
+          clientMetrics, config, tracingPolicy, useDecompression);
         if (clientMetrics != null) {
           Object m = socketMetric;
           conn.metric(m);
@@ -356,7 +352,7 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
   @Override
   public void handleClosed() {
     if (clientMetrics != null) {
-      ((HttpClientMetrics)httpMetrics).endpointDisconnected(clientMetrics);
+      clientMetrics.disconnected();
     }
     super.handleClosed();
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexClientChannelInitializer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexClientChannelInitializer.java
@@ -33,7 +33,6 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
 import io.vertx.core.spi.metrics.TransportMetrics;
 
 public class Http2MultiplexClientChannelInitializer implements Http2ClientChannelInitializer {
@@ -59,8 +58,8 @@ public class Http2MultiplexClientChannelInitializer implements Http2ClientChanne
   @Override
   public void http2Connected(ContextInternal context, HostAndPort authority, TransportMetrics<?> transportMetrics,
                              Object connectionMetric, Channel channel, ClientMetrics<?, ?, ?> clientMetrics,
-                             HttpClientMetrics<?, ?> httpMetrics, PromiseInternal<HttpClientConnection> promise) {
-    Http2MultiplexConnectionFactory connectionFactory = connectionFactory(context, authority, transportMetrics, connectionMetric, clientMetrics, httpMetrics, promise);
+                             PromiseInternal<HttpClientConnection> promise) {
+    Http2MultiplexConnectionFactory connectionFactory = connectionFactory(context, authority, transportMetrics, connectionMetric, clientMetrics, promise);
     io.vertx.core.http.impl.http2.multiplex.Http2MultiplexHandler handler = new io.vertx.core.http.impl.http2.multiplex.Http2MultiplexHandler(channel, context, connectionFactory, initialSettings);
     Http2FrameCodec http2FrameCodec = new Http2CustomFrameCodecBuilder(null, decompressionSupported).server(false)
       .initialSettings(initialSettings)
@@ -81,10 +80,10 @@ public class Http2MultiplexClientChannelInitializer implements Http2ClientChanne
                                                     TransportMetrics<?> transportMetrics,
                                                     Object connectionMetric,
                                                     ClientMetrics<?, ?, ?> clientMetrics,
-                                                    HttpClientMetrics<?, ?> httpMetrics, Promise<HttpClientConnection> promise) {
+                                                    Promise<HttpClientConnection> promise) {
     return (handler, chctx) -> {
       Http2MultiplexClientConnection connection = new Http2MultiplexClientConnection(handler, chctx, context,
-        httpMetrics, clientMetrics, transportMetrics, authority, multiplexingLimit, keepAliveTimeoutMillis,
+        clientMetrics, transportMetrics, authority, multiplexingLimit, keepAliveTimeoutMillis,
         decompressionSupported, promise);
       connection.metric(connectionMetric);
       return connection;
@@ -107,7 +106,7 @@ public class Http2MultiplexClientChannelInitializer implements Http2ClientChanne
                         Buffer content,
                         boolean end,
                         Channel channel,
-                        HttpClientMetrics<?, ?> httpMetrics, ClientMetrics<?, ?, ?> clientMetrics,
+                        ClientMetrics<?, ?, ?> clientMetrics,
                         Http2UpgradeClientConnection.UpgradeResult result) {
       ChannelPipeline pipeline = channel.pipeline();
       HttpClientCodec clientCodec = pipeline.get(HttpClientCodec.class);
@@ -118,7 +117,7 @@ public class Http2MultiplexClientChannelInitializer implements Http2ClientChanne
         .build();
       ContextInternal context = upgradingStream.context();
       PromiseInternal<HttpClientConnection> p = context.promise();
-      Http2MultiplexConnectionFactory connectionFactory = connectionFactory(context, request.authority, transportMetrics, connectionMetric, clientMetrics, httpMetrics, p);
+      Http2MultiplexConnectionFactory connectionFactory = connectionFactory(context, request.authority, transportMetrics, connectionMetric, clientMetrics, p);
       io.vertx.core.http.impl.http2.multiplex.Http2MultiplexHandler handler = new io.vertx.core.http.impl.http2.multiplex.Http2MultiplexHandler(
         channel,
         context,

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexClientConnection.java
@@ -31,13 +31,11 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
 import io.vertx.core.spi.metrics.TransportMetrics;
 
 public class Http2MultiplexClientConnection extends Http2MultiplexConnection<Http2ClientStream> implements HttpClientConnection, Http2ClientConnection {
 
   private final boolean decompressionSupported;
-  private final HttpClientMetrics<?, ?> httpMetrics;
   private final ClientMetrics<?, ?, ?> clientMetrics;
   private final HostAndPort authority;
   private Promise<HttpClientConnection> completion;
@@ -54,7 +52,6 @@ public class Http2MultiplexClientConnection extends Http2MultiplexConnection<Htt
   public Http2MultiplexClientConnection(Http2MultiplexHandler handler,
                                         ChannelHandlerContext chctx,
                                         ContextInternal context,
-                                        HttpClientMetrics<?, ?> httpMetrics,
                                         ClientMetrics<?, ?, ?> clientMetrics,
                                         TransportMetrics<?> transportMetrics,
                                         HostAndPort authority,
@@ -66,7 +63,6 @@ public class Http2MultiplexClientConnection extends Http2MultiplexConnection<Htt
 
     this.authority = authority;
     this.completion = completion;
-    this.httpMetrics = httpMetrics;
     this.clientMetrics = clientMetrics;
     this.concurrencyChangeHandler = DEFAULT_CONCURRENCY_CHANGE_HANDLER;
     this.maxConcurrency = maxConcurrency < 0 ? Long.MAX_VALUE : maxConcurrency;
@@ -253,7 +249,7 @@ public class Http2MultiplexClientConnection extends Http2MultiplexConnection<Htt
       promise.fail(ConnectionBase.CLOSED_EXCEPTION);
     }
     if (clientMetrics != null) {
-      ((HttpClientMetrics)httpMetrics).endpointDisconnected(clientMetrics);
+      clientMetrics.disconnected();
     }
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ClientConnection.java
@@ -46,7 +46,6 @@ import java.util.function.Function;
 public class Http3ClientConnection extends Http3Connection implements HttpClientConnection {
 
   private final HostAndPort authority;
-  private final HttpClientMetrics<?, ?> httpMetrics;
   private final ClientMetrics<Object, HttpRequest, HttpResponse> clientMetrics;
   private Handler<Void> evictionHandler;
   private final long keepAliveTimeoutMillis;
@@ -55,14 +54,12 @@ public class Http3ClientConnection extends Http3Connection implements HttpClient
 
   public Http3ClientConnection(QuicConnectionInternal connection,
                                HostAndPort authority,
-                               HttpClientMetrics<?, ?> httpMetrics,
                                ClientMetrics<Object, HttpRequest, HttpResponse> clientMetrics,
                                long keepAliveTimeoutMillis,
                                Http3Settings localSettings) {
     super(connection, localSettings);
 
     this.authority = authority;
-    this.httpMetrics = httpMetrics;
     this.clientMetrics = clientMetrics;
     this.keepAliveTimeoutMillis = keepAliveTimeoutMillis;
     this.creationTimetstamp = System.currentTimeMillis();
@@ -86,8 +83,8 @@ public class Http3ClientConnection extends Http3Connection implements HttpClient
 
     pipeline.addBefore("handler", "http3", http3Handler);
 
-    if (httpMetrics != null) {
-      ((HttpClientMetrics)httpMetrics).endpointConnected(clientMetrics);
+    if (clientMetrics != null) {
+      clientMetrics.connected();
     }
   }
 
@@ -113,8 +110,8 @@ public class Http3ClientConnection extends Http3Connection implements HttpClient
     if (handler != null) {
       handler.handle(null);
     }
-    if (httpMetrics != null) {
-      ((HttpClientMetrics)httpMetrics).endpointDisconnected(clientMetrics);
+    if (clientMetrics != null) {
+      clientMetrics.disconnected();
     }
     super.handleClosed();
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/observability/ClientStreamObserver.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/observability/ClientStreamObserver.java
@@ -43,11 +43,7 @@ public class ClientStreamObserver extends StreamObserver {
   public void observePush(HttpRequestHeaders headers) {
     if (clientMetrics != null) {
       Object metric = clientMetrics.init();
-      if (metric == null) {
-        metric = clientMetrics.requestBegin(headers.path().toString(), observableRequest(headers, remoteAddress));
-      } else {
-        clientMetrics.requestBegin(metric, headers.path().toString(), observableRequest(headers, remoteAddress));
-      }
+      clientMetrics.requestBegin(metric, headers.path(), observableRequest(headers, remoteAddress));
       this.metric = metric;
       clientMetrics.requestEnd(metric, 0L);
     }
@@ -61,12 +57,7 @@ public class ClientStreamObserver extends StreamObserver {
   public void observeOutboundHeaders(HttpHeaders headers) {
     HttpRequestHeaders r = (HttpRequestHeaders) headers;
     if (clientMetrics != null) {
-      Object m = metric;
-      if (m == null) {
-        metric = clientMetrics.requestBegin(r.path(), observableRequest(r, remoteAddress));
-      } else {
-        clientMetrics.requestBegin(metric, r.path(), observableRequest(r, remoteAddress));
-      }
+      clientMetrics.requestBegin(metric, r.path(), observableRequest(r, remoteAddress));
     }
     VertxTracer tracer = context.tracer();
     if (tracer != null) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpClientTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpClientTransport.java
@@ -34,12 +34,11 @@ import java.util.Arrays;
 public class QuicHttpClientTransport implements HttpClientTransport {
 
   private final VertxInternal vertx;
-  private final HttpClientMetrics<?, ?> httpMetrics;
   private final QuicClient client;
   private final long keepAliveTimeoutMillis;
   private final Http3Settings localSettings;
 
-  public QuicHttpClientTransport(VertxInternal vertx, HttpClientConfig config, HttpClientMetrics<?, ?> httpMetrics) {
+  public QuicHttpClientTransport(VertxInternal vertx, HttpClientConfig config) {
 
     QuicClientConfig quicConfig = new QuicClientConfig(config.getQuicConfig());
     quicConfig.setMetricsName(config.getMetricsName());
@@ -55,11 +54,10 @@ public class QuicHttpClientTransport implements HttpClientTransport {
     this.keepAliveTimeoutMillis = config.getHttp3Config().getKeepAliveTimeout() == null ? 0L : config.getHttp3Config().getKeepAliveTimeout().toMillis();
     this.localSettings = localSettings;
     this.client = client;
-    this.httpMetrics = httpMetrics;
   }
 
   @Override
-  public Future<HttpClientConnection> connect(ContextInternal context, SocketAddress server, HostAndPort authority, HttpConnectParams params, ClientMetrics<?, ?, ?> clientMetrics, HttpClientMetrics<?, ?> httpMetrics) {
+  public Future<HttpClientConnection> connect(ContextInternal context, SocketAddress server, HostAndPort authority, HttpConnectParams params, ClientMetrics<?, ?, ?> clientMetrics) {
     ClientSSLOptions sslOptions = params.sslOptions;
     if (sslOptions == null) {
       return context.failedFuture("Missing clients SSL options");
@@ -76,7 +74,6 @@ public class QuicHttpClientTransport implements HttpClientTransport {
       Http3ClientConnection c = new Http3ClientConnection(
         (QuicConnectionInternal) res,
         authority,
-        httpMetrics,
         (ClientMetrics<Object, HttpRequest, HttpResponse>) clientMetrics,
         keepAliveTimeoutMillis,
         localSettings);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
@@ -51,7 +51,6 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
   private static final Logger log = LoggerFactory.getLogger(Http2UpgradeClientConnection.class);
 
   private final Http2ChannelUpgrade upgrade;
-  private final HttpClientMetrics<?, ?> httpMetrics;
   private final ClientMetrics<?, ?, ?> clientMetrics;
   private io.vertx.core.http.impl.HttpClientConnection current;
   private boolean upgradeProcessed;
@@ -68,11 +67,10 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
   private Handler<HttpSettings> remoteSettingsHandler;
 
   public Http2UpgradeClientConnection(Http1ClientConnection connection, ClientMetrics<?, ?, ?> clientMetrics,
-                                      HttpClientMetrics<?, ?> httpMetrics, Http2ChannelUpgrade upgrade) {
+                                      Http2ChannelUpgrade upgrade) {
     this.current = connection;
     this.upgrade = upgrade;
     this.clientMetrics = clientMetrics;
-    this.httpMetrics = httpMetrics;
   }
 
   public io.vertx.core.http.impl.HttpClientConnection unwrap() {
@@ -360,7 +358,6 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
     private final Http2ChannelUpgrade upgrade;
     private final HttpClientStream upgradingStream;
     private final Http2UpgradeClientConnection upgradedConnection;
-    private final HttpClientMetrics<?, ?> httpMetrics;
     private final ClientMetrics<?, ?, ?> clientMetrics;
     private HttpClientStream upgradedStream;
     private Handler<io.vertx.core.http.impl.HttpResponseHead> headHandler;
@@ -377,13 +374,12 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
     private Handler<Void> closeHandler;
 
     UpgradingStream(HttpClientStream stream, Http2UpgradeClientConnection upgradedConnection, ClientMetrics<?, ?, ?> clientMetrics,
-                    HttpClientMetrics<?, ?> httpMetrics, Http2ChannelUpgrade upgrade, Http1ClientConnection upgradingConnection) {
+                    Http2ChannelUpgrade upgrade, Http1ClientConnection upgradingConnection) {
       this.upgradedConnection = upgradedConnection;
       this.upgradingConnection = upgradingConnection;
       this.upgradingStream = stream;
       this.upgrade = upgrade;
       this.clientMetrics = clientMetrics;
-      this.httpMetrics = httpMetrics;
     }
 
     @Override
@@ -421,7 +417,7 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
         }
       };
       upgrade.upgrade(upgradingStream, request, buf, end,
-        upgradingConnection.channelHandlerContext().channel(), httpMetrics, clientMetrics, blah);
+        upgradingConnection.channelHandlerContext().channel(), clientMetrics, blah);
       PromiseInternal<Void> promise = upgradingStream.context().promise();
       writeHead(request, chunked, buf, end, priority, connect, promise);
       return promise.future();
@@ -722,7 +718,7 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
     if (current instanceof Http1ClientConnection && !upgradeProcessed) {
       return current
         .createStream(context)
-        .map(stream -> new UpgradingStream(stream, this, clientMetrics, httpMetrics,
+        .map(stream -> new UpgradingStream(stream, this, clientMetrics,
           upgrade, (Http1ClientConnection) current));
     } else {
       return current
@@ -946,7 +942,6 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
                  Buffer content,
                  boolean end,
                  Channel channel,
-                 HttpClientMetrics<?, ?> httpMetrics,
                  ClientMetrics<?, ?, ?> clientMetrics,
                  UpgradeResult result);
   }

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpClientTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpClientTransport.java
@@ -18,7 +18,6 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
 
 import java.time.Duration;
 
@@ -33,8 +32,7 @@ public interface HttpClientTransport {
                                        SocketAddress server,
                                        HostAndPort authority,
                                        HttpConnectParams params,
-                                       ClientMetrics<?, ?, ?> clientMetrics,
-                                       HttpClientMetrics<?, ?> httpMetrics);
+                                       ClientMetrics<?, ?, ?> clientMetrics);
 
   Future<Void> shutdown(Duration timeout);
 

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/ClientMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/ClientMetrics.java
@@ -19,13 +19,7 @@ package io.vertx.core.spi.metrics;
 public interface ClientMetrics<M, Req, Resp> extends Metrics {
 
   /**
-   * Create a request metric instance, when the implementation
-   *
-   * <ul>
-   *   <li>returns {@code null}, {@link #requestBegin(String, Object)} is called (backward compatibility mode)</li>
-   *   <li>returns a non-null value, {@link #requestBegin(Object, String, Object)} is called with the returned request
-   *   metric instance</li>
-   * </ul>
+   * Create a request metric instance.
    *
    * @return a newly created request metric
    */
@@ -34,30 +28,17 @@ public interface ClientMetrics<M, Req, Resp> extends Metrics {
   }
 
   /**
-   * Called when a client request begins and {@link #init()} has returned a non-null value.
+   * Called when a client request begins. Vert.x will invoke {@link #requestEnd} when the request
+   * has ended or {@link #requestReset} if the request/response has failed before.
+   *
+   * <p>The request uri is an arbitrary URI that depends on the client, e.g. an HTTP request uri,
+   * a SQL query, etc...
    *
    * @param requestMetric the request metric
    * @param uri an arbitrary uri
    * @param request the request object
    */
   default void requestBegin(M requestMetric, String uri, Req request) {
-  }
-
-  /**
-   * Called when a client request begins. Vert.x will invoke {@link #requestEnd} when the request
-   * has ended or {@link #requestReset} if the request/response has failed before.
-   *
-   * <p>The request uri is an arbitrary URI that depends on the client, e.g an HTTP request uri,
-   * a SQL query, etc...
-   *
-   * @param uri an arbitrary uri
-   * @param request the request object
-   * @return the request metric
-   * @deprecated instead override {@link #init()} and {@link #requestBegin(Object, String, Object)}
-   */
-  @Deprecated
-  default M requestBegin(String uri, Req request) {
-    return null;
   }
 
   /**
@@ -109,5 +90,19 @@ public interface ClientMetrics<M, Req, Resp> extends Metrics {
    * @param bytesRead the number of bytes read or {@code -1} when it is not known
    */
   default void responseEnd(M requestMetric, long bytesRead) {
+  }
+
+  /**
+   * Called when a connection to the service is created, this can be called multiple times.
+   *
+   */
+  default void connected() {
+  }
+
+  /**
+   * Called when a connection to the service is closed.
+   *
+   */
+  default void disconnected() {
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
@@ -46,20 +46,4 @@ public interface HttpClientMetrics<R, W> extends WebSocketMetrics<W> {
   default ClientMetrics<R, HttpRequest, HttpResponse> createEndpointMetrics(SocketAddress remoteAddress, int maxPoolSize) {
     return null;
   }
-
-  /**
-   * Called when a connection is made to a endpoint.
-   *  @param endpointMetric the endpoint metric
-   *
-   */
-  default void endpointConnected(ClientMetrics<R, ?, ?> endpointMetric) {
-  }
-
-  /**
-   * Called when a connection to an endpoint is closed.
-   *  @param endpointMetric the endpoint metric
-   *
-   */
-  default void endpointDisconnected(ClientMetrics<R, ?, ?> endpointMetric) {
-  }
 }

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/EndpointMetric.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/EndpointMetric.java
@@ -27,43 +27,17 @@ public class EndpointMetric implements ClientMetrics<HttpClientMetric, HttpReque
   public final AtomicInteger connectionCount = new AtomicInteger();
   public final AtomicInteger requestCount = new AtomicInteger();
   public final ConcurrentMap<HttpRequest, HttpClientMetric> requests = new ConcurrentHashMap<>();
-  private final boolean implementInit;
-
-  public EndpointMetric(boolean implementInit) {
-    this.implementInit = implementInit;
-  }
 
   @Override
   public HttpClientMetric init() {
-    if (implementInit) {
-      return new HttpClientMetric(this);
-    } else {
-      return ClientMetrics.super.init();
-    }
+    return new HttpClientMetric(this);
   }
 
   @Override
   public void requestBegin(HttpClientMetric requestMetric, String uri, HttpRequest request) {
-    if (implementInit) {
-      requestCount.incrementAndGet();
-      requestMetric.request.set(request);
-      requests.put(request, requestMetric);
-    } else {
-      ClientMetrics.super.requestBegin(requestMetric, uri, request);
-    }
-  }
-
-  @Override
-  public HttpClientMetric requestBegin(String uri, HttpRequest request) {
-    if (implementInit) {
-      return null;
-    } else {
-      requestCount.incrementAndGet();
-      HttpClientMetric metric = new HttpClientMetric(this);
-      metric.request.set(request);
-      requests.put(request, metric);
-      return metric;
-    }
+    requestCount.incrementAndGet();
+    requestMetric.request.set(request);
+    requests.put(request, requestMetric);
   }
 
   @Override
@@ -105,5 +79,15 @@ public class EndpointMetric implements ClientMetrics<HttpClientMetric, HttpReque
     requestMetric.bytesRead.set(bytesRead);
     requestCount.decrementAndGet();
     requests.remove(requestMetric.request.get());
+  }
+
+  @Override
+  public void connected() {
+    connectionCount.incrementAndGet();
+  }
+
+  @Override
+  public void disconnected() {
+    connectionCount.decrementAndGet();
   }
 }

--- a/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeHttpClientMetrics.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakemetrics/FakeHttpClientMetrics.java
@@ -12,8 +12,6 @@
 package io.vertx.test.fakemetrics;
 
 import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.WebSocket;
-import io.vertx.core.http.WebSocketBase;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
@@ -33,7 +31,6 @@ public class FakeHttpClientMetrics extends FakeWebSocketMetrics implements HttpC
 
   private final String name;
   private final ConcurrentMap<SocketAddress, EndpointMetric> endpoints = new ConcurrentHashMap<>();
-  private volatile boolean implementInit = false;
 
   public FakeHttpClientMetrics(String name) {
     this.name = name;
@@ -54,10 +51,6 @@ public class FakeHttpClientMetrics extends FakeWebSocketMetrics implements HttpC
       }
     }
     return null;
-  }
-
-  public void setImplementInit(boolean implementInit) {
-    this.implementInit = implementInit;
   }
 
   public Set<String> endpoints() {
@@ -85,7 +78,7 @@ public class FakeHttpClientMetrics extends FakeWebSocketMetrics implements HttpC
 
   @Override
   public ClientMetrics<HttpClientMetric, HttpRequest, HttpResponse> createEndpointMetrics(SocketAddress remoteAddress, int maxPoolSize) {
-    EndpointMetric metric = new EndpointMetric(implementInit) {
+    EndpointMetric metric = new EndpointMetric() {
       @Override
       public void close() {
         endpoints.remove(remoteAddress);
@@ -93,15 +86,5 @@ public class FakeHttpClientMetrics extends FakeWebSocketMetrics implements HttpC
     };
     endpoints.put(remoteAddress, metric);
     return metric;
-  }
-
-  @Override
-  public void endpointConnected(ClientMetrics<HttpClientMetric, ?, ?> endpointMetric) {
-    ((EndpointMetric)endpointMetric).connectionCount.incrementAndGet();
-  }
-
-  @Override
-  public void endpointDisconnected(ClientMetrics<HttpClientMetric, ?, ?> endpointMetric) {
-    ((EndpointMetric)endpointMetric).connectionCount.decrementAndGet();
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/Http2MetricsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/Http2MetricsTest.java
@@ -120,13 +120,13 @@ public class Http2MetricsTest extends HttpMetricsTestBase {
   }
 
   @Override
-  void testHttpClientLifecycle(boolean implementInit) throws Exception {
+  public void testHttpClientLifecycle() throws Exception {
     // The test cannot pass for HTTP/2 upgrade for now
     if (clientOptions.getProtocolVersion() == HttpVersion.HTTP_2 &&
       !clientOptions.isSsl() &&
       clientOptions.isHttp2ClearTextUpgrade()) {
       return;
     }
-    super.testHttpClientLifecycle(implementInit);
+    super.testHttpClientLifecycle();
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsContextTest.java
@@ -417,9 +417,8 @@ public class MetricsContextTest extends VertxTestBase {
           public ClientMetrics<Void, HttpRequest, HttpResponse> createEndpointMetrics(SocketAddress remoteAddress, int maxPoolSize) {
             return new ClientMetrics<>() {
               @Override
-              public Void requestBegin(String uri, HttpRequest request) {
+              public void requestBegin(Void requestMetric, String uri, HttpRequest request) {
                 requestBeginCalled.set(uri);
-                return null;
               }
               @Override
               public void responseEnd(Void requestMetric, long bytesRead) {


### PR DESCRIPTION
Motivations:

Things are more convoluted than it could be.

Changes:

- Move the HttpClientMetrics connected/disconnected callbacks to ClientMetrics interface.
- Remove the deprecated ClientMetrics#requestBegin method
