### PR TITLE
Let the HTTP/2 max number of small continuation frames allowed to be configuration.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/Http2ServerConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/Http2ServerConfig.java
@@ -28,6 +28,7 @@ public class Http2ServerConfig {
   private int connectionWindowSize;
   private boolean multiplexImplementation;
   private int rstFloodMaxRstFramePerWindow;
+  private int maxSmallContinuationFrames;
   private Duration rstFloodWindowDuration;
 
   public Http2ServerConfig() {
@@ -35,6 +36,7 @@ public class Http2ServerConfig {
     connectionWindowSize = DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE;
     rstFloodMaxRstFramePerWindow = DEFAULT_HTTP2_RST_FLOOD_MAX_RST_FRAME_PER_WINDOW;
     rstFloodWindowDuration = Duration.of(DEFAULT_HTTP2_RST_FLOOD_WINDOW_DURATION, DEFAULT_HTTP2_RST_FLOOD_WINDOW_DURATION_TIME_UNIT.toChronoUnit());
+    maxSmallContinuationFrames = DEFAULT_HTTP2_MAX_SMALL_CONTINUATION_FRAMES;
     multiplexImplementation = DEFAULT_HTTP_2_MULTIPLEX_IMPLEMENTATION;
   }
 
@@ -43,6 +45,7 @@ public class Http2ServerConfig {
     this.connectionWindowSize = other.connectionWindowSize;
     this.rstFloodMaxRstFramePerWindow = other.rstFloodMaxRstFramePerWindow;
     this.rstFloodWindowDuration = other.rstFloodWindowDuration;
+    this.maxSmallContinuationFrames = other.maxSmallContinuationFrames;
     this.multiplexImplementation = other.multiplexImplementation;
   }
 
@@ -81,6 +84,29 @@ public class Http2ServerConfig {
    */
   public Http2ServerConfig setRstFloodWindowDuration(Duration rstFloodWindowDuration) {
     this.rstFloodWindowDuration = rstFloodWindowDuration;
+    return this;
+  }
+
+  /**
+   * @return the max number of small continuation frame allowed
+   */
+  public int getMaxSmallContinuationFrames() {
+    return maxSmallContinuationFrames;
+  }
+
+  /**
+   * Set the maximum number of small continuation frames allowed, this is used to prevent flood DoS attack
+   * via <a href="https://nvd.nist.gov/vuln/detail/CVE-2026-33871">zero-byte continuation frames</a>. The default value
+   * is {@link HttpServerOptions#DEFAULT_HTTP2_MAX_SMALL_CONTINUATION_FRAMES}.
+   *
+   * @param maxSmallContinuationFrames the max number of small continuation frame allowed
+   * @return a reference to this, so the API can be used fluently
+   */
+  public Http2ServerConfig setMaxSmallContinuationFrames(int maxSmallContinuationFrames) {
+    if (maxSmallContinuationFrames < 1) {
+      throw new IllegalArgumentException();
+    }
+    this.maxSmallContinuationFrames = maxSmallContinuationFrames;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -202,6 +202,11 @@ public class HttpServerOptions extends NetServerOptions {
   public static final TimeUnit DEFAULT_HTTP2_RST_FLOOD_WINDOW_DURATION_TIME_UNIT = TimeUnit.SECONDS;
 
   /**
+   * HTTP/2 maximum allowed number of small continuation frames.
+   */
+  public static final int DEFAULT_HTTP2_MAX_SMALL_CONTINUATION_FRAMES = 16;
+
+  /**
    * Strict thread mode = false.
    */
   public static final boolean DEFAULT_STRICT_THREAD_MODE_STRICT = false;
@@ -1271,6 +1276,26 @@ public class HttpServerOptions extends NetServerOptions {
     Duration tmp = http2Config.getRstFloodWindowDuration();
     this.http2RstFloodWindowDurationTimeUnit = http2RstFloodWindowDurationTimeUnit;
     http2Config.setRstFloodWindowDuration(tmp);
+    return this;
+  }
+
+  /**
+   * @return the max number of small continuation frame allowed
+   */
+  public int getHttp2MaxSmallContinuationFrames() {
+    return http2Config.getMaxSmallContinuationFrames();
+  }
+
+  /**
+   * Set the maximum number of small continuation frames allowed, this is used to prevent flood DoS attack
+   * via <a href="https://nvd.nist.gov/vuln/detail/CVE-2026-33871">zero-byte continuation frames</a>. The default value
+   * is {@link #DEFAULT_HTTP2_MAX_SMALL_CONTINUATION_FRAMES}.
+   *
+   * @param http2MaxSmallContinuationFrames the max number of small continuation frame allowed
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setHttp2MaxSmallContinuationFrames(int http2MaxSmallContinuationFrames) {
+    http2Config.setMaxSmallContinuationFrames(http2MaxSmallContinuationFrames);
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2CodecServerChannelInitializer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2CodecServerChannelInitializer.java
@@ -82,10 +82,12 @@ public class Http2CodecServerChannelInitializer implements Http2ServerChannelIni
   public VertxHttp2ConnectionHandler<Http2ServerConnectionImpl> buildHttp2ConnectionHandler(ContextInternal ctx) {
     int maxRstFramesPerWindow = config.getRstFloodMaxRstFramePerWindow();
     int secondsPerWindow = (int)config.getRstFloodWindowDuration().toSeconds();
+    int maxSmallContinuationFrames = config.getMaxSmallContinuationFrames();
     VertxHttp2ConnectionHandler<Http2ServerConnectionImpl> handler = new VertxHttp2ConnectionHandlerBuilder<Http2ServerConnectionImpl>()
       .server(true)
       .useCompression(compressionManager != null ? compressionManager.options() : null)
       .gracefulShutdownTimeoutMillis(0)
+      .decoderEnforceMaxSmallContinuationFrames(maxSmallContinuationFrames)
       .decoderEnforceMaxRstFramesPerWindow(maxRstFramesPerWindow, secondsPerWindow)
       .encoderEnforceMaxRstFramesPerWindow(maxRstFramesPerWindow, secondsPerWindow)
       .useDecompression(useDecompression)

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/VertxHttp2ConnectionHandlerBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/VertxHttp2ConnectionHandlerBuilder.java
@@ -54,6 +54,11 @@ public class VertxHttp2ConnectionHandlerBuilder<C extends Http2ConnectionImpl> e
   }
 
   @Override
+  public VertxHttp2ConnectionHandlerBuilder<C> decoderEnforceMaxSmallContinuationFrames(int maxSmallContinuationFrames) {
+    return super.decoderEnforceMaxSmallContinuationFrames(maxSmallContinuationFrames);
+  }
+
+  @Override
   public VertxHttp2ConnectionHandlerBuilder<C> decoderEnforceMaxRstFramesPerWindow(int maxRstFramesPerWindow, int secondsPerWindow) {
     return super.decoderEnforceMaxRstFramesPerWindow(maxRstFramesPerWindow, secondsPerWindow);
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2CustomFrameCodecBuilder.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2CustomFrameCodecBuilder.java
@@ -51,6 +51,11 @@ class Http2CustomFrameCodecBuilder extends Http2FrameCodecBuilder {
   }
 
   @Override
+  public Http2CustomFrameCodecBuilder decoderEnforceMaxSmallContinuationFrames(int maxConsecutiveContinuationsFrames) {
+    return (Http2CustomFrameCodecBuilder) super.decoderEnforceMaxSmallContinuationFrames(maxConsecutiveContinuationsFrames);
+  }
+
+  @Override
   public Http2CustomFrameCodecBuilder server(boolean isServer) {
     this.server = isServer;
     return this;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexServerChannelInitializer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexServerChannelInitializer.java
@@ -37,6 +37,7 @@ public class Http2MultiplexServerChannelInitializer implements Http2ServerChanne
   private final Http2MultiplexConnectionFactory connectionFactory;
   private final int rstFloodMaxRstFramePerWindow;
   private final int rstFloodWindowDuration;
+  private final int maxSmallContinuationFrames;
   private final boolean logEnabled;
 
   public Http2MultiplexServerChannelInitializer(ContextInternal context,
@@ -50,6 +51,7 @@ public class Http2MultiplexServerChannelInitializer implements Http2ServerChanne
                                                 Http2Settings initialSettings,
                                                 int rstFloodMaxRstFramePerWindow,
                                                 int rstFloodWindowDuration,
+                                                int maxSmallContinuationFrames,
                                                 boolean logEnabled) {
     Http2MultiplexConnectionFactory connectionFactory = (handler, chctx) -> {
       Http2MultiplexServerConnection connection = new Http2MultiplexServerConnection(
@@ -70,6 +72,7 @@ public class Http2MultiplexServerChannelInitializer implements Http2ServerChanne
     this.decompressionSupported = decompressionSupported;
     this.rstFloodMaxRstFramePerWindow = rstFloodMaxRstFramePerWindow;
     this.rstFloodWindowDuration = rstFloodWindowDuration;
+    this.maxSmallContinuationFrames = maxSmallContinuationFrames;
     this.logEnabled = logEnabled;
   }
 
@@ -83,6 +86,7 @@ public class Http2MultiplexServerChannelInitializer implements Http2ServerChanne
 
     Http2FrameCodec frameCodec = new Http2CustomFrameCodecBuilder(compressionManager, decompressionSupported)
       .server(true)
+      .decoderEnforceMaxSmallContinuationFrames(rstFloodWindowDuration)
       .decoderEnforceMaxRstFramesPerWindow(rstFloodMaxRstFramePerWindow, rstFloodWindowDuration)
       .encoderEnforceMaxRstFramesPerWindow(rstFloodMaxRstFramePerWindow, rstFloodWindowDuration)
       .initialSettings(initialSettings)

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/HttpServerConnectionInitializer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/HttpServerConnectionInitializer.java
@@ -126,6 +126,7 @@ public class HttpServerConnectionInitializer {
           HttpUtils.fromVertxInitialSettings(true, http2Config.getInitialSettings()),
           http2Config.getRstFloodMaxRstFramePerWindow(),
           (int)http2Config.getRstFloodWindowDuration().toSeconds(),
+          http2Config.getMaxSmallContinuationFrames(),
           logEnabled);
       } else {
         http2ChannelInitializer = new Http2CodecServerChannelInitializer(


### PR DESCRIPTION
Motivation:

Netty has a protection against a Zero-Byte Frame Bypass attack, that allows 16 frames by default.

We should make this setting configurable.
