### PR TITLE
Let null handlers to be set on a closed AsyncFile.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -236,23 +236,26 @@ public class AsyncFileImpl implements AsyncFile {
 
   @Override
   public synchronized AsyncFile drainHandler(Handler<Void> handler) {
-    check();
+    if (handler != null) {
+      check();
+    }
     this.drainHandler = handler;
     return this;
   }
 
   @Override
   public synchronized AsyncFile exceptionHandler(Handler<Throwable> handler) {
-    check();
+    if (handler != null) {
+      check();
+    }
     this.exceptionHandler = handler;
     return this;
   }
 
   @Override
   public synchronized AsyncFile handler(Handler<Buffer> handler) {
-    check();
-    if (closed) {
-      return this;
+    if (handler != null) {
+      check();
     }
     this.handler = handler;
     if (handler != null) {
@@ -265,7 +268,9 @@ public class AsyncFileImpl implements AsyncFile {
 
   @Override
   public synchronized AsyncFile endHandler(Handler<Void> handler) {
-    check();
+    if (handler != null) {
+      check();
+    }
     this.endHandler = handler;
     return this;
   }

--- a/vertx-core/src/test/java/io/vertx/tests/file/FileSystemTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/file/FileSystemTest.java
@@ -16,6 +16,7 @@ import io.netty.buffer.Unpooled;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.*;
+import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.FileSystemException;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.file.impl.AsyncFileImpl;
@@ -2300,5 +2301,17 @@ public class FileSystemTest extends VertxTestBase {
     }));
     TestUtils.awaitLatch(latch1);
     file.close();
+  }
+
+  @Test
+  public void testClosedAsyncFileSetNullHandler() throws Exception {
+    createFileWithJunk("file.txt", 100);
+    FileSystem fs = vertx.fileSystem();
+    AsyncFile asyncFile = fs.openBlocking(testDir + pathSep + "file.txt", new OpenOptions().setRead(true));
+    asyncFile.close().await();
+    asyncFile.handler(null);
+    asyncFile.exceptionHandler(null);
+    asyncFile.drainHandler(null);
+    asyncFile.endHandler(null);
   }
 }


### PR DESCRIPTION
Motivation:

Setting a null handler on a closed `AsyncFile` should be allowed, this is often done after a file is closed for cleanup purpose as a safety measure.

Changes:

Allow null handlers to be set on a closed `AsyncFile`.
