### PR TITLE
Keep WebSocket client reachable during connect

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableWebSocketClient.java
@@ -19,6 +19,7 @@ import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 
 import java.lang.ref.Cleaner;
+import java.lang.ref.Reference;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -60,8 +61,12 @@ public class CleanableWebSocketClient implements WebSocketClient, MetricsProvide
     return delegate.webSocket();
   }
 
+  @Override
   public Future<WebSocket> connect(WebSocketConnectOptions options) {
-    return delegate.connect(options);
+    Future<WebSocket> fut = delegate.connect(options);
+    // Keep this cleanable wrapper reachable until the connect attempt completes.
+    fut.onComplete(ar -> Reference.reachabilityFence(CleanableWebSocketClient.this));
+    return fut;
   }
 
   @Override


### PR DESCRIPTION
Motivation:

Addresses #5839 for direct `WebSocketClient.connect(...)`.

When `WebSocketClient.connect(options)` is used directly, the returned future can
outlive the caller's reference to the client. Since `CleanableWebSocketClient`
runs cleanup once it becomes unreachable, GC can close the underlying client
before the connect future completes.

Keep the cleanable client reachable until the connect attempt completes.


Conformance:

I have signed the Eclipse Contributor Agreement.
