### PR TITLE
HTTP server query parameter configuration.

### DIFF
--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -415,7 +415,12 @@ once the entire body has been read:
 
 Form attributes have a maximum size of `8192` bytes. When the client submits a form with an attribute
 size greater than this value, the file upload triggers an exception on `HttpServerRequest` exception handler. You
-can set a different maximum size with {@link io.vertx.core.http.HttpServerConfig#setMaxFormAttributeSize}.
+can set a different maximum size with {@link io.vertx.core.http.FormDecoderConfig#setMaxAttributeSize}.
+
+[source,$lang]
+----
+{@link examples.HttpExamples#configurationOfFormMaxAttributeSize}
+----
 
 ==== Handling form file uploads
 

--- a/vertx-core/src/main/java/examples/HttpExamples.java
+++ b/vertx-core/src/main/java/examples/HttpExamples.java
@@ -12,43 +12,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.AsyncFile;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.OpenOptions;
-import io.vertx.core.http.ClientForm;
-import io.vertx.core.http.ClientMultipartForm;
-import io.vertx.core.http.CompressionConfig;
-import io.vertx.core.http.Cookie;
-import io.vertx.core.http.Http1ClientConfig;
-import io.vertx.core.http.Http1ServerConfig;
-import io.vertx.core.http.Http2ClientConfig;
-import io.vertx.core.http.Http2ServerConfig;
-import io.vertx.core.http.Http2Settings;
-import io.vertx.core.http.Http3ClientConfig;
-import io.vertx.core.http.Http3Settings;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientAgent;
-import io.vertx.core.http.HttpClientConfig;
-import io.vertx.core.http.HttpClientConnection;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpConnectOptions;
-import io.vertx.core.http.HttpConnection;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpResponseExpectation;
-import io.vertx.core.http.HttpResponseHead;
-import io.vertx.core.http.HttpServer;
-import io.vertx.core.http.HttpServerConfig;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.http.HttpSettings;
-import io.vertx.core.http.HttpVersion;
-import io.vertx.core.http.PoolOptions;
-import io.vertx.core.http.RequestOptions;
-import io.vertx.core.http.ServerWebSocket;
-import io.vertx.core.http.StreamResetException;
-import io.vertx.core.http.WebSocket;
-import io.vertx.core.http.WebSocketClient;
-import io.vertx.core.http.WebSocketConnectOptions;
-import io.vertx.core.http.WebSocketFrame;
+import io.vertx.core.http.*;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.JksOptions;
@@ -82,7 +46,8 @@ public class HttpExamples {
   public void configurationOfAnHttpServer(Vertx vertx) {
     HttpServerConfig config = new HttpServerConfig()
       .setVersions(HttpVersion.HTTP_1_1)
-      .setMaxFormFields(512)
+      .setFormDecoderConfig(new FormDecoderConfig()
+        .setMaxFields(512))
       .setHttp1Config(new Http1ServerConfig()
         .setMaxInitialLineLength(1024))
       .setCompressionConfig(new CompressionConfig()
@@ -275,6 +240,12 @@ public class HttpExamples {
         MultiMap formAttributes = request.formAttributes();
       });
     });
+  }
+
+  public void configurationOfFormMaxAttributeSize(int maxAttrSize) {
+    HttpServerConfig config = new HttpServerConfig()
+      .setFormDecoderConfig(
+        new FormDecoderConfig().setMaxAttributeSize(maxAttrSize));
   }
 
   public void serverRequestHandleMultipartUpload(HttpServer server) {

--- a/vertx-core/src/main/java/io/vertx/core/http/FormDecoderConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/FormDecoderConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.DataObject;
+
+/**
+ * Form decoder configuration.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@DataObject
+public class FormDecoderConfig {
+
+  private int maxAttributeSize;
+  private int maxFields;
+  private int maxBufferedBytes;
+
+  public FormDecoderConfig() {
+    this.maxAttributeSize = HttpServerOptions.DEFAULT_MAX_FORM_ATTRIBUTE_SIZE;
+    this.maxFields = HttpServerOptions.DEFAULT_MAX_FORM_FIELDS;
+    this.maxBufferedBytes = HttpServerOptions.DEFAULT_MAX_FORM_BUFFERED_SIZE;
+  }
+
+  public FormDecoderConfig(FormDecoderConfig other) {
+    this.maxAttributeSize = other.maxAttributeSize;
+    this.maxFields = other.maxFields;
+    this.maxBufferedBytes = other.maxBufferedBytes;
+  }
+
+  /**
+   * @return Returns the maximum size of a form attribute
+   */
+  public int getMaxAttributeSize() {
+    return maxAttributeSize;
+  }
+
+  /**
+   * Set the maximum size of a form attribute. Set to {@code -1} to allow unlimited length
+   *
+   * @param maxSize the new maximum size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public FormDecoderConfig setMaxAttributeSize(int maxSize) {
+    this.maxAttributeSize = maxSize;
+    return this;
+  }
+
+  /**
+   * @return Returns the maximum number of form fields
+   */
+  public int getMaxFields() {
+    return maxFields;
+  }
+
+  /**
+   * Set the maximum number of fields of a form. Set to {@code -1} to allow unlimited number of attributes
+   *
+   * @param maxFields the new maximum
+   * @return a reference to this, so the API can be used fluently
+   */
+  public FormDecoderConfig setMaxFields(int maxFields) {
+    this.maxFields = maxFields;
+    return this;
+  }
+
+  /**
+   * @return Returns the maximum number of bytes a server can buffer when decoding a form
+   */
+  public int getMaxBufferedBytes() {
+    return maxBufferedBytes;
+  }
+
+  /**
+   * Set the maximum number of bytes a server can buffer when decoding a form. Set to {@code -1} to allow unlimited length
+   *
+   * @param maxBufferedBytes the new maximum
+   * @return a reference to this, so the API can be used fluently
+   */
+  public FormDecoderConfig setMaxBufferedBytes(int maxBufferedBytes) {
+    this.maxBufferedBytes = maxBufferedBytes;
+    return this;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerConfig.java
@@ -63,6 +63,7 @@ public class HttpServerConfig {
   private int maxFormAttributeSize;
   private int maxFormFields;
   private int maxFormBufferedBytes;
+  private QueryParamDecoderConfig queryParamDecoderConfig;
   private boolean handle100ContinueAutomatically;
   private boolean strictThreadMode;
   private ObservabilityConfig observabilityConfig;
@@ -141,6 +142,7 @@ public class HttpServerConfig {
     this.maxFormAttributeSize = HttpServerOptions.DEFAULT_MAX_FORM_ATTRIBUTE_SIZE;
     this.maxFormFields = HttpServerOptions.DEFAULT_MAX_FORM_FIELDS;
     this.maxFormBufferedBytes = HttpServerOptions.DEFAULT_MAX_FORM_BUFFERED_SIZE;
+    this.queryParamDecoderConfig = null;
     this.handle100ContinueAutomatically = HttpServerOptions.DEFAULT_HANDLE_100_CONTINE_AUTOMATICALLY;
     this.strictThreadMode = HttpServerOptions.DEFAULT_STRICT_THREAD_MODE_STRICT;
     this.observabilityConfig = null;
@@ -163,6 +165,7 @@ public class HttpServerConfig {
     this.maxFormAttributeSize = other.maxFormAttributeSize;
     this.maxFormFields = other.maxFormFields;
     this.maxFormBufferedBytes = other.maxFormBufferedBytes;
+    this.queryParamDecoderConfig = other.queryParamDecoderConfig != null ? new QueryParamDecoderConfig(other.queryParamDecoderConfig) : null;
     this.handle100ContinueAutomatically = other.handle100ContinueAutomatically;
     this.strictThreadMode = other.strictThreadMode;
     this.observabilityConfig = other.observabilityConfig != null ? new ObservabilityConfig(other.observabilityConfig) : null;
@@ -411,6 +414,33 @@ public class HttpServerConfig {
    */
   public HttpServerConfig setMaxFormBufferedBytes(int maxFormBufferedBytes) {
     this.maxFormBufferedBytes = maxFormBufferedBytes;
+    return this;
+  }
+
+  /**
+   * @return the configuration for parsing HTTP request query parameters, when the configuration is {@code null}, the default configuration
+   * is used:
+   *
+   * <ul>
+   *   <li>{@link QueryParamDecoderConfig#DEFAULT_MAX_SIZE}</li>
+   *   <li>{@link QueryParamDecoderConfig#DEFAULT_CHARSET}</li>
+   *   <li>{@link QueryParamDecoderConfig#DEFAULT_USE_SEMICOLON_AS_DELIMITER}</li>
+   * </ul>
+   *
+   * @see HttpServerRequest#params()
+   */
+  public QueryParamDecoderConfig getQueryParamConfig() {
+    return queryParamDecoderConfig;
+  }
+
+  /**
+   * Set the configuration for parsing HTTP request query parameters.
+   *
+   * @param queryParamDecoderConfig the configuration
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerConfig setQueryParamConfig(QueryParamDecoderConfig queryParamDecoderConfig) {
+    this.queryParamDecoderConfig = queryParamDecoderConfig;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerConfig.java
@@ -60,9 +60,7 @@ public class HttpServerConfig {
   }
 
   private Set<HttpVersion> versions;
-  private int maxFormAttributeSize;
-  private int maxFormFields;
-  private int maxFormBufferedBytes;
+  private FormDecoderConfig formDecoderConfig;
   private QueryParamDecoderConfig queryParamDecoderConfig;
   private boolean handle100ContinueAutomatically;
   private boolean strictThreadMode;
@@ -119,10 +117,14 @@ public class HttpServerConfig {
         .setTracingPolicy(options.getTracingPolicy());
     }
 
+    FormDecoderConfig formDecoderConfig = new FormDecoderConfig()
+      .setMaxAttributeSize(options.getMaxFormAttributeSize())
+      .setMaxFields(options.getMaxFormFields())
+      .setMaxFields(options.getMaxFormFields())
+      .setMaxBufferedBytes(options.getMaxFormBufferedBytes());
+
     this.versions = versions;
-    this.maxFormAttributeSize = options.getMaxFormAttributeSize();
-    this.maxFormFields = options.getMaxFormFields();
-    this.maxFormBufferedBytes = options.getMaxFormBufferedBytes();
+    this.formDecoderConfig = formDecoderConfig;
     this.handle100ContinueAutomatically = options.isHandle100ContinueAutomatically();
     this.strictThreadMode = options.getStrictThreadMode();
     this.observabilityConfig = observabilityConfig;
@@ -139,9 +141,7 @@ public class HttpServerConfig {
    */
   public HttpServerConfig() {
     this.versions = EnumSet.of(HttpVersion.HTTP_1_1, HttpVersion.HTTP_2);
-    this.maxFormAttributeSize = HttpServerOptions.DEFAULT_MAX_FORM_ATTRIBUTE_SIZE;
-    this.maxFormFields = HttpServerOptions.DEFAULT_MAX_FORM_FIELDS;
-    this.maxFormBufferedBytes = HttpServerOptions.DEFAULT_MAX_FORM_BUFFERED_SIZE;
+    this.formDecoderConfig = null;
     this.queryParamDecoderConfig = null;
     this.handle100ContinueAutomatically = HttpServerOptions.DEFAULT_HANDLE_100_CONTINE_AUTOMATICALLY;
     this.strictThreadMode = HttpServerOptions.DEFAULT_STRICT_THREAD_MODE_STRICT;
@@ -162,9 +162,7 @@ public class HttpServerConfig {
    */
   public HttpServerConfig(HttpServerConfig other) {
     this.versions = EnumSet.copyOf(other.versions);
-    this.maxFormAttributeSize = other.maxFormAttributeSize;
-    this.maxFormFields = other.maxFormFields;
-    this.maxFormBufferedBytes = other.maxFormBufferedBytes;
+    this.formDecoderConfig = other.formDecoderConfig != null ? new FormDecoderConfig(other.formDecoderConfig) : null;
     this.queryParamDecoderConfig = other.queryParamDecoderConfig != null ? new QueryParamDecoderConfig(other.queryParamDecoderConfig) : null;
     this.handle100ContinueAutomatically = other.handle100ContinueAutomatically;
     this.strictThreadMode = other.strictThreadMode;
@@ -363,57 +361,12 @@ public class HttpServerConfig {
     return this;
   }
 
-  /**
-   * @return Returns the maximum size of a form attribute
-   */
-  public int getMaxFormAttributeSize() {
-    return maxFormAttributeSize;
+  public FormDecoderConfig getFormDecoderConfig() {
+    return formDecoderConfig;
   }
 
-  /**
-   * Set the maximum size of a form attribute. Set to {@code -1} to allow unlimited length
-   *
-   * @param maxSize the new maximum size
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpServerConfig setMaxFormAttributeSize(int maxSize) {
-    this.maxFormAttributeSize = maxSize;
-    return this;
-  }
-
-  /**
-   * @return Returns the maximum number of form fields
-   */
-  public int getMaxFormFields() {
-    return maxFormFields;
-  }
-
-  /**
-   * Set the maximum number of fields of a form. Set to {@code -1} to allow unlimited number of attributes
-   *
-   * @param maxFormFields the new maximum
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpServerConfig setMaxFormFields(int maxFormFields) {
-    this.maxFormFields = maxFormFields;
-    return this;
-  }
-
-  /**
-   * @return Returns the maximum number of bytes a server can buffer when decoding a form
-   */
-  public int getMaxFormBufferedBytes() {
-    return maxFormBufferedBytes;
-  }
-
-  /**
-   * Set the maximum number of bytes a server can buffer when decoding a form. Set to {@code -1} to allow unlimited length
-   *
-   * @param maxFormBufferedBytes the new maximum
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpServerConfig setMaxFormBufferedBytes(int maxFormBufferedBytes) {
-    this.maxFormBufferedBytes = maxFormBufferedBytes;
+  public HttpServerConfig setFormDecoderConfig(FormDecoderConfig formDecoderConfig) {
+    this.formDecoderConfig = formDecoderConfig;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/QueryParamDecoderConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/QueryParamDecoderConfig.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.DataObject;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * Query parameter decoder configuration.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@DataObject
+public class QueryParamDecoderConfig {
+
+  /**
+   * The default max number of query parameter to decode : {@code 1024}
+   */
+  public static final int DEFAULT_MAX_SIZE = 1024;
+
+  /**
+   * The default behavior of the semicolon as a delimiter : {@code true}
+   */
+  public static final boolean DEFAULT_USE_SEMICOLON_AS_DELIMITER = true;
+
+  /**
+   * The default charset for decoding query parameters : {@link StandardCharsets#UTF_8}
+   */
+  public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+  private int maxSize;
+  private boolean useSemicolonAsDelimiter;
+  private Charset charset;
+
+  public QueryParamDecoderConfig() {
+    this.maxSize = DEFAULT_MAX_SIZE;
+    this.useSemicolonAsDelimiter = DEFAULT_USE_SEMICOLON_AS_DELIMITER;
+    this.charset = DEFAULT_CHARSET;
+  }
+
+  public QueryParamDecoderConfig(QueryParamDecoderConfig other) {
+    this.maxSize = other.maxSize;
+    this.useSemicolonAsDelimiter = other.useSemicolonAsDelimiter;
+    this.charset = other.charset;
+  }
+
+  /**
+   * @return the maximum number of parameters to decode
+   */
+  public int getMaxSize() {
+    return maxSize;
+  }
+
+  /**
+   * Set the maximum number of parameters to decode.
+   *
+   * @param maxSize the max size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public QueryParamDecoderConfig setMaxSize(int maxSize) {
+    if (maxSize < 1) {
+      throw new IllegalArgumentException("maxSize must be > 0");
+    }
+    this.maxSize = maxSize;
+    return this;
+  }
+
+  /**
+   * @return whether to use the semicolon char {@code ;} as a delimiter for query string parameters.
+   */
+  public boolean isUseSemicolonAsDelimiter() {
+    return useSemicolonAsDelimiter;
+  }
+
+  /**
+   * Configure whether to use the semicolon char {@code ;} as a delimiter for query string parameters.
+   *
+   * @param useSemicolonAsDelimiter whether to allow semicolon to be used as a delimiter or it is a an actual parameter name or value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public QueryParamDecoderConfig setUseSemicolonAsDelimiter(boolean useSemicolonAsDelimiter) {
+    this.useSemicolonAsDelimiter = useSemicolonAsDelimiter;
+    return this;
+  }
+
+  /**
+   * @return the charset to decode query parameters
+   */
+  public Charset getCharset() {
+    return charset;
+  }
+
+  /**
+   * Set the charset to decode query parameters.
+   *
+   * @param charset the charset
+   * @return a reference to this, so the API can be used fluently
+   */
+  public QueryParamDecoderConfig setCharset(Charset charset) {
+    this.charset = Objects.requireNonNull(charset);
+    return this;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -29,12 +29,12 @@ import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.http.HttpServerRequestInternal;
+import io.vertx.core.internal.http.QueryParamDecoder;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Set;
 
@@ -61,9 +61,8 @@ public class HttpServerRequestImpl extends HttpServerRequestInternal {
   private MultiMap headersMap;
   private HostAndPort authority;
   private HostAndPort realAuthority;
-  private Charset paramsCharset = StandardCharsets.UTF_8;
+  private QueryParamDecoder queryParamDecoder;
   private MultiMap params;
-  private boolean semicolonIsNormalCharInParams;
   private String absoluteURI;
   private MultiMap attributes;
   private HttpEventHandler eventHandler;
@@ -79,6 +78,7 @@ public class HttpServerRequestImpl extends HttpServerRequestInternal {
                                int maxFormAttributeSize,
                                int maxFormFields,
                                int maxFormBufferedBytes,
+                               QueryParamDecoder queryParamDecoder,
                                String serverOrigin) {
     this.handler = handler;
     this.context = context;
@@ -90,6 +90,7 @@ public class HttpServerRequestImpl extends HttpServerRequestInternal {
     this.maxFormAttributeSize = maxFormAttributeSize;
     this.maxFormFields = maxFormFields;
     this.maxFormBufferedBytes = maxFormBufferedBytes;
+    this.queryParamDecoder = queryParamDecoder;
   }
 
   public void init() {
@@ -381,9 +382,12 @@ public class HttpServerRequestImpl extends HttpServerRequestInternal {
   @Override
   public HttpServerRequest setParamsCharset(String charset) {
     Objects.requireNonNull(charset, "Charset must not be null");
-    Charset current = paramsCharset;
-    paramsCharset = Charset.forName(charset);
-    if (!paramsCharset.equals(current)) {
+    Charset cs = Charset.forName(charset);
+    if (!queryParamDecoder.charset().equals(cs)) {
+      queryParamDecoder = new QueryParamDecoder(new QueryParamDecoderConfig()
+        .setMaxSize(queryParamDecoder.maxParams())
+        .setUseSemicolonAsDelimiter(queryParamDecoder.isAcceptSemiColonDelimiter())
+        .setCharset(cs));
       params = null;
     }
     return this;
@@ -391,17 +395,22 @@ public class HttpServerRequestImpl extends HttpServerRequestInternal {
 
   @Override
   public String getParamsCharset() {
-    return paramsCharset.name();
+    return queryParamDecoder.charset().name();
   }
   @Override
   public MultiMap params(boolean semicolonIsNormalChar) {
-    synchronized (connection) {
-      if (params == null || semicolonIsNormalChar != semicolonIsNormalCharInParams) {
-        params = HttpUtils.params(uri(), paramsCharset, semicolonIsNormalChar);
-        semicolonIsNormalCharInParams = semicolonIsNormalChar;
-      }
-      return params;
+    if (queryParamDecoder.isAcceptSemiColonDelimiter() == semicolonIsNormalChar) {
+      queryParamDecoder = new QueryParamDecoder(new QueryParamDecoderConfig()
+        .setCharset(queryParamDecoder.charset())
+        .setMaxSize(queryParamDecoder.maxParams())
+        .setUseSemicolonAsDelimiter(!semicolonIsNormalChar)
+      );
+      params = null;
     }
+    if (params == null) {
+      params = queryParamDecoder.decode(uri());
+    }
+    return params;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerConnection.java
@@ -35,6 +35,7 @@ import io.vertx.core.http.impl.websocket.ServerWebSocketHandshaker;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
+import io.vertx.core.internal.http.QueryParamDecoder;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.impl.MessageWrite;
@@ -79,6 +80,7 @@ public class Http1ServerConnection extends Http1Connection implements HttpServer
   private final int maxFormAttributeSize;
   private final int maxFormFields;
   private final int maxFormBufferedBytes;
+  private final QueryParamDecoder queryParamDecoder;
   private final Http1ServerConfig serverConfig;
   private final boolean registerWebSocketWriteHandlers;
   private final WebSocketServerConfig webSocketConfig;
@@ -105,6 +107,7 @@ public class Http1ServerConnection extends Http1Connection implements HttpServer
                                int maxFormAttributeSize,
                                int maxFormFields,
                                int maxFormBufferedBytes,
+                               QueryParamDecoderConfig queryParamDecoderConfig,
                                Http1ServerConfig serverConfig,
                                boolean registerWebSocketWriteHandlers,
                                WebSocketServerConfig webSocketConfig,
@@ -120,6 +123,7 @@ public class Http1ServerConnection extends Http1Connection implements HttpServer
     this.maxFormAttributeSize = maxFormAttributeSize;
     this.maxFormFields = maxFormFields;
     this.maxFormBufferedBytes = maxFormBufferedBytes;
+    this.queryParamDecoder = new QueryParamDecoder(queryParamDecoderConfig);
     this.serverConfig = serverConfig;
     this.registerWebSocketWriteHandlers = registerWebSocketWriteHandlers;
     this.webSocketConfig = webSocketConfig;
@@ -144,6 +148,10 @@ public class Http1ServerConnection extends Http1Connection implements HttpServer
 
   int maxFormBufferedBytes() {
     return maxFormBufferedBytes;
+  }
+
+  QueryParamDecoder queryParamDecoder() {
+    return queryParamDecoder;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
@@ -33,6 +33,7 @@ import io.vertx.core.http.impl.headers.HeadersAdaptor;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.http.HttpServerRequestInternal;
+import io.vertx.core.internal.http.QueryParamDecoder;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
@@ -45,7 +46,6 @@ import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.streams.impl.InboundBuffer;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Set;
 
@@ -77,9 +77,8 @@ public class Http1ServerRequest extends HttpServerRequestInternal implements io.
   private Http1ServerResponse response;
 
   // Cache this for performance
-  private Charset paramsCharset = StandardCharsets.UTF_8;
+  private QueryParamDecoder queryParamDecoder;
   private MultiMap params;
-  private boolean semicolonIsNormalCharInParams;
   private MultiMap headers;
   private String absoluteURI;
 
@@ -96,6 +95,7 @@ public class Http1ServerRequest extends HttpServerRequestInternal implements io.
     this.conn = conn;
     this.context = context;
     this.request = request;
+    this.queryParamDecoder = conn.queryParamDecoder();
   }
 
   private InboundMessageQueue<Object> queue() {
@@ -321,9 +321,12 @@ public class Http1ServerRequest extends HttpServerRequestInternal implements io.
   @Override
   public HttpServerRequest setParamsCharset(String charset) {
     Objects.requireNonNull(charset, "Charset must not be null");
-    Charset current = paramsCharset;
-    paramsCharset = Charset.forName(charset);
-    if (!paramsCharset.equals(current)) {
+    Charset cs = Charset.forName(charset);
+    if (!queryParamDecoder.charset().equals(cs)) {
+      queryParamDecoder = new QueryParamDecoder(new QueryParamDecoderConfig()
+        .setMaxSize(queryParamDecoder.maxParams())
+        .setUseSemicolonAsDelimiter(queryParamDecoder.isAcceptSemiColonDelimiter())
+        .setCharset(cs));
       params = null;
     }
     return this;
@@ -331,14 +334,21 @@ public class Http1ServerRequest extends HttpServerRequestInternal implements io.
 
   @Override
   public String getParamsCharset() {
-    return paramsCharset.name();
+    return queryParamDecoder.charset().name();
   }
 
   @Override
   public MultiMap params(boolean semicolonIsNormalChar) {
-    if (params == null || semicolonIsNormalChar != semicolonIsNormalCharInParams) {
-      params = HttpUtils.params(uri(), paramsCharset, semicolonIsNormalChar);
-      semicolonIsNormalCharInParams = semicolonIsNormalChar;
+    if (queryParamDecoder.isAcceptSemiColonDelimiter() == semicolonIsNormalChar) {
+      queryParamDecoder = new QueryParamDecoder(new QueryParamDecoderConfig()
+        .setCharset(queryParamDecoder.charset())
+        .setMaxSize(queryParamDecoder.maxParams())
+        .setUseSemicolonAsDelimiter(!semicolonIsNormalChar)
+      );
+      params = null;
+    }
+    if (params == null) {
+      params = queryParamDecoder.decode(uri());
     }
     return params;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpServer.java
@@ -247,8 +247,10 @@ public class QuicHttpServer implements HttpServerInternal {
     QueryParamDecoderConfig queryParamDecoderConfig = config.getQueryParamConfig() != null ?  config.getQueryParamConfig() : new QueryParamDecoderConfig();
     QueryParamDecoder queryParamDecoder = new QueryParamDecoder(queryParamDecoderConfig);
 
+    FormDecoderConfig formDecoderConfig = config.getFormDecoderConfig() != null ? config.getFormDecoderConfig() : new FormDecoderConfig();
+
     quicServer.connectHandler(new ConnectionHandler(quicServer, httpMetrics, requestHandler, connectionHandler,
-      config.isHandle100ContinueAutomatically(), config.getMaxFormAttributeSize(), config.getMaxFormFields(), config.getMaxFormBufferedBytes(),
+      config.isHandle100ContinueAutomatically(), formDecoderConfig.getMaxAttributeSize(), formDecoderConfig.getMaxFields(), formDecoderConfig.getMaxBufferedBytes(),
       queryParamDecoder, http3Config.getInitialSettings() != null ? http3Config.getInitialSettings().copy() : new Http3Settings(),
       logEnabled));
     quicServer.exceptionHandler(exceptionHandler);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/quic/QuicHttpServer.java
@@ -22,6 +22,7 @@ import io.vertx.core.http.impl.http3.Http3ServerConnection;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.http.HttpServerInternal;
+import io.vertx.core.internal.http.QueryParamDecoder;
 import io.vertx.core.internal.quic.QuicConnectionInternal;
 import io.vertx.core.net.*;
 import io.vertx.core.net.impl.quic.QuicServerImpl;
@@ -146,6 +147,7 @@ public class QuicHttpServer implements HttpServerInternal {
     private final int maxFormAttributeSize;
     private final int maxFormFields;
     private final int maxFormBufferedSize;
+    private final QueryParamDecoder queryParamDecoder;
     private final Http3Settings localSettings;
     private final boolean logEnabled;
 
@@ -157,6 +159,7 @@ public class QuicHttpServer implements HttpServerInternal {
                              int maxFormAttributeSize,
                              int maxFormFields,
                              int maxFormBufferedSize,
+                             QueryParamDecoder queryParamDecoder,
                              Http3Settings localSettings,
                              boolean logEnabled) {
       this.transport = transport;
@@ -167,6 +170,7 @@ public class QuicHttpServer implements HttpServerInternal {
       this.maxFormAttributeSize = maxFormAttributeSize;
       this.maxFormFields = maxFormFields;
       this.maxFormBufferedSize = maxFormBufferedSize;
+      this.queryParamDecoder = queryParamDecoder;
       this.localSettings = localSettings;
       this.logEnabled = logEnabled;
     }
@@ -188,7 +192,7 @@ public class QuicHttpServer implements HttpServerInternal {
       http3Connection.streamHandler(stream -> {
         HttpServerRequestImpl request = new HttpServerRequestImpl(requestHandler, stream, stream.context(),
           handle100ContinueAutomatically, maxFormAttributeSize,
-          maxFormFields, maxFormBufferedSize, serverOrigin);
+          maxFormFields, maxFormBufferedSize, queryParamDecoder, serverOrigin);
         request.init();
       });
 
@@ -240,9 +244,13 @@ public class QuicHttpServer implements HttpServerInternal {
     boolean logEnabled = quicConfig.getLogConfig() != null && quicConfig.getLogConfig().isEnabled();
     quicConfig.setLogConfig(null);
 
+    QueryParamDecoderConfig queryParamDecoderConfig = config.getQueryParamConfig() != null ?  config.getQueryParamConfig() : new QueryParamDecoderConfig();
+    QueryParamDecoder queryParamDecoder = new QueryParamDecoder(queryParamDecoderConfig);
+
     quicServer.connectHandler(new ConnectionHandler(quicServer, httpMetrics, requestHandler, connectionHandler,
       config.isHandle100ContinueAutomatically(), config.getMaxFormAttributeSize(), config.getMaxFormFields(), config.getMaxFormBufferedBytes(),
-      http3Config.getInitialSettings() != null ? http3Config.getInitialSettings().copy() : new Http3Settings(), logEnabled));
+      queryParamDecoder, http3Config.getInitialSettings() != null ? http3Config.getInitialSettings().copy() : new Http3Settings(),
+      logEnabled));
     quicServer.exceptionHandler(exceptionHandler);
     return quicServer
       .bind(current, address)

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/HttpServerConnectionHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/HttpServerConnectionHandler.java
@@ -25,6 +25,7 @@ import io.vertx.core.http.impl.http1.Http1ServerConnection;
 import io.vertx.core.http.impl.http1.Http1ServerRequestHandler;
 import io.vertx.core.http.impl.http2.Http2ServerConnection;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.http.QueryParamDecoder;
 
 import java.util.ArrayList;
 
@@ -44,6 +45,7 @@ public class HttpServerConnectionHandler implements Handler<HttpServerConnection
   public final Handler<HttpConnection> connectionHandler;
   public final Handler<Throwable> exceptionHandler;
   public final int connectionWindowSize;
+  private final QueryParamDecoder queryParamDecoder;
 
   public HttpServerConnectionHandler(
     TcpHttpServer server,
@@ -64,6 +66,7 @@ public class HttpServerConnectionHandler implements Handler<HttpServerConnection
     this.connectionHandler = connectionHandler;
     this.exceptionHandler = exceptionHandler;
     this.connectionWindowSize = connectionWindowSize;
+    this.queryParamDecoder = new QueryParamDecoder(server.config.getQueryParamConfig() != null ? server.config.getQueryParamConfig() : new QueryParamDecoderConfig());
   }
 
   // TOdo : improve this
@@ -101,7 +104,7 @@ public class HttpServerConnectionHandler implements Handler<HttpServerConnection
         HttpServerConfig config = server.config;
         HttpServerRequestImpl request = new HttpServerRequestImpl(requestHandler, stream, stream.context(),
           config.isHandle100ContinueAutomatically(), config.getMaxFormAttributeSize(), config.getMaxFormFields(),
-          config.getMaxFormBufferedBytes(), serverOrigin);
+          config.getMaxFormBufferedBytes(), queryParamDecoder, serverOrigin);
         request.init();
       });
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/HttpServerConnectionHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/HttpServerConnectionHandler.java
@@ -102,9 +102,13 @@ public class HttpServerConnectionHandler implements Handler<HttpServerConnection
       Http2ServerConnection http2Conn = (Http2ServerConnection) conn;
       http2Conn.streamHandler(stream -> {
         HttpServerConfig config = server.config;
+        FormDecoderConfig formDecoderConfig = config.getFormDecoderConfig();
+        int maxFormAttributeSize = formDecoderConfig != null ? formDecoderConfig.getMaxAttributeSize() : HttpServerOptions.DEFAULT_MAX_FORM_ATTRIBUTE_SIZE;
+        int maxFormFields = formDecoderConfig != null ? formDecoderConfig.getMaxFields() : HttpServerOptions.DEFAULT_MAX_FORM_FIELDS;
+        int maxFormBufferedBytes = formDecoderConfig != null ? formDecoderConfig.getMaxBufferedBytes() : HttpServerOptions.DEFAULT_MAX_FORM_BUFFERED_SIZE;
         HttpServerRequestImpl request = new HttpServerRequestImpl(requestHandler, stream, stream.context(),
-          config.isHandle100ContinueAutomatically(), config.getMaxFormAttributeSize(), config.getMaxFormFields(),
-          config.getMaxFormBufferedBytes(), queryParamDecoder, serverOrigin);
+          config.isHandle100ContinueAutomatically(), maxFormAttributeSize, maxFormFields,
+          maxFormBufferedBytes, queryParamDecoder, serverOrigin);
         request.init();
       });
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/HttpServerConnectionInitializer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/HttpServerConnectionInitializer.java
@@ -67,6 +67,7 @@ public class HttpServerConnectionInitializer {
   private final int maxFormAttributeSize;
   private final int maxFormFields;
   private final int maxFormBufferedBytes;
+  private final QueryParamDecoderConfig queryParamDecoderConfig;
   private final Http1ServerConfig http1Config;
   private final Http2ServerConfig http2Config;
   private final boolean registerWebSocketWriteHandlers;
@@ -92,6 +93,7 @@ public class HttpServerConnectionInitializer {
                                   int maxFormAttributeSize,
                                   int maxFormFields,
                                   int maxFormBufferedBytes,
+                                  QueryParamDecoderConfig queryParamDecoderConfig,
                                   Http1ServerConfig http1Config,
                                   Http2ServerConfig http2Config,
                                   boolean registerWebSocketWriteHandlers,
@@ -159,6 +161,7 @@ public class HttpServerConnectionInitializer {
     this.maxFormAttributeSize = maxFormAttributeSize;
     this.maxFormFields = maxFormFields;
     this.maxFormBufferedBytes = maxFormBufferedBytes;
+    this.queryParamDecoderConfig = queryParamDecoderConfig;
     this.http1Config = http1Config;
     this.http2Config = http2Config;
     this.connectionHandler = connectionHandler;
@@ -307,6 +310,7 @@ public class HttpServerConnectionInitializer {
         maxFormAttributeSize,
         maxFormFields,
         maxFormBufferedBytes,
+        queryParamDecoderConfig,
         http1Config,
         registerWebSocketWriteHandlers,
         webSocketConfig,

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpServer.java
@@ -242,6 +242,8 @@ public class TcpHttpServer implements HttpServerInternal {
 
       ObservabilityConfig observabilityConfig = config.getObservabilityConfig();
 
+      FormDecoderConfig formDecoderConfig = config.getFormDecoderConfig() != null ? config.getFormDecoderConfig() : new FormDecoderConfig();
+
       List<CompressionOptions> compressors = compression != null ? compression.getCompressors() : null;
       HttpServerConnectionInitializer initializer = new HttpServerConnectionInitializer(
         listenContext,
@@ -256,9 +258,9 @@ public class TcpHttpServer implements HttpServerInternal {
         compressors != null ? compressors.toArray(new CompressionOptions[0]) : null,
         compression != null ? compression.getContentSizeThreshold() : 0,
         config.isHandle100ContinueAutomatically(),
-        config.getMaxFormAttributeSize(),
-        config.getMaxFormFields(),
-        config.getMaxFormBufferedBytes(),
+        formDecoderConfig.getMaxAttributeSize(),
+        formDecoderConfig.getMaxFields(),
+        formDecoderConfig.getMaxBufferedBytes(),
         queryParamDecoderConfig,
         http1Config,
         http2Config,

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpServer.java
@@ -220,6 +220,7 @@ public class TcpHttpServer implements HttpServerInternal {
     Handler<Throwable> h = exceptionHandler;
     Handler<Throwable> exceptionHandler = h != null ? h : DEFAULT_EXCEPTION_HANDLER;
     server.exceptionHandler(exceptionHandler);
+    QueryParamDecoderConfig queryParamDecoderConfig = config.getQueryParamConfig() != null ? config.getQueryParamConfig() : new QueryParamDecoderConfig();
     Http1ServerConfig http1Config = config.getVersions().contains(HttpVersion.HTTP_1_0) || config.getVersions().contains(HttpVersion.HTTP_1_1) ? config.getHttp1Config() != null ? config.getHttp1Config() : new Http1ServerConfig() : null;
     Http2ServerConfig http2Config = config.getVersions().contains(HttpVersion.HTTP_2) ? config.getHttp2Config() != null ? config.getHttp2Config() : new Http2ServerConfig() : null;
     server.connectHandler(so -> {
@@ -258,6 +259,7 @@ public class TcpHttpServer implements HttpServerInternal {
         config.getMaxFormAttributeSize(),
         config.getMaxFormFields(),
         config.getMaxFormBufferedBytes(),
+        queryParamDecoderConfig,
         http1Config,
         http2Config,
         registerWebSocketWriteHandlers,

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/QueryParamDecoder.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/QueryParamDecoder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.internal.http;
+
+import io.netty.handler.codec.http.QueryStringDecoder;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.QueryParamDecoderConfig;
+
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Query parameter decoder, this object is immutable.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class QueryParamDecoder {
+
+  private final Charset charset;
+  private final boolean acceptSemiColonDelimiter;
+  private final int maxSize;
+
+  public QueryParamDecoder(QueryParamDecoderConfig config) {
+    this.charset = config.getCharset();
+    this.acceptSemiColonDelimiter = config.isUseSemicolonAsDelimiter();
+    this.maxSize = config.getMaxSize();
+  }
+
+  /**
+   * @return the actual charset
+   */
+  public Charset charset() {
+    return charset;
+  }
+
+  /**
+   * @return whether to treat semicolon as a delimiter or part of the parameter
+   */
+  public boolean isAcceptSemiColonDelimiter() {
+    return acceptSemiColonDelimiter;
+  }
+
+  /**
+   * @return the maximum number of parameters to decode
+   */
+  public int maxParams() {
+    return maxSize;
+  }
+
+  public MultiMap decode(String uri) {
+    MultiMap params = MultiMap.caseInsensitiveMultiMap();
+    appendTo(uri, params);
+    return params;
+  }
+
+  public void appendTo(String uri, MultiMap params) {
+    QueryStringDecoder queryStringDecoder = new QueryStringDecoder(uri, charset, true, maxSize, !acceptSemiColonDelimiter);
+    Map<String, List<String>> prms = queryStringDecoder.parameters();
+    if (!prms.isEmpty()) {
+      for (Map.Entry<String, List<String>> entry: prms.entrySet()) {
+        params.add(entry.getKey(), entry.getValue());
+      }
+    }
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
+++ b/vertx-core/src/test/java/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
@@ -35,10 +35,7 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.Http1ServerConfig;
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.*;
 import io.vertx.core.http.impl.http1.Http1ServerConnection;
 import io.vertx.core.http.impl.http1.VertxHttpRequestDecoder;
 import io.vertx.core.http.impl.http1.VertxHttpResponseEncoder;
@@ -237,6 +234,7 @@ public class HttpServerHandlerBenchmark extends BenchmarkBase {
         HttpServerOptions.DEFAULT_MAX_FORM_ATTRIBUTE_SIZE,
         HttpServerOptions.DEFAULT_MAX_FORM_FIELDS,
         HttpServerOptions.DEFAULT_MAX_FORM_BUFFERED_SIZE,
+        new QueryParamDecoderConfig(),
         new Http1ServerConfig(),
         false,
         null,

--- a/vertx-core/src/test/java/io/vertx/test/http/HttpConfigurator.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/HttpConfigurator.java
@@ -179,10 +179,24 @@ public interface HttpConfigurator {
           return this;
         }
         @Override
+        public HttpServerConfig config() {
+          return new HttpServerConfig(options);
+        }
+        @Override
+        public ServerSSLOptions sslOptions() {
+          if (options.isSsl()) {
+            return options.getSslOptions();
+          } else {
+            return null;
+          }
+        }
+        @Override
         public HttpServerConfigurator configureSsl(Consumer<ServerSSLOptions> configurator) {
-          // Trigger creation of lazy SSL options
-          options.setKeyCertOptions(options.getKeyCertOptions());
-          configurator.accept(options.getSslOptions());
+          if (options.isSsl()) {
+            // Trigger creation of lazy SSL options
+            options.setKeyCertOptions(options.getKeyCertOptions());
+            configurator.accept(options.getSslOptions());
+          }
           return this;
         }
         @Override

--- a/vertx-core/src/test/java/io/vertx/test/http/HttpServerConfigurator.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/HttpServerConfigurator.java
@@ -4,6 +4,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.CompressionConfig;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerBuilder;
+import io.vertx.core.http.HttpServerConfig;
 import io.vertx.core.net.ServerSSLOptions;
 
 import java.time.Duration;
@@ -22,6 +23,8 @@ public interface HttpServerConfigurator {
   HttpServerConfigurator setLogActivity(boolean logActivity);
   HttpServerConfigurator setHandle100ContinueAutomatically(boolean b);
   HttpServerConfigurator configureSsl(Consumer<ServerSSLOptions> configurator);
+  HttpServerConfig config();
+  ServerSSLOptions sslOptions();
   default HttpServer create(Vertx vertx) {
     return builder(vertx).build();
   }

--- a/vertx-core/src/test/java/io/vertx/tests/benchmark/Http1xServerConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/benchmark/Http1xServerConnectionTest.java
@@ -16,10 +16,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.vertx.core.Handler;
 import io.vertx.core.ThreadingModel;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.Http1ServerConfig;
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.*;
 import io.vertx.core.http.impl.http1.Http1ServerConnection;
 import io.vertx.core.http.impl.http1.VertxHttpRequestDecoder;
 import io.vertx.core.http.impl.http1.VertxHttpResponseEncoder;
@@ -68,6 +65,7 @@ public class Http1xServerConnectionTest extends VertxTestBase {
         HttpServerOptions.DEFAULT_MAX_FORM_ATTRIBUTE_SIZE,
         HttpServerOptions.DEFAULT_MAX_FORM_FIELDS,
         HttpServerOptions.DEFAULT_MAX_FORM_BUFFERED_SIZE,
+        new QueryParamDecoderConfig(),
         new Http1ServerConfig(),
         false,
         null,

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -830,6 +830,60 @@ public abstract class HttpTest extends SimpleHttpTest2 {
   }
 
   @Test
+  public void testConfigureQueryParamsCharsetDecoding() throws Exception {
+    testConfigureQueryParamsDecoding(
+      new QueryParamDecoderConfig().setCharset(StandardCharsets.ISO_8859_1),
+      "/?param=%E2%82%AC",
+      params -> {
+        String val = params.get("param");
+        assertEquals("\u00E2\u0082\u00AC", val);
+      });
+  }
+
+  @Test
+  public void testConfigureQueryParamsSemicolonDelimiterDecoding() throws Exception {
+    MultiMap p = TestUtils.randomMultiMap(10);
+    testConfigureQueryParamsDecoding(
+      new QueryParamDecoderConfig().setUseSemicolonAsDelimiter(false),
+      "/some?" + generateQueryString(p, ';'),
+      params -> {
+        assertEquals(params.size(), params.size());
+        for (Map.Entry<String, String> entry : params) {
+          assertEquals(entry.getValue(), params.get(entry.getKey()));
+        }
+      });
+  }
+
+  @Test
+  public void testConfigureQueryParamsMaxSizeDecoding() throws Exception {
+    int maxSize = 10;
+    MultiMap p = TestUtils.randomMultiMap(maxSize + 1);
+    testConfigureQueryParamsDecoding(
+      new QueryParamDecoderConfig().setMaxSize(maxSize),
+      "/some?" + generateQueryString(p, '&'),
+      params -> {
+        assertEquals(maxSize, params.size());
+        for (Map.Entry<String, String> entry : params) {
+          assertEquals(entry.getValue(), params.get(entry.getKey()));
+        }
+      });
+  }
+
+  private void testConfigureQueryParamsDecoding(QueryParamDecoderConfig queryParamDecoderConfig, String uri, Consumer<MultiMap> checker) throws Exception {
+    server = vertx.httpServerBuilder()
+      .with(config.forServer()
+        .config().setQueryParamConfig(queryParamDecoderConfig))
+      .with(config.forServer().sslOptions())
+      .build();
+    server.requestHandler(req -> {
+      checker.accept(req.params());
+      req.response().end();
+    });
+    startServer(testAddress);
+    sendAndAwait(new RequestOptions(requestOptions).setURI(uri));
+  }
+
+  @Test
   public void testMissingContentTypeMultipartRequest() throws Exception {
     testInvalidMultipartRequest(null, HttpMethod.POST);
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3Configurator.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3Configurator.java
@@ -63,7 +63,7 @@ public class Http3Configurator implements HttpConfigurator {
 
   @Override
   public HttpServerConfigurator forServer() {
-    io.vertx.core.http.HttpServerConfig config = new io.vertx.core.http.HttpServerConfig();
+    HttpServerConfig config = new HttpServerConfig();
     config.setVersions(HttpVersion.HTTP_3);
     config.setQuicPort(port);
     config.setQuicHost(host);
@@ -118,6 +118,14 @@ public class Http3Configurator implements HttpConfigurator {
       public HttpServerConfigurator setHandle100ContinueAutomatically(boolean b) {
         config.setHandle100ContinueAutomatically(b);
         return this;
+      }
+      @Override
+      public HttpServerConfig config() {
+        return config;
+      }
+      @Override
+      public ServerSSLOptions sslOptions() {
+        return sslOptions;
       }
       @Override
       public HttpServerConfigurator configureSsl(Consumer<ServerSSLOptions> configurator) {

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3Configurator.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3Configurator.java
@@ -89,19 +89,29 @@ public class Http3Configurator implements HttpConfigurator {
       public HttpServerConfigurator setCompression(CompressionConfig compression) {
         throw new UnsupportedOperationException();
       }
+      private FormDecoderConfig formDecoderConfig() {
+        FormDecoderConfig cfg = config.getFormDecoderConfig();
+        if (cfg == null) {
+          config.setFormDecoderConfig(cfg = new FormDecoderConfig());
+        }
+        return cfg;
+      }
       @Override
       public HttpServerConfigurator setMaxFormBufferedBytes(int maxFormBufferedBytes) {
-        config.setMaxFormBufferedBytes(maxFormBufferedBytes);
+        formDecoderConfig()
+          .setMaxBufferedBytes(maxFormBufferedBytes);
         return this;
       }
       @Override
       public HttpServerConfigurator setMaxFormAttributeSize(int maxSize) {
-        config.setMaxFormAttributeSize(maxSize);
+        formDecoderConfig()
+          .setMaxAttributeSize(maxSize);
         return this;
       }
       @Override
       public HttpServerConfigurator setMaxFormFields(int maxFormFields) {
-        config.setMaxFormFields(maxFormFields);
+        formDecoderConfig()
+          .setMaxFields(maxFormFields);
         return this;
       }
       @Override


### PR DESCRIPTION
Motivation:

`HttpServerRequest` decodes the request URI query string with a few default knobs.

Some of them can be specified when obtaining the parameters, some of them are still hardcoded (max size).

We should have this configured at the HTTP server level with a configuration object, such object can be then be reused by Vert.x Web which also does parsing (due to rerouting).

Changes:

Introduce `QueryParamConfig` / `QueryParamDecoder` and use that in HTTP server configuration.

See:

- https://github.com/eclipse-vertx/vert.x/pull/3239
- https://github.com/eclipse-vertx/vert.x/pull/4397
- https://github.com/eclipse-vertx/vert.x/pull/5868/changes#diff-16318bd4740869b946c229a3b255087e420fcec06dcd0dbe93db7b92e764b0fd
- https://github.com/vert-x3/vertx-web/issues/2887
