### PR TITLE
Let the HTTP/2 max number of small continuation frames allowed to be configuration.

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -201,6 +201,11 @@ public class HttpServerOptions extends NetServerOptions {
    */
   public static final TimeUnit DEFAULT_HTTP2_RST_FLOOD_WINDOW_DURATION_TIME_UNIT = TimeUnit.SECONDS;
 
+  /**
+   * HTTP/2 maximum allowed number of small continuation frames.
+   */
+  public static final int DEFAULT_HTTP2_MAX_SMALL_CONTINUATION_FRAMES = 16;
+
   private boolean compressionSupported;
   private int compressionLevel;
   private List<CompressionOptions> compressors;
@@ -231,6 +236,7 @@ public class HttpServerOptions extends NetServerOptions {
   private boolean registerWebSocketWriteHandlers;
   private int http2RstFloodMaxRstFramePerWindow;
   private int http2RstFloodWindowDuration;
+  private int http2MaxSmallContinuationFrames;
   private TimeUnit http2RstFloodWindowDurationTimeUnit;
 
   /**
@@ -280,6 +286,7 @@ public class HttpServerOptions extends NetServerOptions {
     this.http2RstFloodMaxRstFramePerWindow = other.http2RstFloodMaxRstFramePerWindow;
     this.http2RstFloodWindowDuration = other.http2RstFloodWindowDuration;
     this.http2RstFloodWindowDurationTimeUnit = other.http2RstFloodWindowDurationTimeUnit;
+    this.http2MaxSmallContinuationFrames = other.http2MaxSmallContinuationFrames;
   }
 
   /**
@@ -335,6 +342,7 @@ public class HttpServerOptions extends NetServerOptions {
     http2RstFloodMaxRstFramePerWindow = DEFAULT_HTTP2_RST_FLOOD_MAX_RST_FRAME_PER_WINDOW;
     http2RstFloodWindowDuration = DEFAULT_HTTP2_RST_FLOOD_WINDOW_DURATION;
     http2RstFloodWindowDurationTimeUnit = DEFAULT_HTTP2_RST_FLOOD_WINDOW_DURATION_TIME_UNIT;
+    http2MaxSmallContinuationFrames = DEFAULT_HTTP2_MAX_SMALL_CONTINUATION_FRAMES;
   }
 
   @Override
@@ -1272,6 +1280,29 @@ public class HttpServerOptions extends NetServerOptions {
       throw new NullPointerException();
     }
     this.http2RstFloodWindowDurationTimeUnit = http2RstFloodWindowDurationTimeUnit;
+    return this;
+  }
+
+  /**
+   * @return the max number of small continuation frame allowed
+   */
+  public int getHttp2MaxSmallContinuationFrames() {
+    return http2MaxSmallContinuationFrames;
+  }
+
+  /**
+   * Set the maximum number of small continuation frames allowed, this is used to prevent flood DoS attack
+   * via <a href="https://nvd.nist.gov/vuln/detail/CVE-2026-33871">zero-byte continuation frames</a>. The default value
+   * is {@link #DEFAULT_HTTP2_MAX_SMALL_CONTINUATION_FRAMES}.
+   *
+   * @param http2MaxSmallContinuationFrames the max number of small continuation frame allowed
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setHttp2MaxSmallContinuationFrames(int http2MaxSmallContinuationFrames) {
+    if (http2MaxSmallContinuationFrames < 1) {
+      throw new IllegalArgumentException();
+    }
+    this.http2MaxSmallContinuationFrames = http2MaxSmallContinuationFrames;
     return this;
   }
 }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerWorker.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerWorker.java
@@ -253,9 +253,11 @@ public class HttpServerWorker implements BiConsumer<Channel, SslChannelProvider>
     HttpServerMetrics metrics = (HttpServerMetrics) server.getMetrics();
     int maxRstFramesPerWindow = options.getHttp2RstFloodMaxRstFramePerWindow();
     int secondsPerWindow = (int)options.getHttp2RstFloodWindowDurationTimeUnit().toSeconds(options.getHttp2RstFloodWindowDuration());
+    int maxSmallContinuationFrames = options.getHttp2MaxSmallContinuationFrames();
     VertxHttp2ConnectionHandler<Http2ServerConnection> handler = new VertxHttp2ConnectionHandlerBuilder<Http2ServerConnection>()
       .server(true)
       .useCompression(compressionOptions)
+      .decoderEnforceMaxSmallContinuationFrames(maxSmallContinuationFrames)
       .decoderEnforceMaxRstFramesPerWindow(maxRstFramesPerWindow, secondsPerWindow)
       .encoderEnforceMaxRstFramesPerWindow(maxRstFramesPerWindow, secondsPerWindow)
       .useDecompression(options.isDecompressionSupported())

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandlerBuilder.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandlerBuilder.java
@@ -59,6 +59,11 @@ class VertxHttp2ConnectionHandlerBuilder<C extends Http2ConnectionBase> extends 
   }
 
   @Override
+  protected VertxHttp2ConnectionHandlerBuilder<C> decoderEnforceMaxSmallContinuationFrames(int maxSmallContinuationFrames) {
+    return super.decoderEnforceMaxSmallContinuationFrames(maxSmallContinuationFrames);
+  }
+
+  @Override
   protected VertxHttp2ConnectionHandlerBuilder<C> decoderEnforceMaxRstFramesPerWindow(int maxRstFramesPerWindow, int secondsPerWindow) {
     return super.decoderEnforceMaxRstFramesPerWindow(maxRstFramesPerWindow, secondsPerWindow);
   }


### PR DESCRIPTION
Motivation:

Netty has a protection against a Zero-Byte Frame Bypass attack, that allows 16 frames by default.

We should make this setting configurable.
