### PR TITLE
Make the alt-svc utils method emission that is protocol dependant to the HttpServerResponse API.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -744,4 +744,17 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    * @return the cookie, if it existed, or {@code null}
    */
   @Nullable Cookie removeCookie(String name, String domain, String path, boolean invalidate);
+
+  /**
+   * <p>Write an <a href="https://datatracker.ietf.org/doc/html/rfc7838"HTTP Alternative Services</a> advertisement for
+   * the given request and its authority, according to the underlying protocol.</p>
+   *
+   * <p>For HTTP/1.x this sets an {@link HttpHeaders#ALT_SVC} header, otherwise it writes a
+   * <a href="https://datatracker.ietf.org/doc/html/rfc7838#section-7.2">custom frame</a>.</p>
+   *
+   * <p>Example usage: {@code response.writeAltSvc("h3=\":443\"")}</p>
+   *
+   * @param advertisement the advertisement
+   */
+  Future<Void> writeAltSvc(String advertisement);
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -847,4 +847,17 @@ public class HttpServerResponseImpl implements HttpServerResponse {
       return (Set) cookies().removeOrInvalidateAll(name, invalidate);
     }
   }
+
+  @Override
+  public Future<Void> writeAltSvc(String advertisement) {
+    switch (stream.version()) {
+      case HTTP_2:
+      case HTTP_3:
+        Buffer value = Buffer.buffer();
+        value.appendShort((short)0);
+        value.appendString(advertisement);
+        return writeCustomFrame(0xA, 0, value);
+    }
+    return context.succeededFuture();
+  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -1050,30 +1050,4 @@ public final class HttpUtils {
     }
     return null;
   }
-
-  /**
-   * Write an alt-svc advertisement for the given request and its authority, according to the underlying protocol.
-   *
-   * @param request the request
-   * @param advertisement the advertisement
-   */
-  public static HttpServerResponse writeAltSvc(HttpServerRequest request, String advertisement) {
-    HttpServerResponse response = request.response();
-    switch (request.version()) {
-      case HTTP_1_0:
-      case HTTP_1_1:
-        response.putHeader(io.vertx.core.http.HttpHeaders.ALT_SVC, advertisement);
-        break;
-      case HTTP_2:
-        Buffer value = Buffer.buffer();
-        value.appendShort((short)0);
-        value.appendString(advertisement);
-        response.writeCustomFrame(0xA, 0, value);
-        break;
-      case HTTP_3:
-        // Not supported for now
-        break;
-    }
-    return response;
-  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerResponse.java
@@ -849,4 +849,10 @@ public class Http1ServerResponse implements HttpServerResponse, HttpResponse {
       return (Set) cookies().removeOrInvalidateAll(name, invalidate);
     }
   }
+
+  @Override
+  public Future<Void> writeAltSvc(String advertisement) {
+    putHeader(io.vertx.core.http.HttpHeaders.ALT_SVC, advertisement);
+    return context.succeededFuture();
+  }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpAlternativesTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpAlternativesTest.java
@@ -42,8 +42,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.vertx.core.http.impl.HttpUtils.writeAltSvc;
-
 public class HttpAlternativesTest extends VertxTestBase {
 
   @Rule
@@ -233,8 +231,9 @@ public class HttpAlternativesTest extends VertxTestBase {
       .handler(request -> {
         assertNull(request.getHeader(HttpHeaders.ALT_USED));
         assertEquals("host2.com", request.connection().indicatedServerName());
-        writeAltSvc(request, advertisement.get())
-          .end(request.authority().toString(false));
+        HttpServerResponse response = request.response();
+        response.writeAltSvc(advertisement.get());
+        response.end(request.authority().toString(false));
       });
     Server alternative = startServer(4044, Cert.SNI_JKS, upgradedProtocol)
       .handler(request -> {


### PR DESCRIPTION
Motivation:

The HttpUtils static method that emits an alt svc event can be moved to HttpServerResponse and be available on this API.
