### PR TITLE
Fix broken Jackson integration test.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -590,11 +590,11 @@
             </goals>
             <configuration>
               <includes>
-                <include>io/vertx/it/json/JacksonConfigOverrideTest.java</include>
+                <include>io/vertx/it/JacksonConfigOverrideTest.java</include>
               </includes>
               <systemProperties>
                 <vertx.jackson.defaultReadMaxNestingDepth>100</vertx.jackson.defaultReadMaxNestingDepth>
-                <vertx.jackson.defaultReadMaxDocumentLength>100</vertx.jackson.defaultReadMaxDocumentLength>
+                <vertx.jackson.defaultReadMaxDocumentLength>1000</vertx.jackson.defaultReadMaxDocumentLength>
                 <vertx.jackson.defaultReadMaxNumberLength>100</vertx.jackson.defaultReadMaxNumberLength>
                 <vertx.jackson.defaultReadMaxStringLength>100</vertx.jackson.defaultReadMaxStringLength>
                 <vertx.jackson.defaultReadMaxNameLength>100</vertx.jackson.defaultReadMaxNameLength>

--- a/src/test/java/io/vertx/core/json/JacksonTest.java
+++ b/src/test/java/io/vertx/core/json/JacksonTest.java
@@ -19,8 +19,6 @@ import org.junit.Test;
 
 import static com.fasterxml.jackson.core.StreamReadConstraints.*;
 import static io.vertx.test.core.TestUtils.repeat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -78,13 +76,15 @@ public class JacksonTest extends VertxTestBase {
       DEFAULT_MAX_DEPTH,
       DEFAULT_MAX_NUM_LEN,
       DEFAULT_MAX_STRING_LEN,
-      DEFAULT_MAX_NAME_LEN);
+      DEFAULT_MAX_NAME_LEN,
+      DEFAULT_MAX_DOC_LEN);
   }
 
   public static void testReadConstraints(int defaultMaxDepth,
                                          int maxNumberLength,
                                          int defaultMaxStringLength,
-                                         int defaultMaxNameLength) {
+                                         int defaultMaxNameLength,
+                                         long defaultMaxDocumentLength) {
     testMaxNestingDepth(defaultMaxDepth);
     try {
       testMaxNestingDepth(defaultMaxDepth + 1);
@@ -111,6 +111,15 @@ public class JacksonTest extends VertxTestBase {
       Assert.fail();
     } catch (DecodeException expected) {
     }
+
+    if (defaultMaxDocumentLength >= 0) {
+      testMaxDocumentLength(defaultMaxDocumentLength);
+      try {
+        testMaxDocumentLength(defaultMaxDocumentLength + 1);
+        Assert.fail();
+      } catch (DecodeException expected) {
+      }
+    }
   }
 
   private static JsonArray testMaxNestingDepth(int depth) {
@@ -131,5 +140,18 @@ public class JacksonTest extends VertxTestBase {
   private static JsonObject testMaxNameLength(int len) {
     String json = "{\"" + repeat("a", len) + "\":3}";
     return new JsonObject(json);
+  }
+
+  private static JsonArray testMaxDocumentLength(long len) {
+    String prefix = len % 2 == 0 ? "[ " : "[";
+    int num = (int) ((len - prefix.length()) / 2);
+    StringBuilder sb = new StringBuilder((int) len);
+    sb.append(prefix);
+    for (int i = 0; i < num;i++) {
+      sb.append("0,");
+    }
+    sb.setCharAt((int) (len - 1), ']');
+    String json = sb.toString();
+    return new JsonArray(json);
   }
 }

--- a/src/test/java/io/vertx/it/JacksonConfigOverrideTest.java
+++ b/src/test/java/io/vertx/it/JacksonConfigOverrideTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.it;
+
+import io.vertx.core.json.JacksonTest;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class JacksonConfigOverrideTest extends VertxTestBase {
+
+  @Test
+  public void testReadConstraints() {
+    JacksonTest.testReadConstraints(100,  100, 100, 100, 1000);
+  }
+}


### PR DESCRIPTION
Motivation:

Jackson bump broke the integration test that was not incorrect due to a fix in max document length enforcement.

Changes:

Increase the max document length so the integration test is correct.

Add a test enforcing max document length is respected.
