### PR TITLE
HttpServerRequestInternal should expose the query param decoder.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestBase.java
@@ -1,0 +1,63 @@
+package io.vertx.core.http.impl;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.QueryParamDecoderConfig;
+import io.vertx.core.internal.http.HttpServerRequestInternal;
+import io.vertx.core.internal.http.QueryParamDecoder;
+
+import java.nio.charset.Charset;
+import java.util.Objects;
+
+/**
+ * Common state / methods between HTTP/1.x implementation and the stream based implementation.
+ */
+public abstract class HttpServerRequestBase extends HttpServerRequestInternal {
+
+  private QueryParamDecoder queryParamDecoder;
+  private MultiMap params;
+
+  public HttpServerRequestBase(QueryParamDecoder queryParamDecoder) {
+    this.queryParamDecoder = queryParamDecoder;
+  }
+
+  @Override
+  public final HttpServerRequest setParamsCharset(String charset) {
+    Objects.requireNonNull(charset, "Charset must not be null");
+    Charset cs = Charset.forName(charset);
+    if (!queryParamDecoder.charset().equals(cs)) {
+      queryParamDecoder = new QueryParamDecoder(new QueryParamDecoderConfig()
+        .setMaxSize(queryParamDecoder.maxParams())
+        .setUseSemicolonAsDelimiter(queryParamDecoder.isUseSemiColonAsDelimiter())
+        .setCharset(cs));
+      params = null;
+    }
+    return this;
+  }
+
+  @Override
+  public final String getParamsCharset() {
+    return queryParamDecoder.charset().name();
+  }
+
+  @Override
+  public final MultiMap params(boolean semicolonIsNormalChar) {
+    if (queryParamDecoder.isUseSemiColonAsDelimiter() == semicolonIsNormalChar) {
+      queryParamDecoder = new QueryParamDecoder(new QueryParamDecoderConfig()
+        .setCharset(queryParamDecoder.charset())
+        .setMaxSize(queryParamDecoder.maxParams())
+        .setUseSemicolonAsDelimiter(!semicolonIsNormalChar)
+      );
+      params = null;
+    }
+    if (params == null) {
+      params = queryParamDecoder.decode(uri());
+    }
+    return params;
+  }
+
+  @Override
+  public final QueryParamDecoder queryParamDecoder() {
+    return queryParamDecoder;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -28,20 +28,17 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.http.HttpServerRequestInternal;
 import io.vertx.core.internal.http.QueryParamDecoder;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 
-import java.nio.charset.Charset;
-import java.util.Objects;
 import java.util.Set;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class HttpServerRequestImpl extends HttpServerRequestInternal {
+public class HttpServerRequestImpl extends HttpServerRequestBase {
 
   private final ContextInternal context;
   private final HttpServerStream stream;
@@ -61,8 +58,6 @@ public class HttpServerRequestImpl extends HttpServerRequestInternal {
   private MultiMap headersMap;
   private HostAndPort authority;
   private HostAndPort realAuthority;
-  private QueryParamDecoder queryParamDecoder;
-  private MultiMap params;
   private String absoluteURI;
   private MultiMap attributes;
   private HttpEventHandler eventHandler;
@@ -80,6 +75,7 @@ public class HttpServerRequestImpl extends HttpServerRequestInternal {
                                int maxFormBufferedBytes,
                                QueryParamDecoder queryParamDecoder,
                                String serverOrigin) {
+    super(queryParamDecoder);
     this.handler = handler;
     this.context = context;
     this.stream = stream;
@@ -90,7 +86,6 @@ public class HttpServerRequestImpl extends HttpServerRequestInternal {
     this.maxFormAttributeSize = maxFormAttributeSize;
     this.maxFormFields = maxFormFields;
     this.maxFormBufferedBytes = maxFormBufferedBytes;
-    this.queryParamDecoder = queryParamDecoder;
   }
 
   public void init() {
@@ -377,40 +372,6 @@ public class HttpServerRequestImpl extends HttpServerRequestInternal {
   @Override
   public MultiMap headers() {
     return headersMap;
-  }
-
-  @Override
-  public HttpServerRequest setParamsCharset(String charset) {
-    Objects.requireNonNull(charset, "Charset must not be null");
-    Charset cs = Charset.forName(charset);
-    if (!queryParamDecoder.charset().equals(cs)) {
-      queryParamDecoder = new QueryParamDecoder(new QueryParamDecoderConfig()
-        .setMaxSize(queryParamDecoder.maxParams())
-        .setUseSemicolonAsDelimiter(queryParamDecoder.isAcceptSemiColonDelimiter())
-        .setCharset(cs));
-      params = null;
-    }
-    return this;
-  }
-
-  @Override
-  public String getParamsCharset() {
-    return queryParamDecoder.charset().name();
-  }
-  @Override
-  public MultiMap params(boolean semicolonIsNormalChar) {
-    if (queryParamDecoder.isAcceptSemiColonDelimiter() == semicolonIsNormalChar) {
-      queryParamDecoder = new QueryParamDecoder(new QueryParamDecoderConfig()
-        .setCharset(queryParamDecoder.charset())
-        .setMaxSize(queryParamDecoder.maxParams())
-        .setUseSemicolonAsDelimiter(!semicolonIsNormalChar)
-      );
-      params = null;
-    }
-    if (params == null) {
-      params = queryParamDecoder.decode(uri());
-    }
-    return params;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
@@ -21,10 +21,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.impl.HttpEventHandler;
-import io.vertx.core.http.impl.HttpUtils;
-import io.vertx.core.http.impl.NettyFileUpload;
-import io.vertx.core.http.impl.NettyFileUploadDataFactory;
+import io.vertx.core.http.impl.*;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpVersion;
@@ -32,8 +29,6 @@ import io.vertx.core.http.*;
 import io.vertx.core.http.impl.headers.HeadersAdaptor;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
-import io.vertx.core.internal.http.HttpServerRequestInternal;
-import io.vertx.core.internal.http.QueryParamDecoder;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
@@ -45,8 +40,6 @@ import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.streams.impl.InboundBuffer;
 
-import java.nio.charset.Charset;
-import java.util.Objects;
 import java.util.Set;
 
 import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
@@ -54,7 +47,7 @@ import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class Http1ServerRequest extends HttpServerRequestInternal implements io.vertx.core.spi.observability.HttpRequest {
+public class Http1ServerRequest extends HttpServerRequestBase implements io.vertx.core.spi.observability.HttpRequest {
 
   private static final HostAndPort NULL_HOST_AND_PORT = HostAndPort.create("", -1);
 
@@ -77,8 +70,6 @@ public class Http1ServerRequest extends HttpServerRequestInternal implements io.
   private Http1ServerResponse response;
 
   // Cache this for performance
-  private QueryParamDecoder queryParamDecoder;
-  private MultiMap params;
   private MultiMap headers;
   private String absoluteURI;
 
@@ -92,10 +83,10 @@ public class Http1ServerRequest extends HttpServerRequestInternal implements io.
   private volatile InboundMessageQueue<Object> queue;
 
   Http1ServerRequest(Http1ServerConnection conn, HttpRequest request, ContextInternal context) {
+    super(conn.queryParamDecoder());
     this.conn = conn;
     this.context = context;
     this.request = request;
-    this.queryParamDecoder = conn.queryParamDecoder();
   }
 
   private InboundMessageQueue<Object> queue() {
@@ -316,41 +307,6 @@ public class Http1ServerRequest extends HttpServerRequestInternal implements io.
       this.headers = headers;
     }
     return headers;
-  }
-
-  @Override
-  public HttpServerRequest setParamsCharset(String charset) {
-    Objects.requireNonNull(charset, "Charset must not be null");
-    Charset cs = Charset.forName(charset);
-    if (!queryParamDecoder.charset().equals(cs)) {
-      queryParamDecoder = new QueryParamDecoder(new QueryParamDecoderConfig()
-        .setMaxSize(queryParamDecoder.maxParams())
-        .setUseSemicolonAsDelimiter(queryParamDecoder.isAcceptSemiColonDelimiter())
-        .setCharset(cs));
-      params = null;
-    }
-    return this;
-  }
-
-  @Override
-  public String getParamsCharset() {
-    return queryParamDecoder.charset().name();
-  }
-
-  @Override
-  public MultiMap params(boolean semicolonIsNormalChar) {
-    if (queryParamDecoder.isAcceptSemiColonDelimiter() == semicolonIsNormalChar) {
-      queryParamDecoder = new QueryParamDecoder(new QueryParamDecoderConfig()
-        .setCharset(queryParamDecoder.charset())
-        .setMaxSize(queryParamDecoder.maxParams())
-        .setUseSemicolonAsDelimiter(!semicolonIsNormalChar)
-      );
-      params = null;
-    }
-    if (params == null) {
-      params = queryParamDecoder.decode(uri());
-    }
-    return params;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestInternal.java
@@ -37,4 +37,10 @@ public abstract class HttpServerRequestInternal implements HttpServerRequest {
   public boolean isValidAuthority() {
     return authority() != null;
   }
+
+  /**
+   * @return the request query param decoder
+   */
+  public abstract QueryParamDecoder queryParamDecoder();
+
 }

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
@@ -111,6 +111,11 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
+  public QueryParamDecoder queryParamDecoder() {
+    return delegate.queryParamDecoder();
+  }
+
+  @Override
   public long bytesRead() {
     return delegate.bytesRead();
   }

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/QueryParamDecoder.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/QueryParamDecoder.java
@@ -26,12 +26,12 @@ import java.util.Map;
 public class QueryParamDecoder {
 
   private final Charset charset;
-  private final boolean acceptSemiColonDelimiter;
+  private final boolean useSemiColonAsDelimiter;
   private final int maxSize;
 
   public QueryParamDecoder(QueryParamDecoderConfig config) {
     this.charset = config.getCharset();
-    this.acceptSemiColonDelimiter = config.isUseSemicolonAsDelimiter();
+    this.useSemiColonAsDelimiter = config.isUseSemicolonAsDelimiter();
     this.maxSize = config.getMaxSize();
   }
 
@@ -45,8 +45,8 @@ public class QueryParamDecoder {
   /**
    * @return whether to treat semicolon as a delimiter or part of the parameter
    */
-  public boolean isAcceptSemiColonDelimiter() {
-    return acceptSemiColonDelimiter;
+  public boolean isUseSemiColonAsDelimiter() {
+    return useSemiColonAsDelimiter;
   }
 
   /**
@@ -63,10 +63,10 @@ public class QueryParamDecoder {
   }
 
   public void appendTo(String uri, MultiMap params) {
-    QueryStringDecoder queryStringDecoder = new QueryStringDecoder(uri, charset, true, maxSize, !acceptSemiColonDelimiter);
-    Map<String, List<String>> prms = queryStringDecoder.parameters();
-    if (!prms.isEmpty()) {
-      for (Map.Entry<String, List<String>> entry: prms.entrySet()) {
+    QueryStringDecoder queryStringDecoder = new QueryStringDecoder(uri, charset, true, maxSize, !useSemiColonAsDelimiter);
+    Map<String, List<String>> parameters = queryStringDecoder.parameters();
+    if (!parameters.isEmpty()) {
+      for (Map.Entry<String, List<String>> entry: parameters.entrySet()) {
         params.add(entry.getKey(), entry.getValue());
       }
     }


### PR DESCRIPTION
Motivation:

Vert.x Web requires access to the HTTP server query param decoder and reuse it, instead of having its own specific configuration for it.

Changes:

- `HttpServerRequestInternal` exposes the query param decoder
- Introduce `HttpServerRequestBase` that factors the common state / method between HTTP/1.x and stream based implementations
