### PR TITLE
Support extended keepalive parameters in epoll and io_uring (5.0)

### DIFF
--- a/vertx-core/src/main/generated/io/vertx/core/net/NetServerOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/NetServerOptionsConverter.java
@@ -59,21 +59,6 @@ public class NetServerOptionsConverter {
             obj.setTrafficShapingOptions(new io.vertx.core.net.TrafficShapingOptions((io.vertx.core.json.JsonObject)member.getValue()));
           }
           break;
-        case "tcpKeepAliveIdleSeconds":
-          if (member.getValue() instanceof Number) {
-            obj.setTcpKeepAliveIdleSeconds(((Number)member.getValue()).intValue());
-          }
-          break;
-        case "tcpKeepAliveCount":
-          if (member.getValue() instanceof Number) {
-            obj.setTcpKeepAliveCount(((Number)member.getValue()).intValue());
-          }
-          break;
-        case "tcpKeepAliveIntervalSeconds":
-          if (member.getValue() instanceof Number) {
-            obj.setTcpKeepAliveIntervalSeconds(((Number)member.getValue()).intValue());
-          }
-          break;
         case "registerWriteHandler":
           if (member.getValue() instanceof Boolean) {
             obj.setRegisterWriteHandler((Boolean)member.getValue());
@@ -105,9 +90,6 @@ public class NetServerOptionsConverter {
     if (obj.getTrafficShapingOptions() != null) {
       json.put("trafficShapingOptions", obj.getTrafficShapingOptions().toJson());
     }
-    json.put("tcpKeepAliveIdleSeconds", obj.getTcpKeepAliveIdleSeconds());
-    json.put("tcpKeepAliveCount", obj.getTcpKeepAliveCount());
-    json.put("tcpKeepAliveIntervalSeconds", obj.getTcpKeepAliveIntervalSeconds());
     json.put("registerWriteHandler", obj.isRegisterWriteHandler());
   }
 }

--- a/vertx-core/src/main/generated/io/vertx/core/net/NetServerOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/NetServerOptionsConverter.java
@@ -59,6 +59,21 @@ public class NetServerOptionsConverter {
             obj.setTrafficShapingOptions(new io.vertx.core.net.TrafficShapingOptions((io.vertx.core.json.JsonObject)member.getValue()));
           }
           break;
