### PR TITLE
TcpClientConfig should allow disabling connect timeout.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/QuicClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/QuicClientConfig.java
@@ -128,7 +128,7 @@ public class QuicClientConfig extends QuicEndpointConfig {
   }
 
   /**
-   * Set the connect timeout.
+   * Set the connect timeout, the value must be greater or equals than zero, use {@code 0} to disable timeout.
    *
    * @param connectTimeout  connect timeout
    * @return a reference to this, so the API can be used fluently

--- a/vertx-core/src/main/java/io/vertx/core/net/TcpClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/TcpClientConfig.java
@@ -109,16 +109,16 @@ public class TcpClientConfig extends TcpEndpointConfig {
   }
 
   /**
-   * Set the connect timeout
+   * Set the connect timeout, the value must be greater or equals than zero, use {@code 0} to disable timeout.
    *
-   * @param connectTimeout  connect timeout, in ms
+   * @param timeout  connect timeout, in ms
    * @return a reference to this, so the API can be used fluently
    */
-  public TcpClientConfig setConnectTimeout(Duration connectTimeout) {
-    if (connectTimeout.isNegative() || connectTimeout.isZero()) {
+  public TcpClientConfig setConnectTimeout(Duration timeout) {
+    if (timeout.isNegative()) {
       throw new IllegalArgumentException("connectTimeout must be >= 0");
     }
-    this.connectTimeout = connectTimeout;
+    this.connectTimeout = timeout;
     return this;
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -4204,6 +4204,21 @@ public class NetTest {
   }
 
   @Test
+  public void testDisableConnectTimeout() throws Exception {
+    Vertx vertx = Vertx.vertx();
+    Future<NetSocket> fut;
+    try {
+      NetClient client = vertx.createNetClient(new NetClientOptions().setConnectTimeout(0));
+      fut = client.connect(1234, NON_ROUTABLE_HOST);
+      Thread.sleep(1000);
+      assertFalse(fut.isComplete());
+    } finally {
+      vertx.close().await();
+    }
+    assertWaitUntil(fut::failed);
+  }
+
+  @Test
   public void testConnectTimeoutOverride(Checkpoint checkpoint) {
     client = vertx.createNetClient();
     client.connect(new ConnectOptions()


### PR DESCRIPTION
Motivation:

`TcpClientConfig#setConnectTimeout` presents a regression that disallow setting a zero connect timeout that disables the connect timeout.

Changes:

Accept zero connect timeout.
