### PR TITLE
Have HTTP client connection pool handle racy uncancellable timeout.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/SharedHttpClientConnectionGroup.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/SharedHttpClientConnectionGroup.java
@@ -159,10 +159,11 @@ class SharedHttpClientConnectionGroup extends ManagedResource implements PoolCon
 
     @Override
     public void complete(Lease<HttpClientConnectionInternal> result, Throwable failure) {
-      if (timerID >= 0) {
-        context.owner().cancelTimer(timerID);
+      if (timerID >= 0 && !context.owner().cancelTimer(timerID)) {
+        result.recycle();
+      } else {
+        promise.complete(result, failure);
       }
-      promise.complete(result, failure);
     }
 
     void acquire() {


### PR DESCRIPTION
Motivation:

The HTTP client connection pool resource acquisition completion can race against the acquisition timeout.

Changes:

When the acquisition timeout cannot be cancelled, the resource should be recycled and the promise should not be completed.
