### PR TITLE
Fix NetSocket (and QuicStream) where the end signal is notified before all messages have been dispatched.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/impl/SocketBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/SocketBase.java
@@ -270,14 +270,17 @@ public abstract class SocketBase<S extends SocketBase<S>> extends VertxConnectio
     }
   }
 
-  protected void handleEnd() {
-    pending.write(InboundBuffer.END_SENTINEL);
+  protected void handleEnded() {
+    read(InboundBuffer.END_SENTINEL);
+    endRead();
   }
 
   @Override
   protected void handleMessage(Object msg) {
     MessageHandler handler = messageHandler();
-    if (handler.accept(msg)) {
+    if (msg == InboundBuffer.END_SENTINEL) {
+      pending.write(InboundBuffer.END_SENTINEL);
+    } else if (handler.accept(msg)) {
       pending.write(handler.transform(msg));
     } else {
       if (msg instanceof ReferenceCounted) {

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -308,6 +308,10 @@ public class VertxConnection extends ConnectionBase {
     }
   }
 
+  final void endRead() {
+    read = false;
+  }
+
   private void addPending(Object msg) {
     if (pending == null) {
       pending = new ArrayDeque<>();

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicStreamImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicStreamImpl.java
@@ -10,7 +10,6 @@
  */
 package io.vertx.core.net.impl.quic;
 
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
@@ -149,7 +148,7 @@ public class QuicStreamImpl extends SocketBase<QuicStreamImpl> implements QuicSt
   @Override
   protected void handleEvent(Object event) {
     if (event == ChannelInputShutdownEvent.INSTANCE) {
-      handleEnd();
+      handleEnded();
     } else {
       super.handleEvent(event);
     }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetSocketImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetSocketImpl.java
@@ -180,7 +180,7 @@ public class NetSocketImpl extends SocketBase<NetSocketImpl> implements NetSocke
 
   @Override
   protected void handleClosed() {
-    handleEnd();
+    handleEnded();
     super.handleClosed();
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -133,6 +133,37 @@ public class NetTest extends VertxTestBase {
   }
 
   @Test
+  public void testEndHandlerCalledAfterAllEmissions() {
+    Buffer  buffer = TestUtils.randomBuffer(1024 * 1024);
+    server = vertx.createNetServer().connectHandler(so -> {
+      so.end(buffer);
+      so.close();
+    });
+    server.listen(1234).await();
+    NetClient client = vertx.createNetClient();
+    AtomicInteger received = new AtomicInteger();
+    AtomicInteger ended = new AtomicInteger();
+    client.connect(1234, "localhost").onComplete(ar -> {
+      if (ar.succeeded()) {
+        NetSocket socket = ar.result();
+        socket.handler(buf -> {
+          int amount = received.addAndGet(buf.length());
+          assertEquals(0, ended.get());
+          socket.pause();
+          vertx.setTimer(50, t -> {
+            socket.resume();
+          });
+        });
+        socket.endHandler(v -> {
+          assertEquals(0, ended.getAndIncrement());
+        });
+      }
+    });
+    assertWaitUntil(() -> received.get() == buffer.length());
+    assertWaitUntil(() -> ended.get() > 0);
+  }
+
+  @Test
   public void testClientOptions() {
     NetClientOptions options = new NetClientOptions();
 


### PR DESCRIPTION
Motivation:

The NetSocket implementation directly write the end sentinel message to the pending message queue, ignoging the potentially buffered messages in the connection.

Changes:

When we consider the message stream ends, we should instead model the last message as a connection message to ensure no reorder happens.
