### PR TITLE
Tcp user timeout fixes for server

### DIFF
--- a/vertx-core/src/main/java/examples/CoreExamples.java
+++ b/vertx-core/src/main/java/examples/CoreExamples.java
@@ -501,13 +501,14 @@ public class CoreExamples {
       .build();
   }
 
-  public void configureLinuxOptions(Vertx vertx, boolean fastOpen, boolean cork, boolean quickAck, boolean reusePort) {
+  public void configureLinuxOptions(Vertx vertx, boolean fastOpen, boolean cork, boolean quickAck, boolean reusePort, int tcpUserTimeout) {
     // Available on Linux
     vertx.createHttpServer(new HttpServerOptions()
       .setTcpFastOpen(fastOpen)
       .setTcpCork(cork)
       .setTcpQuickAck(quickAck)
       .setReusePort(reusePort)
+      .setTcpUserTimeout(tcpUserTimeout)
     );
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -492,6 +492,11 @@ public class HttpServerOptions extends NetServerOptions {
   }
 
   @Override
+  public HttpServerOptions setTcpUserTimeout(int tcpUserTimeout) {
+    return (HttpServerOptions) super.setTcpUserTimeout(tcpUserTimeout);
+  }
+
+  @Override
   public HttpServerOptions addCrlPath(String crlPath) throws NullPointerException {
     return (HttpServerOptions) super.addCrlPath(crlPath);
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
@@ -133,6 +133,7 @@ public class EpollTransport implements Transport {
       if (options.isTcpFastOpen()) {
         bootstrap.option(ChannelOption.TCP_FASTOPEN, options.isTcpFastOpen() ? pendingFastOpenRequestsThreshold : 0);
       }
+      bootstrap.childOption(EpollChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
       bootstrap.childOption(EpollChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
       bootstrap.childOption(EpollChannelOption.TCP_CORK, options.isTcpCork());
     }

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
@@ -138,6 +138,7 @@ public class IoUringTransport implements Transport {
     if (options.isTcpFastOpen()) {
       bootstrap.option(IoUringChannelOption.TCP_FASTOPEN, options.isTcpFastOpen() ? pendingFastOpenRequestsThreshold : 0);
     }
+    bootstrap.childOption(IoUringChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
     bootstrap.childOption(IoUringChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
     bootstrap.childOption(IoUringChannelOption.TCP_CORK, options.isTcpCork());
     Transport.super.configure(options, false, bootstrap);
@@ -151,6 +152,7 @@ public class IoUringTransport implements Transport {
     if (options.isTcpFastOpen()) {
       bootstrap.option(IoUringChannelOption.TCP_FASTOPEN_CONNECT, options.isTcpFastOpen());
     }
+    bootstrap.option(IoUringChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
     bootstrap.option(IoUringChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
     bootstrap.option(IoUringChannelOption.TCP_CORK, options.isTcpCork());
     Transport.super.configure(options, connectTimeout, false, bootstrap);

--- a/vertx-core/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -240,6 +240,11 @@ public class NetClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public NetClientOptions setTcpUserTimeout(int tcpUserTimeout) {
+    return (NetClientOptions) super.setTcpUserTimeout(tcpUserTimeout);
+  }
+
+  @Override
   public NetClientOptions addCrlPath(String crlPath) throws NullPointerException {
     return (NetClientOptions) super.addCrlPath(crlPath);
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -287,6 +287,11 @@ public class NetServerOptions extends TCPSSLOptions {
   }
 
   @Override
+  public NetServerOptions setTcpUserTimeout(int tcpUserTimeout) {
+    return (NetServerOptions) super.setTcpUserTimeout(tcpUserTimeout);
+  }
+
+  @Override
   public NetServerOptions addCrlPath(String crlPath) throws NullPointerException {
     return (NetServerOptions) super.addCrlPath(crlPath);
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -697,6 +697,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @param tcpUserTimeout the tcp user timeout value
    */
   public TCPSSLOptions setTcpUserTimeout(int tcpUserTimeout) {
+    if (tcpUserTimeout < 0) {
+      throw new IllegalArgumentException("tcpUserTimeout must be >= 0");
+    }
     this.tcpUserTimeout = tcpUserTimeout;
     return this;
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -110,6 +110,12 @@ public class Http1xTest extends HttpTest {
     assertEquals(options, options.setTcpKeepAlive(!tcpKeepAlive));
     assertEquals(!tcpKeepAlive, options.isTcpKeepAlive());
 
+    assertEquals(TCPSSLOptions.DEFAULT_TCP_USER_TIMEOUT, options.getTcpUserTimeout());
+    int tcpUserTimeout = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpUserTimeout(tcpUserTimeout));
+    assertEquals(tcpUserTimeout, options.getTcpUserTimeout());
+    assertIllegalArgumentException(() -> options.setTcpUserTimeout(-1000));
+
     int soLinger = -1;
     assertEquals(soLinger, options.getSoLinger());
     rand = TestUtils.randomPositiveInt();
@@ -298,6 +304,12 @@ public class Http1xTest extends HttpTest {
     assertEquals(tcpKeepAlive, options.isTcpKeepAlive());
     assertEquals(options, options.setTcpKeepAlive(!tcpKeepAlive));
     assertEquals(!tcpKeepAlive, options.isTcpKeepAlive());
+
+    assertEquals(TCPSSLOptions.DEFAULT_TCP_USER_TIMEOUT, options.getTcpUserTimeout());
+    int tcpUserTimeout = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpUserTimeout(tcpUserTimeout));
+    assertEquals(tcpUserTimeout, options.getTcpUserTimeout());
+    assertIllegalArgumentException(() -> options.setTcpUserTimeout(-1000));
 
     int soLinger = -1;
     assertEquals(soLinger, options.getSoLinger());
@@ -559,6 +571,7 @@ public class Http1xTest extends HttpTest {
     int trafficClass = TestUtils.randomByte() + 128;
     boolean tcpNoDelay = rand.nextBoolean();
     boolean tcpKeepAlive = rand.nextBoolean();
+    int tcpUserTimeout = TestUtils.randomPositiveInt();
     int soLinger = TestUtils.randomPositiveInt();
     int idleTimeout = TestUtils.randomPositiveInt();
     boolean ssl = rand.nextBoolean();
@@ -609,6 +622,7 @@ public class Http1xTest extends HttpTest {
       .put("trafficClass", trafficClass)
       .put("tcpNoDelay", tcpNoDelay)
       .put("tcpKeepAlive", tcpKeepAlive)
+      .put("tcpUserTimeout", tcpUserTimeout)
       .put("soLinger", soLinger)
       .put("idleTimeout", idleTimeout)
       .put("ssl", ssl)
@@ -656,6 +670,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(reuseAddress, options.isReuseAddress());
     assertEquals(trafficClass, options.getTrafficClass());
     assertEquals(tcpKeepAlive, options.isTcpKeepAlive());
+    assertEquals(tcpUserTimeout, options.getTcpUserTimeout());
     assertEquals(tcpNoDelay, options.isTcpNoDelay());
     assertEquals(soLinger, options.getSoLinger());
     assertEquals(idleTimeout, options.getIdleTimeout());
@@ -861,6 +876,7 @@ public class Http1xTest extends HttpTest {
     int trafficClass = TestUtils.randomByte() + 128;
     boolean tcpNoDelay = rand.nextBoolean();
     boolean tcpKeepAlive = rand.nextBoolean();
+    int tcpUserTimeout = TestUtils.randomPositiveInt();
     int soLinger = TestUtils.randomPositiveInt();
     int idleTimeout = TestUtils.randomPositiveInt();
     boolean ssl = rand.nextBoolean();
@@ -904,6 +920,7 @@ public class Http1xTest extends HttpTest {
       .put("trafficClass", trafficClass)
       .put("tcpNoDelay", tcpNoDelay)
       .put("tcpKeepAlive", tcpKeepAlive)
+      .put("tcpUserTimeout", tcpUserTimeout)
       .put("soLinger", soLinger)
       .put("idleTimeout", idleTimeout)
       .put("ssl", ssl)
@@ -944,6 +961,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(reuseAddress, options.isReuseAddress());
     assertEquals(trafficClass, options.getTrafficClass());
     assertEquals(tcpKeepAlive, options.isTcpKeepAlive());
+    assertEquals(tcpUserTimeout, options.getTcpUserTimeout());
     assertEquals(tcpNoDelay, options.isTcpNoDelay());
     assertEquals(soLinger, options.getSoLinger());
     assertEquals(idleTimeout, options.getIdleTimeout());

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -169,6 +169,12 @@ public class NetTest extends VertxTestBase {
     assertEquals(options, options.setTcpKeepAlive(!tcpKeepAlive));
     assertEquals(!tcpKeepAlive, options.isTcpKeepAlive());
 
+    assertEquals(TCPSSLOptions.DEFAULT_TCP_USER_TIMEOUT, options.getTcpUserTimeout());
+    int tcpUserTimeout = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpUserTimeout(tcpUserTimeout));
+    assertEquals(tcpUserTimeout, options.getTcpUserTimeout());
+    assertIllegalArgumentException(() -> options.setTcpUserTimeout(-1000));
+
     int soLinger = -1;
     assertEquals(soLinger, options.getSoLinger());
     rand = TestUtils.randomPositiveInt();
@@ -278,6 +284,12 @@ public class NetTest extends VertxTestBase {
     assertEquals(options, options.setTcpKeepAlive(!tcpKeepAlive));
     assertEquals(!tcpKeepAlive, options.isTcpKeepAlive());
 
+    assertEquals(TCPSSLOptions.DEFAULT_TCP_USER_TIMEOUT, options.getTcpUserTimeout());
+    int tcpUserTimeout = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpUserTimeout(tcpUserTimeout));
+    assertEquals(tcpUserTimeout, options.getTcpUserTimeout());
+    assertIllegalArgumentException(() -> options.setTcpUserTimeout(-1000));
+
     int soLinger = -1;
     assertEquals(soLinger, options.getSoLinger());
     rand = TestUtils.randomPositiveInt();
@@ -368,6 +380,7 @@ public class NetTest extends VertxTestBase {
     int trafficClass = TestUtils.randomByte() + 128;
     boolean tcpNoDelay = rand.nextBoolean();
     boolean tcpKeepAlive = rand.nextBoolean();
+    int tcpUserTimeout = TestUtils.randomPositiveInt();
     int soLinger = TestUtils.randomPositiveInt();
     int idleTimeout = TestUtils.randomPositiveInt();
     boolean ssl = rand.nextBoolean();
@@ -397,6 +410,7 @@ public class NetTest extends VertxTestBase {
     options.setSsl(ssl);
     options.setTcpNoDelay(tcpNoDelay);
     options.setTcpKeepAlive(tcpKeepAlive);
+    options.setTcpUserTimeout(tcpUserTimeout);
     options.setSoLinger(soLinger);
     options.setIdleTimeout(idleTimeout);
     options.setKeyCertOptions(keyStoreOptions);
@@ -429,6 +443,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(def.getConnectTimeout(), json.getConnectTimeout());
     assertEquals(def.isTcpNoDelay(), json.isTcpNoDelay());
     assertEquals(def.isTcpKeepAlive(), json.isTcpKeepAlive());
+    assertEquals(def.getTcpUserTimeout(), json.getTcpUserTimeout());
     assertEquals(def.getSoLinger(), json.getSoLinger());
     assertEquals(def.isSsl(), json.isSsl());
     assertEquals(def.isUseAlpn(), json.isUseAlpn());
@@ -446,6 +461,7 @@ public class NetTest extends VertxTestBase {
     int trafficClass = TestUtils.randomByte() + 128;
     boolean tcpNoDelay = rand.nextBoolean();
     boolean tcpKeepAlive = rand.nextBoolean();
+    int tcpUserTimeout = TestUtils.randomPositiveInt();
     int soLinger = TestUtils.randomPositiveInt();
     int idleTimeout = TestUtils.randomPositiveInt();
     boolean ssl = rand.nextBoolean();
@@ -488,6 +504,7 @@ public class NetTest extends VertxTestBase {
         .put("trafficClass", trafficClass)
         .put("tcpNoDelay", tcpNoDelay)
         .put("tcpKeepAlive", tcpKeepAlive)
+        .put("tcpUserTimeout", tcpUserTimeout)
         .put("soLinger", soLinger)
         .put("idleTimeout", idleTimeout)
         .put("ssl", ssl)
@@ -516,6 +533,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(reuseAddress, options.isReuseAddress());
     assertEquals(trafficClass, options.getTrafficClass());
     assertEquals(tcpKeepAlive, options.isTcpKeepAlive());
+    assertEquals(tcpUserTimeout, options.getTcpUserTimeout());
     assertEquals(tcpNoDelay, options.isTcpNoDelay());
     assertEquals(soLinger, options.getSoLinger());
     assertEquals(idleTimeout, options.getIdleTimeout());
@@ -577,6 +595,7 @@ public class NetTest extends VertxTestBase {
     int trafficClass = TestUtils.randomByte() + 128;
     boolean tcpNoDelay = rand.nextBoolean();
     boolean tcpKeepAlive = rand.nextBoolean();
+    int tcpUserTimeout = TestUtils.randomPositiveInt();
     int soLinger = TestUtils.randomPositiveInt();
     boolean usePooledBuffers = rand.nextBoolean();
     int idleTimeout = TestUtils.randomPositiveInt();
@@ -607,6 +626,7 @@ public class NetTest extends VertxTestBase {
     options.setTrafficClass(trafficClass);
     options.setTcpNoDelay(tcpNoDelay);
     options.setTcpKeepAlive(tcpKeepAlive);
+    options.setTcpUserTimeout(tcpUserTimeout);
     options.setSoLinger(soLinger);
     options.setIdleTimeout(idleTimeout);
     options.setSsl(ssl);
@@ -646,6 +666,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(def.getHost(), json.getHost());
     assertEquals(def.isTcpNoDelay(), json.isTcpNoDelay());
     assertEquals(def.isTcpKeepAlive(), json.isTcpKeepAlive());
+    assertEquals(def.getTcpUserTimeout(), json.getTcpUserTimeout());
     assertEquals(def.getSoLinger(), json.getSoLinger());
     assertEquals(def.isSsl(), json.isSsl());
     assertEquals(def.isUseAlpn(), json.isUseAlpn());
@@ -667,6 +688,7 @@ public class NetTest extends VertxTestBase {
     int trafficClass = TestUtils.randomByte() + 128;
     boolean tcpNoDelay = rand.nextBoolean();
     boolean tcpKeepAlive = rand.nextBoolean();
+    int tcpUserTimeout = TestUtils.randomPositiveInt();
     int soLinger = TestUtils.randomPositiveInt();
     boolean usePooledBuffers = rand.nextBoolean();
     int idleTimeout = TestUtils.randomPositiveInt();
@@ -701,6 +723,7 @@ public class NetTest extends VertxTestBase {
       .put("trafficClass", trafficClass)
       .put("tcpNoDelay", tcpNoDelay)
       .put("tcpKeepAlive", tcpKeepAlive)
+      .put("tcpUserTimeout", tcpUserTimeout)
       .put("soLinger", soLinger)
       .put("usePooledBuffers", usePooledBuffers)
       .put("idleTimeout", idleTimeout)
@@ -726,6 +749,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(reuseAddress, options.isReuseAddress());
     assertEquals(trafficClass, options.getTrafficClass());
     assertEquals(tcpKeepAlive, options.isTcpKeepAlive());
+    assertEquals(tcpUserTimeout, options.getTcpUserTimeout());
     assertEquals(tcpNoDelay, options.isTcpNoDelay());
     assertEquals(soLinger, options.getSoLinger());
     assertEquals(idleTimeout, options.getIdleTimeout());


### PR DESCRIPTION
Motivation:

- Configures TCP_USER_TIMEOUT for EpollTransport and IoUringTransport
- Fixes fluent api pattern for the same in client and server configs
- Related tests
