### PR TITLE
Fixing offset calculation for reg-name parsing

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/impl/UriParser.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/UriParser.java
@@ -64,7 +64,7 @@ public class UriParser {
       char c = s.charAt(from);
       if (isUnreserved(c) || isSubDelims(c)) {
         from++;
-      } else if (c == '%' && (from + 2) < to && isHEXDIG(s.charAt(c + 1)) && isHEXDIG(s.charAt(c + 2))) {
+      } else if (c == '%' && (from + 2) < to && isHEXDIG(s.charAt(from + 1)) && isHEXDIG(s.charAt(from + 2))) {
         from += 3;
       } else {
         break;

--- a/vertx-core/src/test/java/io/vertx/tests/net/HostAndPortTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/HostAndPortTest.java
@@ -189,6 +189,8 @@ public class HostAndPortTest {
     assertHostAndPort("127.0.0.1", 8080, "127.0.0.1:8080");
     assertHostAndPort("example.com", 8080, "example.com:8080");
     assertHostAndPort("example.com", -1, "example.com");
+    assertHostAndPort("host%3F", -1, "host%3F");
+    assertHostAndPort("host%3F", 8080, "host%3F:8080");
     assertHostAndPort("0.1.2.3", -1, "0.1.2.3");
     assertHostAndPort("[0::]", -1, "[0::]");
     assertHostAndPort("", -1, "");
@@ -212,6 +214,10 @@ public class HostAndPortTest {
     assertFalse(HostAndPortImpl.isValidAuthority("^"));
     assertNull(HostAndPortImpl.parseAuthority("bücher.de", -1));
     assertFalse(HostAndPortImpl.isValidAuthority("bücher.de"));
+    assertNull(HostAndPortImpl.parseAuthority("host%3", -1));
+    assertFalse(HostAndPortImpl.isValidAuthority("host%3"));
+    assertNull(HostAndPortImpl.parseAuthority("host%3:8080", -1));
+    assertFalse(HostAndPortImpl.isValidAuthority("host%3:8080"));
   }
 
   private void assertHostAndPort(String expectedHost, int expectedPort, String actual) {


### PR DESCRIPTION
Closes #5926

This updates the calculation to ensure enough bytes are available to continue the parsing.