### PR TITLE
Add support for HA Proxy Protocol TLV's

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -23,6 +23,7 @@ import java.security.cert.Certificate;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -303,5 +304,15 @@ public interface HttpConnection {
    * @return the indicated server name
    */
   String indicatedServerName();
+
+  /**
+   * @return the type-length-values present in the TCP header as a list of map entries
+   * where the key contains the TLV type and the value contains the TLV value.
+   * This is mainly used for HA Proxy Protocol v2
+   */
+  @GenIgnore()
+  default List<Map.Entry<Buffer, Buffer>> proxyProtocolV2HeaderTLVs() {
+    return List.of();
+  }
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpNetSocket.java
@@ -16,7 +16,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClosedException;
-import io.vertx.core.http.StreamResetException;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SSLOptions;
@@ -26,6 +25,8 @@ import io.vertx.core.streams.WriteStream;
 
 import javax.net.ssl.SSLSession;
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -227,6 +228,11 @@ public class HttpNetSocket implements NetSocket {
   @Override
   public SocketAddress localAddress(boolean real) {
     return stream.connection().localAddress(real);
+  }
+
+  @Override
+  public List<Map.Entry<Buffer, Buffer>> proxyProtocolV2HeaderTLVs() {
+    return stream.connection().proxyProtocolV2HeaderTLVs();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
@@ -26,7 +26,8 @@ import javax.net.ssl.SSLSession;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.concurrent.TimeUnit;
+import java.util.List;
+import java.util.Map;
 
 /**
  * An un-pooled HTTP client connection that maintains a queue for pending requests that cannot be served
@@ -205,6 +206,11 @@ public class UnpooledHttpClientConnection implements io.vertx.core.http.HttpClie
   @Override
   public String indicatedServerName() {
     return actual.indicatedServerName();
+  }
+
+  @Override
+  public List<Map.Entry<Buffer, Buffer>> proxyProtocolV2HeaderTLVs() {
+    return actual.proxyProtocolV2HeaderTLVs();
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
@@ -34,10 +34,12 @@ import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.ClientMetrics;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
+
 
 import javax.net.ssl.SSLSession;
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A connection that attempts to perform a protocol upgrade to H2C. The connection might use HTTP/1 or H2C
@@ -899,6 +901,11 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
   @Override
   public String indicatedServerName() {
     return current.indicatedServerName();
+  }
+
+  @Override
+  public List<Map.Entry<Buffer, Buffer>> proxyProtocolV2HeaderTLVs() {
+    return current.proxyProtocolV2HeaderTLVs();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/NetSocket.java
@@ -18,7 +18,6 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
@@ -29,6 +28,7 @@ import java.security.cert.Certificate;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a socket-like interface to a TCP connection on either the
@@ -313,6 +313,14 @@ public interface NetSocket extends Socket {
    * @return the application-level protocol negotiated during the TLS handshake
    */
   String applicationLayerProtocol();
+
+  /**
+   * @return the type-length-values present in the TCP header as a list of map entries
+   * where the key contains the TLV type and the value contains the TLV value.
+   * This is mainly used for HA Proxy Protocol v2
+   */
+  @GenIgnore()
+  List<Map.Entry<Buffer, Buffer>> proxyProtocolV2HeaderTLVs();
 
 }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -19,6 +19,7 @@ import io.netty.handler.traffic.AbstractTrafficShapingHandler;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.FutureListener;
 import io.vertx.core.*;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.VertxInternal;
@@ -32,6 +33,8 @@ import io.vertx.core.spi.metrics.TransportMetrics;
 
 import javax.net.ssl.SSLSession;
 import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Abstract base class for connections managed by a vertx instance. This base implementation does not handle
@@ -53,10 +56,12 @@ public abstract class ConnectionBase {
   public static final VertxException CLOSED_EXCEPTION = NetSocketInternal.CLOSED_EXCEPTION;
   public static final AttributeKey<SocketAddress> REMOTE_ADDRESS_OVERRIDE = AttributeKey.valueOf("RemoteAddressOverride");
   public static final AttributeKey<SocketAddress> LOCAL_ADDRESS_OVERRIDE = AttributeKey.valueOf("LocalAddressOverride");
+  public static final AttributeKey<List<Map.Entry<Buffer, Buffer>>> PROXY_PROTOCOL_V2_HEADER_TLVS = AttributeKey.valueOf("proxyProtocolV2HeaderTLVs");
   private static final Logger log = LoggerFactory.getLogger(ConnectionBase.class);
 
   protected final VertxInternal vertx;
   protected final ChannelHandlerContext chctx;
+
   protected final Channel channel;
   protected final ContextInternal context;
   private Handler<Throwable> exceptionHandler;
@@ -424,6 +429,10 @@ public abstract class ConnectionBase {
     } else {
       return localAddress();
     }
+  }
+
+  public List<Map.Entry<Buffer, Buffer>> proxyProtocolV2HeaderTLVs() {
+    return channel.hasAttr(PROXY_PROTOCOL_V2_HEADER_TLVS) ? channel.attr(PROXY_PROTOCOL_V2_HEADER_TLVS).getAndSet(List.of()) : List.of();
   }
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/HAProxyMessageCompletionHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/HAProxyMessageCompletionHandler.java
@@ -1,19 +1,26 @@
 package io.vertx.core.net.impl;
 
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
+import io.netty.handler.codec.haproxy.HAProxyTLV;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.concurrent.Promise;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.SocketAddress;
 
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class HAProxyMessageCompletionHandler extends MessageToMessageDecoder<HAProxyMessage> {
   //Public because its used in tests
@@ -71,6 +78,11 @@ public class HAProxyMessageCompletionHandler extends MessageToMessageDecoder<HAP
           ctx.channel().attr(ConnectionBase.LOCAL_ADDRESS_OVERRIDE)
             .set(createAddress(protocol, msg.destinationAddress(), msg.destinationPort()));
         }
+
+        if (msg.tlvs() != null) {
+          ctx.channel().attr(ConnectionBase.PROXY_PROTOCOL_V2_HEADER_TLVS)
+            .set(createTLVs(msg.tlvs()));
+        }
       }
       ctx.pipeline().remove(this);
       promise.setSuccess(ctx.channel());
@@ -102,5 +114,13 @@ public class HAProxyMessageCompletionHandler extends MessageToMessageDecoder<HAP
       default:
         throw new IllegalStateException("Should never happen");
     }
