### PR TITLE
HTTP server builder.

### DIFF
--- a/vertx-core/src/main/asciidoc/net.adoc
+++ b/vertx-core/src/main/asciidoc/net.adoc
@@ -515,22 +515,6 @@ NOTE: The options object is compared (using `equals`) against the existing optio
 are equals since loading options can be costly. When object are equals, you can use the `force` parameter to force
 the update.
 
-==== SSL engine
-
-The engine implementation can be configured to use https://www.openssl.org[OpenSSL] instead of the JDK implementation.
-Before JDK started to use hardware intrinsics (CPU instructions) for AES in Java 8 and for RSA in Java 9,
-OpenSSL provided much better performances and CPU usage than the JDK engine.
-
-The engine options to use is
-
-- the {@link io.vertx.core.net.TCPSSLOptions#getSslEngineOptions()} options when it is set
-- otherwise {@link io.vertx.core.net.JdkSSLEngineOptions}
-
-[source,$lang]
-----
-{@link examples.NetExamples#exampleSSLEngine}
-----
-
 === Using a proxy for client connections
 
 The {@link io.vertx.core.net.NetClient} supports either an HTTP/1.x _CONNECT_, _SOCKS4a_ or _SOCKS5_ proxy.

--- a/vertx-core/src/main/asciidoc/ssl.adoc
+++ b/vertx-core/src/main/asciidoc/ssl.adoc
@@ -55,3 +55,14 @@ Protocol versions can be specified on the {@link io.vertx.core.net.ServerSSLOpti
 
 NOTE: TLS 1.0 (TLSv1) and TLS 1.1 (TLSv1.1) are widely deprecated and have been disabled by default since Vert.x 4.4.0.
 
+=== SSL engine
+
+The engine implementation can be configured to use https://www.openssl.org[OpenSSL] instead of the JDK implementation.
+Before JDK started to use hardware intrinsics (CPU instructions) for AES in Java 8 and for RSA in Java 9,
+OpenSSL provided much better performances and CPU usage than the JDK engine.
+
+[source,$lang]
+----
+{@link examples.SslExamples#exampleSSLEngine}
+----
+

--- a/vertx-core/src/main/generated/io/vertx/core/net/JdkSSLEngineOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/JdkSSLEngineOptionsConverter.java
@@ -1,0 +1,31 @@
+package io.vertx.core.net;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+
+/**
+ * Converter and mapper for {@link io.vertx.core.net.JdkSSLEngineOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.core.net.JdkSSLEngineOptions} original class using Vert.x codegen.
+ */
+public class JdkSSLEngineOptionsConverter {
+
+   static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, JdkSSLEngineOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "useWorkerThread":
+          if (member.getValue() instanceof Boolean) {
+            obj.setUseWorkerThread((Boolean)member.getValue());
+          }
+          break;
+      }
+    }
+  }
+
+   static void toJson(JdkSSLEngineOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+   static void toJson(JdkSSLEngineOptions obj, java.util.Map<String, Object> json) {
+    json.put("useWorkerThread", obj.getUseWorkerThread());
+  }
+}

--- a/vertx-core/src/main/java/examples/NetExamples.java
+++ b/vertx-core/src/main/java/examples/NetExamples.java
@@ -362,23 +362,6 @@ public class NetExamples {
           setPassword("password-of-your-keystore")));
   }
 
