### PR TITLE
Fix 'occured' -> 'occurred' in ReplyFailure.ERROR Javadoc

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/ReplyFailure.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/ReplyFailure.java
@@ -37,7 +37,7 @@ public enum ReplyFailure {
   RECIPIENT_FAILURE,
 
   /**
-   * A fatal error occured while delivering the message. Do not retry to send.
+   * A fatal error occurred while delivering the message. Do not retry to send.
    */
   ERROR;
 


### PR DESCRIPTION
Trivial spelling fix on the `ReplyFailure.ERROR` enum Javadoc (rendered in the `vertx-core` API docs):

`A fatal error occurred while delivering the message. Do not retry to send.`

No functional changes.