### PR TITLE
Rework SSL/TLS documentation.

### DIFF
--- a/vertx-core/src/main/asciidoc/client_ssl.adoc
+++ b/vertx-core/src/main/asciidoc/client_ssl.adoc
@@ -1,0 +1,115 @@
+=== Client SSL/TLS configuration
+
+==== Client trust configuration
+
+Like server configuration, the client trust can be configured in several ways:
+
+The first method is by specifying the location of a Java trust-store which contains the certificate authority.
+
+It is just a standard Java key store, the same as the key stores on the server side. The client
+trust store location is set by using the function {@link io.vertx.core.net.JksOptions#setPath path} on the
+{@link io.vertx.core.net.JksOptions jks options}. If a server presents a certificate during connection which is not
+in the client trust store, the connection attempt will not succeed.
+
+[source,$lang]
+----
+{@link examples.SslExamples#example30}
+----
+
+Buffer configuration is also supported:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example31}
+----
+
+Certificate authority in PKCS#12 format (http://en.wikipedia.org/wiki/PKCS_12), usually with the `.pfx`  or the `.p12`
+extension can also be loaded in a similar fashion than JKS trust stores:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example32}
+----
+
+Buffer configuration is also supported:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example33}
+----
+
+Another way of providing server certificate authority using a list `.pem` files.
+
+[source,$lang]
+----
+{@link examples.SslExamples#example34}
+----
+
+Buffer configuration is also supported:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example35}
+----
+
+If the {@link io.vertx.core.net.ClientSSLOptions#setTrustAll trustALl} is set to true on the client, then the client will
+trust all server certificates. The connection will still be encrypted but this mode is vulnerable to 'man in the middle' attacks. I.e. you can't
+be sure who you are connecting to. Use this with caution. Default value is false.
+
+[source,$lang]
+----
+{@link examples.SslExamples#example29}
+----
+
+==== Specifying key/certificate for the client
+
+If the server requires client authentication then the client must present its own certificate to the server when
+connecting. The client can be configured in several ways:
+
+The first method is by specifying the location of a Java key-store which contains the key and certificate.
+Again it's just a regular Java key store. The client keystore location is set by using the function
+{@link io.vertx.core.net.JksOptions#setPath(java.lang.String) path} on the
+{@link io.vertx.core.net.JksOptions jks options}.
+
+[source,$lang]
+----
+{@link examples.SslExamples#example36}
+----
+
+Buffer configuration is also supported:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example37}
+----
+
+Key/certificate in PKCS#12 format (http://en.wikipedia.org/wiki/PKCS_12), usually with the `.pfx`  or the `.p12`
+extension can also be loaded in a similar fashion than JKS key stores:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example38}
+----
+
+Buffer configuration is also supported:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example39}
+----
+
+Another way of providing server private key and certificate separately using `.pem` files.
+
+[source,$lang]
+----
+{@link examples.SslExamples#example40}
+----
+
+Buffer configuration is also supported:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example41}
+----
+
+Keep in mind that pem configuration, the private key is not crypted.

--- a/vertx-core/src/main/asciidoc/index.adoc
+++ b/vertx-core/src/main/asciidoc/index.adoc
@@ -909,6 +909,16 @@ SEVERE: java.io.IOException: Connection reset by peer
 It means that the client is resetting the HTTP connection instead of closing it. This message also indicates that you
 may have not consumed the complete payload (the connection was cut before you were able to).
 
+== Configuring SSL
+
+[[server_ssl]]
+include::server_ssl.adoc[]
+
+[[client_ssl]]
+include::client_ssl.adoc[]
+
+include::ssl.adoc[]
+
 == Host name resolution
 
 Vert.x uses an an address resolver for resolving host name into IP addresses instead of

--- a/vertx-core/src/main/asciidoc/net.adoc
+++ b/vertx-core/src/main/asciidoc/net.adoc
@@ -159,13 +159,6 @@ read and write streams.
 
 See the chapter on <<streams, streams >> for more information.
 
-=== Upgrading connections to SSL/TLS
-
-A non SSL/TLS connection can be upgraded to SSL/TLS using {@link io.vertx.core.net.NetSocket#upgradeToSsl()}.
-
-The server or client must be configured for SSL/TLS for this to work correctly. Please see the <<ssl, chapter on SSL/TLS>>
-for more information.
-
 === TCP graceful shut down
 
 You can shut down a {@link io.vertx.core.net.NetServer#shutdown() server} or {@link io.vertx.core.net.NetClient#shutdown() client}.
@@ -414,158 +407,70 @@ These traffic shaping options can also be dynamically updated after server start
 TCP clients and servers can be configured to use http://en.wikipedia.org/wiki/Transport_Layer_Security[Transport Layer Security]
 - earlier versions of TLS were known as SSL.
 
-The APIs of the servers and clients are identical whether or not SSL/TLS is used, and it's enabled by configuring
+The APIs of the servers and clients are identical whether SSL/TLS is used, and it's enabled by configuring
 the {@link io.vertx.core.net.NetClientOptions} or {@link io.vertx.core.net.NetServerOptions} instances used
 to create the servers or clients.
 
 ==== Enabling SSL/TLS on the server
 
-SSL/TLS is enabled with  {@link io.vertx.core.net.NetServerOptions#setSsl(boolean) ssl}.
+Server SSL/TLS is enabled with the `NetServerOptions` {@link io.vertx.core.net.NetServerOptions#setSsl(boolean) ssl} setting.
 
-By default it is disabled.
-
-==== Specifying key/certificate for the server
-
-SSL/TLS servers usually provide certificates to clients in order to verify their identity to clients.
-
-Certificates/keys can be configured for servers in several ways:
-
-The first method is by specifying the location of a Java key-store which contains the certificate and private key.
-
-Java key stores can be managed with the http://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html[keytool]
-utility which ships with the JDK.
-
-The password for the key store should also be provided:
+By default, it is disabled.
 
 [source,$lang]
 ----
-{@link examples.NetExamples#example17}
+{@link examples.NetExamples#sslServerConfiguration}
 ----
 
-Alternatively you can read the key store yourself as a buffer and provide that directly:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example18}
-----
-
-Key/certificate in PKCS#12 format (http://en.wikipedia.org/wiki/PKCS_12), usually with the `.pfx`  or the `.p12`
-extension can also be loaded in a similar fashion than JKS key stores:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example19}
-----
-
-Buffer configuration is also supported:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example20}
-----
-
-Another way of providing server private key and certificate separately using `.pem` files.
-
-[source,$lang]
-----
-{@link examples.NetExamples#example21}
-----
-
-Buffer configuration is also supported:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example22}
-----
-
-Vert.x supports reading of unencrypted RSA and/or ECC based private keys from PKCS8 PEM files.
-RSA based private keys can also be read from PKCS1 PEM files.
-X.509 certificates can be read from PEM files containing a textual encoding of the certificate as defined by
-https://tools.ietf.org/html/rfc7468#section-5[RFC 7468, Section 5].
-
-WARNING: Keep in mind that the keys contained in an unencrypted PKCS8 or a PKCS1 PEM file can be extracted by
-anybody who can read the file. Thus, make sure to put proper access restrictions on such PEM files in order to
-prevent misuse.
-
-Finally, you can also load generic Java keystore, it is useful for using other KeyStore implementations
-like Bouncy Castle:
-
-[source,$lang]
-----
-{@link examples.NetExamples#exampleBKS}
-----
-
-==== Specifying trust for the server
-
-SSL/TLS servers can use a certificate authority in order to verify the identity of the clients.
-
-Certificate authorities can be configured for servers in several ways:
-
-Java trust stores can be managed with the http://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html[keytool]
-utility which ships with the JDK.
-
-The password for the trust store should also be provided:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example23}
-----
-
-Alternatively you can read the trust store yourself as a buffer and provide that directly:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example24}
-----
-
-Certificate authority in PKCS#12 format (http://en.wikipedia.org/wiki/PKCS_12), usually with the `.pfx`  or the `.p12`
-extension can also be loaded in a similar fashion than JKS trust stores:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example25}
-----
-
-Buffer configuration is also supported:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example26}
-----
-
-Another way of providing server certificate authority using a list `.pem` files.
-
-[source,$lang]
-----
-{@link examples.NetExamples#example27}
-----
-
-Buffer configuration is also supported:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example28}
-----
+You can read more about <<server_ssl,SSL server configuration>>
 
 ==== Enabling SSL/TLS on the client
 
-Net Clients can also be easily configured to use SSL. They have the exact same API when using SSL as when using standard sockets.
+Client SSL/TLS is enabled with the `NetClientOptions` {@link io.vertx.core.net.NetClientOptions#setSsl(boolean) ssl} property or {@link io.vertx.core.net.ConnectOptions#setSsl(boolean) ssl} property.
 
-To enable SSL on a NetClient the function setSSL(true) is called.
+The former defines the default client behavior.
 
-==== Client trust configuration
-
-If the {@link io.vertx.core.net.ClientOptionsBase#setTrustAll trustALl} is set to true on the client, then the client will
-trust all server certificates. The connection will still be encrypted but this mode is vulnerable to 'man in the middle' attacks. I.e. you can't
-be sure who you are connecting to. Use this with caution. Default value is false.
+When enabled, the client performs an SSL/TLS handshake with the provided SSL configuration.
 
 [source,$lang]
 ----
-{@link examples.NetExamples#example29}
+{@link examples.NetExamples#sslClientConfiguration}
 ----
 
-If {@link io.vertx.core.net.ClientOptionsBase#setTrustAll trustAll} is not set then a client trust store must be
-configured and should contain the certificates of the servers that the client trusts.
+The latter provides a fine-grained per socket configuration
+
+[source,$lang]
+----
+{@link examples.NetExamples#sslClientSocketConfiguration}
+----
+
+You can also set {@link io.vertx.core.net.ClientSSLOptions} at connect time.
+
+[source,$lang]
+----
+{@link examples.NetExamples#sslClientSocketConfiguration2}
+----
+
+You can read more about <<client_ssl,SSL client configuration>>.
+
+==== Client Server Name Indication (SNI)
+
+The client implicitly sends the connecting host as an SNI server name for Fully Qualified Domain Name (FQDN).
+
+You can provide an explicit server name when connecting a socket
+
+[source,$lang]
+----
+{@link examples.NetExamples#useSNIInClient}
+----
+
+It can be used for different purposes:
+
+* present a server name different than the server host
+* present a server name while connecting to an IP
+* force to present a server name when using shortname
+
+==== Client host verification
 
 By default, host verification is *not* configured on the client. This verifies the CN portion of the server certificate against the server hostname to avoid https://en.wikipedia.org/wiki/Man-in-the-middle_attack[Man-in-the-middle attacks].
 
@@ -582,108 +487,17 @@ You must configure it explicitly on your client
 
 NOTE: the Vert.x HTTP client uses the TCP client and configures with `"HTTPS"` the verification algorithm.
 
-Like server configuration, the client trust can be configured in several ways:
+==== Upgrading connections to SSL/TLS
 
-The first method is by specifying the location of a Java trust-store which contains the certificate authority.
-
-It is just a standard Java key store, the same as the key stores on the server side. The client
-trust store location is set by using the function {@link io.vertx.core.net.JksOptions#setPath path} on the
-{@link io.vertx.core.net.JksOptions jks options}. If a server presents a certificate during connection which is not
-in the client trust store, the connection attempt will not succeed.
+A non SSL/TLS connection can be upgraded to SSL/TLS using {@link io.vertx.core.net.NetSocket#upgradeToSsl()}.
 
 [source,$lang]
 ----
-{@link examples.NetExamples#example30}
+{@link examples.NetExamples#upgradeToSSL}
 ----
 
-Buffer configuration is also supported:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example31}
-----
-
-Certificate authority in PKCS#12 format (http://en.wikipedia.org/wiki/PKCS_12), usually with the `.pfx`  or the `.p12`
-extension can also be loaded in a similar fashion than JKS trust stores:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example32}
-----
-
-Buffer configuration is also supported:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example33}
-----
-
-Another way of providing server certificate authority using a list `.pem` files.
-
-[source,$lang]
-----
-{@link examples.NetExamples#example34}
-----
-
-Buffer configuration is also supported:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example35}
-----
-
-==== Specifying key/certificate for the client
-
-If the server requires client authentication then the client must present its own certificate to the server when
-connecting. The client can be configured in several ways:
-
-The first method is by specifying the location of a Java key-store which contains the key and certificate.
-Again it's just a regular Java key store. The client keystore location is set by using the function
-{@link io.vertx.core.net.JksOptions#setPath(java.lang.String) path} on the
-{@link io.vertx.core.net.JksOptions jks options}.
-
-[source,$lang]
-----
-{@link examples.NetExamples#example36}
-----
-
-Buffer configuration is also supported:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example37}
-----
-
-Key/certificate in PKCS#12 format (http://en.wikipedia.org/wiki/PKCS_12), usually with the `.pfx`  or the `.p12`
-extension can also be loaded in a similar fashion than JKS key stores:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example38}
-----
-
-Buffer configuration is also supported:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example39}
-----
-
-Another way of providing server private key and certificate separately using `.pem` files.
-
-[source,$lang]
-----
-{@link examples.NetExamples#example40}
-----
-
-Buffer configuration is also supported:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example41}
-----
-
-Keep in mind that pem configuration, the private key is not crypted.
+NOTE: usually client and server perform the handshake upgrade simultaneously, this is usually known as StartTLS and
+it used in protocols that start a conversation in plain text and decide to upgrade the connection with a TLS handshake
 
 ==== Updating SSL/TLS configuration
 
@@ -701,63 +515,6 @@ NOTE: The options object is compared (using `equals`) against the existing optio
 are equals since loading options can be costly. When object are equals, you can use the `force` parameter to force
 the update.
 
-==== Revoking certificate authorities
-
-Trust can be configured to use a certificate revocation list (CRL) for revoked certificates that should no
-longer be trusted. The {@link io.vertx.core.net.NetClientOptions#addCrlPath(java.lang.String) crlPath} configures
-the crl list to use:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example42}
-----
-
-Buffer configuration is also supported:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example43}
-----
-
-==== Configuring the Cipher suite
-
-By default, the TLS configuration will use the list of Cipher suites of the SSL engine:
-
-- JDK SSL engine when {@link io.vertx.core.net.JdkSSLEngineOptions} is used
-- OpenSSL engine when {@link io.vertx.core.net.OpenSSLEngineOptions} is used
-
-This Cipher suite can be configured with a suite of enabled ciphers:
-
-[source,$lang]
-----
-{@link examples.NetExamples#example44}
-----
-
-When the enabled cipher suites is defined (i.e not empty), it takes precedence over the default cipher suites of the SSL engine.
-
-Cipher suite can be specified on the {@link io.vertx.core.net.NetServerOptions} or {@link io.vertx.core.net.NetClientOptions} configuration.
-
-==== Configuring TLS protocol versions
-
-By default, the default TLS configuration enables the following protocols: TLSv1.2 and TLSv1.3. Protocol versions can be
-enabled by explicitly adding them:
-
-[source,$lang]
-----
-{@link examples.NetExamples#addEnabledTLSPrococol}
-----
-
-They can also be removed:
-
-[source,$lang]
-----
-{@link examples.NetExamples#removeEnabledTLSPrococol}
-----
-
-Protocol versions can be specified on the {@link io.vertx.core.net.NetServerOptions} or {@link io.vertx.core.net.NetClientOptions} configuration.
-
-NOTE: TLS 1.0 (TLSv1) and TLS 1.1 (TLSv1.1) are widely deprecated and have been disabled by default since Vert.x 4.4.0.
-
 ==== SSL engine
 
 The engine implementation can be configured to use https://www.openssl.org[OpenSSL] instead of the JDK implementation.
@@ -773,75 +530,6 @@ The engine options to use is
 ----
 {@link examples.NetExamples#exampleSSLEngine}
 ----
-
-==== Server Name Indication (SNI)
-
-Server Name Indication (SNI) is a TLS extension by which a client specifies a hostname attempting to connect: during
-the TLS handshake the client gives a server name and the server can use it to respond with a specific certificate
-for this server name instead of the default deployed certificate.
-If the server requires client authentication the server can use a specific trusted CA certificate depending on the
-indicated server name.
-
-When SNI is active the server uses
-
-* the certificate CN or SAN DNS (Subject Alternative Name with DNS) to do an exact match, e.g `www.example.com`
-* the certificate CN or SAN DNS certificate to match a wildcard name, e.g `*.example.com`
-* otherwise the first certificate when the client does not present a server name or the presented server name cannot be matched
-
-When the server additionally requires client authentication:
-
-* when {@link io.vertx.core.net.JksOptions} is {@link io.vertx.core.net.NetServerOptions#setTrustOptions set on trust options} then an exact match with the trust store alias is done
-* otherwise the available CA certificates are used in the same way as if no SNI is in place
-
-CAUTION: the server fails to bind with an error reporting an incorrect alias
-
-You can enable SNI on the server by setting {@link io.vertx.core.net.NetServerOptions#setSni(boolean)} to `true` and
-configured the server with multiple key/certificate pairs.
-
-Java KeyStore files or PKCS12 files can store multiple key/cert pairs out of the box.
-
-[source,$lang]
-----
-{@link examples.NetExamples#configureSNIServer}
-----
-
-{@link io.vertx.core.net.PemKeyCertOptions} can be configured to hold multiple entries:
-
-[source,$lang]
-----
-{@link examples.NetExamples#configureSNIServerWithPems}
-----
-
-The client implicitly sends the connecting host as an SNI server name for Fully Qualified Domain Name (FQDN).
-
-You can provide an explicit server name when connecting a socket
-
-[source,$lang]
-----
-{@link examples.NetExamples#useSNIInClient}
-----
-
-It can be used for different purposes:
-
-* present a server name different than the server host
-* present a server name while connecting to an IP
-* force to present a server name when using shortname
-
-==== Application-Layer Protocol Negotiation (ALPN)
-
-Application-Layer Protocol Negotiation (ALPN) is a TLS extension for application layer protocol negotiation. It is used by
-HTTP/2: during the TLS handshake the client gives the list of application protocols it accepts and the server responds
-with a protocol it supports.
-
-Java TLS supports ALPN (Java 8 with the most recent versions).
-
-===== OpenSSL ALPN support
-
-OpenSSL also supports (native) ALPN.
-
-OpenSSL requires to configure {@link io.vertx.core.net.TCPSSLOptions#setSslEngineOptions(SSLEngineOptions)}
-and use http://netty.io/wiki/forked-tomcat-native.html[netty-tcnative] jar on the classpath. Using tcnative may require
-OpenSSL to be installed on your OS depending on the tcnative implementation.
 
 === Using a proxy for client connections
 

--- a/vertx-core/src/main/asciidoc/server_ssl.adoc
+++ b/vertx-core/src/main/asciidoc/server_ssl.adoc
@@ -1,0 +1,163 @@
+=== Server SSL/TLS configuration
+
+==== Specifying key/certificate for the server
+
+SSL/TLS servers usually provide certificates to clients in order to verify their identity to clients.
+
+Certificates/keys can be configured for servers in several ways:
+
+The first method is by specifying the location of a Java key-store which contains the certificate and private key.
+
+Java key stores can be managed with the http://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html[keytool]
+utility which ships with the JDK.
+
+The password for the key store should also be provided:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example17}
+----
+
+Alternatively you can read the key store yourself as a buffer and provide that directly:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example18}
+----
+
+Key/certificate in PKCS#12 format (http://en.wikipedia.org/wiki/PKCS_12), usually with the `.pfx`  or the `.p12`
+extension can also be loaded in a similar fashion than JKS key stores:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example19}
+----
+
+Buffer configuration is also supported:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example20}
+----
+
+Another way of providing server private key and certificate separately using `.pem` files.
+
+[source,$lang]
+----
+{@link examples.SslExamples#example21}
+----
+
+Buffer configuration is also supported:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example22}
+----
+
+Vert.x supports reading of unencrypted RSA and/or ECC based private keys from PKCS8 PEM files.
+RSA based private keys can also be read from PKCS1 PEM files.
+X.509 certificates can be read from PEM files containing a textual encoding of the certificate as defined by
+https://tools.ietf.org/html/rfc7468#section-5[RFC 7468, Section 5].
+
+WARNING: Keep in mind that the keys contained in an unencrypted PKCS8 or a PKCS1 PEM file can be extracted by
+anybody who can read the file. Thus, make sure to put proper access restrictions on such PEM files in order to
+prevent misuse.
+
+Finally, you can also load generic Java keystore, it is useful for using other KeyStore implementations
+like Bouncy Castle:
+
+[source,$lang]
+----
+{@link examples.SslExamples#exampleBKS}
+----
+
+==== Specifying trust for the server
+
+SSL/TLS servers can use a certificate authority in order to verify the identity of the clients.
+
+Certificate authorities can be configured for servers in several ways:
+
+Java trust stores can be managed with the http://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html[keytool]
+utility which ships with the JDK.
+
+The password for the trust store should also be provided:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example23}
+----
+
+Alternatively you can read the trust store yourself as a buffer and provide that directly:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example24}
+----
+
+Certificate authority in PKCS#12 format (http://en.wikipedia.org/wiki/PKCS_12), usually with the `.pfx`  or the `.p12`
+extension can also be loaded in a similar fashion than JKS trust stores:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example25}
+----
+
+Buffer configuration is also supported:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example26}
+----
+
+Another way of providing server certificate authority using a list `.pem` files.
+
+[source,$lang]
+----
+{@link examples.SslExamples#example27}
+----
+
+Buffer configuration is also supported:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example28}
+----
+
+==== Server Name Indication (SNI)
+
+Server Name Indication (SNI) is a TLS extension by which a client specifies a hostname attempting to connect: during
+the TLS handshake the client gives a server name and the server can use it to respond with a specific certificate
+for this server name instead of the default deployed certificate.
+
+If the server requires client authentication the server can use a specific trusted CA certificate depending on the
+indicated server name.
+
+When SNI is active the server uses
+
+* the certificate CN or SAN DNS (Subject Alternative Name with DNS) to do an exact match, e.g `www.example.com`
+* the certificate CN or SAN DNS certificate to match a wildcard name, e.g `*.example.com`
+* otherwise the first certificate when the client does not present a server name or the presented server name cannot be matched
+
+When the server additionally requires client authentication:
+
+* when {@link io.vertx.core.net.JksOptions} is {@link io.vertx.core.net.NetServerOptions#setTrustOptions set on trust options} then an exact match with the trust store alias is done
+* otherwise the available CA certificates are used in the same way as if no SNI is in place
+
+CAUTION: the server fails to bind with an error reporting an incorrect alias
+
+You can enable SNI on the server by setting {@link io.vertx.core.net.NetServerOptions#setSni(boolean)} to `true` and
+configured the server with multiple key/certificate pairs.
+
+Java KeyStore files or PKCS12 files can store multiple key/cert pairs out of the box.
+
+[source,$lang]
+----
+{@link examples.SslExamples#configureSNIServer}
+----
+
+{@link io.vertx.core.net.PemKeyCertOptions} can be configured to hold multiple entries:
+
+[source,$lang]
+----
+{@link examples.SslExamples#configureSNIServerWithPems}
+----

--- a/vertx-core/src/main/asciidoc/ssl.adoc
+++ b/vertx-core/src/main/asciidoc/ssl.adoc
@@ -1,0 +1,57 @@
+=== Revoking certificate authorities
+
+Trust can be configured to use a certificate revocation list (CRL) for revoked certificates that should no
+longer be trusted. The {@link io.vertx.core.net.NetClientOptions#addCrlPath(java.lang.String) crlPath} configures
+the crl list to use:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example42}
+----
+
+Buffer configuration is also supported:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example43}
+----
+
+=== Configuring the Cipher suite
+
+By default, the TLS configuration will use the list of Cipher suites of the SSL engine:
+
+- JDK SSL engine when {@link io.vertx.core.net.JdkSSLEngineOptions} is used
+- OpenSSL engine when {@link io.vertx.core.net.OpenSSLEngineOptions} is used
+
+This Cipher suite can be configured with a suite of enabled ciphers:
+
+[source,$lang]
+----
+{@link examples.SslExamples#example44}
+----
+
+When the enabled cipher suites is defined (i.e not empty), it takes precedence over the default cipher suites of the SSL engine.
+
+Cipher suite can be specified on the {@link io.vertx.core.net.NetServerOptions} or {@link io.vertx.core.net.NetClientOptions} configuration.
+
+=== Configuring TLS protocol versions
+
+By default, the default TLS configuration enables the following protocols: TLSv1.2 and TLSv1.3. Protocol versions can be
+enabled by explicitly adding them:
+
+[source,$lang]
+----
+{@link examples.SslExamples#addEnabledTLSPrococol}
+----
+
+They can also be removed:
+
+[source,$lang]
+----
+{@link examples.SslExamples#removeEnabledTLSPrococol}
+----
+
+Protocol versions can be specified on the {@link io.vertx.core.net.NetServerOptions} or {@link io.vertx.core.net.NetClientOptions} configuration.
+
+NOTE: TLS 1.0 (TLSv1) and TLS 1.1 (TLSv1.1) are widely deprecated and have been disabled by default since Vert.x 4.4.0.
+

--- a/vertx-core/src/main/java/examples/NetExamples.java
+++ b/vertx-core/src/main/java/examples/NetExamples.java
@@ -255,155 +255,20 @@ public class NetExamples {
     NetClient client = vertx.createNetClient(options);
   }
 
-  // SSL/TLS server key/cert
-
-  public void example17(Vertx vertx) {
-    NetServerOptions options = new NetServerOptions().setSsl(true).setKeyCertOptions(
-      new JksOptions().
-        setPath("/path/to/your/server-keystore.jks").
-        setPassword("password-of-your-keystore")
-    );
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  public void example18(Vertx vertx) {
-    Buffer myKeyStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/server-keystore.jks");
-    JksOptions jksOptions = new JksOptions().
-      setValue(myKeyStoreAsABuffer).
-      setPassword("password-of-your-keystore");
-    NetServerOptions options = new NetServerOptions().
-      setSsl(true).
-      setKeyCertOptions(jksOptions);
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  public void example19(Vertx vertx) {
-    NetServerOptions options = new NetServerOptions().setSsl(true).setKeyCertOptions(
-      new PfxOptions().
-        setPath("/path/to/your/server-keystore.pfx").
-        setPassword("password-of-your-keystore")
-    );
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  public void example20(Vertx vertx) {
-    Buffer myKeyStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/server-keystore.pfx");
-    PfxOptions pfxOptions = new PfxOptions().
-      setValue(myKeyStoreAsABuffer).
-      setPassword("password-of-your-keystore");
-    NetServerOptions options = new NetServerOptions().
-      setSsl(true).
-      setKeyCertOptions(pfxOptions);
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  public void example21(Vertx vertx) {
-    NetServerOptions options = new NetServerOptions().setSsl(true).setKeyCertOptions(
-      new PemKeyCertOptions().
-        setKeyPath("/path/to/your/server-key.pem").
-        setCertPath("/path/to/your/server-cert.pem")
-    );
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  public void example22(Vertx vertx) {
-    Buffer myKeyAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/server-key.pem");
-    Buffer myCertAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/server-cert.pem");
-    PemKeyCertOptions pemOptions = new PemKeyCertOptions().
-      setKeyValue(myKeyAsABuffer).
-      setCertValue(myCertAsABuffer);
-    NetServerOptions options = new NetServerOptions().
-      setSsl(true).
-      setKeyCertOptions(pemOptions);
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  public void exampleBKS(Vertx vertx) {
-    NetServerOptions options = new NetServerOptions().setSsl(true).setKeyCertOptions(
-      new KeyStoreOptions().
-        setType("BKS").
-        setPath("/path/to/your/server-keystore.bks").
-        setPassword("password-of-your-keystore")
-    );
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  // SSL/TLS server trust
-
-  public void example23(Vertx vertx) {
-    NetServerOptions options = new NetServerOptions().
-      setSsl(true).
-      setClientAuth(ClientAuth.REQUIRED).
-      setTrustOptions(
+  public void sslServerConfiguration(Vertx vertx) {
+    ServerSSLOptions sslOptions = new ServerSSLOptions()
+      .setKeyCertOptions(
         new JksOptions().
-          setPath("/path/to/your/truststore.jks").
-          setPassword("password-of-your-truststore")
+          setPath("/path/to/your/server-keystore.jks").
+          setPassword("password-of-your-keystore")
       );
+
+    NetServerOptions options = new NetServerOptions()
+      .setSsl(true)
+      .setSslOptions(sslOptions);
+
     NetServer server = vertx.createNetServer(options);
   }
-
-  public void example24(Vertx vertx) {
-    Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/truststore.jks");
-    NetServerOptions options = new NetServerOptions().
-      setSsl(true).
-      setClientAuth(ClientAuth.REQUIRED).
-      setTrustOptions(
-        new JksOptions().
-          setValue(myTrustStoreAsABuffer).
-          setPassword("password-of-your-truststore")
-      );
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  public void example25(Vertx vertx) {
-    NetServerOptions options = new NetServerOptions().
-      setSsl(true).
-      setClientAuth(ClientAuth.REQUIRED).
-      setTrustOptions(
-        new PfxOptions().
-          setPath("/path/to/your/truststore.pfx").
-          setPassword("password-of-your-truststore")
-      );
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  public void example26(Vertx vertx) {
-    Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/truststore.pfx");
-    NetServerOptions options = new NetServerOptions().
-      setSsl(true).
-      setClientAuth(ClientAuth.REQUIRED).
-      setTrustOptions(
-        new PfxOptions().
-          setValue(myTrustStoreAsABuffer).
-          setPassword("password-of-your-truststore")
-      );
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  public void example27(Vertx vertx) {
-    NetServerOptions options = new NetServerOptions().
-      setSsl(true).
-      setClientAuth(ClientAuth.REQUIRED).
-      setTrustOptions(
-        new PemTrustOptions().
-          addCertPath("/path/to/your/server-ca.pem")
-      );
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  public void example28(Vertx vertx) {
-    Buffer myCaAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/server-ca.pfx");
-    NetServerOptions options = new NetServerOptions().
-      setSsl(true).
-      setClientAuth(ClientAuth.REQUIRED).
-      setTrustOptions(
-        new PemTrustOptions().
-          addCertValue(myCaAsABuffer)
-      );
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  // SSL/TLS client trust all
 
   public void example29(Vertx vertx) {
     NetClientOptions options = new NetClientOptions().
@@ -412,136 +277,71 @@ public class NetExamples {
     NetClient client = vertx.createNetClient(options);
   }
 
-  // SSL/TLS client trust
-
-  public void example30(Vertx vertx) {
-    NetClientOptions options = new NetClientOptions().
-      setSsl(true).
-      setTrustOptions(
-        new JksOptions().
-          setPath("/path/to/your/truststore.jks").
-          setPassword("password-of-your-truststore")
+  public void sslClientConfiguration(Vertx vertx) {
+    ClientSSLOptions sslOptions = new ClientSSLOptions()
+      .setTrustOptions(new JksOptions().
+        setPath("/path/to/your/truststore.jks").
+        setPassword("password-of-your-truststore")
       );
+
+    NetClientOptions options = new NetClientOptions()
+      .setSsl(true)
+      .setSslOptions(sslOptions);
+
     NetClient client = vertx.createNetClient(options);
   }
 
-  public void example31(Vertx vertx) {
-    Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/truststore.jks");
-    NetClientOptions options = new NetClientOptions().
-      setSsl(true).
-      setTrustOptions(
-        new JksOptions().
-          setValue(myTrustStoreAsABuffer).
-          setPassword("password-of-your-truststore")
+  public void sslClientSocketConfiguration(Vertx vertx, int port, String host) {
+    ClientSSLOptions sslOptions = new ClientSSLOptions()
+      .setTrustOptions(new JksOptions().
+        setPath("/path/to/your/truststore.jks").
+        setPassword("password-of-your-truststore")
       );
+
+    NetClientOptions options = new NetClientOptions().setSslOptions(sslOptions);
+
     NetClient client = vertx.createNetClient(options);
-  }
 
-  public void example32(Vertx vertx) {
-    NetClientOptions options = new NetClientOptions().
-      setSsl(true).
-      setTrustOptions(
-        new PfxOptions().
-          setPath("/path/to/your/truststore.pfx").
-          setPassword("password-of-your-truststore")
-      );
-    NetClient client = vertx.createNetClient(options);
-  }
-
-  public void example33(Vertx vertx) {
-    Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/truststore.pfx");
-    NetClientOptions options = new NetClientOptions().
-      setSsl(true).
-      setTrustOptions(
-        new PfxOptions().
-          setValue(myTrustStoreAsABuffer).
-          setPassword("password-of-your-truststore")
-      );
-    NetClient client = vertx.createNetClient(options);
-  }
-
-  public void example34(Vertx vertx) {
-    NetClientOptions options = new NetClientOptions().
-      setSsl(true).
-      setTrustOptions(
-        new PemTrustOptions().
-          addCertPath("/path/to/your/ca-cert.pem")
-      );
-    NetClient client = vertx.createNetClient(options);
-  }
-
-  public void example35(Vertx vertx) {
-    Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/ca-cert.pem");
-    NetClientOptions options = new NetClientOptions().
-      setSsl(true).
-      setTrustOptions(
-        new PemTrustOptions().
-          addCertValue(myTrustStoreAsABuffer)
-      );
-    NetClient client = vertx.createNetClient(options);
-  }
-
-  // SSL/TLS client key/cert
-
-  public void example36(Vertx vertx) {
-    NetClientOptions options = new NetClientOptions().setSsl(true).setKeyCertOptions(
-      new JksOptions().
-        setPath("/path/to/your/client-keystore.jks").
-        setPassword("password-of-your-keystore")
+    Future<NetSocket> future = client.connect(new ConnectOptions()
+      .setHost(host)
+      .setPort(port)
+      .setSsl(true)
     );
-    NetClient client = vertx.createNetClient(options);
   }
 
-  public void example37(Vertx vertx) {
-    Buffer myKeyStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/client-keystore.jks");
-    JksOptions jksOptions = new JksOptions().
-      setValue(myKeyStoreAsABuffer).
-      setPassword("password-of-your-keystore");
-    NetClientOptions options = new NetClientOptions().
-      setSsl(true).
-      setKeyCertOptions(jksOptions);
-    NetClient client = vertx.createNetClient(options);
-  }
+  public void sslClientSocketConfiguration2(Vertx vertx, int port, String host) {
+    NetClient client = vertx.createNetClient();
 
-  public void example38(Vertx vertx) {
-    NetClientOptions options = new NetClientOptions().setSsl(true).setKeyCertOptions(
-      new PfxOptions().
-        setPath("/path/to/your/client-keystore.pfx").
-        setPassword("password-of-your-keystore")
+    ClientSSLOptions sslOptions = new ClientSSLOptions()
+      .setTrustOptions(new JksOptions().
+        setPath("/path/to/your/truststore.jks").
+        setPassword("password-of-your-truststore")
+      );
+
+    Future<NetSocket> future = client.connect(new ConnectOptions()
+      .setHost(host)
+      .setPort(port)
+      .setSsl(true)
+      .setSslOptions(sslOptions)
     );
-    NetClient client = vertx.createNetClient(options);
   }
 
-  public void example39(Vertx vertx) {
-    Buffer myKeyStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/client-keystore.pfx");
-    PfxOptions pfxOptions = new PfxOptions().
-      setValue(myKeyStoreAsABuffer).
-      setPassword("password-of-your-keystore");
-    NetClientOptions options = new NetClientOptions().
-      setSsl(true).
-      setKeyCertOptions(pfxOptions);
-    NetClient client = vertx.createNetClient(options);
-  }
+  public void upgradeToSSL(NetSocket socket, SSLOptions sslOptions) {
+    // Use the default SSL options of the client or the server
+    socket.upgradeToSsl()
+      .onSuccess(v -> {
+        // Upgrade worked
+      }).onFailure(err -> {
+        // Upgrade failed
+      });
 
-  public void example40(Vertx vertx) {
-    NetClientOptions options = new NetClientOptions().setSsl(true).setKeyCertOptions(
-      new PemKeyCertOptions().
-        setKeyPath("/path/to/your/client-key.pem").
-        setCertPath("/path/to/your/client-cert.pem")
-    );
-    NetClient client = vertx.createNetClient(options);
-  }
-
-  public void example41(Vertx vertx) {
-    Buffer myKeyAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/client-key.pem");
-    Buffer myCertAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/client-cert.pem");
-    PemKeyCertOptions pemOptions = new PemKeyCertOptions().
-      setKeyValue(myKeyAsABuffer).
-      setCertValue(myCertAsABuffer);
-    NetClientOptions options = new NetClientOptions().
-      setSsl(true).
-      setKeyCertOptions(pemOptions);
-    NetClient client = vertx.createNetClient(options);
+    // Use the specified SSL options
+    socket.upgradeToSsl(sslOptions)
+      .onSuccess(v -> {
+        // Upgrade worked
+      }).onFailure(err -> {
+        // Upgrade failed
+      });
   }
 
   public void updateSSLOptions(HttpServer server) {
@@ -550,50 +350,6 @@ public class NetExamples {
         new JksOptions()
           .setPath("/path/to/your/server-keystore.jks").
           setPassword("password-of-your-keystore")));
-  }
-
-  public void example42(Vertx vertx, JksOptions trustOptions) {
-    NetClientOptions options = new NetClientOptions().
-      setSsl(true).
-      setTrustOptions(trustOptions).
-      addCrlPath("/path/to/your/crl.pem");
-    NetClient client = vertx.createNetClient(options);
-  }
-
-  public void example43(Vertx vertx, JksOptions trustOptions) {
-    Buffer myCrlAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/crl.pem");
-    NetClientOptions options = new NetClientOptions().
-      setSsl(true).
-      setTrustOptions(trustOptions).
-      addCrlValue(myCrlAsABuffer);
-    NetClient client = vertx.createNetClient(options);
-  }
-
-  public void example44(Vertx vertx, JksOptions keyStoreOptions) {
-    NetServerOptions options = new NetServerOptions().
-      setSsl(true).
-      setKeyCertOptions(keyStoreOptions).
-      addEnabledCipherSuite("ECDHE-RSA-AES128-GCM-SHA256").
-      addEnabledCipherSuite("ECDHE-ECDSA-AES128-GCM-SHA256").
-      addEnabledCipherSuite("ECDHE-RSA-AES256-GCM-SHA384").
-      addEnabledCipherSuite("CDHE-ECDSA-AES256-GCM-SHA384");
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  public void addEnabledTLSPrococol(Vertx vertx, JksOptions keyStoreOptions) {
-    NetServerOptions options = new NetServerOptions().
-      setSsl(true).
-      setKeyCertOptions(keyStoreOptions).
-      addEnabledSecureTransportProtocol("TLSv1.1");
-    NetServer server = vertx.createNetServer(options);
-  }
-
-  public void removeEnabledTLSPrococol(Vertx vertx, JksOptions keyStoreOptions) {
-    NetServerOptions options = new NetServerOptions().
-      setSsl(true).
-      setKeyCertOptions(keyStoreOptions).
-      removeEnabledSecureTransportProtocol("TLSv1.2");
-    NetServer server = vertx.createNetServer(options);
   }
 
   public void exampleSSLEngine(Vertx vertx, JksOptions keyStoreOptions) {
@@ -616,10 +372,12 @@ public class NetExamples {
       setSslEngineOptions(new OpenSSLEngineOptions());
   }
 
-  public void example46(Vertx vertx, String verificationAlgorithm) {
+  public void example46(Vertx vertx, String verificationAlgorithm, ClientSSLOptions sslOptions) {
     NetClientOptions options = new NetClientOptions().
       setSsl(true).
+      setSslOptions(sslOptions).
       setHostnameVerificationAlgorithm(verificationAlgorithm);
+
     NetClient client = vertx.createNetClient(options);
   }
 

--- a/vertx-core/src/main/java/examples/SslExamples.java
+++ b/vertx-core/src/main/java/examples/SslExamples.java
@@ -1,0 +1,307 @@
+package examples;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.ClientAuth;
+import io.vertx.core.net.ClientSSLOptions;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.KeyStoreOptions;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.NetServer;
+import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.core.net.PfxOptions;
+import io.vertx.core.net.ServerSSLOptions;
+
+import java.util.Arrays;
+
+public class SslExamples {
+
+  public void example17(Vertx vertx) {
+    ServerSSLOptions options = new ServerSSLOptions()
+      .setKeyCertOptions(
+      new JksOptions().
+        setPath("/path/to/your/server-keystore.jks").
+        setPassword("password-of-your-keystore")
+    );
+  }
+
+  public void example18(Vertx vertx) {
+    Buffer myKeyStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/server-keystore.jks");
+    ServerSSLOptions options = new ServerSSLOptions()
+      .setKeyCertOptions(
+        new JksOptions().
+          setValue(myKeyStoreAsABuffer).
+          setPassword("password-of-your-keystore")
+      );
+  }
+
+  public void example19(Vertx vertx) {
+    ServerSSLOptions options = new ServerSSLOptions()
+      .setKeyCertOptions(
+        new PfxOptions().
+          setPath("/path/to/your/server-keystore.pfx").
+          setPassword("password-of-your-keystore")
+      );
+  }
+
+  public void example20(Vertx vertx) {
+    Buffer myKeyStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/server-keystore.pfx");
+    ServerSSLOptions options = new ServerSSLOptions()
+      .setKeyCertOptions(
+        new PfxOptions().
+          setValue(myKeyStoreAsABuffer).
+          setPassword("password-of-your-keystore")
+      );
+  }
+
+  public void example21(Vertx vertx) {
+    ServerSSLOptions options = new ServerSSLOptions()
+      .setKeyCertOptions(
+        new PemKeyCertOptions().
+          setKeyPath("/path/to/your/server-key.pem").
+          setCertPath("/path/to/your/server-cert.pem")
+      );
+  }
+
+  public void example22(Vertx vertx) {
+    Buffer myKeyAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/server-key.pem");
+    Buffer myCertAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/server-cert.pem");
+    ServerSSLOptions options = new ServerSSLOptions()
+      .setKeyCertOptions(
+        new PemKeyCertOptions().
+          setKeyValue(myKeyAsABuffer).
+          setCertValue(myCertAsABuffer)
+      );
+  }
+
+  public void exampleBKS(Vertx vertx) {
+    ServerSSLOptions options = new ServerSSLOptions()
+      .setKeyCertOptions(
+        new KeyStoreOptions().
+          setType("BKS").
+          setPath("/path/to/your/server-keystore.bks").
+          setPassword("password-of-your-keystore")
+      );
+  }
+
+  public void example23(Vertx vertx) {
+    ServerSSLOptions options = new ServerSSLOptions().
+      setClientAuth(ClientAuth.REQUIRED).
+      setTrustOptions(
+        new JksOptions().
+          setPath("/path/to/your/truststore.jks").
+          setPassword("password-of-your-truststore")
+      );
+  }
+
+  public void example24(Vertx vertx) {
+    Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/truststore.jks");
+    ServerSSLOptions options = new ServerSSLOptions().
+      setClientAuth(ClientAuth.REQUIRED).
+      setTrustOptions(
+        new JksOptions().
+          setValue(myTrustStoreAsABuffer).
+          setPassword("password-of-your-truststore")
+      );
+  }
+
+  public void example25(Vertx vertx) {
+    ServerSSLOptions options = new ServerSSLOptions().
+      setClientAuth(ClientAuth.REQUIRED).
+      setTrustOptions(
+        new PfxOptions().
+          setPath("/path/to/your/truststore.pfx").
+          setPassword("password-of-your-truststore")
+      );
+  }
+
+  public void example26(Vertx vertx) {
+    Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/truststore.pfx");
+    ServerSSLOptions options = new ServerSSLOptions().
+      setClientAuth(ClientAuth.REQUIRED).
+      setTrustOptions(
+        new PfxOptions().
+          setValue(myTrustStoreAsABuffer).
+          setPassword("password-of-your-truststore")
+      );
+  }
+
+  public void example27(Vertx vertx) {
+    ServerSSLOptions options = new ServerSSLOptions().
+      setClientAuth(ClientAuth.REQUIRED).
+      setTrustOptions(
+        new PemTrustOptions().
+          addCertPath("/path/to/your/server-ca.pem")
+      );
+  }
+
+  public void example28(Vertx vertx) {
+    Buffer myCaAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/server-ca.pfx");
+    ServerSSLOptions options = new ServerSSLOptions().
+      setClientAuth(ClientAuth.REQUIRED).
+      setTrustOptions(
+        new PemTrustOptions().
+          addCertValue(myCaAsABuffer)
+      );
+  }
+
+  public void example29(Vertx vertx) {
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setTrustAll(true);
+  }
+
+  public void example30(Vertx vertx) {
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setTrustOptions(new JksOptions().
+        setPath("/path/to/your/truststore.jks").
+        setPassword("password-of-your-truststore")
+      );
+  }
+
+  public void example31(Vertx vertx) {
+    Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/truststore.jks");
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setTrustOptions(new JksOptions().
+        setValue(myTrustStoreAsABuffer).
+        setPassword("password-of-your-truststore")
+      );
+  }
+
+  public void example32(Vertx vertx) {
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setTrustOptions(new PfxOptions().
+        setPath("/path/to/your/truststore.pfx").
+        setPassword("password-of-your-truststore")
+      );
+  }
+
+  public void example33(Vertx vertx) {
+    Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/truststore.pfx");
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setTrustOptions(new PfxOptions().
+        setValue(myTrustStoreAsABuffer).
+        setPassword("password-of-your-truststore")
+      );
+  }
+
+  public void example34(Vertx vertx) {
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setTrustOptions(new PemTrustOptions().
+        addCertPath("/path/to/your/ca-cert.pem")
+      );
+  }
+
+  public void example35(Vertx vertx) {
+    Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/ca-cert.pem");
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setTrustOptions(new PemTrustOptions().
+        addCertValue(myTrustStoreAsABuffer)
+      );
+  }
+
+  public void example36(Vertx vertx) {
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setKeyCertOptions(new JksOptions().
+        setPath("/path/to/your/client-keystore.jks").
+        setPassword("password-of-your-keystore")
+      );
+  }
+
+  public void example37(Vertx vertx) {
+    Buffer myKeyStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/client-keystore.jks");
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setKeyCertOptions(new JksOptions().
+        setValue(myKeyStoreAsABuffer).
+        setPassword("password-of-your-keystore")
+      );
+  }
+
+  public void example38(Vertx vertx) {
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setKeyCertOptions(new PfxOptions().
+        setPath("/path/to/your/client-keystore.pfx").
+        setPassword("password-of-your-keystore")
+      );
+  }
+
+  public void example39(Vertx vertx) {
+    Buffer myKeyStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/client-keystore.pfx");
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setKeyCertOptions(new PfxOptions().
+        setValue(myKeyStoreAsABuffer).
+        setPassword("password-of-your-keystore")
+      );
+  }
+
+  public void example40(Vertx vertx) {
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setKeyCertOptions(new PemKeyCertOptions().
+        setKeyPath("/path/to/your/client-key.pem").
+        setCertPath("/path/to/your/client-cert.pem")
+      );
+  }
+
+  public void example41(Vertx vertx) {
+    Buffer myKeyAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/client-key.pem");
+    Buffer myCertAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/client-cert.pem");
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setKeyCertOptions(new PemKeyCertOptions().
+        setKeyValue(myKeyAsABuffer).
+        setCertValue(myCertAsABuffer)
+      );
+  }
+
+  public void example42(Vertx vertx, JksOptions trustOptions) {
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setTrustOptions(trustOptions)
+      .addCrlPath("/path/to/your/crl.pem");
+  }
+
+  public void example43(Vertx vertx, JksOptions trustOptions) {
+    Buffer myCrlAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/crl.pem");
+    ClientSSLOptions options = new ClientSSLOptions()
+      .setTrustOptions(trustOptions)
+      .addCrlValue(myCrlAsABuffer);
+  }
+
+  public void example44(Vertx vertx, JksOptions keyStoreOptions) {
+    ServerSSLOptions options = new ServerSSLOptions().
+      setKeyCertOptions(keyStoreOptions).
+      addEnabledCipherSuite("ECDHE-RSA-AES128-GCM-SHA256").
+      addEnabledCipherSuite("ECDHE-ECDSA-AES128-GCM-SHA256").
+      addEnabledCipherSuite("ECDHE-RSA-AES256-GCM-SHA384").
+      addEnabledCipherSuite("CDHE-ECDSA-AES256-GCM-SHA384");
+  }
+
+  public void addEnabledTLSPrococol(Vertx vertx, JksOptions keyStoreOptions) {
+    ServerSSLOptions options = new ServerSSLOptions().
+      setKeyCertOptions(keyStoreOptions).
+      addEnabledSecureTransportProtocol("TLSv1.1");
+  }
+
+  public void removeEnabledTLSPrococol(Vertx vertx, JksOptions keyStoreOptions) {
+    ServerSSLOptions options = new ServerSSLOptions().
+      setKeyCertOptions(keyStoreOptions).
+      removeEnabledSecureTransportProtocol("TLSv1.2");
+  }
+
+  public void configureSNIServer(Vertx vertx) {
+    ServerSSLOptions options = new ServerSSLOptions()
+      .setKeyCertOptions(new JksOptions()
+        .setPath("keystore.jks")
+        .setPassword("wibble"))
+      .setSni(true);
+  }
+
+  public void configureSNIServerWithPems(Vertx vertx) {
+    ServerSSLOptions options = new ServerSSLOptions()
+      .setKeyCertOptions(new PemKeyCertOptions()
+        .setKeyPaths(Arrays.asList("default-key.pem", "host1-key.pem", "etc..."))
+        .setCertPaths(Arrays.asList("default-cert.pem", "host2-key.pem", "etc...")
+        ))
+      .setSni(true);
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/net/ClientSSLOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/ClientSSLOptions.java
@@ -12,6 +12,7 @@ package io.vertx.core.net;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 
 import java.util.List;
@@ -147,6 +148,36 @@ public class ClientSSLOptions extends SSLOptions {
   @Override
   public ClientSSLOptions setApplicationLayerProtocols(List<String> protocols) {
     return (ClientSSLOptions) super.setApplicationLayerProtocols(protocols);
+  }
+
+  @Override
+  public ClientSSLOptions addCrlPath(String crlPath) throws NullPointerException {
+    return (ClientSSLOptions) super.addCrlPath(crlPath);
+  }
+
+  @Override
+  public ClientSSLOptions addCrlValue(Buffer crlValue) throws NullPointerException {
+    return (ClientSSLOptions) super.addCrlValue(crlValue);
+  }
+
+  @Override
+  public ClientSSLOptions removeEnabledCipherSuite(String suite) {
+    return (ClientSSLOptions) super.removeEnabledCipherSuite(suite);
+  }
+
+  @Override
+  public ClientSSLOptions addEnabledSecureTransportProtocol(String protocol) {
+    return (ClientSSLOptions) super.addEnabledSecureTransportProtocol(protocol);
+  }
+
+  @Override
+  public ClientSSLOptions removeEnabledSecureTransportProtocol(String protocol) {
+    return (ClientSSLOptions) super.removeEnabledSecureTransportProtocol(protocol);
+  }
+
+  @Override
+  public ClientSSLOptions addEnabledCipherSuite(String suite) {
+    return (ClientSSLOptions) super.addEnabledCipherSuite(suite);
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/NetSocket.java
@@ -255,8 +255,6 @@ public interface NetSocket extends Socket {
    *
    * <p>The server name is sent in the client handshake, it should be {@code null} on a server.</p>
    *
-   * <p>Be aware that for this to work SSL must be configured.</p>
-   *
    * @param sslOptions the SSL options
    * @param serverName the server name
    * @param upgrade the upgrade message to send

--- a/vertx-core/src/main/java/io/vertx/core/net/ServerSSLOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/ServerSSLOptions.java
@@ -168,6 +168,16 @@ public class ServerSSLOptions extends SSLOptions {
     return (ServerSSLOptions) super.addEnabledSecureTransportProtocol(protocol);
   }
 
+  @Override
+  public ServerSSLOptions removeEnabledCipherSuite(String suite) {
+    return (ServerSSLOptions) super.removeEnabledCipherSuite(suite);
+  }
+
+  @Override
+  public ServerSSLOptions removeEnabledSecureTransportProtocol(String protocol) {
+    return (ServerSSLOptions) super.removeEnabledSecureTransportProtocol(protocol);
+  }
+
   /**
    * Convert to JSON
    *


### PR DESCRIPTION
Motivation:

The current SSL/TLS documentation is coupled to the Vert.x Net documentation.

Most of the SSL/TLS configuration has been encapsulated in SSLOptions/ClientSSLOptions/ServerSSLOptions.

We should provide a base documentation for configuring those options and keep the Vert.x Net configuration to a minimum and refer to the documentation of those options.

Changes:

Extracted the Vert.x Net client/server SSL configuration part that is generic and not coupled to this section of the documentation in a new top level section that generically documents client/server SSL options.

Keep in Vert.x Net documentation the specific documentation.

Added examples for ConnectOptions SSL configuration.

Move the TLS upgrade documentation to the Net SSL documentation section.
