### PR TITLE
Fix DNS resolver cache selection

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
@@ -97,7 +97,7 @@ public class DnsClientImpl implements DnsClient {
         builder.queryTimeoutMillis(options.getQueryTimeout());
         builder.recursionDesired(options.isRecursionDesired());
         resolver = builder.eventLoop(el).build();
-        ipv4Resolvers.put(el, resolver);
+        resolversToUse.put(el, resolver);
       }
     }
     return resolver;

--- a/vertx-core/src/test/java/io/vertx/tests/dns/DNSTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/dns/DNSTest.java
@@ -12,6 +12,7 @@
 package io.vertx.tests.dns;
 
 import io.netty.handler.codec.dns.DnsMessage;
+import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.resolver.dns.DnsNameResolverTimeoutException;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
@@ -28,6 +29,7 @@ import org.junit.Test;
 
 import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
@@ -354,6 +356,27 @@ public class DNSTest extends VertxTestBase {
         testComplete();
       }));
     await();
+  }
+
+  @Test
+  public void testLookup6ThenLookup4() throws Exception {
+    final String ipv4 = "10.0.0.1";
+    mockDnsServer.store(questionRecord -> {
+      if (questionRecord.type() == DnsRecordType.AAAA) {
+        return List.of(MockDnsServer.aaaa("vertx.io", 100, "::1"));
+      }
+      if (questionRecord.type() == DnsRecordType.A) {
+        return List.of(MockDnsServer.a("vertx.io", 100, ipv4));
+      }
+      return List.of();
+    });
+    DnsClient dns = prepareDns();
+
+    String ipv6Result = dns.lookup6("vertx.io").await();
+    Assert.assertEquals("0:0:0:0:0:0:0:1", ipv6Result);
+
+    String ipv4Result = dns.lookup4("vertx.io").await();
+    Assert.assertEquals(ipv4, ipv4Result);
   }
 
   @Test


### PR DESCRIPTION
Motivation:

#6098

`DnsClientImpl` uses separate resolver caches for the default resolver, IPv4-only lookups, and IPv6-only lookups.

Newly created resolvers were always stored in the IPv4 resolver cache. This meant that after `lookup6()` ran on an event loop, a later `lookup4()` on the same event loop could reuse an IPv6-only resolver.

The fix stores each resolver in the cache selected for that lookup. It also adds a regression test for `lookup6()` followed by `lookup4()`.

Conformance:

Confirmed.