### PR TITLE
Support extended keepalive parameters in epoll and io_uring

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
@@ -39,7 +39,7 @@ public class EpollTransport implements Transport {
 
   /**
    * Return the number of of pending TFO connections in SYN-RCVD state for TCP_FASTOPEN.
-   *
+   * <p>
    * {@see #setPendingFastOpenRequestsThreshold}
    */
   public static int getPendingFastOpenRequestsThreshold() {
@@ -138,6 +138,9 @@ public class EpollTransport implements Transport {
       configChildOption(bootstrap, config, TcpOption.USER_TIMEOUT, EpollChannelOption.TCP_USER_TIMEOUT);
       configChildOption(bootstrap, config, TcpOption.QUICKACK, EpollChannelOption.TCP_QUICKACK);
       configChildOption(bootstrap, config, TcpOption.CORK, EpollChannelOption.TCP_CORK);
+      configChildOption(bootstrap, config, TcpOption.KEEPCNT, EpollChannelOption.TCP_KEEPCNT);
+      configChildOption(bootstrap, config, TcpOption.KEEPINTVL, EpollChannelOption.TCP_KEEPINTVL);
+      configChildOption(bootstrap, config, TcpOption.KEEPIDLE, EpollChannelOption.TCP_KEEPIDLE);
     }
     Transport.super.configure(config, domainSocket, bootstrap);
   }
@@ -145,10 +148,13 @@ public class EpollTransport implements Transport {
   @Override
   public void configure(TcpConfig config, boolean domainSocket, Bootstrap bootstrap) {
     if (!domainSocket) {
-      NioTransport.configOption(bootstrap, config, TcpOption.FASTOPEN_CONNECT, EpollChannelOption.TCP_FASTOPEN_CONNECT);
-      NioTransport.configOption(bootstrap, config, TcpOption.USER_TIMEOUT, EpollChannelOption.TCP_USER_TIMEOUT);
-      NioTransport.configOption(bootstrap, config, TcpOption.QUICKACK, EpollChannelOption.TCP_QUICKACK);
-      NioTransport.configOption(bootstrap, config, TcpOption.CORK, EpollChannelOption.TCP_CORK);
+      configOption(bootstrap, config, TcpOption.FASTOPEN_CONNECT, EpollChannelOption.TCP_FASTOPEN_CONNECT);
+      configOption(bootstrap, config, TcpOption.USER_TIMEOUT, EpollChannelOption.TCP_USER_TIMEOUT);
+      configOption(bootstrap, config, TcpOption.QUICKACK, EpollChannelOption.TCP_QUICKACK);
+      configOption(bootstrap, config, TcpOption.CORK, EpollChannelOption.TCP_CORK);
+      configOption(bootstrap, config, TcpOption.KEEPCNT, EpollChannelOption.TCP_KEEPCNT);
+      configOption(bootstrap, config, TcpOption.KEEPINTVL, EpollChannelOption.TCP_KEEPINTVL);
+      configOption(bootstrap, config, TcpOption.KEEPIDLE, EpollChannelOption.TCP_KEEPIDLE);
     }
     Transport.super.configure(config, domainSocket, bootstrap);
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
@@ -138,9 +138,15 @@ public class EpollTransport implements Transport {
       configChildOption(bootstrap, config, TcpOption.USER_TIMEOUT, EpollChannelOption.TCP_USER_TIMEOUT);
       configChildOption(bootstrap, config, TcpOption.QUICKACK, EpollChannelOption.TCP_QUICKACK);
       configChildOption(bootstrap, config, TcpOption.CORK, EpollChannelOption.TCP_CORK);
-      configChildOption(bootstrap, config, TcpOption.KEEPCNT, EpollChannelOption.TCP_KEEPCNT);
-      configChildOption(bootstrap, config, TcpOption.KEEPINTVL, EpollChannelOption.TCP_KEEPINTVL);
-      configChildOption(bootstrap, config, TcpOption.KEEPIDLE, EpollChannelOption.TCP_KEEPIDLE);
+      if (!config.isNullOrZero(TcpOption.KEEPCNT)) {
+        configChildOption(bootstrap, config, TcpOption.KEEPCNT, EpollChannelOption.TCP_KEEPCNT);
+      }
+      if (!config.isNullOrZero(TcpOption.KEEPINTVL)) {
+        configChildOption(bootstrap, config, TcpOption.KEEPINTVL, EpollChannelOption.TCP_KEEPINTVL);
+      }
+      if (!config.isNullOrZero(TcpOption.KEEPIDLE)) {
+        configChildOption(bootstrap, config, TcpOption.KEEPIDLE, EpollChannelOption.TCP_KEEPIDLE);
+      }
     }
     Transport.super.configure(config, domainSocket, bootstrap);
   }
@@ -152,9 +158,15 @@ public class EpollTransport implements Transport {
       configOption(bootstrap, config, TcpOption.USER_TIMEOUT, EpollChannelOption.TCP_USER_TIMEOUT);
       configOption(bootstrap, config, TcpOption.QUICKACK, EpollChannelOption.TCP_QUICKACK);
       configOption(bootstrap, config, TcpOption.CORK, EpollChannelOption.TCP_CORK);
-      configOption(bootstrap, config, TcpOption.KEEPCNT, EpollChannelOption.TCP_KEEPCNT);
-      configOption(bootstrap, config, TcpOption.KEEPINTVL, EpollChannelOption.TCP_KEEPINTVL);
-      configOption(bootstrap, config, TcpOption.KEEPIDLE, EpollChannelOption.TCP_KEEPIDLE);
+      if (!config.isNullOrZero(TcpOption.KEEPCNT)) {
+        configOption(bootstrap, config, TcpOption.KEEPCNT, EpollChannelOption.TCP_KEEPCNT);
+      }
+      if (!config.isNullOrZero(TcpOption.KEEPINTVL)) {
+        configOption(bootstrap, config, TcpOption.KEEPINTVL, EpollChannelOption.TCP_KEEPINTVL);
+      }
+      if (!config.isNullOrZero(TcpOption.KEEPIDLE)) {
+        configOption(bootstrap, config, TcpOption.KEEPIDLE, EpollChannelOption.TCP_KEEPIDLE);
+      }
     }
     Transport.super.configure(config, domainSocket, bootstrap);
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
@@ -14,6 +14,7 @@ package io.vertx.core.impl.transports;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.*;
+import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.unix.DomainSocketAddress;
@@ -137,9 +138,15 @@ public class IoUringTransport implements Transport {
       configChildOption(bootstrap, config, TcpOption.USER_TIMEOUT, IoUringChannelOption.TCP_USER_TIMEOUT);
       configChildOption(bootstrap, config, TcpOption.QUICKACK, IoUringChannelOption.TCP_QUICKACK);
       configChildOption(bootstrap, config, TcpOption.CORK, IoUringChannelOption.TCP_CORK);
-      configChildOption(bootstrap, config, TcpOption.KEEPCNT, IoUringChannelOption.TCP_KEEPCNT);
-      configChildOption(bootstrap, config, TcpOption.KEEPINTVL, IoUringChannelOption.TCP_KEEPINTVL);
-      configChildOption(bootstrap, config, TcpOption.KEEPIDLE, IoUringChannelOption.TCP_KEEPIDLE);
+      if (!config.isNullOrZero(TcpOption.KEEPCNT)) {
+        configChildOption(bootstrap, config, TcpOption.KEEPCNT, IoUringChannelOption.TCP_KEEPCNT);
+      }
+      if (!config.isNullOrZero(TcpOption.KEEPINTVL)) {
+        configChildOption(bootstrap, config, TcpOption.KEEPINTVL, IoUringChannelOption.TCP_KEEPINTVL);
+      }
+      if (!config.isNullOrZero(TcpOption.KEEPIDLE)) {
+        configChildOption(bootstrap, config, TcpOption.KEEPIDLE, IoUringChannelOption.TCP_KEEPIDLE);
+      }
     }
     Transport.super.configure(config, domainSocket, bootstrap);
   }
@@ -151,9 +158,15 @@ public class IoUringTransport implements Transport {
       configOption(bootstrap, config, TcpOption.USER_TIMEOUT, IoUringChannelOption.TCP_USER_TIMEOUT);
       configOption(bootstrap, config, TcpOption.QUICKACK, IoUringChannelOption.TCP_QUICKACK);
       configOption(bootstrap, config, TcpOption.CORK, IoUringChannelOption.TCP_CORK);
-      configOption(bootstrap, config, TcpOption.KEEPCNT, IoUringChannelOption.TCP_KEEPCNT);
-      configOption(bootstrap, config, TcpOption.KEEPINTVL, IoUringChannelOption.TCP_KEEPINTVL);
-      configOption(bootstrap, config, TcpOption.KEEPIDLE, IoUringChannelOption.TCP_KEEPIDLE);
+      if (!config.isNullOrZero(TcpOption.KEEPCNT)) {
+        configOption(bootstrap, config, TcpOption.KEEPCNT, IoUringChannelOption.TCP_KEEPCNT);
+      }
+      if (!config.isNullOrZero(TcpOption.KEEPINTVL)) {
+        configOption(bootstrap, config, TcpOption.KEEPINTVL, IoUringChannelOption.TCP_KEEPINTVL);
+      }
+      if (!config.isNullOrZero(TcpOption.KEEPIDLE)) {
+        configOption(bootstrap, config, TcpOption.KEEPIDLE, IoUringChannelOption.TCP_KEEPIDLE);
+      }
     }
     Transport.super.configure(config, domainSocket, bootstrap);
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
@@ -137,6 +137,9 @@ public class IoUringTransport implements Transport {
       configChildOption(bootstrap, config, TcpOption.USER_TIMEOUT, IoUringChannelOption.TCP_USER_TIMEOUT);
       configChildOption(bootstrap, config, TcpOption.QUICKACK, IoUringChannelOption.TCP_QUICKACK);
       configChildOption(bootstrap, config, TcpOption.CORK, IoUringChannelOption.TCP_CORK);
+      configChildOption(bootstrap, config, TcpOption.KEEPCNT, IoUringChannelOption.TCP_KEEPCNT);
+      configChildOption(bootstrap, config, TcpOption.KEEPINTVL, IoUringChannelOption.TCP_KEEPINTVL);
+      configChildOption(bootstrap, config, TcpOption.KEEPIDLE, IoUringChannelOption.TCP_KEEPIDLE);
     }
     Transport.super.configure(config, domainSocket, bootstrap);
   }
