### PR TITLE
Provide HTTP server configurability of using the semicolon as a query param delimiter.

### DIFF
--- a/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
@@ -155,6 +155,11 @@ public class HttpServerOptionsConverter {
             obj.setTracingPolicy(io.vertx.core.tracing.TracingPolicy.valueOf((String)member.getValue()));
           }
           break;
+        case "useSemicolonAsQueryParamDelimiter":
+          if (member.getValue() instanceof Boolean) {
+            obj.setUseSemicolonAsQueryParamDelimiter((Boolean)member.getValue());
+          }
+          break;
         case "webSocketAllowServerNoContext":
           if (member.getValue() instanceof Boolean) {
             obj.setWebSocketAllowServerNoContext((Boolean)member.getValue());
@@ -230,6 +235,7 @@ public class HttpServerOptionsConverter {
     if (obj.getTracingPolicy() != null) {
       json.put("tracingPolicy", obj.getTracingPolicy().name());
     }
+    json.put("useSemicolonAsQueryParamDelimiter", obj.isUseSemicolonAsQueryParamDelimiter());
     json.put("webSocketAllowServerNoContext", obj.getWebSocketAllowServerNoContext());
     json.put("webSocketClosingTimeout", obj.getWebSocketClosingTimeout());
     json.put("webSocketCompressionLevel", obj.getWebSocketCompressionLevel());

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -107,6 +107,11 @@ public class HttpServerOptions extends NetServerOptions {
   public static final int DEFAULT_MAX_FORM_BUFFERED_SIZE = 1024;
 
   /**
+   * The default behavior of the semicolon as a delimiter : {@code true}
+   */
+  public static final boolean DEFAULT_USE_SEMICOLON_AS_QUERY_PARAM_DELIMITER = true;
+
+  /**
    * Default value of whether 100-Continue should be handled automatically = {@code false}
    */
   public static final boolean DEFAULT_HANDLE_100_CONTINE_AUTOMATICALLY = false;
@@ -219,6 +224,7 @@ public class HttpServerOptions extends NetServerOptions {
   private int maxFormAttributeSize;
   private int maxFormFields;
   private int maxFormBufferedBytes;
+  private boolean useSemicolonAsQueryParamDelimiter;
   private Http2Settings initialSettings;
   private List<HttpVersion> alpnVersions;
   private boolean http2ClearTextEnabled;
@@ -268,6 +274,7 @@ public class HttpServerOptions extends NetServerOptions {
     this.maxFormAttributeSize = other.getMaxFormAttributeSize();
     this.maxFormFields = other.getMaxFormFields();
     this.maxFormBufferedBytes = other.getMaxFormBufferedBytes();
+    this.useSemicolonAsQueryParamDelimiter = other.isUseSemicolonAsQueryParamDelimiter();
     this.initialSettings = other.initialSettings != null ? new Http2Settings(other.initialSettings) : null;
     this.alpnVersions = other.alpnVersions != null ? new ArrayList<>(other.alpnVersions) : null;
     this.http2ClearTextEnabled = other.http2ClearTextEnabled;
@@ -324,6 +331,7 @@ public class HttpServerOptions extends NetServerOptions {
     maxFormAttributeSize = DEFAULT_MAX_FORM_ATTRIBUTE_SIZE;
     maxFormFields = DEFAULT_MAX_FORM_FIELDS;
     maxFormBufferedBytes = DEFAULT_MAX_FORM_BUFFERED_SIZE;
+    useSemicolonAsQueryParamDelimiter = DEFAULT_USE_SEMICOLON_AS_QUERY_PARAM_DELIMITER;
     initialSettings = new Http2Settings().setMaxConcurrentStreams(DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS);
     alpnVersions = new ArrayList<>(DEFAULT_ALPN_VERSIONS);
     http2ClearTextEnabled = DEFAULT_HTTP2_CLEAR_TEXT_ENABLED;
@@ -892,6 +900,24 @@ public class HttpServerOptions extends NetServerOptions {
    */
   public HttpServerOptions setMaxFormBufferedBytes(int maxFormBufferedBytes) {
     this.maxFormBufferedBytes = maxFormBufferedBytes;
+    return this;
+  }
+
+  /**
+   * @return whether to use the semicolon char {@code ;} as a delimiter for query string parameters.
+   */
+  public boolean isUseSemicolonAsQueryParamDelimiter() {
+    return useSemicolonAsQueryParamDelimiter;
+  }
+
+  /**
+   * Configure whether to use the semicolon char {@code ;} as a delimiter for query string parameters.
+   *
+   * @param useSemicolonAsDelimiter whether to allow semicolon to be used as a delimiter or it is a an actual parameter name or value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setUseSemicolonAsQueryParamDelimiter(boolean useSemicolonAsDelimiter) {
+    this.useSemicolonAsQueryParamDelimiter = useSemicolonAsDelimiter;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -223,7 +223,7 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
    * @return the query parameters in the request
    */
   @CacheReturn
-  default MultiMap params() { return params(false); }
+  MultiMap params();
 
   /**
    * @param semicolonIsNormalChar whether semicolon is treated as a normal character or a query parameter separator

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerRequest.java
@@ -329,6 +329,11 @@ public class Http1xServerRequest extends HttpServerRequestInternal implements io
   }
 
   @Override
+  public boolean isUseSemicolonAsQueryParamDelimiter() {
+    return conn.options.isUseSemicolonAsQueryParamDelimiter();
+  }
+
+  @Override
   public MultiMap params(boolean semicolonIsNormalChar) {
     if (params == null || semicolonIsNormalChar != semicolonIsNormalCharInParams) {
       params = HttpUtils.params(uri(), paramsCharset, semicolonIsNormalChar);

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequest.java
@@ -352,6 +352,11 @@ public class Http2ServerRequest extends HttpServerRequestInternal implements Htt
   }
 
   @Override
+  public boolean isUseSemicolonAsQueryParamDelimiter() {
+    return stream.conn.options.isUseSemicolonAsQueryParamDelimiter();
+  }
+
+  @Override
   public HttpServerRequest setParamsCharset(String charset) {
     Objects.requireNonNull(charset, "Charset must not be null");
     Charset current = paramsCharset;

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestInternal.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestInternal.java
@@ -11,6 +11,7 @@
 package io.vertx.core.http.impl;
 
 import io.vertx.core.Context;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.spi.observability.HttpRequest;
 
@@ -20,6 +21,13 @@ import io.vertx.core.spi.observability.HttpRequest;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public abstract class HttpServerRequestInternal implements HttpServerRequest {
+
+  public abstract boolean isUseSemicolonAsQueryParamDelimiter();
+
+  @Override
+  public MultiMap params() {
+    return params(!isUseSemicolonAsQueryParamDelimiter());
+  }
 
   /**
    * @return the Vert.x context associated with this server request

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
@@ -54,6 +54,11 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
+  public boolean isUseSemicolonAsQueryParamDelimiter() {
+    return delegate.isUseSemicolonAsQueryParamDelimiter();
+  }
+
+  @Override
   public HttpServerRequest exceptionHandler(Handler<Throwable> handler) {
     return delegate.exceptionHandler(handler);
   }

--- a/src/test/java/io/vertx/core/http/HttpTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTest.java
@@ -928,6 +928,55 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   @Test
+  public void testUseQueryParamsSemicolonDelimiterDecoding() throws Exception {
+    MultiMap actual = TestUtils.randomMultiMap(10);
+    testConfigureQueryParamsSemicolonDelimiterDecoding(actual, createBaseServerOptions().setUseSemicolonAsQueryParamDelimiter(true), params -> {
+      assertEquals(actual.size(), params.size());
+      for  (Map.Entry<String, String> header : params) {
+        assertEquals(actual.get(header.getKey()), header.getValue());
+      }
+    });
+  }
+
+  @Test
+  public void testDoNotUseQueryParamsSemicolonDelimiterDecoding() throws Exception {
+    MultiMap actual = TestUtils.randomMultiMap(10);
+    testConfigureQueryParamsSemicolonDelimiterDecoding(actual, createBaseServerOptions().setUseSemicolonAsQueryParamDelimiter(false), params -> {
+      assertEquals(1, params.size());
+    });
+  }
+
+  @Test
+  public void testDefaultQueryParamsSemicolonDelimiterDecoding() throws Exception {
+    MultiMap actual = TestUtils.randomMultiMap(10);
+    testConfigureQueryParamsSemicolonDelimiterDecoding(actual, createBaseServerOptions(), params -> {
+      assertEquals(actual.size(), params.size());
+      for  (Map.Entry<String, String> header : params) {
+        assertEquals(actual.get(header.getKey()), header.getValue());
+      }
+    });
+  }
+
+  private void testConfigureQueryParamsSemicolonDelimiterDecoding(MultiMap p, HttpServerOptions options, Consumer<MultiMap> checker) throws Exception {
+    server.close();
+    server = vertx.createHttpServer(options);
+    server.requestHandler(req -> {
+      MultiMap params = req.params();
+      checker.accept(params);
+      req.response().end();
+    });
+    startServer(testAddress);
+    client
+      .request(new RequestOptions(requestOptions).setURI("/some?" + generateQueryString(p, ';')))
+      .compose(request -> request
+        .send()
+        .expecting(HttpResponseExpectation.SC_OK)
+        .map(HttpClientResponse::body))
+      .onComplete(onSuccess(v -> testComplete()));
+    await();
+  }
+
+  @Test
   public void testMissingContentTypeMultipartRequest() throws Exception {
     testInvalidMultipartRequest(null, HttpMethod.POST);
   }


### PR DESCRIPTION
Motivation:

Vert.x HTTP server considers that the semicolon char is a query param delimiter, this is not always wanted and we should provide a way to change the behavior.

Changes:

Provide an HTTP server option to configure whether the semicolon char is a query param delimiter.