+        case "tcpKeepAliveIdleSeconds":
+          if (member.getValue() instanceof Number) {
+            obj.setTcpKeepAliveIdleSeconds(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "tcpKeepAliveCount":
+          if (member.getValue() instanceof Number) {
+            obj.setTcpKeepAliveCount(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "tcpKeepAliveIntervalSeconds":
+          if (member.getValue() instanceof Number) {
+            obj.setTcpKeepAliveIntervalSeconds(((Number)member.getValue()).intValue());
+          }
+          break;
         case "registerWriteHandler":
           if (member.getValue() instanceof Boolean) {
             obj.setRegisterWriteHandler((Boolean)member.getValue());
@@ -90,6 +105,9 @@ public class NetServerOptionsConverter {
     if (obj.getTrafficShapingOptions() != null) {
       json.put("trafficShapingOptions", obj.getTrafficShapingOptions().toJson());
     }
+    json.put("tcpKeepAliveIdleSeconds", obj.getTcpKeepAliveIdleSeconds());
+    json.put("tcpKeepAliveCount", obj.getTcpKeepAliveCount());
+    json.put("tcpKeepAliveIntervalSeconds", obj.getTcpKeepAliveIntervalSeconds());
     json.put("registerWriteHandler", obj.isRegisterWriteHandler());
   }
 }

--- a/vertx-core/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
@@ -113,6 +113,21 @@ public class TCPSSLOptionsConverter {
             obj.setTcpUserTimeout(((Number)member.getValue()).intValue());
           }
           break;
+        case "tcpKeepAliveIdleSeconds":
+          if (member.getValue() instanceof Number) {
+            obj.setTcpKeepAliveIdleSeconds(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "tcpKeepAliveCount":
+          if (member.getValue() instanceof Number) {
+            obj.setTcpKeepAliveCount(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "tcpKeepAliveIntervalSeconds":
+          if (member.getValue() instanceof Number) {
+            obj.setTcpKeepAliveIntervalSeconds(((Number)member.getValue()).intValue());
+          }
+          break;
         case "sslHandshakeTimeout":
           if (member.getValue() instanceof Number) {
             obj.setSslHandshakeTimeout(((Number)member.getValue()).longValue());
@@ -167,6 +182,9 @@ public class TCPSSLOptionsConverter {
     json.put("tcpCork", obj.isTcpCork());
     json.put("tcpQuickAck", obj.isTcpQuickAck());
     json.put("tcpUserTimeout", obj.getTcpUserTimeout());
+    json.put("tcpKeepAliveIdleSeconds", obj.getTcpKeepAliveIdleSeconds());
+    json.put("tcpKeepAliveCount", obj.getTcpKeepAliveCount());
+    json.put("tcpKeepAliveIntervalSeconds", obj.getTcpKeepAliveIntervalSeconds());
     json.put("sslHandshakeTimeout", obj.getSslHandshakeTimeout());
     if (obj.getSslHandshakeTimeoutUnit() != null) {
       json.put("sslHandshakeTimeoutUnit", obj.getSslHandshakeTimeoutUnit().name());

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
@@ -136,16 +136,9 @@ public class EpollTransport implements Transport {
       bootstrap.childOption(EpollChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
       bootstrap.childOption(EpollChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
       bootstrap.childOption(EpollChannelOption.TCP_CORK, options.isTcpCork());
-
-      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIdleSeconds() != -1) {
-        bootstrap.option(EpollChannelOption.TCP_KEEPIDLE, options.getTcpKeepAliveIdleSeconds());
-      }
-      if (options.isTcpKeepAlive() && options.getTcpKeepAliveCount() != -1) {
-        bootstrap.option(EpollChannelOption.TCP_KEEPCNT, options.getTcpKeepAliveCount());
-      }
-      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIntervalSeconds() != -1) {
-        bootstrap.option(EpollChannelOption.TCP_KEEPINTVL, options.getTcpKeepAliveIntervalSeconds());
-      }
+      bootstrap.childOption(EpollChannelOption.TCP_KEEPIDLE, options.getTcpKeepAliveIdleSeconds());
+      bootstrap.childOption(EpollChannelOption.TCP_KEEPCNT, options.getTcpKeepAliveCount());
+      bootstrap.childOption(EpollChannelOption.TCP_KEEPINTVL, options.getTcpKeepAliveIntervalSeconds());
     }
     Transport.super.configure(options, domainSocket, bootstrap);
   }
@@ -159,16 +152,9 @@ public class EpollTransport implements Transport {
       bootstrap.option(EpollChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
       bootstrap.option(EpollChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
       bootstrap.option(EpollChannelOption.TCP_CORK, options.isTcpCork());
-
-      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIdleSeconds() != -1) {
-        bootstrap.option(EpollChannelOption.TCP_KEEPIDLE, options.getTcpKeepAliveIdleSeconds());
-      }
-      if (options.isTcpKeepAlive() && options.getTcpKeepAliveCount() != -1) {
-        bootstrap.option(EpollChannelOption.TCP_KEEPCNT, options.getTcpKeepAliveCount());
-      }
-      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIntervalSeconds() != -1) {
-        bootstrap.option(EpollChannelOption.TCP_KEEPINTVL, options.getTcpKeepAliveIntervalSeconds());
-      }
+      bootstrap.option(EpollChannelOption.TCP_KEEPIDLE, options.getTcpKeepAliveIdleSeconds());
+      bootstrap.option(EpollChannelOption.TCP_KEEPCNT, options.getTcpKeepAliveCount());
+      bootstrap.option(EpollChannelOption.TCP_KEEPINTVL, options.getTcpKeepAliveIntervalSeconds());
     }
     Transport.super.configure(options, connectTimeout, domainSocket, bootstrap);
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
@@ -136,6 +136,16 @@ public class EpollTransport implements Transport {
       bootstrap.childOption(EpollChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
       bootstrap.childOption(EpollChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
       bootstrap.childOption(EpollChannelOption.TCP_CORK, options.isTcpCork());
+
+      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIdleSeconds() != -1) {
+        bootstrap.option(EpollChannelOption.TCP_KEEPIDLE, options.getTcpKeepAliveIdleSeconds());
+      }
+      if (options.isTcpKeepAlive() && options.getTcpKeepAliveCount() != -1) {
+        bootstrap.option(EpollChannelOption.TCP_KEEPCNT, options.getTcpKeepAliveCount());
+      }
+      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIntervalSeconds() != -1) {
+        bootstrap.option(EpollChannelOption.TCP_KEEPINTVL, options.getTcpKeepAliveIntervalSeconds());
+      }
     }
     Transport.super.configure(options, domainSocket, bootstrap);
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
@@ -149,6 +149,16 @@ public class EpollTransport implements Transport {
       bootstrap.option(EpollChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
       bootstrap.option(EpollChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
       bootstrap.option(EpollChannelOption.TCP_CORK, options.isTcpCork());
+
+      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIdleSeconds() != -1) {
+        bootstrap.option(EpollChannelOption.TCP_KEEPIDLE, options.getTcpKeepAliveIdleSeconds());
+      }
+      if (options.isTcpKeepAlive() && options.getTcpKeepAliveCount() != -1) {
+        bootstrap.option(EpollChannelOption.TCP_KEEPCNT, options.getTcpKeepAliveCount());
+      }
+      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIntervalSeconds() != -1) {
+        bootstrap.option(EpollChannelOption.TCP_KEEPINTVL, options.getTcpKeepAliveIntervalSeconds());
+      }
     }
     Transport.super.configure(options, connectTimeout, domainSocket, bootstrap);
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
@@ -141,6 +141,9 @@ public class IoUringTransport implements Transport {
     bootstrap.childOption(IoUringChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
     bootstrap.childOption(IoUringChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
     bootstrap.childOption(IoUringChannelOption.TCP_CORK, options.isTcpCork());
+    bootstrap.childOption(IoUringChannelOption.TCP_KEEPIDLE, options.getTcpKeepAliveIdleSeconds());
+    bootstrap.childOption(IoUringChannelOption.TCP_KEEPCNT, options.getTcpKeepAliveCount());
+    bootstrap.childOption(IoUringChannelOption.TCP_KEEPINTVL, options.getTcpKeepAliveIntervalSeconds());
     Transport.super.configure(options, false, bootstrap);
   }
 
@@ -155,6 +158,9 @@ public class IoUringTransport implements Transport {
     bootstrap.option(IoUringChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
     bootstrap.option(IoUringChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
     bootstrap.option(IoUringChannelOption.TCP_CORK, options.isTcpCork());
+    bootstrap.option(IoUringChannelOption.TCP_KEEPIDLE, options.getTcpKeepAliveIdleSeconds());
+    bootstrap.option(IoUringChannelOption.TCP_KEEPCNT, options.getTcpKeepAliveCount());
+    bootstrap.option(IoUringChannelOption.TCP_KEEPINTVL, options.getTcpKeepAliveIntervalSeconds());
     Transport.super.configure(options, connectTimeout, false, bootstrap);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -17,6 +17,7 @@ import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ClientAuth;
+import io.vertx.core.impl.Arguments;
 import io.vertx.core.json.JsonObject;
 
 import java.util.Set;
@@ -68,6 +69,21 @@ public class NetServerOptions extends TCPSSLOptions {
    */
   public static final boolean DEFAULT_REGISTER_WRITE_HANDLER = false;
 
+  /**
+   * Default value for tcp keepalive idle time -1 defaults to OS settings
+   */
+  public static final int DEFAULT_TCP_KEEPALIVE_IDLE_SECONDS = -1;
+
+  /**
+   * Default value for tcp keepalive count -1 defaults to OS settings
+   */
+  public static final int DEFAULT_TCP_KEEPALIVE_COUNT = -1;
+
+  /**
+   * Default value for tcp keepalive interval -1 defaults to OS settings
+   */
+  public static final int DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS = -1;
+
   private int port;
   private String host;
   private int acceptBacklog;
@@ -76,6 +92,9 @@ public class NetServerOptions extends TCPSSLOptions {
   private TimeUnit proxyProtocolTimeoutUnit;
   private boolean registerWriteHandler;
   private TrafficShapingOptions trafficShapingOptions;
+  private int tcpKeepAliveIdleSeconds;
+  private int tcpKeepAliveCount;
+  private int tcpKeepAliveIntervalSeconds;
 
   /**
    * Default constructor
@@ -88,7 +107,7 @@ public class NetServerOptions extends TCPSSLOptions {
   /**
    * Copy constructor
    *
-   * @param other  the options to copy
+   * @param other the options to copy
    */
   public NetServerOptions(NetServerOptions other) {
     super(other);
@@ -102,12 +121,15 @@ public class NetServerOptions extends TCPSSLOptions {
       DEFAULT_PROXY_PROTOCOL_TIMEOUT_TIME_UNIT;
     this.registerWriteHandler = other.registerWriteHandler;
     this.trafficShapingOptions = other.getTrafficShapingOptions();
+    this.tcpKeepAliveIdleSeconds = other.getTcpKeepAliveIdleSeconds();
+    this.tcpKeepAliveCount = other.getTcpKeepAliveCount();
+    this.tcpKeepAliveIntervalSeconds = other.getTcpKeepAliveIntervalSeconds();
   }
 
   /**
    * Create some options from JSON
    *
-   * @param json  the JSON
+   * @param json the JSON
    */
   public NetServerOptions(JsonObject json) {
     super(json);
@@ -335,7 +357,6 @@ public class NetServerOptions extends TCPSSLOptions {
   }
 
   /**
-   *
    * @return the port
    */
   public int getPort() {
@@ -345,7 +366,7 @@ public class NetServerOptions extends TCPSSLOptions {
   /**
    * Set the port
    *
-   * @param port  the port
+   * @param port the port
    * @return a reference to this, so the API can be used fluently
    */
   public NetServerOptions setPort(int port) {
@@ -357,7 +378,6 @@ public class NetServerOptions extends TCPSSLOptions {
   }
 
   /**
-   *
    * @return the host
    */
   public String getHost() {
@@ -366,7 +386,8 @@ public class NetServerOptions extends TCPSSLOptions {
 
   /**
    * Set the host
-   * @param host  the host
+   *
+   * @param host the host
    * @return a reference to this, so the API can be used fluently
    */
   public NetServerOptions setHost(String host) {
@@ -423,7 +444,9 @@ public class NetServerOptions extends TCPSSLOptions {
   /**
    * @return whether the server uses the HA Proxy protocol
    */
-  public boolean isUseProxyProtocol() { return useProxyProtocol; }
+  public boolean isUseProxyProtocol() {
+    return useProxyProtocol;
+  }
 
   /**
    * Set whether the server uses the HA Proxy protocol
@@ -492,6 +515,62 @@ public class NetServerOptions extends TCPSSLOptions {
     return this;
   }
 
+  /**
+   * @return the time in seconds the connection needs to remain idle before TCP starts sending keepalive probes
+   */
+  public int getTcpKeepAliveIdleSeconds() {
+    return tcpKeepAliveIdleSeconds;
+  }
+
+  /**
+   * The time in seconds the connection needs to remain idle before TCP starts sending keepalive probes,
+   * if the socket option keepalive has been set.
+   *
+   * @param tcpKeepAliveIdleSeconds
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetServerOptions setTcpKeepAliveIdleSeconds(int tcpKeepAliveIdleSeconds) {
+    Arguments.require(tcpKeepAliveIdleSeconds > 0 || tcpKeepAliveIdleSeconds == DEFAULT_TCP_KEEPALIVE_IDLE_SECONDS, "tcpKeepAliveIdleSeconds must be > 0");
+    this.tcpKeepAliveIdleSeconds = tcpKeepAliveIdleSeconds;
+    return this;
+  }
+
+  /**
+   * @return the maximum number of keepalive probes TCP should send before dropping the connection.
+   */
+  public int getTcpKeepAliveCount() {
+    return tcpKeepAliveCount;
+  }
+
+  /**
+   * The maximum number of keepalive probes TCP should send before dropping the connection.
+   * @param tcpKeepAliveCount
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NetServerOptions setTcpKeepAliveCount(int tcpKeepAliveCount) {
+    Arguments.require(tcpKeepAliveCount > 0 || tcpKeepAliveCount == DEFAULT_TCP_KEEPALIVE_COUNT, "tcpKeepAliveCount must be > 0");
+    this.tcpKeepAliveCount = tcpKeepAliveCount;
+    return this;
+  }
+
+  /**
+   * @return the time in seconds between individual keepalive probes.
+   */
+  public int getTcpKeepAliveIntervalSeconds() {
+    return tcpKeepAliveIntervalSeconds;
+  }
+
+  /**
+   * The time in seconds between individual keepalive probes.
+   * @param tcpKeepAliveIntervalSeconds
+   * @return
+   */
+  public NetServerOptions setTcpKeepAliveIntervalSeconds(int tcpKeepAliveIntervalSeconds) {
+    Arguments.require(tcpKeepAliveIntervalSeconds > 0 || tcpKeepAliveIntervalSeconds == DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS, "tcpKeepAliveIntervalSeconds must be > 0");
+    this.tcpKeepAliveIntervalSeconds = tcpKeepAliveIntervalSeconds;
+    return this;
+  }
+
   private void init() {
     this.port = DEFAULT_PORT;
     this.host = DEFAULT_HOST;
@@ -500,6 +579,9 @@ public class NetServerOptions extends TCPSSLOptions {
     this.proxyProtocolTimeout = DEFAULT_PROXY_PROTOCOL_TIMEOUT;
     this.proxyProtocolTimeoutUnit = DEFAULT_PROXY_PROTOCOL_TIMEOUT_TIME_UNIT;
     this.registerWriteHandler = DEFAULT_REGISTER_WRITE_HANDLER;
+    this.tcpKeepAliveIdleSeconds = DEFAULT_TCP_KEEPALIVE_IDLE_SECONDS;
+    this.tcpKeepAliveCount = DEFAULT_TCP_KEEPALIVE_COUNT;
+    this.tcpKeepAliveIntervalSeconds = DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS;
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -69,21 +69,6 @@ public class NetServerOptions extends TCPSSLOptions {
    */
   public static final boolean DEFAULT_REGISTER_WRITE_HANDLER = false;
 
-  /**
-   * Default value for tcp keepalive idle time -1 defaults to OS settings
-   */
-  public static final int DEFAULT_TCP_KEEPALIVE_IDLE_SECONDS = -1;
-
-  /**
-   * Default value for tcp keepalive count -1 defaults to OS settings
-   */
-  public static final int DEFAULT_TCP_KEEPALIVE_COUNT = -1;
-
-  /**
-   * Default value for tcp keepalive interval -1 defaults to OS settings
-   */
-  public static final int DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS = -1;
-
   private int port;
   private String host;
   private int acceptBacklog;
@@ -92,9 +77,6 @@ public class NetServerOptions extends TCPSSLOptions {
   private TimeUnit proxyProtocolTimeoutUnit;
   private boolean registerWriteHandler;
   private TrafficShapingOptions trafficShapingOptions;
-  private int tcpKeepAliveIdleSeconds;
-  private int tcpKeepAliveCount;
-  private int tcpKeepAliveIntervalSeconds;
 
   /**
    * Default constructor
@@ -121,9 +103,6 @@ public class NetServerOptions extends TCPSSLOptions {
       DEFAULT_PROXY_PROTOCOL_TIMEOUT_TIME_UNIT;
     this.registerWriteHandler = other.registerWriteHandler;
     this.trafficShapingOptions = other.getTrafficShapingOptions();
-    this.tcpKeepAliveIdleSeconds = other.getTcpKeepAliveIdleSeconds();
-    this.tcpKeepAliveCount = other.getTcpKeepAliveCount();
-    this.tcpKeepAliveIntervalSeconds = other.getTcpKeepAliveIntervalSeconds();
   }
 
   /**
@@ -515,62 +494,6 @@ public class NetServerOptions extends TCPSSLOptions {
     return this;
   }
 
-  /**
-   * @return the time in seconds the connection needs to remain idle before TCP starts sending keepalive probes
-   */
-  public int getTcpKeepAliveIdleSeconds() {
-    return tcpKeepAliveIdleSeconds;
-  }
-
-  /**
-   * The time in seconds the connection needs to remain idle before TCP starts sending keepalive probes,
-   * if the socket option keepalive has been set.
-   *
-   * @param tcpKeepAliveIdleSeconds
-   * @return a reference to this, so the API can be used fluently
-   */
-  public NetServerOptions setTcpKeepAliveIdleSeconds(int tcpKeepAliveIdleSeconds) {
-    Arguments.require(tcpKeepAliveIdleSeconds > 0 || tcpKeepAliveIdleSeconds == DEFAULT_TCP_KEEPALIVE_IDLE_SECONDS, "tcpKeepAliveIdleSeconds must be > 0");
-    this.tcpKeepAliveIdleSeconds = tcpKeepAliveIdleSeconds;
-    return this;
-  }
-
-  /**
-   * @return the maximum number of keepalive probes TCP should send before dropping the connection.
-   */
-  public int getTcpKeepAliveCount() {
-    return tcpKeepAliveCount;
-  }
-
-  /**
-   * The maximum number of keepalive probes TCP should send before dropping the connection.
-   * @param tcpKeepAliveCount
-   * @return a reference to this, so the API can be used fluently
-   */
-  public NetServerOptions setTcpKeepAliveCount(int tcpKeepAliveCount) {
-    Arguments.require(tcpKeepAliveCount > 0 || tcpKeepAliveCount == DEFAULT_TCP_KEEPALIVE_COUNT, "tcpKeepAliveCount must be > 0");
-    this.tcpKeepAliveCount = tcpKeepAliveCount;
-    return this;
-  }
-
-  /**
-   * @return the time in seconds between individual keepalive probes.
-   */
-  public int getTcpKeepAliveIntervalSeconds() {
-    return tcpKeepAliveIntervalSeconds;
-  }
-
-  /**
-   * The time in seconds between individual keepalive probes.
-   * @param tcpKeepAliveIntervalSeconds
-   * @return
-   */
-  public NetServerOptions setTcpKeepAliveIntervalSeconds(int tcpKeepAliveIntervalSeconds) {
-    Arguments.require(tcpKeepAliveIntervalSeconds > 0 || tcpKeepAliveIntervalSeconds == DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS, "tcpKeepAliveIntervalSeconds must be > 0");
-    this.tcpKeepAliveIntervalSeconds = tcpKeepAliveIntervalSeconds;
-    return this;
-  }
-
   private void init() {
     this.port = DEFAULT_PORT;
     this.host = DEFAULT_HOST;
@@ -579,9 +502,6 @@ public class NetServerOptions extends TCPSSLOptions {
     this.proxyProtocolTimeout = DEFAULT_PROXY_PROTOCOL_TIMEOUT;
     this.proxyProtocolTimeoutUnit = DEFAULT_PROXY_PROTOCOL_TIMEOUT_TIME_UNIT;
     this.registerWriteHandler = DEFAULT_REGISTER_WRITE_HANDLER;
-    this.tcpKeepAliveIdleSeconds = DEFAULT_TCP_KEEPALIVE_IDLE_SECONDS;
-    this.tcpKeepAliveCount = DEFAULT_TCP_KEEPALIVE_COUNT;
-    this.tcpKeepAliveIntervalSeconds = DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS;
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -15,6 +15,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.Arguments;
 import io.vertx.core.json.JsonObject;
 import io.netty.handler.logging.ByteBufFormat;
 
@@ -97,6 +98,27 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    */
   public static final int DEFAULT_TCP_USER_TIMEOUT = 0;
 
+  /**
+   * Default value for tcp keepalive idle time.
+   * <p>
+   * {@code -1} defaults to OS settings
+   */
+  public static final int DEFAULT_TCP_KEEPALIVE_IDLE_SECONDS = -1;
+
+  /**
+   * Default value for tcp keepalive count.
+   * <p>
+   * {@code -1} defaults to OS settings
+   */
+  public static final int DEFAULT_TCP_KEEPALIVE_COUNT = -1;
+
+  /**
+   * Default value for tcp keepalive interval.
+   * <p>
+   * {@code -1} defaults to OS settings
+   */
+  public static final int DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS = -1;
+
   private boolean tcpNoDelay;
   private boolean tcpKeepAlive;
   private int soLinger;
@@ -111,6 +133,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
   private boolean tcpCork;
   private boolean tcpQuickAck;
   private int tcpUserTimeout;
+  private int tcpKeepAliveIdleSeconds;
+  private int tcpKeepAliveCount;
+  private int tcpKeepAliveIntervalSeconds;
 
   private Set<String> enabledCipherSuites;
   private List<String> crlPaths;
@@ -144,6 +169,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     this.tcpCork = other.isTcpCork();
     this.tcpQuickAck = other.isTcpQuickAck();
     this.tcpUserTimeout = other.getTcpUserTimeout();
+    this.tcpKeepAliveIdleSeconds = other.getTcpKeepAliveIdleSeconds();
+    this.tcpKeepAliveCount = other.getTcpKeepAliveCount();
+    this.tcpKeepAliveIntervalSeconds = other.getTcpKeepAliveIntervalSeconds();
 
     SSLOptions sslOptions = other.sslOptions;
     if (sslOptions != null) {
@@ -240,6 +268,9 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     tcpCork = DEFAULT_TCP_CORK;
     tcpQuickAck = DEFAULT_TCP_QUICKACK;
     tcpUserTimeout = DEFAULT_TCP_USER_TIMEOUT;
+    tcpKeepAliveIdleSeconds = DEFAULT_TCP_KEEPALIVE_IDLE_SECONDS;
+    tcpKeepAliveCount = DEFAULT_TCP_KEEPALIVE_COUNT;
+    tcpKeepAliveIntervalSeconds = DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS;
     sslOptions = null;
   }
 
@@ -701,6 +732,62 @@ public abstract class TCPSSLOptions extends NetworkOptions {
       throw new IllegalArgumentException("tcpUserTimeout must be >= 0");
     }
     this.tcpUserTimeout = tcpUserTimeout;
+    return this;
+  }
+
+  /**
+   * @return the time in seconds the connection needs to remain idle before TCP starts sending keepalive probes
+   */
+  public int getTcpKeepAliveIdleSeconds() {
+    return tcpKeepAliveIdleSeconds;
+  }
+
+  /**
+   * The time in seconds the connection needs to remain idle before TCP starts sending keepalive probes,
+   * if the socket option keepalive has been set.
+   *
+   * @param tcpKeepAliveIdleSeconds
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TCPSSLOptions setTcpKeepAliveIdleSeconds(int tcpKeepAliveIdleSeconds) {
+    Arguments.require(tcpKeepAliveIdleSeconds > 0 || tcpKeepAliveIdleSeconds == DEFAULT_TCP_KEEPALIVE_IDLE_SECONDS, "tcpKeepAliveIdleSeconds must be > 0");
+    this.tcpKeepAliveIdleSeconds = tcpKeepAliveIdleSeconds;
+    return this;
+  }
+
+  /**
+   * @return the maximum number of keepalive probes TCP should send before dropping the connection.
+   */
+  public int getTcpKeepAliveCount() {
+    return tcpKeepAliveCount;
+  }
+
+  /**
+   * The maximum number of keepalive probes TCP should send before dropping the connection.
+   * @param tcpKeepAliveCount
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TCPSSLOptions setTcpKeepAliveCount(int tcpKeepAliveCount) {
+    Arguments.require(tcpKeepAliveCount > 0 || tcpKeepAliveCount == DEFAULT_TCP_KEEPALIVE_COUNT, "tcpKeepAliveCount must be > 0");
+    this.tcpKeepAliveCount = tcpKeepAliveCount;
+    return this;
+  }
+
+  /**
+   * @return the time in seconds between individual keepalive probes.
+   */
+  public int getTcpKeepAliveIntervalSeconds() {
+    return tcpKeepAliveIntervalSeconds;
+  }
+
+  /**
+   * The time in seconds between individual keepalive probes.
+   * @param tcpKeepAliveIntervalSeconds
+   * @return
+   */
+  public TCPSSLOptions setTcpKeepAliveIntervalSeconds(int tcpKeepAliveIntervalSeconds) {
+    Arguments.require(tcpKeepAliveIntervalSeconds > 0 || tcpKeepAliveIntervalSeconds == DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS, "tcpKeepAliveIntervalSeconds must be > 0");
+    this.tcpKeepAliveIntervalSeconds = tcpKeepAliveIntervalSeconds;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/spi/transport/Transport.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/transport/Transport.java
@@ -172,15 +172,6 @@ public interface Transport {
     if (!domainSocket) {
       bootstrap.option(ChannelOption.SO_REUSEADDR, options.isReuseAddress());
       bootstrap.childOption(ChannelOption.SO_KEEPALIVE, options.isTcpKeepAlive());
-      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIdleSeconds() != -1) {
-        bootstrap.childOption(EpollChannelOption.TCP_KEEPIDLE, options.getTcpKeepAliveIdleSeconds());
-      }
-      if (options.isTcpKeepAlive() && options.getTcpKeepAliveCount() != -1) {
-        bootstrap.childOption(EpollChannelOption.TCP_KEEPCNT, options.getTcpKeepAliveIdleSeconds());
-      }
-      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIntervalSeconds() != -1) {
-        bootstrap.childOption(EpollChannelOption.TCP_KEEPINTVL, options.getTcpKeepAliveIdleSeconds());
-      }
       bootstrap.childOption(ChannelOption.TCP_NODELAY, options.isTcpNoDelay());
     }
     if (options.getSendBufferSize() != -1) {

--- a/vertx-core/src/main/java/io/vertx/core/spi/transport/Transport.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/transport/Transport.java
@@ -14,6 +14,7 @@ package io.vertx.core.spi.transport;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.*;
+import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.vertx.core.datagram.DatagramSocketOptions;
@@ -82,11 +83,10 @@ public interface Transport {
   IoHandlerFactory ioHandlerFactory();
 
   /**
-   * @param type one of {@link #ACCEPTOR_EVENT_LOOP_GROUP} or {@link #IO_EVENT_LOOP_GROUP}.
-   * @param nThreads the number of threads that will be used by this instance.
+   * @param type          one of {@link #ACCEPTOR_EVENT_LOOP_GROUP} or {@link #IO_EVENT_LOOP_GROUP}.
+   * @param nThreads      the number of threads that will be used by this instance.
    * @param threadFactory the ThreadFactory to use.
-   * @param ioRatio the IO ratio
-   *
+   * @param ioRatio       the IO ratio
    * @return a new event loop group
    */
   default EventLoopGroup eventLoopGroup(int type, int nThreads, ThreadFactory threadFactory, int ioRatio) {
@@ -104,14 +104,14 @@ public interface Transport {
   DatagramChannel datagramChannel(InternetProtocolFamily family);
 
   /**
-   * @return the type for channel
    * @param domainSocket whether to create a unix domain channel or a socket channel
+   * @return the type for channel
    */
   ChannelFactory<? extends Channel> channelFactory(boolean domainSocket);
 
   /**
-   * @return the type for server channel
    * @param domainSocket whether to create a server unix domain channel or a regular server socket channel
+   * @return the type for server channel
    */
   ChannelFactory<? extends ServerChannel> serverChannelFactory(boolean domainSocket);
 
@@ -172,6 +172,15 @@ public interface Transport {
     if (!domainSocket) {
       bootstrap.option(ChannelOption.SO_REUSEADDR, options.isReuseAddress());
       bootstrap.childOption(ChannelOption.SO_KEEPALIVE, options.isTcpKeepAlive());
+      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIdleSeconds() != -1) {
+        bootstrap.childOption(EpollChannelOption.TCP_KEEPIDLE, options.getTcpKeepAliveIdleSeconds());
+      }
+      if (options.isTcpKeepAlive() && options.getTcpKeepAliveCount() != -1) {
+        bootstrap.childOption(EpollChannelOption.TCP_KEEPCNT, options.getTcpKeepAliveIdleSeconds());
+      }
+      if (options.isTcpKeepAlive() && options.getTcpKeepAliveIntervalSeconds() != -1) {
+        bootstrap.childOption(EpollChannelOption.TCP_KEEPINTVL, options.getTcpKeepAliveIdleSeconds());
+      }
       bootstrap.childOption(ChannelOption.TCP_NODELAY, options.isTcpNoDelay());
     }
     if (options.getSendBufferSize() != -1) {

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -274,6 +274,27 @@ public class NetTest extends VertxTestBase {
     assertEquals(randLong, options.getSslHandshakeTimeout());
     assertIllegalArgumentException(() -> options.setSslHandshakeTimeout(-123));
 
+    assertEquals(NetClientOptions.DEFAULT_TCP_KEEPALIVE_IDLE_SECONDS, options.getTcpKeepAliveIdleSeconds());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpKeepAliveIdleSeconds(rand));
+    assertEquals(rand, options.getTcpKeepAliveIdleSeconds());
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIdleSeconds(0));
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIdleSeconds(-123));
+
+    assertEquals(NetClientOptions.DEFAULT_TCP_KEEPALIVE_COUNT, options.getTcpKeepAliveCount());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpKeepAliveCount(rand));
+    assertEquals(rand, options.getTcpKeepAliveCount());
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveCount(0));
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveCount(-123));
+
+    assertEquals(NetClientOptions.DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS, options.getTcpKeepAliveIntervalSeconds());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpKeepAliveIntervalSeconds(rand));
+    assertEquals(rand, options.getTcpKeepAliveIntervalSeconds());
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIntervalSeconds(0));
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIntervalSeconds(-123));
+
     testComplete();
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -398,6 +398,27 @@ public class NetTest extends VertxTestBase {
     assertEquals(randomProxyTimeout, options.getProxyProtocolTimeout());
     assertIllegalArgumentException(() -> options.setProxyProtocolTimeout(-123));
 
+    assertEquals(NetServerOptions.DEFAULT_TCP_KEEPALIVE_IDLE_SECONDS, options.getTcpKeepAliveIdleSeconds());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpKeepAliveIdleSeconds(rand));
+    assertEquals(rand, options.getTcpKeepAliveIdleSeconds());
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIdleSeconds(0));
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIdleSeconds(-123));
+
+    assertEquals(NetServerOptions.DEFAULT_TCP_KEEPALIVE_COUNT, options.getTcpKeepAliveCount());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpKeepAliveCount(rand));
+    assertEquals(rand, options.getTcpKeepAliveCount());
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveCount(0));
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveCount(-123));
+
+    assertEquals(NetServerOptions.DEFAULT_TCP_KEEAPLIVE_INTERVAL_SECONDS, options.getTcpKeepAliveIntervalSeconds());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setTcpKeepAliveIntervalSeconds(rand));
+    assertEquals(rand, options.getTcpKeepAliveIntervalSeconds());
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIntervalSeconds(0));
+    assertIllegalArgumentException(() -> options.setTcpKeepAliveIntervalSeconds(-123));
+
     testComplete();
   }
 
@@ -650,6 +671,9 @@ public class NetTest extends VertxTestBase {
     long sslHandshakeTimeout = TestUtils.randomPositiveLong();
     boolean useProxyProtocol = TestUtils.randomBoolean();
     long proxyProtocolTimeout = TestUtils.randomPositiveLong();
+    int tcpKeepAliveIdleSeconds = TestUtils.randomPositiveInt();
+    int tcpKeepAliveCount = TestUtils.randomPositiveInt();
+    int tcpKeepAliveIntervalSeconds = TestUtils.randomPositiveInt();
 
     options.setSendBufferSize(sendBufferSize);
     options.setReceiveBufferSize(receiverBufferSize);
@@ -675,6 +699,9 @@ public class NetTest extends VertxTestBase {
     options.setSslHandshakeTimeout(sslHandshakeTimeout);
     options.setUseProxyProtocol(useProxyProtocol);
     options.setProxyProtocolTimeout(proxyProtocolTimeout);
+    options.setTcpKeepAliveIdleSeconds(tcpKeepAliveIdleSeconds);
+    options.setTcpKeepAliveCount(tcpKeepAliveCount);
+    options.setTcpKeepAliveIntervalSeconds(tcpKeepAliveIntervalSeconds);
 
     NetServerOptions copy = new NetServerOptions(options);
     assertEquals(options.toJson(), copy.toJson());
@@ -746,6 +773,9 @@ public class NetTest extends VertxTestBase {
     long sslHandshakeTimeout = TestUtils.randomPositiveLong();
     boolean useProxyProtocol = TestUtils.randomBoolean();
     long proxyProtocolTimeout = TestUtils.randomPositiveLong();
+    int tcpKeepAliveIdleSeconds = TestUtils.randomPositiveInt();
+    int tcpKeepAliveCount = TestUtils.randomPositiveInt();
+    int tcpKeepAliveIntervalSeconds = TestUtils.randomPositiveInt();
 
     JsonObject json = new JsonObject();
     json.put("sendBufferSize", sendBufferSize)
@@ -772,7 +802,10 @@ public class NetTest extends VertxTestBase {
       .put("sni", sni)
       .put("sslHandshakeTimeout", sslHandshakeTimeout)
       .put("useProxyProtocol", useProxyProtocol)
-      .put("proxyProtocolTimeout", proxyProtocolTimeout);
+      .put("proxyProtocolTimeout", proxyProtocolTimeout)
+      .put("tcpKeepAliveIdleSeconds", tcpKeepAliveIdleSeconds)
+      .put("tcpKeepAliveCount", tcpKeepAliveCount)
+      .put("tcpKeepAliveIntervalSeconds", tcpKeepAliveIntervalSeconds);
 
     NetServerOptions options = new NetServerOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());
@@ -814,6 +847,9 @@ public class NetTest extends VertxTestBase {
     assertEquals(sni, options.isSni());
     assertEquals(useProxyProtocol, options.isUseProxyProtocol());
     assertEquals(proxyProtocolTimeout, options.getProxyProtocolTimeout());
+    assertEquals(tcpKeepAliveIdleSeconds, options.getTcpKeepAliveIdleSeconds());
+    assertEquals(tcpKeepAliveCount, options.getTcpKeepAliveCount());
+    assertEquals(tcpKeepAliveIntervalSeconds, options.getTcpKeepAliveIntervalSeconds());
 
     // Test other keystore/truststore types
     json.remove("keyStoreOptions");


### PR DESCRIPTION
EpollTransport: support extended keepalive parameters TCP_KEEPIDLE, TCP_KEEPCNT and TCP_KEEPINTVL

Builds on #5183. This work has not made it into 5.0, so I'm catching up on that.

I hope I've ported it correctly (moved to EPollTransport from Transport base)

For motivation, see #5163 and #5183 and #5970