### PR TITLE
Improve the resiliency of Vert.x Logger.

### DIFF
--- a/vertx-core-logging/src/main/java/io/vertx/core/internal/logging/LoggerAdapter.java
+++ b/vertx-core-logging/src/main/java/io/vertx/core/internal/logging/LoggerAdapter.java
@@ -13,91 +13,180 @@ package io.vertx.core.internal.logging;
 
 import io.vertx.core.spi.logging.LogDelegate;
 
+import java.util.Objects;
+import java.util.function.Consumer;
+
 /**
  * @author Thomas Segismont
  */
 public final class LoggerAdapter implements Logger {
 
+  private static volatile Consumer<Throwable> loggerFailureHandler;
+
+  /**
+   * Set a JVM wide handler that gets reported exception thrown by actual logger implementations.
+   *
+   * @param handler the handler getting reported failures
+   */
+  public static void setLoggerFailureHandler(Consumer<Throwable> handler) {
+    loggerFailureHandler = handler;
+  }
+
   private final LogDelegate adapted;
 
   // Visible for testing
   public LoggerAdapter(LogDelegate adapted) {
-    this.adapted = adapted;
+    this.adapted = Objects.requireNonNull(adapted);
+  }
+
+  private static void reportLoggerFailure(Throwable t) {
+    Consumer<Throwable> handler = loggerFailureHandler;
+    if (handler != null) {
+      try {
+        handler.accept(t);
+      } catch (Throwable ignore) {
+      }
+    }
   }
 
   @Override
   public String implementation() {
-    return adapted.implementation();
+    try {
+      return adapted.implementation();
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+      return "Unknown";
+    }
   }
 
   @Override
   public boolean isTraceEnabled() {
-    return adapted.isTraceEnabled();
+    try {
+      return adapted.isTraceEnabled();
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+      return false;
+    }
   }
 
   @Override
   public void trace(Object message) {
-    adapted.trace(message);
+    try {
+      adapted.trace(message);
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+    }
   }
 
   @Override
   public void trace(Object message, Throwable t) {
-    adapted.trace(message, t);
+    try {
+      adapted.trace(message, t);
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+    }
   }
 
   @Override
   public boolean isDebugEnabled() {
-    return adapted.isDebugEnabled();
+    try {
+      return adapted.isDebugEnabled();
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+      return false;
+    }
   }
 
   @Override
   public void debug(Object message) {
-    adapted.debug(message);
+    try {
+      adapted.debug(message);
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+    }
   }
 
   @Override
   public void debug(Object message, Throwable t) {
-    adapted.debug(message, t);
+    try {
+      adapted.debug(message, t);
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+    }
   }
 
   @Override
   public boolean isInfoEnabled() {
-    return adapted.isInfoEnabled();
+    try {
+      return adapted.isInfoEnabled();
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+      return false;
+    }
   }
 
   @Override
   public void info(Object message) {
-    adapted.info(message);
+    try {
+      adapted.info(message);
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+    }
   }
 
   @Override
   public void info(Object message, Throwable t) {
-    adapted.info(message, t);
+    try {
+      adapted.info(message, t);
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+    }
   }
 
   @Override
   public boolean isWarnEnabled() {
-    return adapted.isWarnEnabled();
+    try {
+      return adapted.isWarnEnabled();
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+      return false;
+    }
   }
 
   @Override
   public void warn(Object message) {
-    adapted.warn(message);
+    try {
+      adapted.warn(message);
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+    }
   }
 
   @Override
   public void warn(Object message, Throwable t) {
-    adapted.warn(message, t);
+    try {
+      adapted.warn(message, t);
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+    }
   }
 
   @Override
   public void error(Object message) {
-    adapted.error(message);
+    try {
+      adapted.error(message);
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+    }
   }
 
   @Override
   public void error(Object message, Throwable t) {
-    adapted.error(message, t);
+    try {
+      adapted.error(message, t);
+    } catch (Exception e) {
+      reportLoggerFailure(e);
+    }
   }
 
   public LogDelegate unwrap() {

--- a/vertx-core-logging/src/main/java/module-info.java
+++ b/vertx-core-logging/src/main/java/module-info.java
@@ -16,5 +16,6 @@ module io.vertx.core.logging {
   // Internal API
 
   exports io.vertx.core.internal.logging;
+  exports io.vertx.core.spi.logging;
 
 }

--- a/vertx-core-logging/src/test/java/io/vertx/it/ResilienceTest.java
+++ b/vertx-core-logging/src/test/java/io/vertx/it/ResilienceTest.java
@@ -1,0 +1,135 @@
+package io.vertx.it;
+
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerAdapter;
+import io.vertx.core.spi.logging.LogDelegate;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ResilienceTest {
+
+  private static final RuntimeException ERR = new RuntimeException();
+
+  final Map<String, AtomicInteger> loggerUsage = new HashMap<>();
+  LogDelegate logDelegate = new LogDelegate() {
+    private <T> T fail() {
+      StackTraceElement[] trace = Thread.currentThread().getStackTrace();
+      StackTraceElement elt = trace[2];
+      AtomicInteger cnt = loggerUsage.computeIfAbsent(elt.getMethodName(), curr -> new AtomicInteger());
+      cnt.incrementAndGet();
+      throw ERR;
+    }
+    @Override
+    public String implementation() {
+      return fail();
+    }
+    @Override
+    public boolean isWarnEnabled() {
+      return fail();
+    }
+    @Override
+    public boolean isInfoEnabled() {
+      return fail();
+    }
+    @Override
+    public boolean isDebugEnabled() {
+      return fail();
+    }
+    @Override
+    public boolean isTraceEnabled() {
+      return fail();
+    }
+    @Override
+    public void error(Object message) {
+      fail();
+    }
+    @Override
+    public void error(Object message, Throwable t) {
+      fail();
+    }
+    @Override
+    public void warn(Object message) {
+      fail();
+    }
+    @Override
+    public void warn(Object message, Throwable t) {
+      fail();
+    }
+    @Override
+    public void info(Object message) {
+      fail();
+    }
+    @Override
+    public void info(Object message, Throwable t) {
+      fail();
+    }
+    @Override
+    public void debug(Object message) {
+      fail();
+    }
+    @Override
+    public void debug(Object message, Throwable t) {
+      fail();
+    }
+    @Override
+    public void trace(Object message) {
+      fail();
+    }
+    @Override
+    public void trace(Object message, Throwable t) {
+      fail();
+    }
+  };
+
+  @Before
+  public void before() {
+    loggerUsage.clear();
+  }
+
+  @Test
+  public void testCatchAndReportFailures() {
+    Logger logger = new LoggerAdapter(logDelegate);
+    List<Throwable> uncaughtReports = new ArrayList<>();
+    LoggerAdapter.setLoggerFailureHandler(uncaughtReports::add);
+    try {
+      logger.isDebugEnabled();
+      assertEquals(1, loggerUsage.size());
+      AtomicInteger c = loggerUsage.get("isDebugEnabled");
+      assertNotNull(c);
+      assertEquals(1, c.get());
+      assertEquals(List.of(ERR), uncaughtReports);
+    } finally {
+      LoggerAdapter.setLoggerFailureHandler(null);
+    }
+  }
+
+  @Test
+  public void testUncaughtHandlerFailure() {
+    AtomicInteger uncaughtCount = new AtomicInteger();
+    Logger logger = new LoggerAdapter(logDelegate);
+    LoggerAdapter.setLoggerFailureHandler(err -> {
+      uncaughtCount.incrementAndGet();
+      throw new AssertionError();
+    });
+    try {
+      logger.isDebugEnabled();
+      assertEquals(1, loggerUsage.size());
+      AtomicInteger c = loggerUsage.get("isDebugEnabled");
+      assertNotNull(c);
+      assertEquals(1, c.get());
+      assertEquals(1, uncaughtCount.get());
+    } finally {
+      LoggerAdapter.setLoggerFailureHandler(null);
+    }
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/impl/TaskQueue.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/TaskQueue.java
@@ -33,9 +33,10 @@ import java.util.concurrent.RejectedExecutionException;
  */
 public class TaskQueue {
 
-  static final Logger log = LoggerFactory.getLogger(TaskQueue.class);
+  static final Logger LOGGER = LoggerFactory.getLogger(TaskQueue.class);
 
   // @protectedby tasks
+  private final Logger log;
   private final LinkedList<Task> tasks = new LinkedList<>();
   private final Set<ContinuationTask> continuations = new HashSet<>();
   private boolean closed;
@@ -45,8 +46,13 @@ public class TaskQueue {
 
   private final Runnable runner;
 
-  public TaskQueue() {
+  public TaskQueue(Logger log) {
+    this.log = log;
     runner = this::run;
+  }
+
+  public TaskQueue() {
+    this(LOGGER);
   }
 
   private void run() {
@@ -79,7 +85,10 @@ public class TaskQueue {
         currentTask = execute;
         execute.runnable.run();
       } catch (Throwable t) {
-        log.error("Caught unexpected Throwable", t);
+        try {
+          log.error("Caught unexpected Throwable", t);
+        } catch (Throwable ignore) {
+        }
       } finally {
         currentThread = null;
         currentTask = null;

--- a/vertx-core/src/test/java/io/vertx/tests/context/TaskQueueTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/TaskQueueTest.java
@@ -2,8 +2,11 @@ package io.vertx.tests.context;
 
 import io.vertx.core.impl.TaskQueue;
 import io.vertx.core.impl.WorkerExecutor;
+import io.vertx.core.internal.logging.LoggerAdapter;
+import io.vertx.core.spi.logging.LogDelegate;
 import io.vertx.test.core.AsyncTestBase;
 import org.assertj.core.api.Assertions;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -352,5 +355,80 @@ public class TaskQueueTest extends AsyncTestBase {
     }, exec);
     pending.poll().run();
     assertTrue(seq.get() >= 2);
+  }
+
+  @Test
+  public void testFaultyLogger() {
+    AtomicInteger errorCounts = new AtomicInteger();
+    LogDelegate logDelegate = new LogDelegate() {
+      @Override
+      public String implementation() {
+        return "test";
+      }
+      @Override
+      public boolean isWarnEnabled() {
+        return true;
+      }
+      @Override
+      public boolean isInfoEnabled() {
+        return true;
+      }
+      @Override
+      public boolean isDebugEnabled() {
+        return true;
+      }
+      @Override
+      public boolean isTraceEnabled() {
+        return true;
+      }
+      @Override
+      public void error(Object message) {
+      }
+      @Override
+      public void error(Object message, Throwable t) {
+        errorCounts.incrementAndGet();
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void warn(Object message) {
+      }
+      @Override
+      public void warn(Object message, Throwable t) {
+      }
+      @Override
+      public void info(Object message) {
+      }
+      @Override
+      public void info(Object message, Throwable t) {
+      }
+      @Override
+      public void debug(Object message) {
+      }
+      @Override
+      public void debug(Object message, Throwable t) {
+      }
+      @Override
+      public void trace(Object message) {
+      }
+      @Override
+      public void trace(Object message, Throwable t) {
+      }
+    };
+    TaskQueue taskQueue = new TaskQueue(new LoggerAdapter(logDelegate));
+    Deque<Runnable> pending = new ConcurrentLinkedDeque<>();
+    taskQueue.execute(() -> {
+      throw new RuntimeException();
+    }, pending::add);
+    Runnable next = pending.poll();
+    Assert.assertNotNull(next);
+    next.run();
+    assertEquals(1, errorCounts.get());
+    AtomicInteger executeCounts = new AtomicInteger();
+    taskQueue.execute(executeCounts::incrementAndGet, pending::add);
+    assertEquals(1, pending.size());
+    next = pending.poll();
+    Assert.assertNotNull(next);
+    next.run();
+    assertEquals(1, errorCounts.get());
   }
 }


### PR DESCRIPTION
Motivation:

Vert.x should improve it's logger resiliency when handling faulty loggers, otherwise special care needs to be taken when logging happens in order to avoid breaking invariants, for instance TaskQueue log taks failures and assumes that the logging will not fail.

Changes:

Vert.x should redirect logger failures to a special global handler (to avoid ignoring them) and isolate the caller of such issues as part of the Logger contract.
