### PR TITLE
Make TCP option generic for the new TcpConfig.

### DIFF
--- a/vertx-core/src/main/java/examples/CoreExamples.java
+++ b/vertx-core/src/main/java/examples/CoreExamples.java
@@ -522,7 +522,7 @@ public class CoreExamples {
 
     // Available on BSD
     tcpConfig
-      .setReusePort(reusePort);
+      .setSoReusePort(reusePort);
 
     vertx.createHttpServer(config);
   }

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/EpollTransport.java
@@ -18,12 +18,17 @@ import io.netty.channel.epoll.*;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.channel.unix.UnixChannelOption;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.net.TcpConfig;
+import io.vertx.core.net.TcpOption;
 import io.vertx.core.net.impl.SocketAddressImpl;
 import io.vertx.core.spi.transport.Transport;
 
 import java.net.SocketAddress;
+
+import static io.vertx.core.impl.transports.NioTransport.configChildOption;
+import static io.vertx.core.impl.transports.NioTransport.configOption;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -42,7 +47,7 @@ public class EpollTransport implements Transport {
   }
 
   /**
-   * Set the number of of pending TFO connections in SYN-RCVD state for TCP_FASTOPEN
+   * Set the number of pending TFO connections in SYN-RCVD state for TCP_FASTOPEN
    * <p/>
    * If this value goes over a certain limit the server disables all TFO connections.
    */
@@ -126,29 +131,25 @@ public class EpollTransport implements Transport {
   }
 
   @Override