@@ -144,11 +147,13 @@ public class IoUringTransport implements Transport {
   @Override
   public void configure(TcpConfig config, boolean domainSocket, Bootstrap bootstrap) {
     if (!domainSocket) {
-      NioTransport.configOption(bootstrap, config, TcpOption.FASTOPEN_CONNECT,
-        IoUringChannelOption.TCP_FASTOPEN_CONNECT);
-      NioTransport.configOption(bootstrap, config, TcpOption.USER_TIMEOUT, IoUringChannelOption.TCP_USER_TIMEOUT);
-      NioTransport.configOption(bootstrap, config, TcpOption.QUICKACK, IoUringChannelOption.TCP_QUICKACK);
-      NioTransport.configOption(bootstrap, config, TcpOption.CORK, IoUringChannelOption.TCP_CORK);
+      configOption(bootstrap, config, TcpOption.FASTOPEN_CONNECT, IoUringChannelOption.TCP_FASTOPEN_CONNECT);
+      configOption(bootstrap, config, TcpOption.USER_TIMEOUT, IoUringChannelOption.TCP_USER_TIMEOUT);
+      configOption(bootstrap, config, TcpOption.QUICKACK, IoUringChannelOption.TCP_QUICKACK);
+      configOption(bootstrap, config, TcpOption.CORK, IoUringChannelOption.TCP_CORK);
+      configOption(bootstrap, config, TcpOption.KEEPCNT, IoUringChannelOption.TCP_KEEPCNT);
+      configOption(bootstrap, config, TcpOption.KEEPINTVL, IoUringChannelOption.TCP_KEEPINTVL);
+      configOption(bootstrap, config, TcpOption.KEEPIDLE, IoUringChannelOption.TCP_KEEPIDLE);
     }
     Transport.super.configure(config, domainSocket, bootstrap);
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
@@ -14,7 +14,6 @@ package io.vertx.core.impl.transports;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.*;
-import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.unix.DomainSocketAddress;

--- a/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -97,6 +97,27 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    */
   public static final int DEFAULT_TCP_USER_TIMEOUT = 0;
 
+  /**
+   * Default value for tcp keepalive idle time.
+   * <p>
+   * {@code -1} defaults to OS settings
+   */
+  public static final int DEFAULT_TCP_KEEAPLIVE_IDLE_SECONDS = -1;
+
+  /**
+   * Default value for tcp keepalive count.
+   * <p>
+   * {@code -1} defaults to OS settings
+   */
+  public static final int DEFAULT_TCP_KEEAPLIVE_COUNT = -1;
+
+  /**
+   * Default value for tcp keepalive interval.
+   * <p>
+   * {@code -1} defaults to OS settings
+   */
+  public static final int DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS = -1;
+
   private TcpConfig transportOptions;
   private int idleTimeout;
   private int readIdleTimeout;
@@ -762,6 +783,65 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    */
   public TCPSSLOptions setTcpUserTimeout(int tcpUserTimeout) {
     transportOptions.setOption(TcpOption.USER_TIMEOUT, tcpUserTimeout);
+    return this;
+  }
+
+  /**
+   * @return the time in seconds the connection needs to remain idle before TCP starts sending keepalive probes
+   */
+  public int getTcpKeepAliveIdleSeconds() {
+    return getOrDefaultOption(TcpOption.KEEPIDLE);
+  }
+
+  /**
+   * The time in seconds the connection needs to remain idle before TCP starts sending keepalive probes,
+   * if the socket option keepalive has been set.
+   * <p>
+   * Only works with linux native support (EPoll, IoUring).
+   *
+   * @param tcpKeepAliveIdleSeconds idle time in seconds
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TCPSSLOptions setTcpKeepAliveIdleSeconds(int tcpKeepAliveIdleSeconds) {
+    transportOptions.setOption(TcpOption.KEEPIDLE, tcpKeepAliveIdleSeconds);
+    return this;
+  }
+
+  /**
+   * @return the maximum number of keepalive probes TCP should send before dropping the connection.
+   */
+  public int getTcpKeepAliveCount() {
+    return getOrDefaultOption(TcpOption.KEEPCNT);
+  }
+
+  /**
+   * The maximum number of keepalive probes TCP should send before dropping the connection.
+   * <p>
+   * Only works with linux native support (EPoll, IoUring).
+   * @param tcpKeepAliveCount number of probes
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TCPSSLOptions setTcpKeepAliveCount(int tcpKeepAliveCount) {
+    transportOptions.setOption(TcpOption.KEEPCNT, tcpKeepAliveCount);
+    return this;
+  }
+
+  /**
+   * @return the time in seconds between individual keepalive probes (while the channel is idle).
+   */
+  public int getTcpKeepAliveIntervalSeconds() {
+    return getOrDefaultOption(TcpOption.KEEPINTVL);
+  }
+
+  /**
+   * The time in seconds between individual keepalive probes (while the channel is idle).
+   * <p>
+   * Only works with linux native support (EPoll, IoUring).
+   * @param tcpKeepAliveIntervalSeconds interval in seconds
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TCPSSLOptions setTcpKeepAliveIntervalSeconds(int tcpKeepAliveIntervalSeconds) {
+    transportOptions.setOption(TcpOption.KEEPINTVL, tcpKeepAliveIntervalSeconds);
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -100,23 +100,23 @@ public abstract class TCPSSLOptions extends NetworkOptions {
   /**
    * Default value for tcp keepalive idle time.
    * <p>
-   * {@code -1} defaults to OS settings
+   * A value of {@code 0} means: Do not set this socket option, which will result in an OS-specific default value.
    */
-  public static final int DEFAULT_TCP_KEEAPLIVE_IDLE_SECONDS = -1;
+  public static final int DEFAULT_TCP_KEEAPLIVE_IDLE_SECONDS = 0;
 
   /**
    * Default value for tcp keepalive count.
    * <p>
-   * {@code -1} defaults to OS settings
+   * A value of {@code 0} means: Do not set this socket option, which will result in an OS-specific default value.
    */
-  public static final int DEFAULT_TCP_KEEAPLIVE_COUNT = -1;
+  public static final int DEFAULT_TCP_KEEAPLIVE_COUNT = 0;
 
   /**
    * Default value for tcp keepalive interval.
    * <p>
-   * {@code -1} defaults to OS settings
+   * A value of {@code 0} means: Do not set this socket option, which will result in an OS-specific default value.
    */
-  public static final int DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS = -1;
+  public static final int DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS = 0;
 
   private TcpConfig transportOptions;
   private int idleTimeout;

--- a/vertx-core/src/main/java/io/vertx/core/net/TcpConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TcpConfig.java
@@ -55,6 +55,7 @@ public class TcpConfig extends TransportConfig {
     reuseAddress = NetworkOptions.DEFAULT_REUSE_ADDRESS;
     trafficClass = NetworkOptions.DEFAULT_TRAFFIC_CLASS;
     soReusePort = NetworkOptions.DEFAULT_REUSE_PORT;
+    soKeepAlive = TCPSSLOptions.DEFAULT_TCP_KEEP_ALIVE;
     soLinger = DEFAULT_SO_LINGER;
     options = null;
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/TcpConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TcpConfig.java
@@ -214,6 +214,17 @@ public class TcpConfig extends TransportConfig {
   }
 
   /**
+   * Returns true if the given option is not set or set to {@code 0}.
+   * @param option a tcp option
+   * @return true if the given option is not set or set to {@code 0}.
+   * @param <T> the value type of the option, must be a {@link Number}.
+   */
+  public <T extends Number> boolean isNullOrZero(TcpOption<T> option) {
+    Number value = getOption(option);
+    return value == null || value.longValue() == 0;
+  }
+
+  /**
    * Configure a TCP option.
    *
    * @param option the option to configure

--- a/vertx-core/src/main/java/io/vertx/core/net/TcpOption.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TcpOption.java
@@ -52,6 +52,48 @@ public class TcpOption<T> {
    */
   public static final TcpOption<Integer> FASTOPEN = new TcpOption<>(Integer.class, 0);
 
+  /**
+   * The {@code TCP_KEEPCNT} option - only with Linux native transport.
+   * <p>
+   * The maximum number of keepalive probes TCP should send before dropping the connection.
+   */
+  public static final TcpOption<Integer> KEEPCNT = new TcpOption<>(Integer.class, TCPSSLOptions.DEFAULT_TCP_KEEAPLIVE_COUNT) {
+    @Override
+    protected void validate(final Integer value) {
+      if (value < -1) {
+        throw new IllegalArgumentException("KEEPCNT must be >= -1");
+      }
+    }
+  };
+
+  /**
+   * The {@code TCP_KEEPIDLE} option - only with Linux native transport.
+   * <p>
+   * The time (in seconds) the connection needs to remain idle before TCP starts sending keepalive probes, if enabled.
+   */
+  public static final TcpOption<Integer> KEEPIDLE = new TcpOption<>(Integer.class, TCPSSLOptions.DEFAULT_TCP_KEEAPLIVE_IDLE_SECONDS) {
+    @Override
+    protected void validate(final Integer value) {
+      if (value < -1) {
+        throw new IllegalArgumentException("KEEPIDLE must be >= -1");
+      }
+    }
+  };
+
+  /**
+   * The {@code TCP_KEEPINTVL} option - only with Linux native transport.
+   * <p>
+   * The time (in seconds) between individual keepalive probes.
+   */
+  public static final TcpOption<Integer> KEEPINTVL = new TcpOption<>(Integer.class, TCPSSLOptions.DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS) {
+    @Override
+    protected void validate(final Integer value) {
+      if (value < -1) {
+        throw new IllegalArgumentException("KEEPINTVL must be >= -1");
+      }
+    }
+  };
+
   final Class<T> type;
   final T defaultValue;
 

--- a/vertx-core/src/main/java/io/vertx/core/net/TcpOption.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TcpOption.java
@@ -60,8 +60,8 @@ public class TcpOption<T> {
   public static final TcpOption<Integer> KEEPCNT = new TcpOption<>(Integer.class, TCPSSLOptions.DEFAULT_TCP_KEEAPLIVE_COUNT) {
     @Override
     protected void validate(final Integer value) {
-      if (value < -1) {
-        throw new IllegalArgumentException("KEEPCNT must be >= -1");
+      if (value == 0 || value < -1) {
+        throw new IllegalArgumentException("KEEPCNT must be > 0 or == -1");
       }
     }
   };
@@ -74,8 +74,8 @@ public class TcpOption<T> {
   public static final TcpOption<Integer> KEEPIDLE = new TcpOption<>(Integer.class, TCPSSLOptions.DEFAULT_TCP_KEEAPLIVE_IDLE_SECONDS) {
     @Override
     protected void validate(final Integer value) {
-      if (value < -1) {
-        throw new IllegalArgumentException("KEEPIDLE must be >= -1");
+      if (value == 0 || value < -1) {
+        throw new IllegalArgumentException("KEEPIDLE must be > 0 or == -1");
       }
     }
   };
@@ -88,8 +88,8 @@ public class TcpOption<T> {
   public static final TcpOption<Integer> KEEPINTVL = new TcpOption<>(Integer.class, TCPSSLOptions.DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS) {
     @Override
     protected void validate(final Integer value) {
-      if (value < -1) {
-        throw new IllegalArgumentException("KEEPINTVL must be >= -1");
+      if (value == 0 || value < -1) {
+        throw new IllegalArgumentException("KEEPINTVL must be > 0 or == -1");
       }
     }
   };

--- a/vertx-core/src/main/java/io/vertx/core/net/TcpOption.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TcpOption.java
@@ -56,12 +56,14 @@ public class TcpOption<T> {
    * The {@code TCP_KEEPCNT} option - only with Linux native transport.
    * <p>
    * The maximum number of keepalive probes TCP should send before dropping the connection.
+   * <p>
+   * A value of {@code 0} means: Do not set this socket option, which will result in an OS-specific default value.
    */
   public static final TcpOption<Integer> KEEPCNT = new TcpOption<>(Integer.class, TCPSSLOptions.DEFAULT_TCP_KEEAPLIVE_COUNT) {
     @Override
     protected void validate(final Integer value) {
-      if (value == 0 || value < -1) {
-        throw new IllegalArgumentException("KEEPCNT must be > 0 or == -1");
+      if (value < 0) {
+        throw new IllegalArgumentException("KEEPCNT must be >= 0");
       }
     }
   };
@@ -70,12 +72,14 @@ public class TcpOption<T> {
    * The {@code TCP_KEEPIDLE} option - only with Linux native transport.
    * <p>
    * The time (in seconds) the connection needs to remain idle before TCP starts sending keepalive probes, if enabled.
+   * <p>
+   * A value of {@code 0} means: Do not set this socket option, which will result in an OS-specific default value.
    */
   public static final TcpOption<Integer> KEEPIDLE = new TcpOption<>(Integer.class, TCPSSLOptions.DEFAULT_TCP_KEEAPLIVE_IDLE_SECONDS) {
     @Override
     protected void validate(final Integer value) {
-      if (value == 0 || value < -1) {
-        throw new IllegalArgumentException("KEEPIDLE must be > 0 or == -1");
+      if (value < 0) {
+        throw new IllegalArgumentException("KEEPIDLE must be >= 0");
       }
     }
   };
@@ -84,12 +88,14 @@ public class TcpOption<T> {
    * The {@code TCP_KEEPINTVL} option - only with Linux native transport.
    * <p>
    * The time (in seconds) between individual keepalive probes.
+   * <p>
+   * A value of {@code 0} means: Do not set this socket option, which will result in an OS-specific default value.
    */
   public static final TcpOption<Integer> KEEPINTVL = new TcpOption<>(Integer.class, TCPSSLOptions.DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS) {
     @Override
     protected void validate(final Integer value) {
-      if (value == 0 || value < -1) {
-        throw new IllegalArgumentException("KEEPINTVL must be > 0 or == -1");
+      if (value < 0) {
+        throw new IllegalArgumentException("KEEPINTVL must be >= 0");
       }
     }
   };

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -296,6 +296,27 @@ public class NetTest {
     assertEquals(options, options.setSslHandshakeTimeout(randLong));
     assertEquals(randLong, options.getSslHandshakeTimeout());
     assertIllegalArgumentException(() -> options.setSslHandshakeTimeout(-123));
+
+    assertEquals(NetClientOptions.DEFAULT_TCP_KEEAPLIVE_IDLE_SECONDS, options.getTcpKeepAliveIdleSeconds());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpKeepAliveIdleSeconds(rand));
+    assertEquals(rand, options.getTcpKeepAliveIdleSeconds());
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIdleSeconds(0));
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIdleSeconds(-123));
+
+    assertEquals(NetClientOptions.DEFAULT_TCP_KEEAPLIVE_COUNT, options.getTcpKeepAliveCount());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpKeepAliveCount(rand));
+    assertEquals(rand, options.getTcpKeepAliveCount());
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveCount(0));
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveCount(-123));
+
+    assertEquals(NetClientOptions.DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS, options.getTcpKeepAliveIntervalSeconds());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpKeepAliveIntervalSeconds(rand));
+    assertEquals(rand, options.getTcpKeepAliveIntervalSeconds());
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIntervalSeconds(0));
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIntervalSeconds(-123));
   }
 
   @Test
@@ -418,6 +439,27 @@ public class NetTest {
     assertEquals(options, options.setProxyProtocolTimeout(randomProxyTimeout));
     assertEquals(randomProxyTimeout, options.getProxyProtocolTimeout());
     assertIllegalArgumentException(() -> options.setProxyProtocolTimeout(-123));
+
+    assertEquals(NetServerOptions.DEFAULT_TCP_KEEAPLIVE_IDLE_SECONDS, options.getTcpKeepAliveIdleSeconds());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpKeepAliveIdleSeconds(rand));
+    assertEquals(rand, options.getTcpKeepAliveIdleSeconds());
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIdleSeconds(0));
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIdleSeconds(-123));
+
+    assertEquals(NetServerOptions.DEFAULT_TCP_KEEAPLIVE_COUNT, options.getTcpKeepAliveCount());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpKeepAliveCount(rand));
+    assertEquals(rand, options.getTcpKeepAliveCount());
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveCount(0));
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveCount(-123));
+
+    assertEquals(NetServerOptions.DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS, options.getTcpKeepAliveIntervalSeconds());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpKeepAliveIntervalSeconds(rand));
+    assertEquals(rand, options.getTcpKeepAliveIntervalSeconds());
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIntervalSeconds(0));
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIntervalSeconds(-123));
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -301,21 +301,18 @@ public class NetTest {
     rand = TestUtils.randomPositiveInt();
     assertEquals(options, options.setTcpKeepAliveIdleSeconds(rand));
     assertEquals(rand, options.getTcpKeepAliveIdleSeconds());
-    assertIllegalArgumentException(() -> options.setTcpKeepAliveIdleSeconds(0));
     assertIllegalArgumentException(() -> options.setTcpKeepAliveIdleSeconds(-123));
 
     assertEquals(NetClientOptions.DEFAULT_TCP_KEEAPLIVE_COUNT, options.getTcpKeepAliveCount());
     rand = TestUtils.randomPositiveInt();
     assertEquals(options, options.setTcpKeepAliveCount(rand));
     assertEquals(rand, options.getTcpKeepAliveCount());
-    assertIllegalArgumentException(() -> options.setTcpKeepAliveCount(0));
     assertIllegalArgumentException(() -> options.setTcpKeepAliveCount(-123));
 
     assertEquals(NetClientOptions.DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS, options.getTcpKeepAliveIntervalSeconds());
     rand = TestUtils.randomPositiveInt();
     assertEquals(options, options.setTcpKeepAliveIntervalSeconds(rand));
     assertEquals(rand, options.getTcpKeepAliveIntervalSeconds());
-    assertIllegalArgumentException(() -> options.setTcpKeepAliveIntervalSeconds(0));
     assertIllegalArgumentException(() -> options.setTcpKeepAliveIntervalSeconds(-123));
   }
 
