### PR TITLE
Fix unstable VirtualThreadDeploymentTest.testHttpClientStopRequestInProgress

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/deployment/VirtualThreadDeploymentTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/deployment/VirtualThreadDeploymentTest.java
@@ -168,12 +168,12 @@ public class VirtualThreadDeploymentTest extends VertxTestBase {
     Assert.assertEquals(5, max.get());
   }
   @Test
-  public void testHttpClientStopRequestInProgress() throws Exception {
+  public void testHttpClientStopRequestInProgress() {
     Assume.assumeTrue(isVirtualThreadAvailable());
     AtomicInteger inflight = new AtomicInteger();
     vertx.createHttpServer().requestHandler(request -> {
       inflight.incrementAndGet();
-    }).listen(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST);
+    }).listen(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTP_HOST).await();
     int numReq = 10;
     Set<Thread> threads = Collections.synchronizedSet(new HashSet<>());
     Set<Thread> interruptedThreads = Collections.synchronizedSet(new HashSet<>());


### PR DESCRIPTION
Closes #5939

(cherry picked from commit 01e00da0e9d2a2cf360cc0a1e2001f231b725b09)

Motivation: This waits for the server to be started before continuing with the test.