-  public void configure(TcpConfig options, boolean domainSocket, ServerBootstrap bootstrap) {
+  public void configure(TcpConfig config, boolean domainSocket, ServerBootstrap bootstrap) {
     if (!domainSocket) {
-      bootstrap.option(EpollChannelOption.SO_REUSEPORT, options.isReusePort());
-      if (options.isTcpFastOpen()) {
-        bootstrap.option(ChannelOption.TCP_FASTOPEN, options.isTcpFastOpen() ? pendingFastOpenRequestsThreshold : 0);
-      }
-      bootstrap.childOption(EpollChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
-      bootstrap.childOption(EpollChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
-      bootstrap.childOption(EpollChannelOption.TCP_CORK, options.isTcpCork());
+      bootstrap.option(UnixChannelOption.SO_REUSEPORT, config.isSoReusePort());
+      configOption(bootstrap, config, TcpOption.FASTOPEN, EpollChannelOption.TCP_FASTOPEN);
+      configChildOption(bootstrap, config, TcpOption.USER_TIMEOUT, EpollChannelOption.TCP_USER_TIMEOUT);
+      configChildOption(bootstrap, config, TcpOption.QUICKACK, EpollChannelOption.TCP_QUICKACK);
+      configChildOption(bootstrap, config, TcpOption.CORK, EpollChannelOption.TCP_CORK);
     }
-    Transport.super.configure(options, domainSocket, bootstrap);
+    Transport.super.configure(config, domainSocket, bootstrap);
   }
 
   @Override
-  public void configure(TcpConfig options, boolean domainSocket, Bootstrap bootstrap) {
+  public void configure(TcpConfig config, boolean domainSocket, Bootstrap bootstrap) {
     if (!domainSocket) {
-      if (options.isTcpFastOpen()) {
-        bootstrap.option(ChannelOption.TCP_FASTOPEN_CONNECT, options.isTcpFastOpen());
-      }
-      bootstrap.option(EpollChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
-      bootstrap.option(EpollChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
-      bootstrap.option(EpollChannelOption.TCP_CORK, options.isTcpCork());
+      NioTransport.configOption(bootstrap, config, TcpOption.FASTOPEN_CONNECT, EpollChannelOption.TCP_FASTOPEN_CONNECT);
+      NioTransport.configOption(bootstrap, config, TcpOption.USER_TIMEOUT, EpollChannelOption.TCP_USER_TIMEOUT);
+      NioTransport.configOption(bootstrap, config, TcpOption.QUICKACK, EpollChannelOption.TCP_QUICKACK);
+      NioTransport.configOption(bootstrap, config, TcpOption.CORK, EpollChannelOption.TCP_CORK);
     }
-    Transport.super.configure(options, domainSocket, bootstrap);
+    Transport.super.configure(config, domainSocket, bootstrap);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/IoUringTransport.java
@@ -19,10 +19,14 @@ import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.uring.*;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.net.TcpConfig;
+import io.vertx.core.net.TcpOption;
 import io.vertx.core.net.impl.SocketAddressImpl;
 import io.vertx.core.spi.transport.Transport;
 
 import java.net.SocketAddress;
+
+import static io.vertx.core.impl.transports.NioTransport.configChildOption;
+import static io.vertx.core.impl.transports.NioTransport.configOption;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -129,31 +133,27 @@ public class IoUringTransport implements Transport {
   }
 
   @Override
-  public void configure(TcpConfig options, boolean domainSocket, ServerBootstrap bootstrap) {
+  public void configure(TcpConfig config, boolean domainSocket, ServerBootstrap bootstrap) {
     if (domainSocket) {
       throw new IllegalArgumentException();
     }
-    bootstrap.option(IoUringChannelOption.SO_REUSEPORT, options.isReusePort());
-    if (options.isTcpFastOpen()) {
-      bootstrap.option(IoUringChannelOption.TCP_FASTOPEN, options.isTcpFastOpen() ? pendingFastOpenRequestsThreshold : 0);
-    }
-    bootstrap.childOption(IoUringChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
-    bootstrap.childOption(IoUringChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
-    bootstrap.childOption(IoUringChannelOption.TCP_CORK, options.isTcpCork());
-    Transport.super.configure(options, false, bootstrap);
+    bootstrap.option(IoUringChannelOption.SO_REUSEPORT, config.isSoReusePort());
+    configOption(bootstrap, config, TcpOption.FASTOPEN, IoUringChannelOption.TCP_FASTOPEN);
+    configChildOption(bootstrap, config, TcpOption.USER_TIMEOUT, IoUringChannelOption.TCP_USER_TIMEOUT);
+    configChildOption(bootstrap, config, TcpOption.QUICKACK, IoUringChannelOption.TCP_QUICKACK);
+    configChildOption(bootstrap, config, TcpOption.CORK, IoUringChannelOption.TCP_CORK);
+    Transport.super.configure(config, false, bootstrap);
   }
 
   @Override
-  public void configure(TcpConfig options, boolean domainSocket, Bootstrap bootstrap) {
+  public void configure(TcpConfig config, boolean domainSocket, Bootstrap bootstrap) {
     if (domainSocket) {
       throw new IllegalArgumentException();
     }
-    if (options.isTcpFastOpen()) {
-      bootstrap.option(IoUringChannelOption.TCP_FASTOPEN_CONNECT, options.isTcpFastOpen());
-    }
-    bootstrap.option(IoUringChannelOption.TCP_USER_TIMEOUT, options.getTcpUserTimeout());
-    bootstrap.option(IoUringChannelOption.TCP_QUICKACK, options.isTcpQuickAck());
-    bootstrap.option(IoUringChannelOption.TCP_CORK, options.isTcpCork());
-    Transport.super.configure(options, false, bootstrap);
+    NioTransport.configOption(bootstrap, config, TcpOption.FASTOPEN_CONNECT, IoUringChannelOption.TCP_FASTOPEN_CONNECT);
+    NioTransport.configOption(bootstrap, config, TcpOption.USER_TIMEOUT, IoUringChannelOption.TCP_USER_TIMEOUT);
+    NioTransport.configOption(bootstrap, config, TcpOption.QUICKACK, IoUringChannelOption.TCP_QUICKACK);
+    NioTransport.configOption(bootstrap, config, TcpOption.CORK, IoUringChannelOption.TCP_CORK);
+    Transport.super.configure(config, false, bootstrap);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/KQueueTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/KQueueTransport.java
@@ -98,11 +98,11 @@ public class KQueueTransport implements Transport {
   }
 
   @Override
-  public void configure(TcpConfig options, boolean domainSocket, ServerBootstrap bootstrap) {
+  public void configure(TcpConfig config, boolean domainSocket, ServerBootstrap bootstrap) {
     if (!domainSocket) {
-      bootstrap.option(KQueueChannelOption.SO_REUSEPORT, options.isReusePort());
+      bootstrap.option(KQueueChannelOption.SO_REUSEPORT, config.isSoReusePort());
     }
-    Transport.super.configure(options, domainSocket, bootstrap);
+    Transport.super.configure(config, domainSocket, bootstrap);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/NioTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/NioTransport.java
@@ -10,19 +10,21 @@
  */
 package io.vertx.core.impl.transports;
 
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFactory;
-import io.netty.channel.IoHandlerFactory;
-import io.netty.channel.ServerChannel;
+import io.netty.bootstrap.AbstractBootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.*;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.nio.*;
+import io.vertx.core.net.TcpConfig;
+import io.vertx.core.net.TcpOption;
 import io.vertx.core.spi.transport.Transport;
 
 import java.net.SocketAddress;
 
 public class NioTransport implements Transport {
+
   /**
    * The NIO transport, always there.
    */
@@ -95,5 +97,19 @@ public class NioTransport implements Transport {
       return NioServerDomainSocketChannel::new;
     }
     return NioServerSocketChannel::new;
+  }
+
+  public static <T> void configOption(AbstractBootstrap<?, ?> bootstrap, TcpConfig config, TcpOption<T> tcpOption, ChannelOption<T> channelOption) {
+    T value = config.getOption(tcpOption);
+    if (value != null) {
+      bootstrap.option(channelOption, value);
+    }
+  }
+
+  public static <T> void configChildOption(ServerBootstrap bootstrap, TcpConfig config, TcpOption<T> tcpOption, ChannelOption<T> channelOption) {
+    T value = config.getOption(tcpOption);
+    if (value != null) {
+      bootstrap.childOption(channelOption, value);
+    }
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -15,6 +15,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.transports.EpollTransport;
 import io.vertx.core.json.JsonObject;
 
 import java.util.*;
@@ -224,6 +225,11 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     sslOptions = null;
   }
 
+  private <T> T getOrDefaultOption(TcpOption<T> option) {
+    T value = transportOptions.getOption(option);
+    return value != null ? value : option.defaultValue;
+  }
+
   protected SSLOptions getOrCreateSSLOptions() {
     if (sslOptions == null) {
       sslOptions = createSSLOptions();
@@ -307,12 +313,12 @@ public abstract class TCPSSLOptions extends NetworkOptions {
 
   @Override
   public boolean isReusePort() {
-    return transportOptions.isReusePort();
+    return transportOptions.isSoReusePort();
   }
 
   @Override
   public TCPSSLOptions setReusePort(boolean reusePort) {
-    transportOptions.setReusePort(reusePort);
+    transportOptions.setSoReusePort(reusePort);
     return this;
   }
 
@@ -320,7 +326,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @return TCP no delay enabled ?
    */
   public boolean isTcpNoDelay() {
-    return transportOptions.isTcpNoDelay();
+    return getOrDefaultOption(TcpOption.NODELAY);
   }
 
   /**
@@ -330,7 +336,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @return a reference to this, so the API can be used fluently
    */
   public TCPSSLOptions setTcpNoDelay(boolean tcpNoDelay) {
-    transportOptions.setTcpNoDelay(tcpNoDelay);
+    transportOptions.setOption(TcpOption.NODELAY, tcpNoDelay);
     return this;
   }
 
@@ -338,7 +344,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @return is TCP keep alive enabled?
    */
   public boolean isTcpKeepAlive() {
-    return transportOptions.isTcpKeepAlive();
+    return transportOptions.isSoKeepAlive();
   }
 
   /**
@@ -348,7 +354,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @return a reference to this, so the API can be used fluently
    */
   public TCPSSLOptions setTcpKeepAlive(boolean tcpKeepAlive) {
-    transportOptions.setTcpKeepAlive(tcpKeepAlive);
+    transportOptions.setSoKeepAlive(tcpKeepAlive);
     return this;
   }
 
@@ -681,7 +687,12 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @return wether {@code TCP_FASTOPEN} option is enabled
    */
   public boolean isTcpFastOpen() {
-    return transportOptions.isTcpFastOpen();
+    if (this instanceof ClientOptionsBase) {
+      return getOrDefaultOption(TcpOption.FASTOPEN_CONNECT);
+    } else {
+      Integer value = transportOptions.getOption(TcpOption.FASTOPEN);
+      return value != null && value > 0;
+    }
   }
 
   /**
@@ -690,7 +701,15 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @param tcpFastOpen the fast open value
    */
   public TCPSSLOptions setTcpFastOpen(boolean tcpFastOpen) {
-    transportOptions.setTcpFastOpen(tcpFastOpen);
+    if (this instanceof ClientOptionsBase) {
+      transportOptions.setOption(TcpOption.FASTOPEN_CONNECT, tcpFastOpen);
+    } else {
+      if (tcpFastOpen) {
+        transportOptions.setOption(TcpOption.FASTOPEN, EpollTransport.getPendingFastOpenRequestsThreshold());
+      } else {
+        transportOptions.setOption(TcpOption.FASTOPEN, null);
+      }
+    }
     return this;
   }
 
@@ -698,7 +717,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @return wether {@code TCP_CORK} option is enabled
    */
   public boolean isTcpCork() {
-    return transportOptions.isTcpCork();
+    return getOrDefaultOption(TcpOption.CORK);
   }
 
   /**
@@ -707,7 +726,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @param tcpCork the cork value
    */
   public TCPSSLOptions setTcpCork(boolean tcpCork) {
-    transportOptions.setTcpCork(tcpCork);
+    transportOptions.setOption(TcpOption.CORK, tcpCork);
     return this;
   }
 
@@ -715,7 +734,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @return wether {@code TCP_QUICKACK} option is enabled
    */
   public boolean isTcpQuickAck() {
-    return transportOptions.isTcpQuickAck();
+    return getOrDefaultOption(TcpOption.QUICKACK);
   }
 
   /**
@@ -724,7 +743,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @param tcpQuickAck the quick ack value
    */
   public TCPSSLOptions setTcpQuickAck(boolean tcpQuickAck) {
-    transportOptions.setTcpQuickAck(tcpQuickAck);
+    transportOptions.setOption(TcpOption.QUICKACK, tcpQuickAck);
     return this;
   }
 
@@ -733,7 +752,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @return the {@code TCP_USER_TIMEOUT} value
    */
   public int getTcpUserTimeout() {
-    return transportOptions.getTcpUserTimeout();
+    return getOrDefaultOption(TcpOption.USER_TIMEOUT);
   }
 
   /**
@@ -742,7 +761,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @param tcpUserTimeout the tcp user timeout value
    */
   public TCPSSLOptions setTcpUserTimeout(int tcpUserTimeout) {
-    transportOptions.setTcpUserTimeout(tcpUserTimeout);
+    transportOptions.setOption(TcpOption.USER_TIMEOUT, tcpUserTimeout);
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/TcpConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TcpConfig.java
@@ -12,6 +12,9 @@ package io.vertx.core.net;
 
 import io.vertx.core.impl.Arguments;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static io.vertx.core.net.TCPSSLOptions.DEFAULT_SO_LINGER;
 
 /**
@@ -23,14 +26,10 @@ public class TcpConfig extends TransportConfig {
   private int receiveBufferSize;
   private int trafficClass;
   private boolean reuseAddress;
-  private boolean reusePort;
-  private boolean tcpNoDelay;
-  private boolean tcpKeepAlive;
+  private boolean soReusePort;
+  private boolean soKeepAlive;
   private int soLinger;
-  private boolean tcpFastOpen;
-  private boolean tcpCork;
-  private boolean tcpQuickAck;
-  private int tcpUserTimeout;
+  private Map<TcpOption<?>, Object> options;
 
   public TcpConfig() {
     init();
@@ -42,14 +41,10 @@ public class TcpConfig extends TransportConfig {
     this.receiveBufferSize = other.getReceiveBufferSize();
     this.reuseAddress = other.isReuseAddress();
     this.trafficClass = other.getTrafficClass();
-    this.reusePort = other.isReusePort();
-    this.tcpNoDelay = other.isTcpNoDelay();
-    this.tcpKeepAlive = other.isTcpKeepAlive();
+    this.soReusePort = other.isSoReusePort();
+    this.soKeepAlive = other.isSoKeepAlive();
     this.soLinger = other.getSoLinger();
-    this.tcpFastOpen = other.isTcpFastOpen();
-    this.tcpCork = other.isTcpCork();
-    this.tcpQuickAck = other.isTcpQuickAck();
-    this.tcpUserTimeout = other.getTcpUserTimeout();
+    this.options = other.options != null ? new HashMap<>(other.options) : null;
   }
 
   void init() {
@@ -57,14 +52,9 @@ public class TcpConfig extends TransportConfig {
     receiveBufferSize = NetworkOptions.DEFAULT_RECEIVE_BUFFER_SIZE;
     reuseAddress = NetworkOptions.DEFAULT_REUSE_ADDRESS;
     trafficClass = NetworkOptions.DEFAULT_TRAFFIC_CLASS;
-    reusePort = NetworkOptions.DEFAULT_REUSE_PORT;
-    tcpNoDelay = TCPSSLOptions.DEFAULT_TCP_NO_DELAY;
-    tcpKeepAlive = TCPSSLOptions.DEFAULT_TCP_KEEP_ALIVE;
+    soReusePort = NetworkOptions.DEFAULT_REUSE_PORT;
     soLinger = DEFAULT_SO_LINGER;
-    tcpFastOpen = TCPSSLOptions.DEFAULT_TCP_FAST_OPEN;
-    tcpCork = TCPSSLOptions.DEFAULT_TCP_CORK;
-    tcpQuickAck = TCPSSLOptions.DEFAULT_TCP_QUICKACK;
-    tcpUserTimeout = TCPSSLOptions.DEFAULT_TCP_USER_TIMEOUT;
+    options = null;
   }
 
   @Override
@@ -153,8 +143,8 @@ public class TcpConfig extends TransportConfig {
   /**
    * @return  the value of reuse address - only supported by native transports
    */
-  public boolean isReusePort() {
-    return reusePort;
+  public boolean isSoReusePort() {
+    return soReusePort;
   }
 
   /**
@@ -162,47 +152,29 @@ public class TcpConfig extends TransportConfig {
    * <p/>
    * This is only supported by native transports.
    *
-   * @param reusePort  the value of reuse port
+   * @param soReusePort  the value of reuse port
    * @return a reference to this, so the API can be used fluently
    */
-  public TcpConfig setReusePort(boolean reusePort) {
-    this.reusePort = reusePort;
+  public TcpConfig setSoReusePort(boolean soReusePort) {
+    this.soReusePort = soReusePort;
     return this;
   }
 
   /**
-   * @return TCP no delay enabled ?
+   * @return is keep alive enabled?
    */
-  public boolean isTcpNoDelay() {
-    return tcpNoDelay;
+  public boolean isSoKeepAlive() {
+    return soKeepAlive;
   }
 
   /**
-   * Set whether TCP no delay is enabled
+   * Set whether keep alive is enabled
    *
-   * @param tcpNoDelay true if TCP no delay is enabled (Nagle disabled)
+   * @param keepAlive true if keep alive is enabled
    * @return a reference to this, so the API can be used fluently
    */
-  public TcpConfig setTcpNoDelay(boolean tcpNoDelay) {
-    this.tcpNoDelay = tcpNoDelay;
-    return this;
-  }
-
-  /**
-   * @return is TCP keep alive enabled?
-   */
-  public boolean isTcpKeepAlive() {
-    return tcpKeepAlive;
-  }
-
-  /**
-   * Set whether TCP keep alive is enabled
-   *
-   * @param tcpKeepAlive true if TCP keep alive is enabled
-   * @return a reference to this, so the API can be used fluently
-   */
-  public TcpConfig setTcpKeepAlive(boolean tcpKeepAlive) {
-    this.tcpKeepAlive = tcpKeepAlive;
+  public TcpConfig setSoKeepAlive(boolean keepAlive) {
+    this.soKeepAlive = keepAlive;
     return this;
   }
 
@@ -229,74 +201,34 @@ public class TcpConfig extends TransportConfig {
   }
 
   /**
-   * @return wether {@code TCP_FASTOPEN} option is enabled
-   */
-  public boolean isTcpFastOpen() {
-    return tcpFastOpen;
-  }
-
-  /**
-   * Enable the {@code TCP_FASTOPEN} option - only with linux native transport.
+   * Returns a configurable TCP option.
    *
-   * @param tcpFastOpen the fast open value
+   * @param option the option to probe
+   * @return the option value or {@code null} when not set
    */
-  public TcpConfig setTcpFastOpen(boolean tcpFastOpen) {
-    this.tcpFastOpen = tcpFastOpen;
-    return this;
+  public <T> T getOption(TcpOption<T> option) {
+    return options != null ? option.type.cast(options.get(option)) : null;
   }
 
   /**
-   * @return wether {@code TCP_CORK} option is enabled
-   */
-  public boolean isTcpCork() {
-    return tcpCork;
-  }
-
-  /**
-   * Enable the {@code TCP_CORK} option - only with linux native transport.
+   * Configure a TCP option.
    *
-   * @param tcpCork the cork value
+   * @param option the option to configure
+   * @param value the value to set or {@code null} to unset
+   * @return a reference to this, so the API can be used fluently
    */
-  public TcpConfig setTcpCork(boolean tcpCork) {
-    this.tcpCork = tcpCork;
-    return this;
-  }
-
-  /**
-   * @return wether {@code TCP_QUICKACK} option is enabled
-   */
-  public boolean isTcpQuickAck() {
-    return tcpQuickAck;
-  }
-
-  /**
-   * Enable the {@code TCP_QUICKACK} option - only with linux native transport.
-   *
-   * @param tcpQuickAck the quick ack value
-   */
-  public TcpConfig setTcpQuickAck(boolean tcpQuickAck) {
-    this.tcpQuickAck = tcpQuickAck;
-    return this;
-  }
-
-  /**
-   *
-   * @return the {@code TCP_USER_TIMEOUT} value
-   */
-  public int getTcpUserTimeout() {
-    return tcpUserTimeout;
-  }
-
-  /**
-   * Sets the {@code TCP_USER_TIMEOUT} option - only with linux native transport.
-   *
-   * @param tcpUserTimeout the tcp user timeout value
-   */
-  public TcpConfig setTcpUserTimeout(int tcpUserTimeout) {
-    if (tcpUserTimeout < 0) {
-      throw new IllegalArgumentException("tcpUserTimeout must be >= 0");
+  public <T> TcpConfig setOption(TcpOption<T> option, T value) {
+    if (value == null) {
+      if (options != null) {
+        options.remove(option);
+      }
+    } else {
+      option.validate(value);
+      if (options == null) {
+        options = new HashMap<>();
+      }
+      options.put(option, value);
     }
-    this.tcpUserTimeout = tcpUserTimeout;
     return this;
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/TcpOption.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TcpOption.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net;
+
+/**
+ * Generic TCP configuration option.
+ */
+public class TcpOption<T> {
+
+  /**
+   * The {@code TCP_NODELAY} option - only with Linux native transport.
+   */
+  public static final TcpOption<Boolean> NODELAY = new TcpOption<>(Boolean.class, TCPSSLOptions.DEFAULT_TCP_NO_DELAY);
+
+  /**
+   * The {@code TCP_QUICKACK} option - only with Linux native transport.
+   */
+  public static final TcpOption<Boolean> QUICKACK = new TcpOption<>(Boolean.class, TCPSSLOptions.DEFAULT_TCP_QUICKACK);
+
+  /**
+   * The {@code TCP_CORK} option - only with Linux native transport.
+   */
+  public static final TcpOption<Boolean> CORK = new TcpOption<>(Boolean.class, TCPSSLOptions.DEFAULT_TCP_CORK);
+
+  /**
+   * The {@code TCP_USER_TIMEOUT} option - only with Linux native transport.
+   */
+  public static final TcpOption<Integer> USER_TIMEOUT = new TcpOption<>(Integer.class, TCPSSLOptions.DEFAULT_TCP_USER_TIMEOUT) {
+    @Override
+    protected void validate(Integer value) {
+      if (value < 0) {
+        throw new IllegalArgumentException("USER_TIMEOUT must be >= 0");
+      }
+    }
+  };
+
+  /**
+   * The {@code TCP_FASTOPEN_CONNECT} option - only with Linux native transport.
+   */
+  public static final TcpOption<Boolean> FASTOPEN_CONNECT = new TcpOption<>(Boolean.class, TCPSSLOptions.DEFAULT_TCP_FAST_OPEN);
+
+  /**
+   * The {@code TCP_FASTOPEN} option - only with Linux native transport.
+   */
+  public static final TcpOption<Integer> FASTOPEN = new TcpOption<>(Integer.class, 0);
+
+  final Class<T> type;
+  final T defaultValue;
+
+  private TcpOption(Class<T> type, T defaultValue) {
+    this.type = type;
+    this.defaultValue = defaultValue;
+  }
+
+  protected void validate(T value) {
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/spi/transport/Transport.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/transport/Transport.java
@@ -19,6 +19,7 @@ import io.netty.channel.socket.InternetProtocolFamily;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.impl.transports.NioTransport;
 import io.vertx.core.net.TcpConfig;
+import io.vertx.core.net.TcpOption;
 import io.vertx.core.net.impl.SocketAddressImpl;
 
 import java.net.*;
@@ -142,23 +143,23 @@ public interface Transport {
     }
   }
 
-  default void configure(TcpConfig options, boolean domainSocket, Bootstrap bootstrap) {
+  default void configure(TcpConfig config, boolean domainSocket, Bootstrap bootstrap) {
     if (!domainSocket) {
-      bootstrap.option(ChannelOption.TCP_NODELAY, options.isTcpNoDelay());
-      bootstrap.option(ChannelOption.SO_KEEPALIVE, options.isTcpKeepAlive());
+      NioTransport.configOption(bootstrap, config, TcpOption.NODELAY, ChannelOption.TCP_NODELAY);
+      bootstrap.option(ChannelOption.SO_KEEPALIVE, config.isSoKeepAlive());
     }
-    if (options.getSoLinger() != -1) {
-      bootstrap.option(ChannelOption.SO_LINGER, options.getSoLinger());
+    if (config.getSoLinger() != -1) {
+      bootstrap.option(ChannelOption.SO_LINGER, config.getSoLinger());
     }
   }
 
-  default void configure(TcpConfig options, boolean domainSocket, ServerBootstrap bootstrap) {
+  default void configure(TcpConfig config, boolean domainSocket, ServerBootstrap bootstrap) {
     if (!domainSocket) {
-      bootstrap.childOption(ChannelOption.TCP_NODELAY, options.isTcpNoDelay());
-      bootstrap.childOption(ChannelOption.SO_KEEPALIVE, options.isTcpKeepAlive());
+      NioTransport.configChildOption(bootstrap, config, TcpOption.NODELAY, ChannelOption.TCP_NODELAY);
+      bootstrap.childOption(ChannelOption.SO_KEEPALIVE, config.isSoKeepAlive());
     }
-    if (options.getSoLinger() != -1) {
-      bootstrap.childOption(ChannelOption.SO_LINGER, options.getSoLinger());
+    if (config.getSoLinger() != -1) {
+      bootstrap.childOption(ChannelOption.SO_LINGER, config.getSoLinger());
     }
   }
 }


### PR DESCRIPTION
Motivation:

TcpConfig holds the same specialized TCP option than `TCPSSLOptions`.

Some of them are OS specific.

Changes:

Make the TCP option a generic `TcpOption` constant like class.
