### PR TITLE
Change the return type of QuicEndpoint#bind to return the local address the endpoint is bound to.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpServer.java
@@ -243,8 +243,8 @@ public class QuicHttpServer implements HttpServerInternal {
       http3Config.getInitialSettings() != null ? http3Config.getInitialSettings().copy() : new Http3Settings(), logEnabled));
     return quicServer
       .bind(current, address)
-      .map(port -> {
-        actualPort = port;
+      .map(addr -> {
+        actualPort = addr.port();
         return this;
       });
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicEndpoint.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicEndpoint.java
@@ -36,10 +36,10 @@ public interface QuicEndpoint extends Measured {
    * </ul>
    *
    * @param address the bind address
-   * @return a future signaling the success or failure of the bind operation, the future completion is the bound this
-   *         endpoint was bound to
+   * @return a future signaling the success or failure of the bind operation, the result is socket address
+   *        this endpoint is bound to
    */
-  Future<Integer> bind(SocketAddress address);
+  Future<SocketAddress> bind(SocketAddress address);
 
   /**
    * Close the endpoint and release all associated resources.

--- a/vertx-core/src/main/java/io/vertx/core/net/QuicServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicServer.java
@@ -34,9 +34,10 @@ public interface QuicServer extends QuicEndpoint {
    * Start listening on the {@code port} and {@code host} as configured in the {@link io.vertx.core.net.QuicServerConfig} used when
    * creating the server.
    *
-   * @return a future completed with the listen operation result
+   * @return a future signaling the success or failure of the listen operation, the result is socket address
+   *        this endpoint is bound to
    */
-  Future<Integer> listen();
+  Future<SocketAddress> listen();
 
   /**
    * Start listening on the specified {@code port} and {@code host}.
@@ -45,9 +46,10 @@ public interface QuicServer extends QuicEndpoint {
    * <p>
    * Host {@code 0.0.0.0} can be specified meaning "listen on all available interfaces".
    *
-   * @return a future completed with the port the server is bound to
+   * @return a future signaling the success or failure of the listen operation, the result is socket address
+   *        this endpoint is bound to
    */
-  default Future<Integer> listen(int port, String host) {
+  default Future<SocketAddress> listen(int port, String host) {
     return listen(new SocketAddressImpl(port, host));
   }
 
@@ -56,9 +58,10 @@ public interface QuicServer extends QuicEndpoint {
    * <p>
    * Port {@code 0} can be specified meaning "choose an random port".
    *
-   * @return a future completed with the port the server is bound to
+   * @return a future signaling the success or failure of the listen operation, the result is socket address
+   *        this endpoint is bound to
    */
-  default Future<Integer> listen(int port) {
+  default Future<SocketAddress> listen(int port) {
     return listen(port, "0.0.0.0");
   }
 
@@ -66,9 +69,10 @@ public interface QuicServer extends QuicEndpoint {
    * Start listening on the specified local address.
    *
    * @param localAddress the local address to listen on
-   * @return a future completed with the port the server is bound to
+   * @return a future signaling the success or failure of the listen operation, the result is socket address
+   *        this endpoint is bound to
    */
-  default Future<Integer> listen(SocketAddress localAddress) {
+  default Future<SocketAddress> listen(SocketAddress localAddress) {
     return bind(localAddress);
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/CleanableQuicClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/CleanableQuicClient.java
@@ -37,7 +37,7 @@ public class CleanableQuicClient extends QuicClientImpl implements Closeable {
   }
 
   @Override
-  public Future<Integer> bind(ContextInternal current, SocketAddress address) {
+  public Future<SocketAddress> bind(ContextInternal current, SocketAddress address) {
     synchronized (this) {
       if (listenContext != null) {
         return current.failedFuture(new IllegalStateException());

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/CleanableQuicServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/CleanableQuicServer.java
@@ -40,7 +40,7 @@ public class CleanableQuicServer extends QuicServerImpl implements Closeable {
   }
 
   @Override
-  public Future<Integer> bind(ContextInternal current, SocketAddress address) {
+  public Future<SocketAddress> bind(ContextInternal current, SocketAddress address) {
     synchronized (this) {
       if (listenContext != null) {
         return current.failedFuture(new IllegalStateException());

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicClientImpl.java
@@ -54,7 +54,7 @@ public class QuicClientImpl extends QuicEndpointImpl implements QuicClient {
   private final QuicClientConfig config;
   private final ClientSSLOptions sslOptions;
   private TransportMetrics<?> metrics;
-  private Future<Integer> clientFuture;
+  private Future<SocketAddress> clientFuture;
   private volatile Channel channel;
 
   public QuicClientImpl(VertxInternal vertx, QuicClientConfig config, String protocol, ClientSSLOptions sslOptions) {
@@ -143,7 +143,7 @@ public class QuicClientImpl extends QuicEndpointImpl implements QuicClient {
       return connect(ch, remoteAddress, resolvedAddress, qLogConfig, context, connectTimeout,
         applicationProtocols, sslContextProvider);
     }
-    Future<Integer> cf;
+    Future<SocketAddress> cf;
     synchronized (this) {
       cf = clientFuture;
       if (cf == null) {

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicEndpointImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicEndpointImpl.java
@@ -198,11 +198,11 @@ public abstract class QuicEndpointImpl implements QuicEndpointInternal, MetricsP
   }
 
   @Override
-  public Future<Integer> bind(SocketAddress address) {
+  public Future<SocketAddress> bind(SocketAddress address) {
     return bind(vertx.getOrCreateContext(), address);
   }
 
-  public Future<Integer> bind(ContextInternal current, SocketAddress address) {
+  public Future<SocketAddress> bind(ContextInternal current, SocketAddress address) {
     synchronized (this) {
       if (context != null) {
         return current.failedFuture("Already bound");
@@ -218,7 +218,7 @@ public abstract class QuicEndpointImpl implements QuicEndpointInternal, MetricsP
     return bind(current, address, metrics)
       .map(ch -> {
         handleBind(ch, metrics);
-        return ((InetSocketAddress)ch.localAddress()).getPort();
+        return vertx.transport().convert(ch.localAddress());
       });
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicServerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/quic/QuicServerImpl.java
@@ -288,7 +288,7 @@ public class QuicServerImpl extends QuicEndpointImpl implements QuicServerIntern
   }
 
   @Override
-  public Future<Integer> listen() {
+  public Future<SocketAddress> listen() {
     return listen(config.getPort(), config.getHost());
   }
 

--- a/vertx-core/src/test/java/io/vertx/it/networklogging/QuicTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/networklogging/QuicTest.java
@@ -31,7 +31,7 @@ public class QuicTest extends VertxTestBase {
 
           });
         });
-        Integer port = server.listen().await();
+        int port = server.listen().await().port();
         QuicClient client = vertx.createQuicClient(new QuicClientConfig(), QuicClientTest.SSL_OPTIONS);
         QuicConnection connection = client.connect(SocketAddress.inetSocketAddress(port, "localhost")).await();
         QuicStream stream = connection.openStream().await();

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicMetricsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicMetricsTest.java
@@ -74,7 +74,7 @@ public class QuicMetricsTest extends VertxTestBase {
           stream.endHandler(v -> stream.end());
         });
       });
-      port = server.bind(SocketAddress.sharedRandomPort(1, "localhost")).await();
+      port = server.bind(SocketAddress.sharedRandomPort(1, "localhost")).await().port();
       servers.add(server);
     }
     while (i++ < numberOfServers);

--- a/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/quic/QuicServerTest.java
@@ -76,7 +76,9 @@ public class QuicServerTest extends VertxTestBase {
   @Test
   public void testBind() {
     QuicServer server = vertx.createQuicServer(SSL_OPTIONS);
-    server.bind(SocketAddress.inetSocketAddress(9999, "localhost")).await();
+    SocketAddress addr = server.bind(SocketAddress.inetSocketAddress(9999, "localhost")).await();
+    assertEquals(9999, addr.port());
+    assertEquals("127.0.0.1", addr.host());
     server.close().await();
   }
 
@@ -114,7 +116,7 @@ public class QuicServerTest extends VertxTestBase {
         });
       });
     });
-    int actualPort = server.bind(SocketAddress.inetSocketAddress(port, "localhost")).await();
+    int actualPort = server.bind(SocketAddress.inetSocketAddress(port, "localhost")).await().port();
     if (port == 0) {
       assertTrue(actualPort > 0);
     } else {
@@ -981,7 +983,7 @@ public class QuicServerTest extends VertxTestBase {
     server.handler(conn -> {
       serverName.set(conn.indicatedServerName());
     });
-    int actualPort = server.bind(SocketAddress.inetSocketAddress(9999, "localhost")).await();
+    int actualPort = server.bind(SocketAddress.inetSocketAddress(9999, "localhost")).await().port();
     QuicTestClient client = new QuicTestClient();
     try {
       client = new QuicTestClient();


### PR DESCRIPTION
Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
