### PR TITLE
Make sure that Context.unwrap always returns a raw context

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
@@ -481,6 +481,8 @@ public class ContextTest extends VertxTestBase {
     assertSame(ctx.deployment(), duplicated.deployment());
     assertSame(ctx.classLoader(), duplicated.classLoader());
     assertSame(ctx.owner(), duplicated.owner());
+    // Check that unwrap always returns a raw context, even when it was created by duplicating a duplicate
+    assertTrue(!ctx.isDuplicate() && duplicated.isDuplicate() && ctx == duplicated.unwrap());
     Object shared = new Object();
     Object local = new Object();
     ctx.put("key", shared);


### PR DESCRIPTION
Even when the instance was created by duplicating a duplicated context.