-  public void exampleSSLEngine(Vertx vertx, JksOptions keyStoreOptions) {
-
-    // Use JDK SSL engine
-    TcpServerConfig options = new TcpServerConfig().
-      setSsl(true);
-
-    // Use JDK SSL engine explicitly
-    options = new TcpServerConfig().
-      setSsl(true).
-      setSslEngineOptions(new JdkSSLEngineOptions());
-
-    // Use OpenSSL engine
-    options = new TcpServerConfig().
-      setSsl(true).
-      setSslEngineOptions(new OpenSSLEngineOptions());
-  }
-
   public void example46(Vertx vertx, String verificationAlgorithm, TrustOptions trustOptions) {
     TcpClientConfig config = new TcpClientConfig().
       setSsl(true);

--- a/vertx-core/src/main/java/examples/SslExamples.java
+++ b/vertx-core/src/main/java/examples/SslExamples.java
@@ -3,17 +3,22 @@ package examples;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ClientAuth;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerConfig;
 import io.vertx.core.net.ClientSSLOptions;
+import io.vertx.core.net.JdkSSLEngineOptions;
 import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.KeyStoreOptions;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.net.OpenSSLEngineOptions;
 import io.vertx.core.net.PemKeyCertOptions;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.core.net.ServerSSLOptions;
+import io.vertx.core.net.TcpServerConfig;
 
 import java.util.Arrays;
 
@@ -303,5 +308,30 @@ public class SslExamples {
         .setCertPaths(Arrays.asList("default-cert.pem", "host2-key.pem", "etc...")
         ))
       .setSni(true);
+  }
+
+  public void exampleSSLEngine(Vertx vertx, JksOptions keyStoreOptions) {
+
+    ServerSSLOptions sslOptions = new ServerSSLOptions()
+      .setKeyCertOptions(keyStoreOptions);
+    HttpServerConfig config = new HttpServerConfig()
+      .setSsl(true);
+
+    // Use JDK SSL engine
+    HttpServer server = vertx.createHttpServer(config);
+
+    // Use JDK SSL engine explicitly
+    server = vertx.httpServerBuilder()
+      .with(config)
+      .with(sslOptions)
+      .with(new JdkSSLEngineOptions())
+      .build();
+
+    // Use OpenSSL engine
+    server = vertx.httpServerBuilder()
+      .with(config)
+      .with(sslOptions)
+      .with(new OpenSSLEngineOptions())
+      .build();
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -129,11 +129,7 @@ public final class ClusteredEventBus extends EventBusImpl {
   }
 
   private NetClient createNetClient(VertxInternal vertx, NetClientOptions clientOptions) {
-    TcpClientConfig config = new TcpClientConfig(clientOptions);
-    NetClientBuilder builder = new NetClientBuilder(vertx, config)
-      .sslOptions(clientOptions.getSslOptions())
-      .registerWriteHandler(clientOptions.isRegisterWriteHandler());
-    return builder.build();
+    return new NetClientBuilder(vertx, clientOptions).build();
   }
 
   private NetServerOptions getServerOptions() {

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientBuilder.java
@@ -16,6 +16,7 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.net.ClientSSLOptions;
+import io.vertx.core.net.SSLEngineOptions;
 import io.vertx.core.net.endpoint.LoadBalancer;
 import io.vertx.core.net.AddressResolver;
 
@@ -60,6 +61,14 @@ public interface HttpClientBuilder {
    */
   @Fluent
   HttpClientBuilder with(ClientSSLOptions options);
+
+  /**
+   * Configure the client with the given SSL {@code engine}.
+   * @param engine the SSL engine options
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpClientBuilder with(SSLEngineOptions engine);
 
   /**
    * Set a connection handler for the client. This handler is called when a new connection is established.

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerBuilder.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+import io.vertx.core.net.SSLEngineOptions;
+import io.vertx.core.net.ServerSSLOptions;
+
+/**
+ * A builder for {@link HttpServer}.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface HttpServerBuilder {
+
+  /**
+   * Configure the server.
+   * @param config the server config
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpServerBuilder with(HttpServerConfig config);
+
+  /**
+   * Configure the server with the given SSL {@code options}.
+   * @param options the SSL options
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpServerBuilder with(ServerSSLOptions options);
+
+  /**
+   * Configure the server with the given SSL {@code engine}.
+   * @param engine the SSL engine options
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpServerBuilder with(SSLEngineOptions engine);
+
+  /**
+   * Set a connection handler for the server. This handler is called when a new connection is established.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpServerBuilder withConnectHandler(Handler<HttpConnection> handler);
+
+  /**
+   * Build and return the server.
+   * @return the server as configured by this builder
+   */
+  HttpServer build();
+
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -19,6 +19,7 @@ import io.vertx.core.internal.net.NetClientInternal;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.NetworkLogging;
 import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.SSLEngineOptions;
 import io.vertx.core.net.endpoint.LoadBalancer;
 import io.vertx.core.net.AddressResolver;
 import io.vertx.core.net.endpoint.impl.EndpointResolverImpl;
@@ -37,6 +38,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
   private HttpClientConfig clientConfig;
   private HttpClientOptions clientOptions; // To be removed
   private ClientSSLOptions sslOptions;
+  private SSLEngineOptions sslEngineOptions;
   private PoolOptions poolOptions;
   private Handler<HttpConnection> connectHandler;
   private Function<HttpClientResponse, Future<RequestOptions>> redirectHandler;
@@ -58,6 +60,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
   public HttpClientBuilder with(HttpClientOptions options) {
     this.clientConfig = new HttpClientConfig(options);
     this.sslOptions = options.getSslOptions();
+    this.sslEngineOptions = options.getSslEngineOptions();
     this.clientOptions = options;
     return this;
   }
@@ -71,6 +74,12 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
   @Override
   public HttpClientBuilder with(ClientSSLOptions options) {
     this.sslOptions = options;
+    return this;
+  }
+
+  @Override
+  public HttpClientBuilder with(SSLEngineOptions engine) {
+    this.sslEngineOptions = engine;
     return this;
   }
 
@@ -255,6 +264,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       NetClientInternal tcpClient = new NetClientBuilder(vertx, clientConfig)
         .protocol("http")
         .sslOptions(sslOptions)
+        .sslEngineOptions(sslEngineOptions)
         .build();
       NetworkLogging networkLogging = co.getTcpConfig().getNetworkLogging();
       transport = new TcpHttpClientTransport(

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerBuilderImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerBuilderImpl.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerBuilder;
+import io.vertx.core.http.HttpServerConfig;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.impl.quic.QuicHttpServer;
+import io.vertx.core.http.impl.tcp.TcpHttpServer;
+import io.vertx.core.impl.VertxImpl;
+import io.vertx.core.net.SSLEngineOptions;
+import io.vertx.core.net.ServerSSLOptions;
+
+/**
+ * The server builder implementation.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class HttpServerBuilderImpl implements HttpServerBuilder {
+
+  private final VertxImpl vertx;
+  private HttpServerConfig config;
+  private ServerSSLOptions sslOptions;
+  private SSLEngineOptions sslEngineOptions;
+  private Handler<HttpConnection> connectHandler;
+  private boolean registerWebSocketWriteHandlers;
+
+  public HttpServerBuilderImpl(VertxImpl vertx) {
+    this.vertx = vertx;
+    this.registerWebSocketWriteHandlers = false;
+  }
+
+  @Override
+  public HttpServerBuilderImpl with(HttpServerConfig config) {
+    this.config = config;
+    return this;
+  }
+
+  @Override
+  public HttpServerBuilderImpl with(ServerSSLOptions options) {
+    this.sslOptions = options;
+    return this;
+  }
+
+  @Override
+  public HttpServerBuilderImpl with(SSLEngineOptions engine) {
+    this.sslEngineOptions = engine;
+    return this;
+  }
+
+  public HttpServerBuilderImpl registerWebSocketWriteHandlers(boolean registerWebSocketWriteHandlers) {
+    this.registerWebSocketWriteHandlers = registerWebSocketWriteHandlers;
+    return this;
+  }
+
+  @Override
+  public HttpServerBuilderImpl withConnectHandler(Handler<HttpConnection> handler) {
+    this.connectHandler = handler;
+    return this;
+  }
+
+  @Override
+  public HttpServer build() {
+    boolean useTcp = config.getVersions().contains(HttpVersion.HTTP_1_1) || config.getVersions().contains(HttpVersion.HTTP_2) || config.getVersions().contains(HttpVersion.HTTP_1_0);
+    boolean useQuic = config.getVersions().contains(HttpVersion.HTTP_3);
+    if (useQuic && sslOptions == null) {
+      throw new NullPointerException("SSL configuration is necessary for a QUIC server");
+    }
+    if (useTcp && config.isSsl() && sslOptions == null) {
+      throw new NullPointerException("SSL configuration is necessary for a TCP/SSL server");
+    }
+    HttpServer server;
+    if (useTcp) {
+      if (useQuic) {
+        HybridHttpServer compositeServer = new HybridHttpServer(vertx, new HttpServerConfig(config), sslOptions.copy(), sslEngineOptions);
+        server = new CleanableHttpServer(vertx, compositeServer);
+      } else {
+        if (sslOptions != null) {
+          sslOptions = sslOptions.copy();
+        }
+        server = new CleanableHttpServer(vertx, new TcpHttpServer(vertx, new HttpServerConfig(config), sslOptions, sslEngineOptions, null, registerWebSocketWriteHandlers));
+      }
+    } else if (useQuic) {
+      server = new CleanableHttpServer(vertx, new QuicHttpServer(vertx, new HttpServerConfig(config), sslOptions.copy(), null));
+    } else {
+      throw new IllegalArgumentException("You must set at least one supported HTTP version");
+    }
+    Handler<HttpConnection> handler = connectHandler;
+    if (handler != null) {
+      return server.connectionHandler(handler);
+    }
+    return server;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HybridHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HybridHttpServer.java
@@ -19,6 +19,7 @@ import io.vertx.core.http.impl.tcp.TcpHttpServer;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.http.HttpServerInternal;
+import io.vertx.core.net.SSLEngineOptions;
 import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.TrafficShapingOptions;
@@ -38,6 +39,7 @@ public class HybridHttpServer implements HttpServerInternal {
   private final VertxInternal vertx;
   private final HttpServerConfig config;
   private final ServerSSLOptions sslOptions;
+  private final SSLEngineOptions engineOptions;
   private Handler<HttpServerRequest> requestHandler;
   private Handler<HttpServerRequest> invalidRequestHandler;
   private Handler<HttpConnection> connectionHandler;
@@ -48,15 +50,16 @@ public class HybridHttpServer implements HttpServerInternal {
   private HttpServerInternal quicServer;
   private HttpServerMetrics<?, ?> httpMetrics;
 
-  public HybridHttpServer(VertxInternal vertx, HttpServerConfig config, ServerSSLOptions sslOptions) {
+  public HybridHttpServer(VertxInternal vertx, HttpServerConfig config, ServerSSLOptions sslOptions, SSLEngineOptions engineOptions) {
     this.vertx = vertx;
     this.config = config;
     this.sslOptions = sslOptions;
+    this.engineOptions = engineOptions;
   }
 
   public HttpServerInternal tcpServer(HttpServerMetrics<?, ?> httpMetrics) {
     if (tcpServer == null) {
-      TcpHttpServer server = new TcpHttpServer(vertx, new HttpServerConfig(config), sslOptions.copy(), httpMetrics, false);
+      TcpHttpServer server = new TcpHttpServer(vertx, new HttpServerConfig(config), sslOptions.copy(), engineOptions, httpMetrics, false);
       setHandlers(server);
       tcpServer = server;
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpServer.java
@@ -48,6 +48,7 @@ public class TcpHttpServer implements HttpServerInternal {
   private final VertxInternal vertx;
   final HttpServerConfig config;
   private final ServerSSLOptions sslOptions;
+  private final SSLEngineOptions engineOptions;
   private final boolean registerWebSocketWriteHandlers;
   private final boolean manageMetrics;
   private Handler<HttpServerRequest> requestHandler;
@@ -62,10 +63,11 @@ public class TcpHttpServer implements HttpServerInternal {
   private HttpServerMetrics<?, ?> httpMetrics;
 
   public TcpHttpServer(VertxInternal vertx, HttpServerConfig config, ServerSSLOptions sslOptions,
-                       HttpServerMetrics<?, ?> httpMetrics, boolean registerWebSocketWriteHandlers) {
+                       SSLEngineOptions engineOptions, HttpServerMetrics<?, ?> httpMetrics, boolean registerWebSocketWriteHandlers) {
     this.vertx = vertx;
     this.config = config;
     this.sslOptions = sslOptions;
+    this.engineOptions = engineOptions;
     this.registerWebSocketWriteHandlers = registerWebSocketWriteHandlers;
     this.httpMetrics = httpMetrics;
     this.manageMetrics = httpMetrics == null;
@@ -206,6 +208,7 @@ public class TcpHttpServer implements HttpServerInternal {
     HttpCompressionConfig compression = config.getCompression();
     ServerSSLOptions sslOptions = configureSSLOptions(config, this.sslOptions);
     NetServerInternal server = new NetServerBuilder(vertx, config.getTcpConfig(), sslOptions)
+      .sslEngine(engineOptions)
       .fileRegionEnabled(compression == null || !compression.isCompressionEnabled())
       .cleanable(false)
       .protocol("http")

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxWrapper.java
@@ -97,13 +97,8 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public HttpServer createHttpServer(HttpServerOptions options) {
-    return delegate.createHttpServer(options);
-  }
-
-  @Override
-  public HttpServer createHttpServer(HttpServerConfig config, ServerSSLOptions sslOptions) {
-    return delegate.createHttpServer(config, sslOptions);
+  public HttpServerBuilder httpServerBuilder() {
+    return delegate.httpServerBuilder();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
@@ -13,6 +13,7 @@ package io.vertx.core.net;
 
 import io.netty.handler.ssl.SslProvider;
 import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tls.DefaultSslContextFactory;
 import io.vertx.core.spi.tls.SslContextFactory;
@@ -25,6 +26,7 @@ import javax.net.ssl.SSLEngine;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 @DataObject
+@JsonGen(publicConverter = false, inheritConverter = true)
 public class JdkSSLEngineOptions extends SSLEngineOptions {
 
   private static Boolean jdkAlpnAvailable;

--- a/vertx-core/src/main/java/io/vertx/core/net/OpenSSLEngineOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/OpenSSLEngineOptions.java
@@ -25,7 +25,7 @@ import io.vertx.core.spi.tls.SslContextFactory;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 @DataObject
-@JsonGen(publicConverter = false)
+@JsonGen(publicConverter = false, inheritConverter = true)
 public class OpenSSLEngineOptions extends SSLEngineOptions {
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/net/SSLEngineOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/SSLEngineOptions.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.net;
 
+import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tls.SslContextFactory;
 
@@ -19,6 +20,7 @@ import io.vertx.core.spi.tls.SslContextFactory;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
+@DataObject
 public abstract class SSLEngineOptions {
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/net/TcpClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TcpClientConfig.java
@@ -73,10 +73,6 @@ public class TcpClientConfig extends TcpEndpointConfig {
     return (TcpClientConfig)super.setTransportConfig(transportConfig);
   }
 
-  public TcpClientConfig setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
-    return (TcpClientConfig)super.setSslEngineOptions(sslEngineOptions);
-  }
-
   public TcpClientConfig setIdleTimeout(Duration idleTimeout) {
     return (TcpClientConfig)super.setIdleTimeout(idleTimeout);
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/TcpEndpointConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TcpEndpointConfig.java
@@ -24,26 +24,22 @@ import static io.vertx.core.net.ClientOptionsBase.DEFAULT_METRICS_NAME;
 @DataObject
 public abstract class TcpEndpointConfig extends EndpointConfig {
 
-  private SSLEngineOptions sslEngineOptions;
   private boolean ssl;
 
   public TcpEndpointConfig() {
     super();
     setTransportConfig(new TcpConfig());
-    this.sslEngineOptions = TCPSSLOptions.DEFAULT_SSL_ENGINE;
     this.ssl = TCPSSLOptions.DEFAULT_SSL;
   }
 
   public TcpEndpointConfig(TcpEndpointConfig other) {
     super(other);
-    this.sslEngineOptions = other.sslEngineOptions != null ? other.sslEngineOptions.copy() : null;
     this.ssl = other.ssl;
   }
 
   public TcpEndpointConfig(TCPSSLOptions options) {
     super();
     setTransportConfig(new TcpConfig(options.getTransportOptions()));
-    setSslEngineOptions(options.getSslEngineOptions() != null ? options.getSslEngineOptions().copy() : null);
     setIdleTimeout(Duration.of(options.getIdleTimeout(), options.getIdleTimeoutUnit().toChronoUnit()));
     setReadIdleTimeout(Duration.of(options.getReadIdleTimeout(), options.getIdleTimeoutUnit().toChronoUnit()));
     setWriteIdleTimeout(Duration.of(options.getWriteIdleTimeout(), options.getIdleTimeoutUnit().toChronoUnit()));
@@ -66,24 +62,6 @@ public abstract class TcpEndpointConfig extends EndpointConfig {
    */
   public TcpEndpointConfig setTransportConfig(TcpConfig transportConfig) {
     return (TcpEndpointConfig) super.setTransportConfig(transportConfig);
-  }
-
-  /**
-   * @return the SSL engine implementation to use
-   */
-  public SSLEngineOptions getSslEngineOptions() {
-    return sslEngineOptions;
-  }
-
-  /**
-   * Set to use SSL engine implementation to use.
-   *
-   * @param sslEngineOptions the ssl engine to use
-   * @return a reference to this, so the API can be used fluently
-   */
-  public TcpEndpointConfig setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
-    this.sslEngineOptions = sslEngineOptions;
-    return this;
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/net/TcpServerConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TcpServerConfig.java
@@ -71,10 +71,6 @@ public class TcpServerConfig extends TcpEndpointConfig {
     return (TcpServerConfig)super.setTransportConfig(transportConfig);
   }
 
-  public TcpServerConfig setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
-    return (TcpServerConfig)super.setSslEngineOptions(sslEngineOptions);
-  }
-
   public TcpServerConfig setIdleTimeout(Duration idleTimeout) {
     return (TcpServerConfig)super.setIdleTimeout(idleTimeout);
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetServer.java
@@ -20,9 +20,10 @@ public class CleanableNetServer extends NetServerImpl implements Closeable {
                             TcpServerConfig config,
                             String protocol,
                             ServerSSLOptions sslOptions,
+                            SSLEngineOptions sslEngineOptions,
                             boolean fileRegionEnabled,
                             boolean registerWriteHandler) {
-    super(vertx, config, protocol, sslOptions, fileRegionEnabled, registerWriteHandler);
+    super(vertx, config, protocol, sslOptions, sslEngineOptions, fileRegionEnabled, registerWriteHandler);
     this.vertx = vertx;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientBuilder.java
@@ -14,6 +14,7 @@ import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.net.NetClientInternal;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.SSLEngineOptions;
 import io.vertx.core.net.TcpClientConfig;
 import io.vertx.core.spi.metrics.TransportMetrics;
 
@@ -26,6 +27,7 @@ public class NetClientBuilder {
   private TcpClientConfig config;
   private String protocol;
   private ClientSSLOptions sslOptions;
+  private SSLEngineOptions sslEngineOptions;
   private boolean registerWriteHandler;
 
   public NetClientBuilder(VertxInternal vertx, TcpClientConfig config) {
@@ -35,13 +37,22 @@ public class NetClientBuilder {
     this.protocol = null;
   }
 
+  public NetClientBuilder(VertxInternal vertx, NetClientOptions options) {
+    this.vertx = vertx;
+    this.config = new TcpClientConfig(options);
+    this.registerWriteHandler = options.isRegisterWriteHandler();
+    this.sslOptions = options.getSslOptions();
+    this.sslEngineOptions = options.getSslEngineOptions();
+    this.protocol = null;
+  }
+
   public NetClientBuilder sslOptions(ClientSSLOptions sslOptions) {
     this.sslOptions = sslOptions;
     return this;
   }
 
-  public NetClientBuilder registerWriteHandler(boolean registerWriteHandler) {
-    this.registerWriteHandler =  registerWriteHandler;
+  public NetClientBuilder sslEngineOptions(SSLEngineOptions sslEngineOptions) {
+    this.sslEngineOptions = sslEngineOptions;
     return this;
   }
 
@@ -51,6 +62,6 @@ public class NetClientBuilder {
   }
 
   public NetClientInternal build() {
-    return new NetClientImpl(vertx, config, protocol, sslOptions, registerWriteHandler);
+    return new NetClientImpl(vertx, config, protocol, sslOptions, sslEngineOptions, registerWriteHandler);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
@@ -71,6 +71,7 @@ class NetClientImpl implements NetClientInternal {
                        TcpClientConfig config,
                        String protocol,
                        ClientSSLOptions sslOptions,
+                       SSLEngineOptions sslEngineOptions,
                        boolean registerWriteHandler) {
 
     this.vertx = vertx;
@@ -83,7 +84,7 @@ class NetClientImpl implements NetClientInternal {
     NetworkLogging networkLogging = config.getNetworkLogging();
     this.config = config;
     this.registerWriteHandler = registerWriteHandler;
-    this.sslContextManager = new SslContextManager(SslContextManager.resolveEngineOptions(config.getSslEngineOptions(), sslOptions != null && sslOptions.isUseAlpn()));
+    this.sslContextManager = new SslContextManager(SslContextManager.resolveEngineOptions(sslEngineOptions, sslOptions != null && sslOptions.isUseAlpn()));
     this.metrics = vertx.metrics() != null ? vertx.metrics().createTcpClientMetrics(config, protocol) : null;
     this.logging = networkLogging != null && networkLogging.isEnabled() ? networkLogging.getDataFormat() : null;
     this.idleTimeout = config.getIdleTimeout() != null ? config.getIdleTimeout() : Duration.ofMillis(0L);

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerBuilder.java
@@ -13,10 +13,6 @@ package io.vertx.core.net.impl.tcp;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.net.NetServerInternal;
 import io.vertx.core.net.*;
-import io.vertx.core.spi.metrics.TransportMetrics;
-import io.vertx.core.spi.metrics.VertxMetrics;
-
-import java.util.function.BiFunction;
 
 /**
  * A builder to configure NetServer plugins.
@@ -26,6 +22,7 @@ public class NetServerBuilder {
   private VertxInternal vertx;
   private TcpServerConfig config;
   private ServerSSLOptions sslOptions;
+  private SSLEngineOptions sslEngineOptions;
   private String protocol;
   private boolean fileRegionEnabled;
   private boolean registerWriteHandler;
@@ -48,6 +45,7 @@ public class NetServerBuilder {
     this.vertx = vertx;
     this.config = cfg;
     this.sslOptions = options.getSslOptions();
+    this.sslEngineOptions = options.getSslEngineOptions();
     this.fileRegionEnabled = options.isFileRegionEnabled();
     this.registerWriteHandler = options.isRegisterWriteHandler();
     this.cleanable = true;
@@ -68,6 +66,11 @@ public class NetServerBuilder {
     return this;
   }
 
+  public NetServerBuilder sslEngine(SSLEngineOptions options) {
+    this.sslEngineOptions = options;
+    return this;
+  }
+
   public NetServerInternal build() {
     NetServerInternal server;
     if (cleanable) {
@@ -75,6 +78,7 @@ public class NetServerBuilder {
         config,
         protocol,
         sslOptions,
+        sslEngineOptions,
         fileRegionEnabled,
         registerWriteHandler);
     } else {
@@ -83,6 +87,7 @@ public class NetServerBuilder {
         config,
         protocol,
         sslOptions,
+        sslEngineOptions,
         fileRegionEnabled,
         registerWriteHandler
       );

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetServerImpl.java
@@ -66,6 +66,7 @@ public class NetServerImpl implements NetServerInternal {
   private final VertxInternal vertx;
   private final TcpServerConfig config;
   private final ServerSSLOptions sslOptions;
+  private final SSLEngineOptions sslEngineOptions;
   private final boolean fileRegionEnabled;
   private final boolean registerWriteHandler;
   private final String protocol;
@@ -94,6 +95,7 @@ public class NetServerImpl implements NetServerInternal {
                        TcpServerConfig config,
                        String protocol,
                        ServerSSLOptions sslOptions,
+                       SSLEngineOptions sslEngineOptions,
                        boolean fileRegionEnabled,
                        boolean registerWriteHandler) {
 
@@ -107,6 +109,7 @@ public class NetServerImpl implements NetServerInternal {
     this.fileRegionEnabled = fileRegionEnabled;
     this.registerWriteHandler = registerWriteHandler;
     this.sslOptions = sslOptions;
+    this.sslEngineOptions = sslEngineOptions;
   }
 
   public SslContextProvider sslContextProvider() {
@@ -457,7 +460,7 @@ public class NetServerImpl implements NetServerInternal {
 
         SslContextManager helper;
         try {
-          helper = new SslContextManager(SslContextManager.resolveEngineOptions(config.getSslEngineOptions(), sslOptions.isUseAlpn()));
+          helper = new SslContextManager(SslContextManager.resolveEngineOptions(sslEngineOptions, sslOptions.isUseAlpn()));
         } catch (Exception e) {
           return context.failedFuture(e);
         }

--- a/vertx-core/src/test/java/io/vertx/tests/tls/HttpTLSTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tls/HttpTLSTest.java
@@ -37,6 +37,8 @@ import java.util.function.Supplier;
 
 import javax.net.ssl.*;
 
+import io.netty.handler.ssl.OpenSslServerContext;
+import io.netty.handler.ssl.OpenSslServerSessionContext;
 import io.vertx.core.*;
 import io.vertx.core.http.*;
 import io.vertx.core.impl.VertxThread;
@@ -1292,6 +1294,10 @@ public abstract class HttpTLSTest extends HttpTestBase {
         indicatedServerName = req.connection().indicatedServerName();
         assertEquals(version, req.version());
         assertEquals(serverSSL, req.isSSL());
+        if (serverSSL && serverOpenSSL) {
+          String name = req.sslSession().getSessionContext().getClass().getSimpleName();
+          assertTrue(name.contains("OpenSslServerSessionContext"));
+        }
         if (req.method() == HttpMethod.GET || req.method() == HttpMethod.HEAD) {
           req.response().end();
         } else {
@@ -1316,6 +1322,10 @@ public abstract class HttpTLSTest extends HttpTestBase {
               try {
                 clientPeerCert = conn.peerCertificates().get(0);
               } catch (SSLPeerUnverifiedException ignore) {
+              }
+              if (clientSSL && clientOpenSSL) {
+                String name = req.connection().sslSession().getSessionContext().getClass().getSimpleName();
+                assertTrue(name.contains("OpenSslClientSessionContext"));
               }
             }
             if (shouldPass) {


### PR DESCRIPTION
Motivation:

The new TCP configuration still references the SSL engine options, we should externalize that and make it a separate side of the actual TCP configuration.

Changes:

Add a new HTTP server builder that allows to configure various aspects of an HTTP server.

HTTP client builder also gets augmented with SSL engine options configurability.
