### PR TITLE
Define a bounded capacity for the internal SNI to SslContext cache.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/utils/LruCache.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/utils/LruCache.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl.utils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Simple LRU cache based, this class is not thread safe.
+ */
+public class LruCache<K, V> extends LinkedHashMap<K, V> {
+
+  private final int maxSize;
+
+  public LruCache(int maxSize) {
+    super(8, 0.75f, true);
+    if (maxSize < 1) {
+      throw new UnsupportedOperationException();
+    }
+    this.maxSize = maxSize;
+  }
+
+  @Override
+  protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+    return size() > maxSize;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextManager.java
@@ -17,6 +17,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ClientAuth;
+import io.vertx.core.impl.utils.LruCache;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.net.*;
 import io.vertx.core.spi.tls.SslContextFactory;
@@ -40,6 +41,7 @@ public abstract class SslContextManager<P extends SslContextProvider> {
     return CLIENT_AUTH_MAPPING.get(auth);
   }
 
+  public static final int DEFAULT_SSL_CONTEXT_PROVIDER_CACHE_SIZE = 64;
   private static final Config NULL_CONFIG = new Config(null, null, null, null, null);
   private static final EnumMap<ClientAuth, io.netty.handler.ssl.ClientAuth> CLIENT_AUTH_MAPPING = new EnumMap<>(ClientAuth.class);
 
@@ -54,6 +56,10 @@ public abstract class SslContextManager<P extends SslContextProvider> {
   private final Map<ConfigKey, Future<Config>> configMap;
   private final Map<ConfigKey, Future<P>> sslContextProviderMap;
   private boolean closed;
+
+  public SslContextManager(SSLEngineOptions sslEngineOptions) {
+    this(sslEngineOptions, DEFAULT_SSL_CONTEXT_PROVIDER_CACHE_SIZE);
+  }
 
   public SslContextManager(SSLEngineOptions sslEngineOptions, int cacheMaxSize) {
     this.configMap = new LruCache<>(cacheMaxSize);
@@ -113,10 +119,6 @@ public abstract class SslContextManager<P extends SslContextProvider> {
       }
     }
     return size;
-  }
-
-  public SslContextManager(SSLEngineOptions sslEngineOptions) {
-    this(sslEngineOptions, 256);
   }
 
   Future<P> resolveSslContextProvider(SSLOptions options,
@@ -222,23 +224,6 @@ public abstract class SslContextManager<P extends SslContextProvider> {
     // Clear map which might references transitively QuicheQuicSslContext that overrides finalize that releases
     // the native ssl context
     sslContextProviderMap.clear();
-  }
-
-  private static class LruCache<K, V> extends LinkedHashMap<K, V> {
-
-    private final int maxSize;
-
-    public LruCache(int maxSize) {
-      if (maxSize < 1) {
-        throw new UnsupportedOperationException();
-      }
-      this.maxSize = maxSize;
-    }
-
-    @Override
-    protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
-      return size() > maxSize;
-    }
   }
 
   private final static class ConfigKey {

--- a/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextProvider.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextProvider.java
@@ -11,6 +11,7 @@
 package io.vertx.core.internal.tls;
 
 import io.netty.handler.ssl.SslContext;
+import io.vertx.core.impl.utils.LruCache;
 import io.vertx.core.spi.tls.SslContextFactory;
 
 import javax.net.ssl.*;
@@ -29,6 +30,7 @@ import java.util.function.Supplier;
  */
 public abstract class SslContextProvider {
 
+  public static final int DEFAULT_SNI_CACHE_SIZE = 16;
   private static final List<String> VALID_PROTOCOLS = List.of("TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1", "SSLv3", "SSLv2Hello", "DTLSv1.2", "DTLSv1.0");
 
   private final boolean useWorkerPool;
@@ -42,7 +44,7 @@ public abstract class SslContextProvider {
   protected final Set<String> enabledCipherSuites;
 
   private final Map<String, SslContext> sslContexts = new ConcurrentHashMap<>();
-  private final Map<String, SslContext> sslContextMaps = new ConcurrentHashMap<>();
+  private final Map<String, SslContext> sslContextMaps = new LruCache<>(DEFAULT_SNI_CACHE_SIZE);
 
   public SslContextProvider(boolean useWorkerPool,
                             Set<String> enabledCipherSuites,
@@ -74,7 +76,9 @@ public abstract class SslContextProvider {
   }
 
   public int sniEntrySize() {
-    return sslContextMaps.size();
+    synchronized (sslContextMaps) {
+      return sslContextMaps.size();
+    }
   }
 
   protected abstract SslContext createContext(KeyManagerFactory keyManagerFactory,  TrustManager[] trustManagers, String serverName, List<String> applicationProtocols);
@@ -84,9 +88,11 @@ public abstract class SslContextProvider {
       KeyManagerFactory kmf = resolveKeyManagerFactory(serverName);
       TrustManager[] trustManagers = resolveTrustManagers(serverName);
       if (kmf != null || trustManagers != null || !server) {
-        return sslContextMaps.computeIfAbsent(serverName, s -> {
-          return createContext(kmf, trustManagers, s, applicationProtocols);
-        });
+        synchronized (sslContextMaps) {
+          return sslContextMaps.computeIfAbsent(serverName, s -> {
+            return createContext(kmf, trustManagers, s, applicationProtocols);
+          });
+        }
       }
     }
     String alpnKey;

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -35,6 +35,7 @@ import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.internal.net.NetClientInternal;
 import io.vertx.core.internal.net.NetSocketInternal;
+import io.vertx.core.internal.tls.SslContextProvider;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
@@ -42,14 +43,13 @@ import io.vertx.core.net.impl.HAProxyMessageCompletionHandler;
 import io.vertx.core.net.impl.VertxHandler;
 import io.vertx.core.net.impl.tcp.CleanableNetClient;
 import io.vertx.core.internal.net.NetServerInternal;
-import io.vertx.core.net.impl.tcp.NetSocketImpl;
+import io.vertx.core.net.impl.tcp.NetServerImpl;
 import io.vertx.core.spi.tls.SslContextFactory;
 import io.vertx.core.transport.Transport;
 import io.vertx.test.core.*;
 import io.vertx.test.proxy.*;
 import io.vertx.test.tls.Cert;
 import io.vertx.test.tls.Trust;
-import org.assertj.core.api.Assertions;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -1543,6 +1543,52 @@ public class NetTest {
     assertEquals(2, ((NetServerInternal)server).sniEntrySize());
     assertWaitUntil(() -> receivedServerNames.size() == 3);
     assertEquals(receivedServerNames, serverNames);
+  }
+
+  @Test
+  public void testEnabledSniCacheSize() throws Exception {
+    testSniCacheSize(true);
+  }
+
+  @Test
+  public void testDisabledSniCacheSize() throws Exception {
+    testSniCacheSize(false);
+  }
+
+  private void testSniCacheSize(boolean sni) throws Exception {
+    List<String> receivedServerNames = Collections.synchronizedList(new ArrayList<>());
+    server = vertx.createNetServer(new NetServerOptions()
+      .setSni(sni)
+      .setSsl(true)
+      .setKeyCertOptions(Cert.SNI_JKS.get())
+    ).connectHandler(so -> {
+      receivedServerNames.add(so.indicatedServerName());
+    });
+    startServer();
+    client = vertx.createNetClient(new NetClientOptions().setSsl(true).setHostnameVerificationAlgorithm("").setTrustAll(true));
+    int num = 100;
+    List<NetSocket> sockets = new ArrayList<>();
+    List<String> actualServerNames = new ArrayList<>();
+    for (int i = 0;i < num;i++) {
+      String serverName = i + ".host3.com";
+      NetSocket socket = client.connect(testAddress, serverName).await();
+      sockets.add(socket);
+      actualServerNames.add(serverName);
+    }
+    for (NetSocket socket : sockets) {
+      socket.close().await();
+    }
+    assertWaitUntil(() -> num == receivedServerNames.size());
+    int size = ((NetServerImpl) server).sniEntrySize();
+    if (sni) {
+      assertEquals(actualServerNames, receivedServerNames);
+      assertEquals(SslContextProvider.DEFAULT_SNI_CACHE_SIZE, size);
+    } else {
+      for (String receivedServerName : receivedServerNames) {
+        Assert.assertNull(receivedServerName);
+      }
+      assertEquals(0, size);
+    }
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/utils/LruCacheTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/utils/LruCacheTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.utils;
+
+import io.vertx.core.impl.utils.LruCache;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LruCacheTest {
+
+  @Test
+  public void testExpiration() {
+    LruCache<String, String> cache = new LruCache<>(3);
+    cache.put("0", "0");
+    cache.put("1", "1");
+    cache.put("2", "2");
+    assertTrue(cache.containsKey("0"));
+    assertTrue(cache.containsKey("1"));
+    assertTrue(cache.containsKey("2"));
+    assertNotNull(cache.get("0"));
+    assertNotNull(cache.get("2"));
+    cache.put("3", "3");
+    assertTrue(cache.containsKey("0"));
+    assertFalse(cache.containsKey("1"));
+    assertTrue(cache.containsKey("2"));
+    assertTrue(cache.containsKey("3"));
+  }
+}


### PR DESCRIPTION
Motivation:

The SNI to `SslContext` cache does not define a max size, this cache can be filled by TLS client when server SNI is enabled.

Client can trigger to load multiple times the same SslContext for a given certificate with arbitrary SNI names when the server uses certificates with a wildcard CN.

Changes:

Introduce a max size based on LRU policy for the cache with a reasonnable default.
