### PR TITLE
EPoll: Respect extended TCP Keepalive parameters for clients, not just servers

### DIFF
--- a/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
+++ b/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
@@ -169,6 +169,16 @@ public class EpollTransport implements Transport {
       bootstrap.option(EpollChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
       bootstrap.option(EpollChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
       bootstrap.option(EpollChannelOption.TCP_CORK, options.isTcpCork());
+
+      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIdleSeconds() != -1) {
+        bootstrap.option(EpollChannelOption.TCP_KEEPIDLE, options.getTcpKeepAliveIdleSeconds());
+      }
+      if (options.isTcpKeepAlive() && options.getTcpKeepAliveCount() != -1) {
+        bootstrap.option(EpollChannelOption.TCP_KEEPCNT, options.getTcpKeepAliveCount());
+      }
+      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIntervalSeconds() != -1) {
+        bootstrap.option(EpollChannelOption.TCP_KEEPINTVL, options.getTcpKeepAliveIntervalSeconds());
+      }
     }
     Transport.super.configure(options, domainSocket, bootstrap);
   }


### PR DESCRIPTION
I want to use a lower TCP Keepalive interval as a client. Currently this does not work. It does work for servers using the EPoll transport in Vert.x.

This PR makes it work for clients using EPoll.

I noticed that even the code for servers seems to be absent in master / 5.x, maybe worth a "forward-port"?

I have not yet signed the Eclipse Contributor Agreement. I can do that if necessary for this small change.
