### PR TITLE
Define a bounded capacity for the internal SNI to SslContext cache.

### DIFF
--- a/src/main/java/io/vertx/core/impl/utils/LruCache.java
+++ b/src/main/java/io/vertx/core/impl/utils/LruCache.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl.utils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Simple LRU cache based, this class is not thread safe.
+ */
+public class LruCache<K, V> extends LinkedHashMap<K, V> {
+
+  private final int maxSize;
+
+  public LruCache(int maxSize) {
+    super(8, 0.75f, true);
+    if (maxSize < 1) {
+      throw new IllegalArgumentException("Max size must be > 0");
+    }
+    this.maxSize = maxSize;
+  }
+
+  @Override
+  protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+    return size() > maxSize;
+  }
+}

--- a/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
@@ -18,6 +18,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AsyncMapping;
 import io.netty.util.concurrent.ImmediateExecutor;
 import io.vertx.core.VertxException;
+import io.vertx.core.impl.utils.LruCache;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 
@@ -27,6 +28,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+
+import static io.vertx.core.net.impl.SslContextProvider.DEFAULT_SNI_CACHE_SIZE;
 
 /**
  * Provider for {@link SslHandler} and {@link SniHandler}.
@@ -45,7 +48,7 @@ public class SslChannelProvider {
   private final SslContextProvider sslContextProvider;
   private final SslContext[] sslContexts = new SslContext[2];
   private final Map<String, SslContext>[] sslContextMaps = new Map[]{
-    new ConcurrentHashMap<>(), new ConcurrentHashMap<>()
+    new LruCache<>(DEFAULT_SNI_CACHE_SIZE), new LruCache<>(DEFAULT_SNI_CACHE_SIZE)
   };
 
   public SslChannelProvider(SslContextProvider sslContextProvider,
@@ -67,7 +70,14 @@ public class SslChannelProvider {
   }
 
   public int sniEntrySize() {
-    return sslContextMaps[0].size() + sslContextMaps[1].size();
+    int size;
+    synchronized (sslContextMaps[0]) {
+      size = sslContextMaps[0].size();
+    }
+    synchronized (sslContextMaps[1]) {
+      size += sslContextMaps[1].size();
+    }
+    return size;
   }
 
   public SslContextProvider sslContextProvider() {
@@ -92,7 +102,9 @@ public class SslChannelProvider {
       KeyManagerFactory kmf = sslContextProvider.resolveKeyManagerFactory(serverName);
       TrustManager[] trustManagers = trustAll ? null : sslContextProvider.resolveTrustManagers(serverName);
       if (kmf != null || trustManagers != null || !server) {
-        return sslContextMaps[idx].computeIfAbsent(serverName, s -> sslContextProvider.createContext(server, kmf, trustManagers, s, useAlpn, trustAll));
+        synchronized (sslContextMaps[idx]) {
+          return sslContextMaps[idx].computeIfAbsent(serverName, s -> sslContextProvider.createContext(server, kmf, trustManagers, s, useAlpn, trustAll));
+        }
       }
     }
     if (sslContexts[idx] == null) {

--- a/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
@@ -30,6 +30,8 @@ import java.util.function.Supplier;
  */
 public class SslContextProvider {
 
+  public static final int DEFAULT_SNI_CACHE_SIZE = 16;
+
   private final boolean jdkSSLProvider;
   private final Supplier<SslContextFactory> provider;
   private final Set<String> enabledProtocols;

--- a/src/test/java/io/vertx/core/impl/utils/LruCacheTest.java
+++ b/src/test/java/io/vertx/core/impl/utils/LruCacheTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LruCacheTest {
+
+  @Test
+  public void testExpiration() {
+    LruCache<String, String> cache = new LruCache<>(3);
+    cache.put("0", "0");
+    cache.put("1", "1");
+    cache.put("2", "2");
+    assertTrue(cache.containsKey("0"));
+    assertTrue(cache.containsKey("1"));
+    assertTrue(cache.containsKey("2"));
+    assertNotNull(cache.get("0"));
+    assertNotNull(cache.get("2"));
+    cache.put("3", "3");
+    assertTrue(cache.containsKey("0"));
+    assertFalse(cache.containsKey("1"));
+    assertTrue(cache.containsKey("2"));
+    assertTrue(cache.containsKey("3"));
+  }
+}

--- a/src/test/java/io/vertx/core/net/NetTest.java
+++ b/src/test/java/io/vertx/core/net/NetTest.java
@@ -1591,6 +1591,52 @@ public class NetTest extends VertxTestBase {
   }
 
   @Test
+  public void testEnabledSniCacheSize() throws Exception {
+    testSniCacheSize(true);
+  }
+
+  @Test
+  public void testDisabledSniCacheSize() throws Exception {
+    testSniCacheSize(false);
+  }
+
+  private void testSniCacheSize(boolean sni) throws Exception {
+    List<String> receivedServerNames = Collections.synchronizedList(new ArrayList<>());
+    server = vertx.createNetServer(new NetServerOptions()
+      .setSni(sni)
+      .setSsl(true)
+      .setKeyCertOptions(Cert.SNI_JKS.get())
+    ).connectHandler(so -> {
+      receivedServerNames.add(so.indicatedServerName());
+    });
+    startServer();
+    client = vertx.createNetClient(new NetClientOptions().setSsl(true).setHostnameVerificationAlgorithm("").setTrustAll(true));
+    int num = 100;
+    List<NetSocket> sockets = new ArrayList<>();
+    List<String> actualServerNames = new ArrayList<>();
+    for (int i = 0;i < num;i++) {
+      String serverName = i + ".host3.com";
+      NetSocket socket = client.connect(testAddress, serverName).toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+      sockets.add(socket);
+      actualServerNames.add(serverName);
+    }
+    for (NetSocket socket : sockets) {
+      socket.close();
+    }
+    assertWaitUntil(() -> num == receivedServerNames.size());
+    int size = ((NetServerImpl) server).sniEntrySize();
+    if (sni) {
+      assertEquals(actualServerNames, receivedServerNames);
+      assertEquals(SslContextProvider.DEFAULT_SNI_CACHE_SIZE, size);
+    } else {
+      for (String receivedServerName : receivedServerNames) {
+        assertNull(receivedServerName);
+      }
+      assertEquals(0, size);
+    }
+  }
+
+  @Test
   // SNI present an unknown server
   public void testSniWithUnknownServer1() throws Exception {
     TLSTest test = new TLSTest()


### PR DESCRIPTION
Motivation:

The SNI to `SslContext` cache does not define a max size, this cache can be filled by TLS client when server SNI is enabled.

Client can trigger to load multiple times the same `SslContext` for a given certificate with arbitrary SNI names when the server uses certificates with a wildcard CN.

Changes:

Introduce a max size based on LRU policy for the cache with a reasonnable default.
