### PR TITLE
feat: support custom proxy authorization header

### DIFF
--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -2412,7 +2412,8 @@ The `CONNECT` protocol uses HTTP/1.x but can connect to HTTP/1.x and HTTP/2 serv
 
 Connecting to `h2c` (unencrypted HTTP/2 servers) is likely not supported by http proxies since they will support HTTP/1.1 only.
 
-The proxy can be configured in the {@link io.vertx.core.http.HttpClientConfig} by setting a {@link io.vertx.core.net.ProxyOptions} object containing proxy type, hostname, port and optionally username and password.
+The proxy can be configured in the {@link io.vertx.core.http.HttpClientConfig} by setting a {@link io.vertx.core.net.ProxyOptions}
+object containing proxy type, hostname, port and optionally username and password or a prebuilt `Proxy-Authorization` value.
 
 Here's an example of using an HTTP proxy:
 

--- a/vertx-core/src/main/generated/io/vertx/core/net/ProxyOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/ProxyOptionsConverter.java
@@ -32,6 +32,11 @@ public class ProxyOptionsConverter {
             obj.setPassword((String)member.getValue());
           }
           break;
+        case "proxyAuthorization":
+          if (member.getValue() instanceof String) {
+            obj.setProxyAuthorization((String)member.getValue());
+          }
+          break;
         case "type":
           if (member.getValue() instanceof String) {
             obj.setType(io.vertx.core.net.ProxyType.valueOf((String)member.getValue()));
@@ -60,6 +65,9 @@ public class ProxyOptionsConverter {
     }
     if (obj.getPassword() != null) {
       json.put("password", obj.getPassword());
+    }
+    if (obj.getProxyAuthorization() != null) {
+      json.put("proxyAuthorization", obj.getProxyAuthorization());
     }
     if (obj.getType() != null) {
       json.put("type", obj.getType().name());

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/EndpointKey.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/EndpointKey.java
@@ -76,18 +76,17 @@ public final class EndpointKey {
     if (options1 != null && options2 != null) {
       return Objects.equals(options1.getHost(), options2.getHost()) &&
         options1.getPort() == options2.getPort() &&
+        Objects.equals(options1.getType(), options2.getType()) &&
         Objects.equals(options1.getUsername(), options2.getUsername()) &&
-        Objects.equals(options1.getPassword(), options2.getPassword());
+        Objects.equals(options1.getPassword(), options2.getPassword()) &&
+        Objects.equals(options1.getProxyAuthorization(), options2.getProxyAuthorization());
     }
     return false;
   }
 
   private static int hashCode(ProxyOptions options) {
-    if (options.getUsername() != null && options.getPassword() != null) {
-      return Objects.hash(options.getHost(), options.getPort(), options.getType(), options.getUsername(), options.getPassword());
-    } else {
-      return Objects.hash(options.getHost(), options.getPort(), options.getType());
-    }
+    return Objects.hash(options.getHost(), options.getPort(), options.getType(), options.getUsername(),
+      options.getPassword(), options.getProxyAuthorization());
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -96,8 +96,10 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
         String addPort = (authority.port() != -1 && authority.port() != defaultPort) ? (":" + authority.port()) : "";
         requestURI = "http://" + authority.host() + addPort + requestURI;
       }
-      if (proxyOptions.getUsername() != null && proxyOptions.getPassword() != null) {
-        headers().add("Proxy-Authorization", "Basic " + Base64.getEncoder()
+      if (proxyOptions.getProxyAuthorization() != null) {
+        headers().add(PROXY_AUTHORIZATION, proxyOptions.getProxyAuthorization());
+      } else if (proxyOptions.getUsername() != null && proxyOptions.getPassword() != null) {
+        headers().add(PROXY_AUTHORIZATION, "Basic " + Base64.getEncoder()
           .encodeToString((proxyOptions.getUsername() + ":" + proxyOptions.getPassword()).getBytes()));
       }
     }

--- a/vertx-core/src/main/java/io/vertx/core/net/ProxyOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/ProxyOptions.java
@@ -53,6 +53,7 @@ public class ProxyOptions {
   private int port;
   private String username;
   private String password;
+  private String proxyAuthorization;
   private ProxyType type;
   private Duration connectTimeout;
 
@@ -76,6 +77,7 @@ public class ProxyOptions {
     port = other.getPort();
     username = other.getUsername();
     password = other.getPassword();
+    proxyAuthorization = other.getProxyAuthorization();
     type = other.getType();
     connectTimeout = other.getConnectTimeout();
   }
@@ -182,6 +184,28 @@ public class ProxyOptions {
    */
   public ProxyOptions setPassword(String password) {
     this.password = password;
+    return this;
+  }
+
+  /**
+   * Get the Proxy-Authorization header value.
+   *
+   * @return the Proxy-Authorization header value
+   */
+  public String getProxyAuthorization() {
+    return proxyAuthorization;
+  }
+
+  /**
+   * Set the Proxy-Authorization header value.
+   * <p>
+   * When set, this value is sent instead of the Basic value derived from the username and password.
+   *
+   * @param proxyAuthorization the Proxy-Authorization header value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public ProxyOptions setProxyAuthorization(String proxyAuthorization) {
+    this.proxyAuthorization = proxyAuthorization;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/ChannelProvider.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/ChannelProvider.java
@@ -18,6 +18,9 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.proxy.HttpProxyHandler;
 import io.netty.handler.proxy.ProxyConnectionEvent;
 import io.netty.handler.proxy.ProxyHandler;
@@ -187,6 +190,7 @@ public final class ChannelProvider {
     final int proxyPort = proxyOptions.getPort();
     final String proxyUsername = proxyOptions.getUsername();
     final String proxyPassword = proxyOptions.getPassword();
+    final String proxyAuthorization = proxyOptions.getProxyAuthorization();
     final ProxyType proxyType = proxyOptions.getType();
 
     vertx.nameResolver().resolve(proxyHost).onComplete(dnsRes -> {
@@ -198,8 +202,7 @@ public final class ChannelProvider {
         switch (proxyType) {
           default:
           case HTTP:
-            proxy = proxyUsername != null && proxyPassword != null
-              ? new HttpProxyHandler(proxyAddr, proxyUsername, proxyPassword) : new HttpProxyHandler(proxyAddr);
+            proxy = createHttpProxyHandler(proxyAddr, proxyUsername, proxyPassword, proxyAuthorization);
             break;
           case SOCKS5:
             proxy = proxyUsername != null && proxyPassword != null
@@ -254,5 +257,17 @@ public final class ChannelProvider {
         channelHandler.setFailure(dnsRes.cause());
       }
     });
+  }
+
+  private static ProxyHandler createHttpProxyHandler(InetSocketAddress proxyAddr, String proxyUsername, String proxyPassword,
+                                                     String proxyAuthorization) {
+    if (proxyAuthorization != null) {
+      // Some proxy schemes produce their challenge token outside Netty's Basic-only credential constructor.
+      HttpHeaders headers = new DefaultHttpHeaders();
+      headers.set(HttpHeaderNames.PROXY_AUTHORIZATION, proxyAuthorization);
+      return new HttpProxyHandler(proxyAddr, headers);
+    }
+    return proxyUsername != null && proxyPassword != null
+      ? new HttpProxyHandler(proxyAddr, proxyUsername, proxyPassword) : new HttpProxyHandler(proxyAddr);
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xProxyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xProxyTest.java
@@ -205,7 +205,6 @@ public class Http1xProxyTest extends HttpTestBase2 {
   public void testHttpsProxyRequestCustomAuthorization() throws Exception {
     String authorization = "Negotiate token";
 
-    server.close();
     server = vertx.createHttpServer(createBaseServerOptions()
       .setSsl(true)
       .setKeyCertOptions(Cert.SERVER_JKS.get()));

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xProxyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xProxyTest.java
@@ -186,6 +186,53 @@ public class Http1xProxyTest extends HttpTestBase2 {
 
   @WithProxy(kind = ProxyKind.HTTP)
   @Test
+  public void testHttpProxyRequestCustomAuthorization() throws Exception {
+    String authorization = "Negotiate token";
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTP).setHost("localhost").setPort(proxy.port())
+        .setProxyAuthorization(authorization)));
+
+    foo(new RequestOptions()
+      .setHost(DEFAULT_HTTP_HOST)
+      .setPort(DEFAULT_HTTP_PORT)
+      .setURI("/"));
+
+    assertEquals(authorization, proxy.lastRequestHeaders().get("Proxy-Authorization"));
+  }
+
+  @WithProxy(kind = ProxyKind.HTTP)
+  @Test
+  public void testHttpsProxyRequestCustomAuthorization() throws Exception {
+    String authorization = "Negotiate token";
+
+    server.close();
+    server = vertx.createHttpServer(createBaseServerOptions()
+      .setSsl(true)
+      .setKeyCertOptions(Cert.SERVER_JKS.get()));
+    server.requestHandler(req -> req.response().end());
+    startServer(SocketAddress.inetSocketAddress(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST));
+
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setSsl(true)
+      .setTrustOptions(Cert.SERVER_JKS.get())
+      .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTP).setHost("localhost").setPort(proxy.port())
+        .setProxyAuthorization(authorization)));
+
+    client.request(new RequestOptions()
+        .setHost(DEFAULT_HTTPS_HOST)
+        .setPort(DEFAULT_HTTPS_PORT)
+        .setURI("/"))
+      .compose(req -> req.send()
+        .expecting(HttpResponseExpectation.SC_OK))
+      .compose(HttpClientResponse::end)
+      .await();
+
+    assertEquals(HttpMethod.CONNECT, proxy.lastMethod());
+    assertEquals(authorization, proxy.lastRequestHeaders().get("Proxy-Authorization"));
+  }
+
+  @WithProxy(kind = ProxyKind.HTTP)
+  @Test
   public void testHttpProxyFtpRequest() throws Exception {
     client = vertx.createHttpClient(new HttpClientOptions()
       .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTP).setHost(DEFAULT_HTTP_HOST).setPort(proxy.port())));

--- a/vertx-core/src/test/java/io/vertx/tests/http/impl/EndPointKeyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/impl/EndPointKeyTest.java
@@ -42,6 +42,16 @@ public class EndPointKeyTest {
     assertNotEquals(key5, key6);
     assertNotEquals(key5.hashCode(), key6.hashCode());
     assertNotEquals(key1.hashCode(), key6.hashCode());
+    EndpointKey key7 = new EndpointKey(false, HttpVersion.HTTP_1_1, null,
+      new ProxyOptions().setProxyAuthorization("Negotiate token-1"), addr, peer);
+    EndpointKey key8 = new EndpointKey(false, HttpVersion.HTTP_1_1, null,
+      new ProxyOptions().setProxyAuthorization("Negotiate token-1"), addr, peer);
+    EndpointKey key9 = new EndpointKey(false, HttpVersion.HTTP_1_1, null,
+      new ProxyOptions().setProxyAuthorization("Negotiate token-2"), addr, peer);
+    assertEquals(key7, key8);
+    assertEquals(key7.hashCode(), key8.hashCode());
+    assertNotEquals(key7, key9);
+    assertNotEquals(key7.hashCode(), key9.hashCode());
   }
 
 }

--- a/vertx-core/src/test/java/io/vertx/tests/net/ProxyOptionsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/ProxyOptionsTest.java
@@ -31,6 +31,7 @@ public class ProxyOptionsTest extends VertxTestBase {
   int randPort;
   String randUsername;
   String randPassword;
+  String randProxyAuthorization;
 
   @Override
   public void setUp() throws Exception {
@@ -40,6 +41,7 @@ public class ProxyOptionsTest extends VertxTestBase {
     randPort = TestUtils.randomPortInt();
     randUsername = TestUtils.randomAlphaString(10);
     randPassword = TestUtils.randomAlphaString(10);
+    randProxyAuthorization = "Negotiate " + TestUtils.randomAlphaString(10);
   }
 
   @Test
@@ -69,6 +71,10 @@ public class ProxyOptionsTest extends VertxTestBase {
     assertEquals(null, options.getPassword());
     assertEquals(options, options.setPassword(randPassword));
     assertEquals(randPassword, options.getPassword());
+
+    assertEquals(null, options.getProxyAuthorization());
+    assertEquals(options, options.setProxyAuthorization(randProxyAuthorization));
+    assertEquals(randProxyAuthorization, options.getProxyAuthorization());
   }
 
   @Test
@@ -79,6 +85,7 @@ public class ProxyOptionsTest extends VertxTestBase {
     options.setPort(randPort);
     options.setUsername(randUsername);
     options.setPassword(randPassword);
+    options.setProxyAuthorization(randProxyAuthorization);
 
     ProxyOptions copy = new ProxyOptions(options);
     assertEquals(randType, copy.getType());
@@ -86,6 +93,7 @@ public class ProxyOptionsTest extends VertxTestBase {
     assertEquals(randHost, copy.getHost());
     assertEquals(randUsername, copy.getUsername());
     assertEquals(randPassword, copy.getPassword());
+    assertEquals(randProxyAuthorization, copy.getProxyAuthorization());
   }
 
   @Test
@@ -97,6 +105,7 @@ public class ProxyOptionsTest extends VertxTestBase {
     assertEquals(def.getHost(), options.getHost());
     assertEquals(def.getUsername(), options.getUsername());
     assertEquals(def.getPassword(), options.getPassword());
+    assertEquals(def.getProxyAuthorization(), options.getProxyAuthorization());
   }
 
   @Test
@@ -106,12 +115,14 @@ public class ProxyOptionsTest extends VertxTestBase {
         .put("host", randHost)
         .put("port", randPort)
         .put("username", randUsername)
-        .put("password", randPassword);
+        .put("password", randPassword)
+        .put("proxyAuthorization", randProxyAuthorization);
     ProxyOptions options = new ProxyOptions(json);
     assertEquals(randType, options.getType());
     assertEquals(randPort, options.getPort());
     assertEquals(randHost, options.getHost());
     assertEquals(randUsername, options.getUsername());
     assertEquals(randPassword, options.getPassword());
+    assertEquals(randProxyAuthorization, options.getProxyAuthorization());
   }
 }


### PR DESCRIPTION
Fixes #5129.

- Add `ProxyOptions#setProxyAuthorization(...)` for prebuilt proxy auth values such as `Negotiate <token>`.
- Send the custom `Proxy-Authorization` value for plain HTTP proxy requests and HTTPS CONNECT tunneling.
- Use Netty `HttpProxyHandler` outbound headers for CONNECT so non-Basic proxy schemes can be supplied by callers.
- Include the proxy authorization value in endpoint keys to avoid sharing pooled connections across different proxy auth values.
- Add proxy option, endpoint key, HTTP proxy, and HTTPS CONNECT coverage.
