### PR TITLE
Service loading control

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -244,20 +244,22 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     this.shadowContext = enableShadowContext;
   }
 
-  void init() {
+  void init(List<VerticleFactory> verticleFactories) {
     eventBus.start(Promise.promise());
     if (metrics != null) {
       metrics.vertxCreated(this);
     }
+    verticleManager.init(verticleFactories);
   }
 
-  Future<Vertx> initClustered(VertxOptions options) {
+  Future<Vertx> initClustered(VertxOptions options, List<VerticleFactory> verticleFactories) {
     nodeSelector.init(clusterManager);
     clusterManager.registrationListener(nodeSelector);
     clusterManager.init(this);
     Promise<Void> initPromise = Promise.promise();
     clusterManager.join((res, err) -> {
       if (err == null) {
+        verticleManager.init(verticleFactories);
         createHaManager(options, initPromise);
       } else {
         initPromise.fail(err);

--- a/vertx-core/src/main/java/io/vertx/core/impl/verticle/VerticleManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/verticle/VerticleManager.java
@@ -48,12 +48,12 @@ public class VerticleManager {
     this.vertx = (VertxImpl) vertx;
     this.deploymentManager = deploymentManager;
     this.log = log;
-    loadVerticleFactories();
   }
 
-  private void loadVerticleFactories() {
-    Collection<VerticleFactory> factories = ServiceHelper.loadFactories(VerticleFactory.class);
-    factories.forEach(this::registerVerticleFactory);
+  public void init(List<VerticleFactory> factories) {
+    if (factories != null) {
+      factories.forEach(this::registerVerticleFactory);
+    }
     VerticleFactory defaultFactory = new JavaVerticleFactory();
     defaultFactory.init(vertx);
     defaultFactories.add(defaultFactory);

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxBootstrap.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxBootstrap.java
@@ -146,7 +146,7 @@ public interface VertxBootstrap {
    * @param transport the transport
    * @return this builder instance
    */
-  VertxBootstrapImpl transport(Transport transport);
+  VertxBootstrap transport(Transport transport);
 
   /**
    * @return the cluster manager to use

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxBootstrap.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxBootstrap.java
@@ -175,6 +175,19 @@ public interface VertxBootstrap {
   VertxBootstrap clusterManager(ClusterManager clusterManager);
 
   /**
+   * @return the verticle factories to use
+   */
+  List<VerticleFactory> verticleFactories();
+
+  /**
+   * Set the list of {@code VerticleFactory} to use.
+   *
+   * @param verticleFactories the verticle factories
+   * @return the builder instance
+   */
+  VertxBootstrap verticleFactories(List<VerticleFactory> verticleFactories);
+
+  /**
    *
    * Initialize the service providers.
    *

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxBootstrap.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxBootstrap.java
@@ -14,14 +14,13 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.impl.VertxBootstrapImpl;
-import io.vertx.core.spi.ExecutorServiceFactory;
-import io.vertx.core.spi.VertxMetricsFactory;
-import io.vertx.core.spi.VertxThreadFactory;
-import io.vertx.core.spi.VertxTracerFactory;
+import io.vertx.core.spi.*;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.context.executor.EventExecutorProvider;
 import io.vertx.core.spi.file.FileResolver;
 import io.vertx.core.spi.transport.Transport;
+
+import java.util.List;
 
 /**
  * Vertx bootstrap for creating vertx instances with SPI overrides.
@@ -72,8 +71,22 @@ public interface VertxBootstrap {
   EventExecutorProvider eventExecutorProvider();
 
   /**
-   * @return the {@code FileResolver} instance to use
+   * @return the list of service providers to use
    */
+  List<VertxServiceProvider> serviceProviders();
+
+  /**
+   * Set the list of service providers to use, when the list is {@code null}, Java's service loader
+   * mechanism will be used to discover service providers.
+   *
+   * @param providers the service providers
+   * @return this builder instance
+   */
+  VertxBootstrap serviceProviders(List<VertxServiceProvider> providers);
+
+    /**
+     * @return the {@code FileResolver} instance to use
+     */
   FileResolver fileResolver();
 
   /**
@@ -162,6 +175,7 @@ public interface VertxBootstrap {
   VertxBootstrap clusterManager(ClusterManager clusterManager);
 
   /**
+   *
    * Initialize the service providers.
    *
    * @return this builder instance

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxBootstrapTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxBootstrapTest.java
@@ -17,11 +17,8 @@ import io.vertx.core.internal.VertxBootstrap;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.impl.transports.NioTransport;
+import io.vertx.core.spi.*;
 import io.vertx.core.spi.transport.Transport;
-import io.vertx.core.spi.ExecutorServiceFactory;
-import io.vertx.core.spi.VertxMetricsFactory;
-import io.vertx.core.spi.VertxThreadFactory;
-import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.tracing.TracingOptions;
 import io.vertx.test.fakecluster.FakeClusterManager;
@@ -38,11 +35,13 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
 
@@ -179,6 +178,19 @@ public class VertxBootstrapTest {
       .init()
       .vertx()
       .close().await();
+  }
+
+  @Test
+  public void testExplicitServiceProviders() {
+    AtomicInteger initialized = new AtomicInteger();
+    VertxServiceProvider provider = builder -> initialized.incrementAndGet();
+    VertxBootstrap factory = VertxBootstrap.create();
+    Vertx vertx = factory
+      .serviceProviders(Collections.singletonList(provider))
+      .init()
+      .vertx();
+    vertx.close();
+    assertEquals(1, initialized.get());
   }
 
   private class CustomExecutorServiceFactory implements ExecutorServiceFactory {


### PR DESCRIPTION
- **Avoid declaring VertxBootstrapImpl in VertxBootstrap contract**
- **Let the VertxBootstrap be configured with a list of service providers to use as an alternative to Service Loader.**
- **Move the discovery of VerticleFactory implementations to the VertxBuilder bootstrap.**
