### PR TITLE
Support for HSM-based Keystores and Truststores

### DIFF
--- a/vertx-core/src/main/asciidoc/client_ssl.adoc
+++ b/vertx-core/src/main/asciidoc/client_ssl.adoc
@@ -113,3 +113,10 @@ Buffer configuration is also supported:
 ----
 
 Keep in mind that pem configuration, the private key is not crypted.
+
+Lastly server private key and certificate can also be provided using PKCS#11 (https://en.wikipedia.org/wiki/PKCS_11) so that they can be stored on an HSM. This works for a single SNI. 
+
+[source,$lang]
+----
+{@link examples.SslExamples#examplePkcs11}
+----

--- a/vertx-core/src/main/java/examples/SslExamples.java
+++ b/vertx-core/src/main/java/examples/SslExamples.java
@@ -330,4 +330,15 @@ public class SslExamples {
       .with(new OpenSSLEngineOptions())
       .build();
   }
+  public void examplePkcs11(Vertx vertx) {
+    ServerSSLOptions options = new ServerSSLOptions()
+            .setKeyCertOptions(
+                    new KeyStoreOptions().
+                            setType("PKCS11").
+                            setPath("NONE").
+                            setAlias("myAlias").
+                            setProvider("SunPKCS11-hsm").
+                            setPassword("password-of-your-keystore")
+            );
+  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/KeyStoreOptionsBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/KeyStoreOptionsBase.java
@@ -55,6 +55,7 @@ public abstract class KeyStoreOptionsBase implements KeyCertOptions, TrustOption
    */
   protected KeyStoreOptionsBase(KeyStoreOptionsBase other) {
     super();
+    this.provider = other.provider;
     this.type = other.type;
     this.password = other.password;
     this.path = other.path;

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
@@ -112,6 +112,10 @@ public class KeyStoreHelper {
             // It's a private key
             continue;
           }
+          if (key.getFormat() == null) {
+            // Hardware security module key, not extractable
+            continue;
+          }
           X509KeyManager mgr = new X509KeyManager() {
             @Override
             public String[] getClientAliases(String s, Principal[] principals) {
@@ -254,10 +258,14 @@ public class KeyStoreHelper {
       if (!ks.containsAlias(alias)) {
         throw new IllegalArgumentException("alias does not exist in the keystore: " + alias);
       }
-      List<String> ksAliases = Collections.list(ks.aliases());
-      for (String ksAlias : ksAliases) {
-        if (!alias.equals(ksAlias)) {
-          ks.deleteEntry(ksAlias);
+      // HSM keys are not extractable to memory. Deleting an entry from the HSM-KeyStore removes the actual entry from the store
+      // This PKCS11 check prevents it
+      if (!type.equalsIgnoreCase("PKCS11")) {
+        List<String> ksAliases = Collections.list(ks.aliases());
+        for (String ksAlias : ksAliases) {
+          if (!alias.equals(ksAlias)) {
+            ks.deleteEntry(ksAlias);
+          }
         }
       }
     }

--- a/vertx-core/src/test/java/io/vertx/tests/security/KeyStoreTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/security/KeyStoreTest.java
@@ -460,6 +460,26 @@ public class KeyStoreTest extends VertxTestBase {
     TrustManager[] keyManagers = helper.getTrustMgrs((VertxInternal) vertx);
     assertTrue(keyManagers.length > 0);
   }
+  @Test
+  public void testCopyKeyStoreOptions() {
+    KeyStoreOptions options = new KeyStoreOptions();
+    options.setPassword("secret");
+    options.setPath("/path/to/keystore.p12");
+    options.setValue(Buffer.buffer("dummy"));
+    options.setType("PKCS11");
+    options.setProvider("SunPKCS11-hsm");
+    options.setAlias("server-key");
+    options.setAliasPassword("key-secret");
+    KeyStoreOptions copy = new KeyStoreOptions(options);
+    assertEquals("secret", copy.getPassword());
+    assertEquals("/path/to/keystore.p12", copy.getPath());
+    assertEquals(Buffer.buffer("dummy"), copy.getValue());
+    assertEquals("PKCS11", copy.getType());
+    assertEquals("SunPKCS11-hsm", copy.getProvider());
+    assertEquals("server-key", copy.getAlias());
+    assertEquals("key-secret", copy.getAliasPassword());
+  }
+
 
   /*
   @Test


### PR DESCRIPTION
Related PRs: 
[54221](https://github.com/quarkusio/quarkus/pull/54221)
[54326](https://github.com/quarkusio/quarkus/pull/54326)
[54147](https://github.com/quarkusio/quarkus/pull/54147)

Motivation: Hardware Security Modules offer various benefits (unextractable Keys, protection from side-channel-attack) for asymmetric cryptography. This PR aims to make it possible for Quarkus to use HSMs for TLS and mTLS. 

Caveats: 
- for now one HSM can't be used for multiple SNIs
- this needs to be backported to 4.x since Quarkus relies on vert.x 4.x 


Conformance:
I have signed the Eclipse Contributor Agreement. 

CC: @sberyozkin