### PR TITLE
Fix HybridJacksonPool stack node publication race

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/json/jackson/HybridJacksonPool.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/jackson/HybridJacksonPool.java
@@ -141,8 +141,8 @@ public class HybridJacksonPool implements RecyclerPool<BufferRecycler> {
       Node next = topStacks.get(vThreadBufferRecycler.slot);
       while (true) {
         newHead.level = next == null ? 1 : next.level + 1;
+        newHead.next = next;
         if (topStacks.compareAndSet(vThreadBufferRecycler.slot, next, newHead)) {
-          newHead.next = next;
           return;
         } else {
           next = topStacks.get(vThreadBufferRecycler.slot);

--- a/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/HybridJacksonPool.java
+++ b/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/HybridJacksonPool.java
@@ -136,8 +136,8 @@ public class HybridJacksonPool implements RecyclerPool<BufferRecycler> {
       Node next = topStacks.get(vThreadBufferRecycler.slot);
       while (true) {
         newHead.level = next == null ? 1 : next.level + 1;
+        newHead.next = next;
         if (topStacks.compareAndSet(vThreadBufferRecycler.slot, next, newHead)) {
-          newHead.next = next;
           return;
         } else {
           next = topStacks.get(vThreadBufferRecycler.slot);


### PR DESCRIPTION
Motivation:

Fixes a race in `HybridJacksonPool.StripedLockFreePool#releasePooled`. #6111 

The virtual-thread pool was publishing a newly created stack node with CAS before assigning its `next` pointer. A concurrent acquire could observe and pop that partially initialized node, see `next == null`, and drop the rest of the stack.
This change initializes `newHead.next` before the CAS, so the node is fully linked before it becomes visible to other threads.

Conformance:

I have signed the Eclipse Contributor Agreemen