### PR TITLE
Fix broken Jackson integration test.

### DIFF
--- a/vertx-core/pom.xml
+++ b/vertx-core/pom.xml
@@ -427,7 +427,7 @@
               </includes>
               <systemProperties>
                 <vertx.jackson.defaultReadMaxNestingDepth>100</vertx.jackson.defaultReadMaxNestingDepth>
-                <vertx.jackson.defaultReadMaxDocumentLength>100</vertx.jackson.defaultReadMaxDocumentLength>
+                <vertx.jackson.defaultReadMaxDocumentLength>1000</vertx.jackson.defaultReadMaxDocumentLength>
                 <vertx.jackson.defaultReadMaxNumberLength>100</vertx.jackson.defaultReadMaxNumberLength>
                 <vertx.jackson.defaultReadMaxStringLength>100</vertx.jackson.defaultReadMaxStringLength>
                 <vertx.jackson.defaultReadMaxNameLength>100</vertx.jackson.defaultReadMaxNameLength>

--- a/vertx-core/src/test/java/io/vertx/it/json/JacksonConfigOverrideTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/json/JacksonConfigOverrideTest.java
@@ -22,6 +22,6 @@ public class JacksonConfigOverrideTest extends VertxTestBase {
 
   @Test
   public void testReadConstraints() {
-    JacksonTest.testReadConstraints(100,  100, 100, 100);
+    JacksonTest.testReadConstraints(100,  100, 100, 100, 1000);
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/json/JacksonTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/json/JacksonTest.java
@@ -21,8 +21,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static com.fasterxml.jackson.core.StreamReadConstraints.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -80,13 +78,15 @@ public class JacksonTest extends VertxTestBase {
       DEFAULT_MAX_DEPTH,
       DEFAULT_MAX_NUM_LEN,
       DEFAULT_MAX_STRING_LEN,
-      DEFAULT_MAX_NAME_LEN);
+      DEFAULT_MAX_NAME_LEN,
+      DEFAULT_MAX_DOC_LEN);
   }
 
   public static void testReadConstraints(int defaultMaxDepth,
                                          int maxNumberLength,
                                          int defaultMaxStringLength,
-                                         int defaultMaxNameLength) {
+                                         int defaultMaxNameLength,
+                                         long defaultMaxDocumentLength) {
     testMaxNestingDepth(defaultMaxDepth);
     try {
       testMaxNestingDepth(defaultMaxDepth + 1);
@@ -113,6 +113,15 @@ public class JacksonTest extends VertxTestBase {
       Assert.fail();
     } catch (DecodeException expected) {
     }
+
+    if (defaultMaxDocumentLength >= 0) {
+      testMaxDocumentLength(defaultMaxDocumentLength);
+      try {
+        testMaxDocumentLength(defaultMaxDocumentLength + 1);
+        Assert.fail();
+      } catch (DecodeException expected) {
+      }
+    }
   }
 
   private static JsonArray testMaxNestingDepth(int depth) {
@@ -133,5 +142,18 @@ public class JacksonTest extends VertxTestBase {
   private static JsonObject testMaxNameLength(int len) {
     String json = "{\"" + "a".repeat(len) + "\":3}";
     return new JsonObject(json);
+  }
+
+  private static JsonArray testMaxDocumentLength(long len) {
+    String prefix = len % 2 == 0 ? "[ " : "[";
+    int num = (int) ((len - prefix.length()) / 2);
+    StringBuilder sb = new StringBuilder((int) len);
+    sb.append(prefix);
+    for (int i = 0; i < num;i++) {
+      sb.append("0,");
+    }
+    sb.setCharAt((int) (len - 1), ']');
+    String json = sb.toString();
+    return new JsonArray(json);
   }
 }


### PR DESCRIPTION
Motivation:

Jackson bump broke the integration test that was not incorrect due to a fix in max document length enforcement.

Changes:

Increase the max document length so the integration test is correct.

Add a test enforcing max document length is respected.
