### PR TITLE
Reusing dispatch method in the emit

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/ContextBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/ContextBase.java
@@ -77,14 +77,7 @@ abstract class ContextBase implements ContextInternal {
   @Override
   public final <T> void emit(T argument, Handler<T> task) {
     if (executor().inThread()) {
-      ContextInternal prev = beginDispatch();
-      try {
-        task.handle(argument);
-      } catch (Throwable t) {
-        reportException(t);
-      } finally {
-        endDispatch(prev);
-      }
+      dispatch(argument, task);
     } else {
       executor().execute(() -> emit(argument, task));
     }


### PR DESCRIPTION
Motivation:

Reuse **dispatch** method in the **emit** to consolidate logic.

Closes https://github.com/eclipse-vertx/vert.x/issues/6086

