### PR TITLE
WIP - delay locals capture from Vertx to contexts

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/LocalSeq.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/LocalSeq.java
@@ -15,7 +15,6 @@ import io.vertx.core.spi.context.storage.ContextLocal;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -38,7 +37,11 @@ public class LocalSeq {
     locals.add(ContextInternal.LOCAL_MAP);
   }
 
-  synchronized static ContextLocal<?>[] get() {
+  synchronized static ContextLocal<?>[] getArray() {
     return locals.toArray(new ContextLocal[0]);
+  }
+
+  synchronized static List<ContextLocal<?>> getList() {
+    return List.copyOf(locals);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -150,8 +150,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   private final FileResolver fileResolver;
   private final EventExecutorProvider eventExecutorProvider;
   private final Map<ServerID, NetServerInternal> sharedNetServers = new HashMap<>();
-  private final ContextLocal<?>[] contextLocals;
-  private final List<ContextLocal<?>> contextLocalsList;
   final WorkerPool workerPool;
   final WorkerPool internalWorkerPool;
   final WorkerPool virtualThreadWorkerPool;
@@ -211,8 +209,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     ThreadFactory virtualThreadFactory = virtualThreadFactory();
     PoolMetrics virtualThreadWorkerPoolMetrics = metrics != null && virtualThreadFactory != null ? metrics.createPoolMetrics("worker", "vert.x-virtual-thread", -1) : null;
 
-    contextLocals = LocalSeq.get();
-    contextLocalsList = Collections.unmodifiableList(Arrays.asList(contextLocals));
     closeFuture = new CloseFuture(log);
     maxEventLoopExecTime = maxEventLoopExecuteTime;
     maxEventLoopExecTimeUnit = maxEventLoopExecuteTimeUnit;
@@ -619,6 +615,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   private Object[] createContextLocals() {
+    ContextLocal<?>[] contextLocals = LocalSeq.getArray();
     if (contextLocals.length == 0) {
       return EMPTY_CONTEXT_LOCALS;
     } else {
@@ -951,7 +948,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public List<ContextLocal<?>> contextLocals() {
-    return contextLocalsList;
+    return LocalSeq.getList();
   }
 
   @Override
@@ -1340,6 +1337,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   }
 
   void duplicate(ContextBase src, ContextBase dst) {
+    ContextLocal<?>[] contextLocals = LocalSeq.getArray();
     for (int i = 0;i < contextLocals.length;i++) {
       ContextLocalImpl<?> contextLocal = (ContextLocalImpl<?>) contextLocals[i];
       Object local = AccessMode.CONCURRENT.get(src.locals, i);

--- a/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
@@ -1242,7 +1242,10 @@ public class ContextTest extends VertxTestBase {
     List<ContextLocal<?>> locals = ((VertxInternal) vertx).contextLocals();
     assertSame(ContextInternal.LOCAL_MAP, locals.get(0));
     assertSame(contextLocal, locals.get(1));
-    assertSame(locals, ((VertxInternal) vertx).contextLocals());
+    List<ContextLocal<?>> localsAgain = ((VertxInternal) vertx).contextLocals();
+    assertNotSame(locals, localsAgain);
+    assertSame(ContextInternal.LOCAL_MAP, localsAgain.get(0));
+    assertSame(contextLocal, localsAgain.get(1));
   }
 
   @Test


### PR DESCRIPTION
I am wondering if we'd benefit from shifting the context local captures from the `Vertx` instance to the actual contexts creation. This involves a few allocations on duplication, but I don't think it'd be that much of a problem.

One possible improvement (but I have not verified) is that it could allow new `ContextLocal` instances to be registered after a `Vertx` context has been initialized.

WDYT?