### PR TITLE
Ensure the list of enabled cipher suite is preserved.

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslContextProvider.java
@@ -62,7 +62,7 @@ public class SslContextProvider {
     this.clientAuth = clientAuth;
     this.endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
     this.applicationProtocols = applicationProtocols;
-    this.enabledCipherSuites = new HashSet<>(enabledCipherSuites);
+    this.enabledCipherSuites = new LinkedHashSet<>(enabledCipherSuites);
     this.enabledProtocols = enabledProtocols;
     this.keyManagerFactory = keyManagerFactory;
     this.trustManagerFactory = trustManagerFactory;

--- a/src/test/java/io/vertx/core/net/SSLHelperTest.java
+++ b/src/test/java/io/vertx/core/net/SSLHelperTest.java
@@ -109,19 +109,22 @@ public class SSLHelperTest extends VertxTestBase {
     SSLContext context = SSLContext.getInstance("TLS");
     context.init(null, null, null);
     SSLEngine engine = context.createSSLEngine();
+    List<String> configuredCipherSuites = new ArrayList<>(Arrays.asList(engine.getEnabledCipherSuites()));
+    assertTrue(configuredCipherSuites.size() > 1);
+    Collections.shuffle(configuredCipherSuites, new Random(12345));
     HttpServerOptions options = new HttpServerOptions();
-    for (String suite : engine.getEnabledCipherSuites()) {
+    for (String suite : configuredCipherSuites) {
       options.addEnabledCipherSuite(suite);
     }
-    assertEquals(new ArrayList<>(options.getEnabledCipherSuites()), Arrays.asList(engine.getEnabledCipherSuites()));
-    assertEquals(new ArrayList<>(new HttpServerOptions(options).getEnabledCipherSuites()), Arrays.asList(engine.getEnabledCipherSuites()));
+    assertEquals(new ArrayList<>(options.getEnabledCipherSuites()), configuredCipherSuites);
+    assertEquals(new ArrayList<>(new HttpServerOptions(options).getEnabledCipherSuites()), configuredCipherSuites);
     JsonObject json = options.toJson();
-    assertEquals(new ArrayList<>(new HttpServerOptions(json).getEnabledCipherSuites()), Arrays.asList(engine.getEnabledCipherSuites()));
+    assertEquals(new ArrayList<>(new HttpServerOptions(json).getEnabledCipherSuites()),configuredCipherSuites);
     SSLHelper helper = new SSLHelper(options.setKeyCertOptions(Cert.SERVER_JKS.get()), null);
     helper
       .buildContextProvider(options.getSslOptions(), (ContextInternal) vertx.getOrCreateContext())
       .onComplete(onSuccess(sslContextProvider -> {
-        assertEquals(new HashSet<>(Arrays.asList(createEngine(sslContextProvider).getEnabledCipherSuites())), new HashSet<>(Arrays.asList(engine.getEnabledCipherSuites())));
+        assertEquals(Arrays.asList(createEngine(sslContextProvider).getEnabledCipherSuites()), configuredCipherSuites);
         testComplete();
       }));
     await();


### PR DESCRIPTION
Motivation:

While SSL options use a linked set to maintain the cipher suite order, the SslContextProvider makes a defensive copy with an hashset which does not preserve the order.

Changes:

Use a linked set in SslContextProvider to guarantee the order.
