### PR TITLE
Remove reflection for virtual threads.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -127,22 +127,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     return INTERNAL_TIMER_HANDLER_DISPOSED.compareAndSet(handler, false, true);
   }
 
-  // Not cached for graalvm
-  private static ThreadFactory virtualThreadFactory() {
-    try {
-      Class<?> builderClass = ClassLoader.getSystemClassLoader().loadClass("java.lang.Thread$Builder");
-      Class<?> ofVirtualClass = ClassLoader.getSystemClassLoader().loadClass("java.lang.Thread$Builder$OfVirtual");
-      Method ofVirtualMethod = Thread.class.getDeclaredMethod("ofVirtual");
-      Object builder = ofVirtualMethod.invoke(null);
-      Method nameMethod = ofVirtualClass.getDeclaredMethod("name", String.class, long.class);
-      Method factoryMethod = builderClass.getDeclaredMethod("factory");
-      builder = nameMethod.invoke(builder, "vert.x-virtual-thread-", 0L);
-      return (ThreadFactory) factoryMethod.invoke(builder);
-    } catch (Exception e) {
-      return null;
-    }
-  }
-
   static {
     // Disable Netty's resource leak detection to reduce the performance overhead if not set by user
     // Supports both the default netty leak detection system property and the deprecated one
@@ -222,7 +206,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     ExecutorService internalWorkerExec = executorServiceFactory.createExecutor(internalWorkerThreadFactory, internalBlockingPoolSize, internalBlockingPoolSize);
     PoolMetrics internalBlockingPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-internal-blocking", internalBlockingPoolSize) : null;
 
-    ThreadFactory virtualThreadFactory = virtualThreadFactory();
+    ThreadFactory virtualThreadFactory = VirtualThreadSupport.VIRTUAL_THREAD_FACTORY;
     PoolMetrics virtualThreadWorkerPoolMetrics = metrics != null && virtualThreadFactory != null ? metrics.createPoolMetrics("worker", "vert.x-virtual-thread", -1) : null;
 
     int numberOfEventLoops = options.getEventLoopPoolSize();
@@ -1227,7 +1211,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public boolean isVirtualThreadAvailable() {
-    return virtualThreadExecutor != null;
+    return VirtualThreadSupport.VIRTUAL_THREAD_AVAILABLE;
   }
 
   private CloseFuture resolveCloseFuture() {

--- a/vertx-core/src/main/java/io/vertx/core/impl/VirtualThreadSupport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VirtualThreadSupport.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl;
+
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Pre Java 21 implementation : no virtual threads.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class VirtualThreadSupport {
+
+  public static final ThreadFactory VIRTUAL_THREAD_FACTORY;
+  public static final boolean VIRTUAL_THREAD_AVAILABLE;
+
+  static {
+    VIRTUAL_THREAD_FACTORY = null;
+    VIRTUAL_THREAD_AVAILABLE = false;
+  }
+
+  /**
+   * @return whether the {@code thread} is virtual
+   */
+  public static boolean isVirtual(Thread thread) {
+    return false;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/json/jackson/HybridJacksonPool.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/jackson/HybridJacksonPool.java
@@ -10,6 +10,7 @@ import java.util.stream.IntStream;
 import com.fasterxml.jackson.core.util.BufferRecycler;
 import com.fasterxml.jackson.core.util.JsonRecyclerPools;
 import com.fasterxml.jackson.core.util.RecyclerPool;
+import io.vertx.core.impl.VirtualThreadSupport;
 
 /**
  * This is a custom implementation of the Jackson's {@link RecyclerPool} intended to work equally well with both
@@ -34,8 +35,6 @@ public class HybridJacksonPool implements RecyclerPool<BufferRecycler> {
 
   private static final HybridJacksonPool INSTANCE = new HybridJacksonPool();
 
-  private static final Predicate<Thread> isVirtual = VirtualPredicate.findIsVirtualPredicate();
-
   private final RecyclerPool<BufferRecycler> nativePool = JsonRecyclerPools.threadLocalPool();
 
   private static class VirtualPoolHolder {
@@ -53,7 +52,7 @@ public class HybridJacksonPool implements RecyclerPool<BufferRecycler> {
 
   @Override
   public BufferRecycler acquirePooled() {
-    return isVirtual.test(Thread.currentThread()) ?
+    return VirtualThreadSupport.isVirtual(Thread.currentThread()) ?
       VirtualPoolHolder.virtualPool.acquirePooled() :
       nativePool.acquirePooled();
   }
@@ -61,7 +60,7 @@ public class HybridJacksonPool implements RecyclerPool<BufferRecycler> {
   @Override
   public BufferRecycler acquireAndLinkPooled() {
     // when using the ThreadLocal based pool it is not necessary to register the BufferRecycler on the pool
-    return isVirtual.test(Thread.currentThread()) ?
+    return VirtualThreadSupport.isVirtual(Thread.currentThread()) ?
       VirtualPoolHolder.virtualPool.acquireAndLinkPooled() :
       nativePool.acquirePooled();
   }
@@ -167,41 +166,6 @@ public class HybridJacksonPool implements RecyclerPool<BufferRecycler> {
 
     VThreadBufferRecycler(int slot) {
       this.slot = slot;
-    }
-  }
-
-  private static class VirtualPredicate {
-    private static final MethodHandle virtualMh = findVirtualMH();
-
-    private static MethodHandle findVirtualMH() {
-      try {
-        return MethodHandles.publicLookup().findVirtual(Thread.class, "isVirtual",
-          MethodType.methodType(boolean.class));
-      } catch (Exception e) {
-        return null;
-      }
-    }
-
-    private static Predicate<Thread> findIsVirtualPredicate() {
-      if (virtualMh != null) {
-        return new Predicate<Thread>() {
-          @Override
-          public boolean test(Thread thread) {
-            try {
-              return (boolean) virtualMh.invokeExact(thread);
-            } catch (Throwable e) {
-              throw new RuntimeException(e);
-            }
-          }
-        };
-      }
-
-      return new Predicate<Thread>() {
-        @Override
-        public boolean test(Thread thread) {
-          return false;
-        }
-      };
     }
   }
 

--- a/vertx-core/src/main/java21/io/vertx/core/impl/VirtualThreadSupport.java
+++ b/vertx-core/src/main/java21/io/vertx/core/impl/VirtualThreadSupport.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl;
+
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Virtual thread support.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class VirtualThreadSupport {
+
+  public static final ThreadFactory VIRTUAL_THREAD_FACTORY;
+  public static final boolean VIRTUAL_THREAD_AVAILABLE;
+
+  static {
+    VIRTUAL_THREAD_FACTORY = Thread.ofVirtual().name("vert.x-virtual-thread-").factory();
+    VIRTUAL_THREAD_AVAILABLE = true;
+  }
+
+  /**
+   * @return whether the {@code thread} is virtual
+   */
+  public static boolean isVirtual(Thread thread) {
+    return thread.isVirtual();
+  }
+}


### PR DESCRIPTION
Motivation:

Vert.x relies on reflection to support virtual thread with a Java 11 build.

Recently multi-release jar support has been added to support Jackson V3.

We can reuse this structure to handle virtual thread support as well.

Changes:

Replace reflective code by two implementations of the same class with different behaviors in JDK 11/21.
