### PR TITLE
Fix unstable TimerTest

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/timer/TimerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/timer/TimerTest.java
@@ -17,6 +17,7 @@ import io.vertx.core.impl.VertxImpl;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.test.core.Repeat;
 import io.vertx.test.core.VertxTestBase;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.concurrent.CancellationException;
@@ -62,13 +63,13 @@ public class TimerTest extends VertxTestBase {
    */
   @Test
   public void testTimings() {
-    final long start = System.currentTimeMillis();
+    final long start = System.nanoTime();
     final long delay = 2000;
     vertx.setTimer(delay, timerID -> {
-      long dur = System.currentTimeMillis() - start;
-      assertTrue(dur >= delay);
+      long dur = System.nanoTime() - start;
+      assertTrue(dur >= TimeUnit.MILLISECONDS.toNanos(delay));
       long maxDelay = delay * 2;
-      assertTrue("Timer accuracy: " + dur + " vs " + maxDelay, dur < maxDelay); // 100% margin of error (needed for CI)
+      assertTrue("Timer accuracy: " + dur + " vs " + TimeUnit.MILLISECONDS.toNanos(maxDelay), dur < TimeUnit.MILLISECONDS.toNanos(maxDelay)); // 100% margin of error (needed for CI)
       vertx.cancelTimer(timerID);
       testComplete();
     });
@@ -119,11 +120,11 @@ public class TimerTest extends VertxTestBase {
   private void periodic(PeriodicArg delay, BiFunction<PeriodicArg, Handler<Long>, Long> abc) {
     final int numFires = 10;
     final AtomicLong id = new AtomicLong(-1);
-    long now = System.currentTimeMillis();
+    long now = System.nanoTime();
     id.set(abc.apply(delay, new Handler<Long>() {
       int count;
       public void handle(Long timerID) {
-        assertTrue( System.currentTimeMillis() - now >= delay.initialDelay + count * delay.delay);
+        assertThat(System.nanoTime() - now, Matchers.greaterThanOrEqualTo(TimeUnit.MILLISECONDS.toNanos(delay.initialDelay + count * delay.delay)));
         assertEquals(id.get(), timerID.longValue());
         count++;
         if (count == numFires) {
@@ -363,10 +364,10 @@ public class TimerTest extends VertxTestBase {
 
   @Test
   public void testTimerFire() {
-    long now = System.currentTimeMillis();
+    long now = System.nanoTime();
     Timer timer = vertx.timer(1, TimeUnit.SECONDS);
     timer.onComplete(onSuccess(v -> {
-      assertTrue(System.currentTimeMillis() - now >= 800);
+      assertTrue(System.nanoTime() - now >= TimeUnit.SECONDS.toNanos(1));
       testComplete();
     }));
     await();


### PR DESCRIPTION
Closes #5937

(cherry picked from commit 01e00da0e9d2a2cf360cc0a1e2001f231b725b09)

Motivation: System.nanoTime() should be monotonic. Also more descriptive assertion with a hamcrest matcher so we can dive deeper if it fails again. 


