### PR TITLE
Let HTTP/2 client connection be created without the rst flood protection.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandlerBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandlerBuilder.java
@@ -37,6 +37,11 @@ class VertxHttp2ConnectionHandlerBuilder<C extends Http2ConnectionBase> extends 
     return this;
   }
 
+  @Override
+  protected boolean isServer() {
+    return server;
+  }
+
   VertxHttp2ConnectionHandlerBuilder<C> initialSettings(io.vertx.core.http.Http2Settings settings) {
     HttpUtils.fromVertxInitialSettings(server, settings, initialSettings());
     return this;


### PR DESCRIPTION
Motivation:

HTTP/2 client connection appear as being server connection to the builder because of the server flag behavior.

Changes:

Override the isServer method to have the builder fully aware of the nature of the connection to create and avoid configuring the rst flood protection.
