### PR TITLE
QUIC connection pending stream open queue.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/QuicClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicClientConfig.java
@@ -94,6 +94,16 @@ public class QuicClientConfig extends QuicEndpointConfig {
   }
 
   @Override
+  public QuicClientConfig setMaxStreamBidiRequests(int maxStreamRequests) {
+    return (QuicClientConfig) super.setMaxStreamBidiRequests(maxStreamRequests);
+  }
+
+  @Override
+  public QuicClientConfig setMaxStreamUniRequests(int maxStreamRequests) {
+    return (QuicClientConfig) super.setMaxStreamUniRequests(maxStreamRequests);
+  }
+
+  @Override
   public QuicClientConfig setLogConfig(LogConfig config) {
     return (QuicClientConfig) super.setLogConfig(config);
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicEndpointConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicEndpointConfig.java
@@ -22,13 +22,24 @@ import java.time.Duration;
 @DataObject
 public abstract class QuicEndpointConfig extends EndpointConfig {
 
+  /**
+   * The default maximum value of pending stream requests.
+   */
+  public static final int DEFAULT_MAX_STREAM_BIDI_REQUESTS = 1024;
+  public static final int DEFAULT_MAX_STREAM_UNI_REQUESTS = 1024;
+
   private QLogConfig qlogConfig;
   private String keyLogFile;
+  private int maxStreamBidiRequests;
+  private int maxStreamUniRequests;
 
   public QuicEndpointConfig() {
     super();
     setTransportConfig(new QuicConfig());
     this.qlogConfig = null;
+    this.keyLogFile = null;
+    this.maxStreamBidiRequests = DEFAULT_MAX_STREAM_BIDI_REQUESTS;
+    this.maxStreamUniRequests = DEFAULT_MAX_STREAM_UNI_REQUESTS;
   }
 
   public QuicEndpointConfig(QuicEndpointConfig other) {
@@ -38,6 +49,8 @@ public abstract class QuicEndpointConfig extends EndpointConfig {
 
     this.qlogConfig = qLogConfig != null ? new QLogConfig(qLogConfig) : null;
     this.keyLogFile = other.keyLogFile;
+    this.maxStreamBidiRequests = other.maxStreamBidiRequests;
+    this.maxStreamUniRequests = other.maxStreamUniRequests;
   }
 
   /**
@@ -114,5 +127,45 @@ public abstract class QuicEndpointConfig extends EndpointConfig {
 
   public QuicEndpointConfig setLogConfig(LogConfig config) {
     return (QuicEndpointConfig) super.setLogConfig(config);
+  }
+
+  /**
+   * @return the number of maximum bidi stream requests awaiting in the queue of a connection
+   */
+  public int getMaxStreamBidiRequests() {
+    return maxStreamBidiRequests;
+  }
+
+  /**
+   * Set the maximum number of bidi stream requests per connection that can be queued when the connection stream bidi limit is reached.
+   *
+   * @param maxStreamRequests the maximum value
+   */
+  public QuicEndpointConfig setMaxStreamBidiRequests(int maxStreamRequests) {
+    if (maxStreamRequests < 0L) {
+      throw new IllegalArgumentException("maxStreamBidiRequests must be >= 0");
+    }
+    this.maxStreamBidiRequests = maxStreamRequests;
+    return this;
+  }
+
+  /**
+   * @return the number of maximum uni stream requests awaiting in the queue of a connection
+   */
+  public int getMaxStreamUniRequests() {
+    return maxStreamUniRequests;
+  }
+
+  /**
+   * Set the maximum number of unit stream requests per connection that can be queued when the connection stream uni limit is reached.
+   *
+   * @param maxStreamRequests the maximum value
+   */
+  public QuicEndpointConfig setMaxStreamUniRequests(int maxStreamRequests) {
+    if (maxStreamRequests < 0L) {
+      throw new IllegalArgumentException("maxStreamUniRequests must be >= 0");
+    }
+    this.maxStreamUniRequests = maxStreamRequests;
+    return this;
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicServerConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicServerConfig.java
@@ -111,6 +111,21 @@ public class QuicServerConfig extends QuicEndpointConfig {
     return (QuicServerConfig) super.setLogConfig(config);
   }
 
+  @Override
+  public QuicServerConfig setMetricsName(String metricsName) {
+    return (QuicServerConfig) super.setMetricsName(metricsName);
+  }
+
+  @Override
+  public QuicServerConfig setMaxStreamBidiRequests(int maxStreamRequests) {
+    return (QuicServerConfig) super.setMaxStreamBidiRequests(maxStreamRequests);
+  }
+
+  @Override
+  public QuicServerConfig setMaxStreamUniRequests(int maxStreamRequests) {
+    return (QuicServerConfig) super.setMaxStreamUniRequests(maxStreamRequests);
+  }
+
   /**
    * @return the port
    */

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicClientImpl.java
@@ -189,7 +189,8 @@ public class QuicClientImpl extends QuicEndpointImpl implements QuicClient {
           LogConfig logConfig = config.getLogConfig();
           ByteBufFormat activityLogging = logConfig != null && logConfig.isEnabled()? logConfig.getDataFormat() : null;
           QuicConnectionHandler handler = new QuicConnectionHandler(context, metrics, config.getIdleTimeout(),
-            config.getReadIdleTimeout(), config.getWriteIdleTimeout(), activityLogging, remoteAddress, promise::tryComplete);
+            config.getReadIdleTimeout(), config.getWriteIdleTimeout(), activityLogging, config.getMaxStreamBidiRequests(),
+            config.getMaxStreamUniRequests(), remoteAddress, promise::tryComplete);
           ch.pipeline().addLast("handler", handler);
         }
       })

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicConnectionHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicConnectionHandler.java
@@ -16,6 +16,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.quic.QuicChannel;
 import io.netty.handler.codec.quic.QuicConnectionCloseEvent;
 import io.netty.handler.codec.quic.QuicStreamChannel;
+import io.netty.handler.codec.quic.QuicStreamLimitChangedEvent;
 import io.netty.handler.logging.ByteBufFormat;
 import io.netty.handler.ssl.SniCompletionEvent;
 import io.vertx.core.Handler;
@@ -46,6 +47,8 @@ public class QuicConnectionHandler extends ChannelDuplexHandler implements Netwo
   private final long readIdleTimeout;
   private final long writeIdleTimeout;
   private final ByteBufFormat activityLogging;
+  private final int maxStreamBidiRequests;
+  private final int maxStreamUniRequests;
   private Handler<QuicConnection> handler;
   private QuicChannel channel;
   private QuicConnectionImpl connection;
@@ -53,13 +56,15 @@ public class QuicConnectionHandler extends ChannelDuplexHandler implements Netwo
 
   public QuicConnectionHandler(ContextInternal context, TransportMetrics<?> metrics, Duration idleTimeout,
                                Duration readIdleTimeout, Duration writeIdleTimeout, ByteBufFormat activityLogging,
-                               SocketAddress remoteAddress, Handler<QuicConnection> handler) {
+                               int maxStreamBidiRequests, int maxStreamUniRequests, SocketAddress remoteAddress, Handler<QuicConnection> handler) {
     this.context = context;
     this.metrics = metrics;
     this.idleTimeout = timeoutMillis(idleTimeout);
     this.readIdleTimeout = timeoutMillis(readIdleTimeout);
     this.writeIdleTimeout = timeoutMillis(writeIdleTimeout);
     this.activityLogging = activityLogging;
+    this.maxStreamBidiRequests = maxStreamBidiRequests;
+    this.maxStreamUniRequests = maxStreamUniRequests;
     this.handler = handler;
     this.remoteAddress = remoteAddress;
   }
@@ -68,7 +73,8 @@ public class QuicConnectionHandler extends ChannelDuplexHandler implements Netwo
   public void handlerAdded(ChannelHandlerContext ctx) {
     QuicChannel ch = (QuicChannel) ctx.channel();
     channel = ch;
-    connection = new QuicConnectionImpl(context, metrics, idleTimeout, readIdleTimeout, writeIdleTimeout, activityLogging, ch, remoteAddress, ctx);
+    connection = new QuicConnectionImpl(context, metrics, idleTimeout, readIdleTimeout, writeIdleTimeout, activityLogging,
+      maxStreamBidiRequests, maxStreamUniRequests, ch, remoteAddress, ctx);
     if (ch.isActive()) {
       activate();
     }
@@ -123,6 +129,8 @@ public class QuicConnectionHandler extends ChannelDuplexHandler implements Netwo
       if (c != null) {
         c.shutdown(shutdown.timeout());
       }
+    } else if (evt instanceof QuicStreamLimitChangedEvent) {
+      connection.handleQuicStreamLimitChanged();
     }
     super.userEventTriggered(ctx, evt);
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicConnectionImpl.java
@@ -25,10 +25,12 @@ import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.buffer.BufferInternal;
+import io.vertx.core.internal.net.NetSocketInternal;
 import io.vertx.core.internal.quic.QuicConnectionInternal;
 import io.vertx.core.net.*;
 import io.vertx.core.net.impl.ConnectionBase;
@@ -39,6 +41,10 @@ import io.vertx.core.spi.metrics.TransportMetrics;
 
 import javax.net.ssl.SSLEngine;
 import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -65,11 +71,17 @@ public class QuicConnectionImpl extends ConnectionBase implements QuicConnection
   private final NetworkMetrics<?> streamMetrics;
   private final SocketAddress remoteAddress;
   private QuicTransportParams transportParams;
+  private final Map<QuicStreamType, StreamOpenRequestQueue> pendingStreamOpenRequestsMap;
 
   public QuicConnectionImpl(ContextInternal context, TransportMetrics metrics, long idleTimeout,
-                            long readIdleTimeout,  long writeIdleTimeout, ByteBufFormat activityLogging, QuicChannel channel,
-                            SocketAddress remoteAddress, ChannelHandlerContext chctx) {
+                            long readIdleTimeout,  long writeIdleTimeout, ByteBufFormat activityLogging, int maxStreamBidiRequests,
+                            int maxStreamUniRequests, QuicChannel channel, SocketAddress remoteAddress, ChannelHandlerContext chctx) {
     super(context, chctx);
+
+    Map<QuicStreamType, StreamOpenRequestQueue> pendingStreamRequestsMap = new EnumMap<>(QuicStreamType.class);
+    pendingStreamRequestsMap.put(QuicStreamType.BIDIRECTIONAL, new StreamOpenRequestQueue(maxStreamBidiRequests));
+    pendingStreamRequestsMap.put(QuicStreamType.UNIDIRECTIONAL, new StreamOpenRequestQueue(maxStreamUniRequests));
+
     this.channel = channel;
     this.metrics = metrics;
     this.idleTimeout = idleTimeout;
@@ -78,6 +90,7 @@ public class QuicConnectionImpl extends ConnectionBase implements QuicConnection
     this.activityLogging = activityLogging;
     this.context = context;
     this.remoteAddress = remoteAddress;
+    this.pendingStreamOpenRequestsMap = pendingStreamRequestsMap;
     this.streamGroup = new ConnectionGroup(context.nettyEventLoop()) {
       @Override
       protected void handleShutdown(Duration timeout, Completable<Void> completion) {
@@ -165,6 +178,21 @@ public class QuicConnectionImpl extends ConnectionBase implements QuicConnection
     }
   }
 
+  void handleQuicStreamLimitChanged() {
+    trySatisfyPendingStreamOpenRequests(QuicStreamType.BIDIRECTIONAL);
+    trySatisfyPendingStreamOpenRequests(QuicStreamType.UNIDIRECTIONAL);
+  }
+
+  private void trySatisfyPendingStreamOpenRequests(QuicStreamType type) {
+    long maxBidStreams = channel.peerAllowedStreams(type);
+    Deque<StreamOpenRequest> pendingStreamOpenRequests = pendingStreamOpenRequestsMap.get(type);
+    StreamOpenRequest streamOpenRequest;
+    while (maxBidStreams > 0 && (streamOpenRequest = pendingStreamOpenRequests.poll()) != null) {
+      maxBidStreams--;
+      openStream(streamOpenRequest, type);
+    }
+  }
+
   @Override
   public QuicConnectionImpl closeHandler(Handler<Void> handler) {
     return (QuicConnectionImpl) super.closeHandler(handler);
@@ -177,6 +205,12 @@ public class QuicConnectionImpl extends ConnectionBase implements QuicConnection
 
   void handleClosed(QuicConnectionClose payload) {
     this.closePayload = payload;
+    for (Deque<StreamOpenRequest> pendingStreamOpenRequests : pendingStreamOpenRequestsMap.values()) {
+      StreamOpenRequest pendingStreamOpenRequest;
+      while ((pendingStreamOpenRequest = pendingStreamOpenRequests.poll()) != null) {
+        pendingStreamOpenRequest.promise.fail(NetSocketInternal.CLOSED_EXCEPTION);
+      }
+    }
     handleClosed();
   }
 
@@ -241,29 +275,51 @@ public class QuicConnectionImpl extends ConnectionBase implements QuicConnection
   }
 
   @Override
-  public Future<QuicStream> openStream(ContextInternal context, boolean bidirectional, Function<Consumer<QuicStreamChannel>, ChannelInitializer<QuicStreamChannel>> initializerProvider) {
-    Promise<QuicStream> promise = context.promise();
-    VertxHandler<QuicStreamImpl> handler = VertxHandler.create(chctx -> new QuicStreamImpl(this, context, (QuicStreamChannel) chctx.channel(), streamMetrics, chctx));
+  public Future<QuicStream> openStream(ContextInternal streamContext, boolean bidirectional, Function<Consumer<QuicStreamChannel>, ChannelInitializer<QuicStreamChannel>> initializerProvider) {
+    Promise<QuicStream> promise = streamContext.promise();
+    StreamOpenRequest streamOpenRequest = new StreamOpenRequest(streamContext, initializerProvider, promise);
+    if (context.inThread()) {
+      tryOpenStream(streamOpenRequest, bidirectional ? QuicStreamType.BIDIRECTIONAL : QuicStreamType.UNIDIRECTIONAL);
+    } else {
+      context.execute(() -> {
+        tryOpenStream(streamOpenRequest, bidirectional ? QuicStreamType.BIDIRECTIONAL : QuicStreamType.UNIDIRECTIONAL);
+      });
+    }
+    return promise.future();
+  }
+
+  private void tryOpenStream(StreamOpenRequest streamOpenRequest, QuicStreamType type) {
+    long allowedStreams = channel.peerAllowedStreams(type);
+    if (allowedStreams == 0) {
+      StreamOpenRequestQueue streamOpenRequests = pendingStreamOpenRequestsMap.get(type);
+      if (!streamOpenRequests.offerLast(streamOpenRequest)) {
+        streamOpenRequest.promise.fail(new VertxException("QUIC connection pending stream request limit reached"));
+      }
+    } else {
+      openStream(streamOpenRequest, type);
+    }
+  }
+
+  private void openStream(StreamOpenRequest streamOpenRequest, QuicStreamType streamType) {
+    VertxHandler<QuicStreamImpl> handler = VertxHandler.create(chctx -> new QuicStreamImpl(this, streamOpenRequest.context, (QuicStreamChannel) chctx.channel(), streamMetrics, chctx));
     handler.addHandler(stream -> {
       if (metrics != null) {
         metrics.streamOpened(metric());
       }
-      promise.tryComplete(stream);
+      streamOpenRequest.promise.tryComplete(stream);
     });
-    QuicStreamType type = bidirectional ? QuicStreamType.BIDIRECTIONAL : QuicStreamType.UNIDIRECTIONAL;
-    ChannelInitializer<QuicStreamChannel> initializer = initializerProvider.apply(ch -> {
+    ChannelInitializer<QuicStreamChannel> initializer = streamOpenRequest.initializerProvider.apply(ch -> {
       ChannelPipeline pipeline = ch.pipeline();
       configureStreamChannelPipeline(pipeline);
       pipeline.addLast("handler", handler);
       streamGroup.add(ch);
     });
-    io.netty.util.concurrent.Future<QuicStreamChannel> future = channel.createStream(type, initializer);
-    future.addListener(future1 -> {
-      if (!future1.isSuccess()) {
-        promise.tryFail(future1.cause());
+    io.netty.util.concurrent.Future<QuicStreamChannel> future = channel.createStream(streamType, initializer);
+    future.addListener(f -> {
+      if (!f.isSuccess()) {
+        streamOpenRequest.promise.tryFail(f.cause());
       }
     });
-    return promise.future();
   }
 
   private void configureStreamChannelPipeline(ChannelPipeline pipeline) {
@@ -329,5 +385,44 @@ public class QuicConnectionImpl extends ConnectionBase implements QuicConnection
   @Override
   protected SocketAddress channelRemoteAddress() {
     return remoteAddress;
+  }
+
+  /**
+   * A queue of stream open requests.
+   */
+  private static class StreamOpenRequestQueue extends ArrayDeque<StreamOpenRequest> {
+
+    final int maxSize;
+
+    StreamOpenRequestQueue(int maxSize) {
+      super(10);
+      this.maxSize = maxSize;
+    }
+
+    @Override
+    public boolean offerLast(StreamOpenRequest request) {
+      if (size() < maxSize) {
+        return super.offerLast(request);
+      } else {
+        return false;
+      }
+    }
+  }
+
+  /**
+   * A request to open a stream.
+   */
+  private static class StreamOpenRequest {
+
+    private final ContextInternal context;
+    private final Function<Consumer<QuicStreamChannel>, ChannelInitializer<QuicStreamChannel>> initializerProvider;
+    private final Promise<QuicStream> promise;
+
+    StreamOpenRequest(ContextInternal context, Function<Consumer<QuicStreamChannel>,
+      ChannelInitializer<QuicStreamChannel>> initializerProvider, Promise<QuicStream> promise) {
+      this.context = context;
+      this.initializerProvider = initializerProvider;
+      this.promise = promise;
+    }
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicServerImpl.java
@@ -160,8 +160,8 @@ public class QuicServerImpl extends QuicEndpointImpl implements QuicServerIntern
                 LogConfig logConfig = config.getLogConfig();
                 ByteBufFormat activityLogging = logConfig != null && logConfig.isEnabled() ? logConfig.getDataFormat() : null;
                 QuicConnectionHandler handler = new QuicConnectionHandler(context, metrics, config.getIdleTimeout(),
-                  config.getReadIdleTimeout(), config.getWriteIdleTimeout(), activityLogging,
-                  vertx.transport().convert(channel.remoteSocketAddress()), QuicServerImpl.this.handler);
+                  config.getReadIdleTimeout(), config.getWriteIdleTimeout(), activityLogging, config.getMaxStreamBidiRequests(),
+                  config.getMaxStreamUniRequests(), vertx.transport().convert(channel.remoteSocketAddress()), QuicServerImpl.this.handler);
                 ChannelPipeline pipeline = channel.pipeline();
                 pipeline.addLast("handler", handler);
               }

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicClientTest.java
@@ -14,7 +14,10 @@ import io.netty.channel.ConnectTimeoutException;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.NetUtil;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.internal.net.NetSocketInternal;
 import io.vertx.core.internal.quic.QuicStreamInternal;
 import io.vertx.core.net.*;
 import io.vertx.test.core.LinuxOrOsx;
@@ -461,5 +464,137 @@ public class QuicClientTest extends VertxTestBase {
     stream.end();
     assertWaitUntil(() -> received.get() == buffer.length());
     assertWaitUntil(() -> ended.get() > 0);
+  }
+
+  @Test
+  public void testQuicStreamParking() {
+    server.close();
+    int maxStreams = 100;
+    QuicServerConfig config = new QuicServerConfig();
+    config.getTransportConfig().setInitialMaxStreamsBidi(maxStreams);
+    server = vertx.createQuicServer(config, QuicServerTest.SSL_OPTIONS);
+    server.handler(connection -> {
+      connection.handler(stream -> {
+        stream.endHandler(v -> {
+          int delay = 1 + TestUtils.randomPositiveInt() % 10;
+          vertx.setTimer(delay, id -> {
+            stream.end();
+          });
+        });
+      });
+    });
+    SocketAddress addr = SocketAddress.inetSocketAddress(9999, "localhost");
+    server
+      .listen(addr)
+      .await();
+    client.close();
+    int numStreams = 1000;
+    client = vertx.createQuicClient(new QuicClientConfig().setMaxStreamBidiRequests(numStreams), SSL_OPTIONS);
+    QuicConnection connection = client.connect(addr).await();
+    AtomicInteger inflight = new AtomicInteger(numStreams);
+    AtomicInteger remaining = new AtomicInteger(numStreams);
+    Promise<Void> done = Promise.promise();
+    for (int i = 0;i < numStreams;i++) {
+      tryOpenStream(inflight, remaining, connection, done);
+    }
+    done.future().await();
+  }
+
+  private void tryOpenStream(AtomicInteger inflight, AtomicInteger remaining, QuicConnection connection, Promise<Void> done) {
+    int val = remaining.decrementAndGet();
+    if (val >= 0) {
+      connection.openStream()
+        .onComplete(ar -> {
+          if (ar.succeeded()) {
+            QuicStream stream = ar.result();
+            stream.endHandler(v -> {
+              if (inflight.decrementAndGet() == 0) {
+                done.tryComplete();
+              } else {
+                tryOpenStream(inflight, remaining, connection, done);
+              }
+            });
+            stream.end();
+          } else {
+            done.tryFail(ar.cause());
+          }
+        });
+    }
+  }
+
+  @Test
+  public void testQuicStreamParkingFailure() throws Exception {
+    server.close();
+    int maxStreams = 100;
+    QuicServerConfig config = new QuicServerConfig();
+    config.getTransportConfig().setInitialMaxStreamsBidi(maxStreams);
+    server = vertx.createQuicServer(config, QuicServerTest.SSL_OPTIONS);
+    AtomicInteger count = new AtomicInteger();
+    server.handler(connection -> {
+      connection.handler(stream -> {
+        if (count.incrementAndGet() == maxStreams) {
+          connection.close();
+        }
+      });
+    });
+    SocketAddress addr = SocketAddress.inetSocketAddress(9999, "localhost");
+    server
+      .listen(addr)
+      .await();
+    QuicConnection connection = client.connect(addr).await();
+    CountDownLatch close = new CountDownLatch(1);
+    connection.closeHandler(v -> close.countDown());
+    int numStreams = 100 + 1;
+    List<Future<QuicStream>> futures = new ArrayList<>();
+    for (int i = 0;i < numStreams;i++) {
+      Future<QuicStream> fut = connection.openStream();
+      fut.onComplete(ar -> {
+        if (ar.succeeded()) {
+          ar.result()
+            .end();
+        }
+      });
+      futures.add(fut);
+    }
+    awaitLatch(close);
+    assertWaitUntil(() -> futures.get(maxStreams).isComplete());
+    assertTrue(futures.get(maxStreams).failed());
+    assertTrue(futures.get(maxStreams).cause() == NetSocketInternal.CLOSED_EXCEPTION);
+  }
+
+  @Test
+  public void testQuicStreamParkingLimit() throws Exception {
+    server.close();
+    int maxStreams = 100;
+    QuicServerConfig config = new QuicServerConfig();
+    config.getTransportConfig().setInitialMaxStreamsBidi(maxStreams);
+    server = vertx.createQuicServer(config, QuicServerTest.SSL_OPTIONS);
+    AtomicInteger count = new AtomicInteger();
+    server.handler(connection -> {
+      connection.handler(stream -> {
+        if (count.incrementAndGet() == maxStreams) {
+          connection.close();
+        }
+      });
+    });
+    SocketAddress addr = SocketAddress.inetSocketAddress(9999, "localhost");
+    server
+      .listen(addr)
+      .await();
+    client.close();
+    client = vertx.createQuicClient(new QuicClientConfig().setMaxStreamBidiRequests(0), SSL_OPTIONS);
+    QuicConnection connection = client.connect(addr).await();
+    int numStreams = 100;
+    for (int i = 0;i < numStreams;i++) {
+      Future<QuicStream> fut = connection.openStream();
+      fut.await();
+    }
+    Future<QuicStream> fut = connection.openStream();
+    try {
+      fut.await();
+      fail();
+    } catch (VertxException ignore) {
+      // Expected
+    }
   }
 }


### PR DESCRIPTION
Motivation:

A QUIC connection is only capable of creating a stream when the stream limit is not reached.

When the limit is reached we should be capable to schedule pending requests on behalf of the user and schedule the pending requests when the connection signals the limit has changed.

Changes:

A QUIC connection now maintains a queue of pending stream open requests.

Upon stream creation, when the stream limit is reached, the stream is added to the corresponding queue.

When the connection signals the stream limit changes, the queue is checked for dequeuing pending requests.

The queue has a max size that is configurable at the endpoint level.
