### PR TITLE
Fix NetSocket where the end signal is notified before all messages have been dispatched.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -255,6 +255,10 @@ public class VertxConnection extends ConnectionBase {
     }
   }
 
+  final void endRead() {
+    read = false;
+  }
+
   private void addPending(Object msg) {
     if (pending == null) {
       pending = new ArrayDeque<>();


### PR DESCRIPTION
Motivation:

The NetSocket implementation directly write the end sentinel message to the pending message queue, ignoging the potentially buffered messages in the connection.

Changes:

When we consider the message stream ends, we should instead model the last message as a connection message to ensure no reorder happens.
