### PR TITLE
Support Unix Domain Sockets with io_uring transport

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -8,6 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
+
 package io.vertx.core.impl.transports;
 
 import io.netty.bootstrap.Bootstrap;
@@ -16,6 +17,7 @@ import io.netty.channel.*;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.channel.unix.UnixChannelOption;
 import io.netty.channel.uring.*;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.net.TcpConfig;
@@ -61,7 +63,7 @@ public class IoUringTransport implements Transport {
 
   @Override
   public boolean supportsDomainSockets() {
-    return false;
+    return true;
   }
 
   @Override
@@ -72,7 +74,7 @@ public class IoUringTransport implements Transport {
   @Override
   public SocketAddress convert(io.vertx.core.net.SocketAddress address) {
     if (address.isDomainSocket()) {
-      throw new IllegalArgumentException("Domain socket not supported by IOUring transport");
+      return new DomainSocketAddress(address.path());
     }
     return Transport.super.convert(address);
   }
@@ -113,7 +115,7 @@ public class IoUringTransport implements Transport {
   @Override
   public ChannelFactory<? extends Channel> channelFactory(boolean domainSocket) {
     if (domainSocket) {
-      throw new IllegalArgumentException();
+      return IoUringDomainSocketChannel::new;
     }
     return IoUringSocketChannel::new;
   }
@@ -121,7 +123,7 @@ public class IoUringTransport implements Transport {
   @Override
   public ChannelFactory<? extends ServerChannel> serverChannelFactory(boolean domainSocket) {
     if (domainSocket) {
-      throw new IllegalArgumentException();
+      return IoUringServerDomainSocketChannel::new;
     }
     return IoUringServerSocketChannel::new;
   }
@@ -134,26 +136,25 @@ public class IoUringTransport implements Transport {
 
   @Override
   public void configure(TcpConfig config, boolean domainSocket, ServerBootstrap bootstrap) {
-    if (domainSocket) {
-      throw new IllegalArgumentException();
+    if (!domainSocket) {
+      bootstrap.option(UnixChannelOption.SO_REUSEPORT, config.isSoReusePort());
+      configOption(bootstrap, config, TcpOption.FASTOPEN, IoUringChannelOption.TCP_FASTOPEN);
+      configChildOption(bootstrap, config, TcpOption.USER_TIMEOUT, IoUringChannelOption.TCP_USER_TIMEOUT);
+      configChildOption(bootstrap, config, TcpOption.QUICKACK, IoUringChannelOption.TCP_QUICKACK);
+      configChildOption(bootstrap, config, TcpOption.CORK, IoUringChannelOption.TCP_CORK);
     }
-    bootstrap.option(IoUringChannelOption.SO_REUSEPORT, config.isSoReusePort());
-    configOption(bootstrap, config, TcpOption.FASTOPEN, IoUringChannelOption.TCP_FASTOPEN);
-    configChildOption(bootstrap, config, TcpOption.USER_TIMEOUT, IoUringChannelOption.TCP_USER_TIMEOUT);
-    configChildOption(bootstrap, config, TcpOption.QUICKACK, IoUringChannelOption.TCP_QUICKACK);
-    configChildOption(bootstrap, config, TcpOption.CORK, IoUringChannelOption.TCP_CORK);
-    Transport.super.configure(config, false, bootstrap);
+    Transport.super.configure(config, domainSocket, bootstrap);
   }
 
   @Override
   public void configure(TcpConfig config, boolean domainSocket, Bootstrap bootstrap) {
-    if (domainSocket) {
-      throw new IllegalArgumentException();
+    if (!domainSocket) {
+      NioTransport.configOption(bootstrap, config, TcpOption.FASTOPEN_CONNECT,
+        IoUringChannelOption.TCP_FASTOPEN_CONNECT);
+      NioTransport.configOption(bootstrap, config, TcpOption.USER_TIMEOUT, IoUringChannelOption.TCP_USER_TIMEOUT);
+      NioTransport.configOption(bootstrap, config, TcpOption.QUICKACK, IoUringChannelOption.TCP_QUICKACK);
+      NioTransport.configOption(bootstrap, config, TcpOption.CORK, IoUringChannelOption.TCP_CORK);
     }
-    NioTransport.configOption(bootstrap, config, TcpOption.FASTOPEN_CONNECT, IoUringChannelOption.TCP_FASTOPEN_CONNECT);
-    NioTransport.configOption(bootstrap, config, TcpOption.USER_TIMEOUT, IoUringChannelOption.TCP_USER_TIMEOUT);
-    NioTransport.configOption(bootstrap, config, TcpOption.QUICKACK, IoUringChannelOption.TCP_QUICKACK);
-    NioTransport.configOption(bootstrap, config, TcpOption.CORK, IoUringChannelOption.TCP_CORK);
-    Transport.super.configure(config, false, bootstrap);
+    Transport.super.configure(config, domainSocket, bootstrap);
   }
 }


### PR DESCRIPTION
In Netty 4.2, Unix Domain Sockets with io_uring are supported.

But they were not integrated by Vert.x yet.