@@ -444,21 +441,18 @@ public class NetTest {
     rand = TestUtils.randomPositiveInt();
     assertEquals(options, options.setTcpKeepAliveIdleSeconds(rand));
     assertEquals(rand, options.getTcpKeepAliveIdleSeconds());
-    assertIllegalArgumentException(() -> options.setTcpKeepAliveIdleSeconds(0));
     assertIllegalArgumentException(() -> options.setTcpKeepAliveIdleSeconds(-123));
 
     assertEquals(NetServerOptions.DEFAULT_TCP_KEEAPLIVE_COUNT, options.getTcpKeepAliveCount());
     rand = TestUtils.randomPositiveInt();
     assertEquals(options, options.setTcpKeepAliveCount(rand));
     assertEquals(rand, options.getTcpKeepAliveCount());
-    assertIllegalArgumentException(() -> options.setTcpKeepAliveCount(0));
     assertIllegalArgumentException(() -> options.setTcpKeepAliveCount(-123));
 
     assertEquals(NetServerOptions.DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS, options.getTcpKeepAliveIntervalSeconds());
     rand = TestUtils.randomPositiveInt();
     assertEquals(options, options.setTcpKeepAliveIntervalSeconds(rand));
     assertEquals(rand, options.getTcpKeepAliveIntervalSeconds());
-    assertIllegalArgumentException(() -> options.setTcpKeepAliveIntervalSeconds(0));
     assertIllegalArgumentException(() -> options.setTcpKeepAliveIntervalSeconds(-123));
   }
 


### PR DESCRIPTION
EpollTransport: support extended keepalive parameters TCP_KEEPIDLE, TCP_KEEPCNT and TCP_KEEPINTVL

Builds on #5183. This work has not made it into master, so I'm catching up on that.

I hope I've ported it correctly given the refactoring of the TCPSSLOptions / TCPConfig.

For motivation, see #5163 and #5183 and #5970
