### PR TITLE
Fix premature tracer span closure for fire-and-forget and publish

### DIFF
--- a/vertx-core/src/main/asciidoc/eventbus.adoc
+++ b/vertx-core/src/main/asciidoc/eventbus.adoc
@@ -240,6 +240,25 @@ persisted in storage, or `false` if not.
 * A message consumer which processes an order might acknowledge with `true` when the order has been successfully processed
 so it can be deleted from the database
 
+==== Manual Ack Mode
+
+By default, Vert.x automatically acks messages when the message handler returns.
+This works well for synchronous handlers but may not be ideal for asynchronous or blocking operations where you need precise control over when processing is considered complete, especially for tracing purposes.
+
+You can enable *manual ack mode* by setting `autoAck` to `false` in {@link io.vertx.core.eventbus.MessageConsumerOptions}:
+
+[source,$lang]
+----
+{@link examples.EventBusExamples#example13}
+----
+
+In manual ack mode, you must explicitly call {@link io.vertx.core.eventbus.Message#ack()} to ack the message:
+
+[source,$lang]
+----
+{@link examples.EventBusExamples#example14}
+----
+
 ==== Sending with timeouts
 
 When sending a message with a reply handler, you can specify a timeout in the {@link io.vertx.core.eventbus.DeliveryOptions}.

--- a/vertx-core/src/main/asciidoc/eventbus.adoc
+++ b/vertx-core/src/main/asciidoc/eventbus.adoc
@@ -240,19 +240,27 @@ persisted in storage, or `false` if not.
 * A message consumer which processes an order might acknowledge with `true` when the order has been successfully processed
 so it can be deleted from the database
 
-==== Manual Ack Mode
+==== Observability and Message Processing
 
-By default, Vert.x automatically acks messages when the message handler returns.
-This works well for synchronous handlers but may not be ideal for asynchronous or blocking operations where you need precise control over when processing is considered complete, especially for tracing purposes.
+When messages are consumed, Vert.x automatically manages observability signals (tracing and metrics) to track message processing lifecycle.
+By default, these signals are completed when the message handler returns.
 
-You can enable *manual ack mode* by setting `autoAck` to `false` in {@link io.vertx.core.eventbus.MessageConsumerOptions}:
+This works well for synchronous handlers but may not be ideal for asynchronous or blocking operations.
+
+For example, if your handler performs work on a worker thread, the tracer span would be closed before the actual work completes, resulting in inaccurate trace timing and context loss.
+
+You can enable *manual ack mode* to defer the completion of observability signals until you explicitly signal that processing is complete:
+
+IMPORTANT: Message acknowledgment in Vert.x event bus is purely for observability purposes (tracing and metrics).
+It does NOT send any acknowledgment back to the message producer and does NOT affect message delivery semantics.
+This is different from traditional message queue acknowledgment patterns.
 
 [source,$lang]
 ----
 {@link examples.EventBusExamples#example13}
 ----
 
-In manual ack mode, you must explicitly call {@link io.vertx.core.eventbus.Message#ack()} to ack the message:
+In manual ack mode, you must explicitly call {@link io.vertx.core.eventbus.Message#ack()} to complete the observability signals:
 
 [source,$lang]
 ----

--- a/vertx-core/src/main/generated/io/vertx/core/eventbus/MessageConsumerOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/eventbus/MessageConsumerOptionsConverter.java
@@ -27,6 +27,11 @@ public class MessageConsumerOptionsConverter {
             obj.setMaxBufferedMessages(((Number)member.getValue()).intValue());
           }
           break;
+        case "autoAck":
+          if (member.getValue() instanceof Boolean) {
+            obj.setAutoAck((Boolean)member.getValue());
+          }
+          break;
       }
     }
   }
@@ -41,5 +46,6 @@ public class MessageConsumerOptionsConverter {
     }
     json.put("localOnly", obj.isLocalOnly());
     json.put("maxBufferedMessages", obj.getMaxBufferedMessages());
+    json.put("autoAck", obj.isAutoAck());
   }
 }

--- a/vertx-core/src/main/java/examples/EventBusExamples.java
+++ b/vertx-core/src/main/java/examples/EventBusExamples.java
@@ -173,4 +173,49 @@ public class EventBusExamples {
   class MyPOJO {
 
   }
+
+  public void example13(Vertx vertx) {
+    EventBus eb = vertx.eventBus();
+
+    MessageConsumerOptions options = new MessageConsumerOptions()
+      .setAddress("news.uk.sport")
+      .setAutoAck(false);  // Enable manual ack mode
+
+    eb.consumer(options, message -> {
+      System.out.println("Received: " + message.body());
+      // Perform async operation
+      vertx.setTimer(1000, id -> {
+        // Ack the message after async work
+        message.ack();
+      });
+    });
+  }
+
+  public void example14(Vertx vertx) {
+    EventBus eb = vertx.eventBus();
+
+    MessageConsumerOptions options = new MessageConsumerOptions()
+      .setAddress("order.process")
+      .setAutoAck(false);
+
+    eb.<String>consumer(options, message -> {
+      String orderId = message.body();
+
+      // Simulate async database operation
+      processOrderAsync(orderId, result -> {
+        if (result.succeeded()) {
+          System.out.println("Order processed: " + orderId);
+          // Ack the message after async work is done
+          message.ack();
+        } else {
+          System.err.println("Order processing failed: " + result.cause());
+          message.ack();  // Still ack even on failure
+        }
+      });
+    });
+  }
+
+  private void processOrderAsync(String orderId, io.vertx.core.Handler<io.vertx.core.AsyncResult<Void>> handler) {
+    // Simulated async operation
+  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/Message.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/Message.java
@@ -125,4 +125,18 @@ public interface Message<T> {
     reply(new ReplyException(ReplyFailure.RECIPIENT_FAILURE, failureCode, message));
   }
 
+  /**
+   * Acknowledge that processing of this message is complete (for tracing purposes).
+   * <p>
+   * This method is only relevant when the consumer is configured with manual ack mode
+   * (see {@link MessageConsumerOptions#setAutoAck(boolean)}).
+   * <p>
+   * In automatic mode (default), this method has no effect as ack is signaled
+   * automatically when the message handler returns.
+   * <p>
+   * For request/reply messages, calling {@link #reply(Object)}
+   * automatically acks the message, so this method needs not to be called.
+   */
+  default void ack() {
+  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/MessageConsumerOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/MessageConsumerOptions.java
@@ -34,9 +34,15 @@ public class MessageConsumerOptions {
    */
   public static final boolean DEFAULT_LOCAL_ONLY = false;
 
+  /**
+   * The default auto-ack mode = {@code true}
+   */
+  public static final boolean DEFAULT_AUTO_ACK = true;
+
   private String address;
   private boolean localOnly;
   private int maxBufferedMessages;
+  private boolean autoAck;
 
   /**
    * Default constructor
@@ -44,6 +50,7 @@ public class MessageConsumerOptions {
   public MessageConsumerOptions() {
     maxBufferedMessages = DEFAULT_MAX_BUFFERED_MESSAGES;
     localOnly = DEFAULT_LOCAL_ONLY;
+    autoAck = DEFAULT_AUTO_ACK;
   }
 
   /**
@@ -56,6 +63,7 @@ public class MessageConsumerOptions {
     maxBufferedMessages = other.getMaxBufferedMessages();
     localOnly = other.isLocalOnly();
     address = other.getAddress();
+    autoAck = other.isAutoAck();
   }
 
   /**
@@ -124,6 +132,33 @@ public class MessageConsumerOptions {
   public MessageConsumerOptions setMaxBufferedMessages(int maxBufferedMessages) {
     Arguments.require(maxBufferedMessages >= 0, "Max buffered messages cannot be negative");
     this.maxBufferedMessages = maxBufferedMessages;
+    return this;
+  }
+
+  /**
+   * @return whether message ack is signaled automatically
+   */
+  public boolean isAutoAck() {
+    return autoAck;
+  }
+
+  /**
+   * Set whether message ack should be signaled automatically.
+   * <p>
+   * When {@code true} (default), ack is signaled automatically when the message handler returns.
+   * <p>
+   * When {@code false}, the user must explicitly call {@link Message#ack()} to ack the message.
+   * This is useful for async/blocking handlers where you need precise control over when tracing
+   * spans are closed.
+   * <p>
+   * Note: For request/reply messages, calling {@link Message#reply(Object)} always acks the
+   * message regardless of this setting.
+   *
+   * @param autoAck whether to automatically ack messages
+   * @return this options instance for chaining
+   */
+  public MessageConsumerOptions setAutoAck(boolean autoAck) {
+    this.autoAck = autoAck;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -14,9 +14,9 @@ package io.vertx.core.eventbus.impl;
 import io.vertx.core.*;
 import io.vertx.core.eventbus.*;
 import io.vertx.core.impl.Arguments;
+import io.vertx.core.impl.utils.ConcurrentCyclicSequence;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
-import io.vertx.core.impl.utils.ConcurrentCyclicSequence;
 import io.vertx.core.spi.metrics.EventBusMetrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.metrics.VertxMetrics;
@@ -172,7 +172,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
     checkStarted();
     String address = options.getAddress();
     Arguments.require(options.getAddress() != null, "Consumer address must not be null");
-    return new MessageConsumerImpl<>(vertx.getOrCreateContext(), this, address, options.isLocalOnly(), options.getMaxBufferedMessages());
+    return new MessageConsumerImpl<>(vertx.getOrCreateContext(), this, address, options.isLocalOnly(), options.getMaxBufferedMessages(), options.isAutoAck());
   }
 
   @Override
@@ -187,7 +187,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   public <T> MessageConsumer<T> consumer(String address) {
     checkStarted();
     Objects.requireNonNull(address, "address");
-    return new MessageConsumerImpl<>(vertx.getOrCreateContext(), this, address, false, MessageConsumerOptions.DEFAULT_MAX_BUFFERED_MESSAGES);
+    return new MessageConsumerImpl<>(vertx.getOrCreateContext(), this, address, false, MessageConsumerOptions.DEFAULT_MAX_BUFFERED_MESSAGES, MessageConsumerOptions.DEFAULT_AUTO_ACK);
   }
 
   @Override
@@ -202,7 +202,7 @@ public class EventBusImpl implements EventBusInternal, MetricsProvider {
   public <T> MessageConsumer<T> localConsumer(String address) {
     checkStarted();
     Objects.requireNonNull(address, "address");
-    return new MessageConsumerImpl<>(vertx.getOrCreateContext(), this, address, true, MessageConsumerOptions.DEFAULT_MAX_BUFFERED_MESSAGES);
+    return new MessageConsumerImpl<>(vertx.getOrCreateContext(), this, address, true, MessageConsumerOptions.DEFAULT_MAX_BUFFERED_MESSAGES, MessageConsumerOptions.DEFAULT_AUTO_ACK);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -29,17 +29,20 @@ public abstract class HandlerRegistration<T> implements Closeable {
   protected final EventBusImpl bus;
   protected final String address;
   protected final boolean src;
+  protected final boolean autoAck;
   private Consumer<Promise<Void>> registered;
   private Object metric;
 
   HandlerRegistration(ContextInternal context,
                       EventBusImpl bus,
                       String address,
-                      boolean src) {
+                      boolean src,
+                      boolean autoAck) {
     this.context = context;
     this.bus = bus;
     this.src = src;
     this.address = address;
+    this.autoAck = autoAck;
   }
 
   void receive(MessageImpl msg) {
@@ -104,19 +107,27 @@ public abstract class HandlerRegistration<T> implements Closeable {
 
   private void dispatch(ContextInternal ctx, MessageImpl<?, T> message, Handler<Message<T>> handler) {
     Object m = metric;
-    VertxTracer tracer = ctx.tracer();
     if (bus.metrics != null) {
       bus.metrics.messageDelivered(m, message.isLocal());
     }
-    if (tracer != null && !src) {
-      message.trace = tracer.receiveRequest(ctx, SpanKind.RPC, TracingPolicy.PROPAGATE, message, message.isSend() ? "send" : "publish", message.headers(), MessageTagExtractor.INSTANCE);
+    if (ctx.tracer() != null && !src) {
+      traceReceive(ctx, message);
       dispatchMessage(message, ctx, handler);
-      Object trace = message.trace;
-      if (message.replyAddress == null && trace != null) {
-        tracer.sendResponse(ctx, null, trace, null, TagExtractor.empty());
+      if (message.replyAddress == null && autoAck) {
+        message.ack();
       }
     } else {
       dispatchMessage(message, ctx, handler);
+    }
+  }
+
+  private void traceReceive(ContextInternal ctx, MessageImpl<?, T> message) {
+    VertxTracer tracer = ctx.tracer();
+    String operation = message.isSend() ? "send" : "publish";
+    if ((message.trace = tracer.receiveRequest(ctx, SpanKind.RPC, TracingPolicy.PROPAGATE, message, operation, message.headers(), MessageTagExtractor.INSTANCE)) != null) {
+      message.ackHandler = v -> {
+        tracer.sendResponse(ctx, null, message.trace, null, TagExtractor.empty());
+      };
     }
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageConsumerImpl.java
@@ -11,7 +11,10 @@
 
 package io.vertx.core.eventbus.impl;
 
-import io.vertx.core.*;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.internal.ContextInternal;
@@ -36,8 +39,8 @@ public class MessageConsumerImpl<T> extends HandlerRegistration<T> implements Me
   private boolean registered;
   private boolean full;
 
-  MessageConsumerImpl(ContextInternal context, EventBusImpl eventBus, String address, boolean localOnly, int maxBufferedMessages) {
-    super(context, eventBus, address, false);
+  MessageConsumerImpl(ContextInternal context, EventBusImpl eventBus, String address, boolean localOnly, int maxBufferedMessages, boolean autoAck) {
+    super(context, eventBus, address, false, autoAck);
     this.localOnly = localOnly;
     this.result = context.promise();
     this.maxBufferedMessages = maxBufferedMessages;

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -12,8 +12,11 @@
 package io.vertx.core.eventbus.impl;
 
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
-import io.vertx.core.eventbus.*;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageCodec;
 
 import java.util.List;
 import java.util.Map;
@@ -32,6 +35,8 @@ public class MessageImpl<U, V> implements Message<V> {
   protected V receivedBody;
   protected boolean send;
   protected Object trace;
+  protected Handler<Void> ackHandler = v -> {
+  };
 
   public MessageImpl(EventBusImpl bus) {
     this.bus = bus;
@@ -127,6 +132,11 @@ public class MessageImpl<U, V> implements Message<V> {
   @Override
   public boolean isSend() {
     return send;
+  }
+
+  @Override
+  public void ack() {
+    ackHandler.handle(null);
   }
 
   public void setReplyAddress(String replyAddress) {

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/ReplyHandler.java
@@ -33,7 +33,7 @@ class ReplyHandler<T> extends HandlerRegistration<T> implements Handler<Long> {
   Object trace;
 
   ReplyHandler(EventBusImpl eventBus, ContextInternal context, String address, String repliedAddress, boolean src, long timeout) {
-    super(context, eventBus, address, src);
+    super(context, eventBus, address, src, true);
     this.result = context.promise();
     this.repliedAddress = repliedAddress;
     this.timeoutID = context.setTimer(timeout, this);

--- a/vertx-core/src/test/java/io/vertx/tests/tracing/EventBusTracerTestBase.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tracing/EventBusTracerTestBase.java
@@ -14,6 +14,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumerOptions;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.spi.context.storage.ContextLocal;
 import io.vertx.core.spi.tracing.SpanKind;
@@ -300,5 +301,73 @@ public abstract class EventBusTracerTestBase extends VertxTestBase {
     waitUntil(() -> ebTracer.sendEvents.size() + ebTracer.receiveEvents.size() == 8);
     assertEquals(Arrays.asList("sendRequest[the_address]", "receiveResponse[]", "sendRequest[generated]", "receiveResponse[]"), ebTracer.sendEvents);
     assertEquals(Arrays.asList("receiveRequest[the_address]", "sendResponse[]", "receiveRequest[generated]", "sendResponse[]"), ebTracer.receiveEvents);
+  }
+
+  @Test
+  public void testEventBusSendManualAck() throws Exception {
+    EventBusTracer ebTracer = new EventBusTracer();
+    tracer = ebTracer;
+
+    CountDownLatch ackLatch = new CountDownLatch(1);
+
+    MessageConsumerOptions options = new MessageConsumerOptions()
+      .setAddress("the_address")
+      .setAutoAck(false);
+
+    vertx2.eventBus().consumer(options, msg -> {
+      assertEquals("msg", msg.body());
+      vertx2.executeBlocking(() -> {
+        ackLatch.await();
+        return null;
+      }).onSuccess(v -> msg.ack());
+    }).completion().await();
+
+    vertx1.runOnContext(v -> {
+      Context ctx = vertx1.getOrCreateContext();
+      sendKey.put(ctx, ebTracer.sendVal);
+      vertx1.eventBus().send("the_address", "msg");
+    });
+
+    waitUntil(() -> ebTracer.receiveEvents.contains("receiveRequest[the_address]"));
+    assertFalse(ebTracer.receiveEvents.contains("sendResponse[]"));
+
+    ackLatch.countDown();
+    waitUntil(() -> ebTracer.sendEvents.size() + ebTracer.receiveEvents.size() == 4);
+    assertEquals(Arrays.asList("receiveRequest[the_address]", "sendResponse[]"), ebTracer.receiveEvents);
+  }
+
+  @Test
+  public void testEventBusPublishManualAck() throws Exception {
+    EventBusTracer ebTracer = new EventBusTracer();
+    tracer = ebTracer;
+
+    CountDownLatch ackLatch = new CountDownLatch(1);
+
+    MessageConsumerOptions options = new MessageConsumerOptions()
+      .setAddress("the_address")
+      .setAutoAck(false);
+
+    for (int i = 0; i < 2; i++) {
+      vertx2.eventBus().consumer(options, msg -> {
+        assertEquals("msg", msg.body());
+        vertx2.executeBlocking(() -> {
+          ackLatch.await();
+          return null;
+        }).onSuccess(v -> msg.ack());
+      }).completion().await();
+    }
+
+    vertx1.runOnContext(v -> {
+      Context ctx = vertx1.getOrCreateContext();
+      sendKey.put(ctx, ebTracer.sendVal);
+      vertx1.eventBus().publish("the_address", "msg");
+    });
+
+    waitUntil(() -> ebTracer.receiveEvents.stream().filter(e -> e.equals("receiveRequest[the_address]")).count() == 2);
+    assertEquals(0, ebTracer.receiveEvents.stream().filter(e -> e.equals("sendResponse[]")).count());
+
+    ackLatch.countDown();
+    waitUntil(() -> ebTracer.sendEvents.size() + ebTracer.receiveEvents.size() == 6);
+    assertEquals(2, ebTracer.receiveEvents.stream().filter(e -> e.equals("sendResponse[]")).count());
   }
 }


### PR DESCRIPTION
See #6021

Add `MessageConsumerOptions#setAutoProcessed` and `Message#processed()` so consumers can defer trace span closure until async/blocking handler completion.

Some portions of this content were created with the assistance of IBM Bob.