### PR TITLE
Property handle QUIC connection datagram extension.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/QuicConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicConnection.java
@@ -154,6 +154,11 @@ public interface QuicConnection {
   QuicTransportParams transportParams();
 
   /**
+   * @return the maximum number of bytes the datagram payload can be or {@code 0} when the datagram extension is disabled
+   */
+  int maxDatagramLength();
+
+  /**
    * @return SSLSession associated with the underlying socket. Returns null if connection is
    *         not SSL.
    * @see javax.net.ssl.SSLSession

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicConnectionHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicConnectionHandler.java
@@ -15,6 +15,7 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.quic.QuicChannel;
 import io.netty.handler.codec.quic.QuicConnectionCloseEvent;
+import io.netty.handler.codec.quic.QuicDatagramExtensionEvent;
 import io.netty.handler.codec.quic.QuicStreamChannel;
 import io.netty.handler.codec.quic.QuicStreamLimitChangedEvent;
 import io.netty.handler.logging.ByteBufFormat;
@@ -131,6 +132,10 @@ public class QuicConnectionHandler extends ChannelDuplexHandler implements Netwo
       }
     } else if (evt instanceof QuicStreamLimitChangedEvent) {
       connection.handleQuicStreamLimitChanged();
+    } else if (evt instanceof QuicDatagramExtensionEvent) {
+      QuicDatagramExtensionEvent datagramExtensionEvent = (QuicDatagramExtensionEvent) evt;
+      QuicConnectionImpl c = connection;
+      c.enableDatagramExtension(datagramExtensionEvent.maxLength());
     }
     super.userEventTriggered(ctx, evt);
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicConnectionImpl.java
@@ -71,6 +71,7 @@ public class QuicConnectionImpl extends ConnectionBase implements QuicConnection
   private final NetworkMetrics<?> streamMetrics;
   private final SocketAddress remoteAddress;
   private QuicTransportParams transportParams;
+  private int maxDatagramLength;
   private final Map<QuicStreamType, StreamOpenRequestQueue> pendingStreamOpenRequestsMap;
 
   public QuicConnectionImpl(ContextInternal context, TransportMetrics metrics, long idleTimeout,
@@ -91,6 +92,7 @@ public class QuicConnectionImpl extends ConnectionBase implements QuicConnection
     this.context = context;
     this.remoteAddress = remoteAddress;
     this.pendingStreamOpenRequestsMap = pendingStreamRequestsMap;
+    this.maxDatagramLength = 0;
     this.streamGroup = new ConnectionGroup(context.nettyEventLoop()) {
       @Override
       protected void handleShutdown(Duration timeout, Completable<Void> completion) {
@@ -176,6 +178,10 @@ public class QuicConnectionImpl extends ConnectionBase implements QuicConnection
     } else {
       byteBuf.release();
     }
+  }
+
+  void enableDatagramExtension(int maxDatagramLength) {
+    this.maxDatagramLength = Math.max(0, maxDatagramLength);
   }
 
   void handleQuicStreamLimitChanged() {
@@ -375,6 +381,11 @@ public class QuicConnectionImpl extends ConnectionBase implements QuicConnection
       }
     }
     return transportParams;
+  }
+
+  @Override
+  public int maxDatagramLength() {
+    return maxDatagramLength;
   }
 
   @Override

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicClientTest.java
@@ -601,16 +601,13 @@ public class QuicClientTest extends VertxTestBase {
   }
 
   @Test
-  public void testDatagrams() throws Exception {
+  public void testDatagrams() {
     QuicServerConfig serverConfig = new QuicServerConfig();
     serverConfig.getTransportConfig().setEnableDatagrams(true);
     server.close();
     server = vertx.createQuicServer(serverConfig, QuicServerTest.SSL_OPTIONS);
     server.handler(conn -> {
-      conn.datagramHandler(dgram -> {
-        assertEquals("ping", dgram.toString());
-        conn.writeDatagram(Buffer.buffer("pong"));
-      });
+      conn.datagramHandler(conn::writeDatagram);
     });
     server.bind(SocketAddress.inetSocketAddress(9999, "localhost")).await();
     client.close();
@@ -619,11 +616,19 @@ public class QuicClientTest extends VertxTestBase {
     client = vertx.createQuicClient(clientConfig, SSL_OPTIONS);
     client.bind(SocketAddress.inetSocketAddress(0, "localhost")).await();
     QuicConnection connection = client.connect(SocketAddress.inetSocketAddress(9999, "localhost")).await();
+    int maxLen = connection.maxDatagramLength();
+    Buffer datagram = Buffer.buffer(TestUtils.randomAlphaString(maxLen));
     connection.datagramHandler(dgram -> {
-      assertEquals("pong", dgram.toString());
+      assertEquals(datagram.toString(), dgram.toString());
       testComplete();
     });
-    connection.writeDatagram(Buffer.buffer("ping")).await();
+    try {
+      connection.writeDatagram(Buffer.buffer(TestUtils.randomAlphaString(maxLen + 1))).await();
+      fail();
+    } catch (java.nio.BufferUnderflowException ignore) {
+      // Expected
+    }
+    connection.writeDatagram(datagram).await();
     await();
   }
 }


### PR DESCRIPTION
Motivation:

The QUIC connection datagram extension support should be capable to provide the maximum datagram size to allow proper datagram sizing that fits in the agreed MTU.

Changes:

Handle the datagram extension event to capture the maximum datagram length.