+  }
+
+  private List<Map.Entry<Buffer, Buffer>> createTLVs(List<HAProxyTLV> haProxyTLVs) {
+    return haProxyTLVs.stream()
+      .filter(Objects::nonNull)
+      .map(tlv -> new AbstractMap.SimpleEntry<>(Buffer.buffer().appendByte(tlv.typeByteValue()),
+        Buffer.buffer(ByteBufUtil.getBytes(tlv.content()))))
+      .collect(Collectors.toList());
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HAProxyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HAProxyTest.java
@@ -20,8 +20,15 @@ import io.vertx.test.http.HttpTestBase;
 import io.vertx.test.proxy.HAProxy;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assume.assumeTrue;
 
 public abstract class HAProxyTest extends HttpTestBase {
@@ -158,6 +165,7 @@ public abstract class HAProxyTest extends HttpTestBase {
             proxy.getConnectionRemoteAddress() :
             local,
           req.localAddress());
+        assertUniqueIdTLV(header, req.connection().proxyProtocolV2HeaderTLVs());
         req.response().end();
         complete();
       });
@@ -276,5 +284,20 @@ public abstract class HAProxyTest extends HttpTestBase {
       assertEquals(address1.hostAddress(), address2.hostAddress());
       assertEquals(address1.port(), address2.port());
     }
+  }
+
+  private void assertUniqueIdTLV(Buffer header, List<Map.Entry<Buffer, Buffer>> tlvs) {
+    // only supported for v2 header and protocol family != unknown
+    if (header.length() < 12 || header.getByte(12) != 0x21 || header.getByte(13) == 0x00) {
+      return;
+    }
+
+    assertThat(tlvs, hasSize(1));
+
+    Map.Entry<Buffer, Buffer> uniqueIdTLV = tlvs.stream().findFirst().orElse(null);
+    assertThat(uniqueIdTLV.getKey().getByte(0), equalTo((byte)0x05));
+
+    UUID uuid = new UUID(uniqueIdTLV.getValue().getLong(0), uniqueIdTLV.getValue().getLong(Long.BYTES));
+    assertThat(uuid, equalTo(UUID.fromString("1f29a3b5-7cc4-4592-a8f1-879ff1f47124")));
   }
 }


### PR DESCRIPTION
Motivation:

TLV's are supported in netty, but currently not accessible to vert.x users.
Here the TLV's are exposed in `NetSocket#tlvs`

This also answers to #5452 

Conformance:
ECA signed
