### PR TITLE
fix unnecessary inclusion of -1 port in requestURI

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -331,7 +331,7 @@ public final class HttpUtils {
     HostAndPort authority = req.authority();
     if (authority != null) {
       StringBuilder sb = new StringBuilder(req.scheme()).append("://").append(authority.host());
-      if (authority.port() > 0 && (ssl && authority.port() != 443) || (!ssl && authority.port() != 80)) {
+      if (authority.port() > 0 && ((ssl && authority.port() != 443) || (!ssl && authority.port() != 80))) {
         sb.append(':').append(authority.port());
       }
       sb.append(uri);

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -6040,4 +6040,21 @@ public class Http1xTest extends HttpTest {
       netClient.close();
     }
   }
+
+  // Host with no port (common when a proxy forwards hostname-only Host header)
+  @Test
+  public void testAbsoluteURINoPortInHostHeader() throws Exception {
+    server.requestHandler(req -> req.response().end(req.absoluteURI()));
+    startServer(testAddress);
+    Buffer body = client.request(new RequestOptions(requestOptions).setURI("/path"))
+      .compose(req -> {
+        req.putHeader("Host", "example.com");
+        return req.send()
+          .expecting(HttpResponseExpectation.SC_OK)
+          .compose(HttpClientResponse::body);
+      })
+      .await();
+    Assert.assertEquals("absoluteURI() should not synthesize ':-1'", "http://example.com/path", body.toString());
+  }
+
 }


### PR DESCRIPTION
Motivation:

fixes #6092

Changes operator precedence in `HttpUtils.absoluteURI` that had caused ':-1' to be added for the port when an HTTP server request includes a `Host` header with a plain hostname. The presence of a -1 port in the string returned from `HttpServerRequest.requestURI()` causes a stack-unwinding `URISyntaxException` to be internally thrown and handled within `URI.create(String)`