### PR TITLE
Support HTTP/2 / HTTP/3 extended connect.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/Http2Settings.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/Http2Settings.java
@@ -161,7 +161,7 @@ public final class Http2Settings extends HttpSettings {
    * Default constructor
    */
   public Http2Settings() {
-    super(7);
+    super(9);
     extraSettings = DEFAULT_EXTRA_SETTINGS;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/Http3Settings.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/Http3Settings.java
@@ -65,7 +65,7 @@ public class Http3Settings extends HttpSettings {
   }
 
   public Http3Settings() {
-    super(8);
+    super(9);
   }
 
   public Http3Settings(Http3Settings other) {

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -175,6 +175,20 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   MultiMap headers();
 
   /**
+   * @return the pseudo header {@code :protocol} to use for extended connect
+   */
+  String connectProtocol();
+
+  /**
+   * Set the {@code :protocol} pseudo header used for extended connect.
+   *
+   * @param protocol the pseudo header value
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpClientRequest connectProtocol(String protocol);
+
+  /**
    * Put an HTTP header
    *
    * @param name  The header name

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -200,6 +200,20 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   MultiMap headers();
 
   /**
+   * @return the pseudo header {@code :protocol} to use for extended connect
+   */
+  String connectProtocol();
+
+  /**
+   * Set the {@code :protocol} pseudo header used for extended connect.
+   *
+   * @param protocol the pseudo header value
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpClientRequest connectProtocol(String protocol);
+
+  /**
    * Put an HTTP header
    *
    * @param name  The header name

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -492,6 +492,12 @@ public interface HttpHeaders {
   CharSequence PSEUDO_METHOD = Http2Headers.PseudoHeaderName.METHOD.value();
 
   /**
+   * HTTP/2 {@code :protocol} pseudo header
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence PSEUDO_PROTOCOL = Http2Headers.PseudoHeaderName.PROTOCOL.value();
+
+  /**
    * Create an optimized {@link CharSequence} which can be used as header name or value.
    * This should be used if you expect to use it multiple times liked for example adding the same header name or value
    * for multiple responses or requests.

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -498,6 +498,12 @@ public interface HttpHeaders {
   CharSequence PSEUDO_METHOD = Http2Headers.PseudoHeaderName.METHOD.value();
 
   /**
+   * HTTP/2 {@code :protocol} pseudo header
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence PSEUDO_PROTOCOL = Http2Headers.PseudoHeaderName.PROTOCOL.value();
+
+  /**
    * Create an optimized {@link CharSequence} which can be used as header name or value.
    * This should be used if you expect to use it multiple times liked for example adding the same header name or value
    * for multiple responses or requests.

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -138,6 +138,11 @@ public interface HttpServerRequest extends ReadStream<Buffer>, HttpRequestHead {
   HostAndPort authority(boolean real);
 
   /**
+   * @return the {@code :protocol} pseudo header used by extended connect
+   */
+  String connectProtocol();
+
+  /**
    * @return the total number of bytes read for the body of the request.
    */
   long bytesRead();

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpSettings.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpSettings.java
@@ -10,9 +10,13 @@
  */
 package io.vertx.core.http;
 
+import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.impl.Arguments;
 
 import java.util.Arrays;
+import java.util.Set;
+import java.util.function.LongConsumer;
 
 /**
  * Base container for HTTP settings.
@@ -21,6 +25,19 @@ import java.util.Arrays;
  */
 @DataObject
 public abstract class HttpSettings {
+
+  /**
+   * HTTP {@code ENABLE_CONNECT_PROTOCOL} setting
+   */
+  public static final HttpSetting<Boolean> ENABLE_CONNECT_PROTOCOL;
+
+  static {
+    LongConsumer enableConnectProtocolValidator = value -> Arguments.require(value == 0L ||  value == 1L,
+      "enableConnectProtocol must be >= " + Http2CodecUtil.MIN_HEADER_LIST_SIZE);
+    ENABLE_CONNECT_PROTOCOL = new HttpSetting<>(0x08, "ENABLE_CONNECT_PROTOCOL", false,
+      val -> val ? 1L : 0L, val -> val == 1L, enableConnectProtocolValidator, Set.of(HttpVersion.HTTP_2, HttpVersion.HTTP_3));
+
+  }
 
   private long presence; // Could be first element of values
   private final long[] values;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -53,6 +53,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   private int maxRedirects;
   private int numberOfRedirections;
   private final MultiMap headers;
+  private String connectProtocol;
   private boolean trailersSent;
   private boolean headersSent;
   private StreamPriority priority;
@@ -184,6 +185,17 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   @Override
   public MultiMap headers() {
     return headers;
+  }
+
+  @Override
+  public String connectProtocol() {
+    return connectProtocol;
+  }
+
+  @Override
+  public HttpClientRequestImpl connectProtocol(String protocol) {
+    this.connectProtocol = protocol;
+    return this;
   }
 
   @Override
@@ -533,7 +545,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
       if (uri.isEmpty()) {
         uri = "/";
       }
-      HttpRequestHead head = new HttpRequestHead(ssl ? "https" : "http", method, uri, headers, authority(), absoluteURI(), traceOperation);
+      HttpRequestHead head = new HttpRequestHead(ssl ? "https" : "http", method, uri,  connectProtocol, headers, authority(), absoluteURI(), traceOperation);
       future = stream.writeHead(head, chunked, buff, writeEnd, priority, connect);
     } else {
       if (buff == null && !end) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -56,6 +56,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   private int maxRedirects;
   private int numberOfRedirections;
   private final MultiMap headers;
+  private String connectProtocol;
   private boolean trailersSent;
   private boolean headersSent;
   private StreamPriority priority;
@@ -203,6 +204,17 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   @Override
   public MultiMap headers() {
     return headers;
+  }
+
+  @Override
+  public String connectProtocol() {
+    return connectProtocol;
+  }
+
+  @Override
+  public HttpClientRequestImpl connectProtocol(String protocol) {
+    this.connectProtocol = protocol;
+    return this;
   }
 
   @Override
@@ -587,7 +599,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
       if (uri.isEmpty()) {
         uri = "/";
       }
-      HttpRequestHead head = new HttpRequestHead(ssl ? "https" : "http", method, uri, headers, authority(), absoluteURI(), traceOperation);
+      HttpRequestHead head = new HttpRequestHead(ssl ? "https" : "http", method, uri,  connectProtocol, headers, authority(), absoluteURI(), traceOperation);
       future = stream.writeHead(head, chunked, buff, writeEnd, priority, connect);
     } else {
       if (buff == null && !end) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -66,6 +66,16 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
+  public String connectProtocol() {
+    return null;
+  }
+
+  @Override
+  public HttpClientRequest connectProtocol(String protocol) {
+    throw new IllegalStateException();
+  }
+
+  @Override
   public Future<Void> write(Buffer data) {
     throw new IllegalStateException();
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -68,6 +68,16 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
+  public String connectProtocol() {
+    return null;
+  }
+
+  @Override
+  public HttpClientRequest connectProtocol(String protocol) {
+    throw new IllegalStateException();
+  }
+
+  @Override
   public Future<Void> write(Buffer data) {
     throw new IllegalStateException();
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpRequestHead.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpRequestHead.java
@@ -22,15 +22,17 @@ public class HttpRequestHead {
   public final String scheme;
   public final HttpMethod method;
   public final String uri;
+  public final String protocol;
   public final MultiMap headers;
   public final HostAndPort authority;
   public final String absoluteURI;
   public final String traceOperation;
 
-  public HttpRequestHead(String scheme, HttpMethod method, String uri, MultiMap headers, HostAndPort authority, String absoluteURI, String traceOperation) {
+  public HttpRequestHead(String scheme, HttpMethod method, String uri, String protocol, MultiMap headers, HostAndPort authority, String absoluteURI, String traceOperation) {
     this.scheme = scheme;
     this.method = method;
     this.uri = uri;
+    this.protocol = protocol;
     this.headers = headers;
     this.authority = authority;
     this.absoluteURI = absoluteURI;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -57,6 +57,7 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
   private String uri;
   private MultiMap headersMap;
   private HostAndPort authority;
+  private String protocol;
   private HostAndPort realAuthority;
   private String absoluteURI;
   private MultiMap attributes;
@@ -112,6 +113,7 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
     method = headers.method();
     realAuthority = headers.authority;
     authority = headers.authority;
+    protocol = headers.protocol;
     if (authority == null) {
       String hostHeader = headers.headers.get(HttpHeaders.HOST);
       if (hostHeader != null) {
@@ -357,6 +359,11 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
   @Override
   public @Nullable HostAndPort authority(boolean real) {
     return real ? realAuthority : authority;
+  }
+
+  @Override
+  public String connectProtocol() {
+    return protocol;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -58,6 +58,7 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
   private String uri;
   private MultiMap headersMap;
   private HostAndPort authority;
+  private String protocol;
   private HostAndPort realAuthority;
   private String absoluteURI;
   private MultiMap attributes;
@@ -113,6 +114,7 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
     method = headers.method();
     realAuthority = headers.authority;
     authority = headers.authority;
+    protocol = headers.protocol;
     if (authority == null) {
       String hostHeader = headers.headers.get(HttpHeaders.HOST);
       if (hostHeader != null) {
@@ -363,6 +365,11 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
   @Override
   public @Nullable HostAndPort authority(boolean real) {
     return real ? realAuthority : authority;
+  }
+
+  @Override
+  public String connectProtocol() {
+    return protocol;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -27,6 +27,7 @@ import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.core.http.HttpClosedException;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpSettings;
 import io.vertx.core.http.StreamPriority;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
@@ -379,6 +380,12 @@ public final class HttpUtils {
     if (vertxSettings.getMaxHeaderListSize() != DEFAULT_MAX_HEADER_LIST_SIZE) {
       nettySettings.maxHeaderListSize(vertxSettings.getMaxHeaderListSize());
     }
+    if (vertxSettings.getMaxHeaderListSize() != DEFAULT_MAX_HEADER_LIST_SIZE) {
+      nettySettings.maxHeaderListSize(vertxSettings.getMaxHeaderListSize());
+    }
+    if (vertxSettings.get(HttpSettings.ENABLE_CONNECT_PROTOCOL) == Boolean.TRUE) {
+      nettySettings.put((char)0x08, (Long)1L);
+    }
     Map<Integer, Long> extraSettings = vertxSettings.getExtraSettings();
     if (extraSettings != null) {
       extraSettings.forEach((code, setting) -> {
@@ -429,8 +436,12 @@ public final class HttpUtils {
     if (headerTableSize != null) {
       converted.setHeaderTableSize(headerTableSize);
     }
+    Long enableConnectProtocol = settings.get((char)0x08);
+    if (enableConnectProtocol != null && enableConnectProtocol == 1L) {
+      converted.set(HttpSettings.ENABLE_CONNECT_PROTOCOL, true);
+    }
     settings.forEach((key, value) -> {
-      if (key > 6) {
+      if (key > 6 && key != 8) {
         converted.set(key, value);
       }
     });

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/headers/HttpRequestHeaders.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/headers/HttpRequestHeaders.java
@@ -108,6 +108,7 @@ public class HttpRequestHeaders extends HttpHeaders {
   private HostAndPort authority;
   private String uri;
   private String scheme;
+  private String protocol;
   private String trace;
 
   public HttpRequestHeaders(Headers<CharSequence, CharSequence, ?> headers) {
@@ -167,6 +168,15 @@ public class HttpRequestHeaders extends HttpHeaders {
     return this;
   }
 
+  public String protocol() {
+    return protocol;
+  }
+
+  public HttpHeaders protocol(String protocol) {
+    this.protocol = protocol;
+    return this;
+  }
+
   public boolean validate() {
     CharSequence methodHeader = headers.get(io.vertx.core.http.HttpHeaders.PSEUDO_METHOD);
     if (methodHeader == null) {
@@ -197,7 +207,15 @@ public class HttpRequestHeaders extends HttpHeaders {
       authorityPresence = authority;
     }
 
-    if (method == HttpMethod.CONNECT) {
+    CharSequence protocolHeader = headers.get(io.vertx.core.http.HttpHeaders.PSEUDO_PROTOCOL);
+    String protocol;
+    if (method == HttpMethod.CONNECT && protocolHeader != null) {
+      protocol = protocolHeader.toString();
+    } else {
+      protocol = null;
+    }
+
+    if (method == HttpMethod.CONNECT && protocol == null) {
       if (scheme != null || uri != null || authorityPresence == null) {
         return false;
       }
@@ -225,6 +243,7 @@ public class HttpRequestHeaders extends HttpHeaders {
     this.uri = uri;
     this.authority = authority;
     this.scheme = scheme;
+    this.protocol = protocol;
 
     return true;
   }
@@ -253,6 +272,9 @@ public class HttpRequestHeaders extends HttpHeaders {
     }
     if (scheme != null) {
       headers.set(io.vertx.core.http.HttpHeaders.PSEUDO_SCHEME, scheme);
+    }
+    if (method == HttpMethod.CONNECT && protocol != null) {
+      headers.set(io.vertx.core.http.HttpHeaders.PSEUDO_PROTOCOL, protocol);
     }
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
@@ -1106,7 +1106,7 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
 
           if (webSocketMetrics != null) {
             ws.setMetric(webSocketMetrics.connected(new ObservableRequest(new HttpRequestHead(
-              ssl ? "https" : "http", HttpMethod.GET, requestURI, headers, authority, "/", null
+              ssl ? "https" : "http", HttpMethod.GET, requestURI, null, headers, authority, "/", null
             ))));
           }
           ws.pause();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
@@ -1125,7 +1125,7 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
 
           if (webSocketMetrics != null) {
             ws.setMetric(webSocketMetrics.connected(new ObservableRequest(new HttpRequestHead(
-              ssl ? "https" : "http", HttpMethod.GET, requestURI, headers, authority, "/", null
+              ssl ? "https" : "http", HttpMethod.GET, requestURI, null, headers, authority, "/", null
             ))));
           }
           ws.pause();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
@@ -283,6 +283,11 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
   }
 
   @Override
+  public String connectProtocol() {
+    return null;
+  }
+
+  @Override
   public long bytesRead() {
     synchronized (conn) {
       return bytesRead;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
@@ -289,6 +289,11 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
   }
 
   @Override
+  public String connectProtocol() {
+    return null;
+  }
+
+  @Override
   public long bytesRead() {
     synchronized (conn) {
       return bytesRead;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2ClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2ClientStream.java
@@ -156,6 +156,11 @@ class DefaultHttp2ClientStream extends DefaultHttp2Stream<DefaultHttp2ClientStre
           throw new IllegalArgumentException("Missing :authority / host header");
         }
         headers.authority(request.authority);
+        if (request.protocol != null) {
+          headers.protocol(request.protocol);
+          headers.path(request.uri);
+          headers.scheme(connection.isSsl() ? "https" : "http");
+        }
         // don't end stream for CONNECT
         e = false;
       } else {
@@ -217,7 +222,7 @@ class DefaultHttp2ClientStream extends DefaultHttp2Stream<DefaultHttp2ClientStre
   }
 
   public void onPush(DefaultHttp2ClientStream pushStream, int promisedStreamId, HttpRequestHeaders headers, boolean writable) {
-    HttpClientPush push = new HttpClientPush(new HttpRequestHead(headers.scheme(), headers.method(), headers.path(), headers, headers.authority(), null, null), pushStream);
+    HttpClientPush push = new HttpClientPush(new HttpRequestHead(headers.scheme(), headers.method(), headers.path(), null, headers, headers.authority(), null, null), pushStream);
     pushStream.init(promisedStreamId, writable);
     if (pushStream.observable != null) {
       pushStream.observable.observePush(headers);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2ServerStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2ServerStream.java
@@ -152,6 +152,7 @@ class DefaultHttp2ServerStream extends DefaultHttp2Stream<DefaultHttp2ServerStre
       requestHeaders.scheme(),
       requestHeaders.method(),
       requestHeaders.path(),
+      requestHeaders.protocol(),
       map,
       requestHeaders.authority(),
       null,

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ClientStream.java
@@ -131,6 +131,12 @@ public class Http3ClientStream extends Http3Stream<Http3ClientStream, Http3Clien
     if (request.method != HttpMethod.CONNECT) {
       headers.path(request.uri);
       headers.scheme("https");
+    } else {
+      if (request.protocol != null) {
+        headers.path(request.uri);
+        headers.scheme("https");
+        headers.protocol(request.protocol);
+      }
     }
     headers.prepare();
     return writeHeaders(headers, chunk, end);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Connection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Connection.java
@@ -68,15 +68,19 @@ public abstract class Http3Connection implements HttpConnection {
 
   io.netty.handler.codec.http3.Http3Settings nettyLocalSettings() {
     io.netty.handler.codec.http3.Http3Settings nSettings = new io.netty.handler.codec.http3.Http3Settings();
-    Long val;
-    if ((val = localSettings.get(Http3Settings.MAX_FIELD_SECTION_SIZE)) != null) {
-      nSettings.maxFieldSectionSize(val);
+    Long lval;
+    if ((lval = localSettings.get(Http3Settings.MAX_FIELD_SECTION_SIZE)) != null) {
+      nSettings.maxFieldSectionSize(lval);
     }
-    if ((val = localSettings.get(Http3Settings.QPACK_BLOCKED_STREAMS)) != null) {
-      nSettings.qpackBlockedStreams(val);
+    if ((lval = localSettings.get(Http3Settings.QPACK_BLOCKED_STREAMS)) != null) {
+      nSettings.qpackBlockedStreams(lval);
     }
-    if ((val = localSettings.get(Http3Settings.QPACK_MAX_TABLE_CAPACITY)) != null) {
-      nSettings.qpackMaxTableCapacity(val);
+    if ((lval = localSettings.get(Http3Settings.QPACK_MAX_TABLE_CAPACITY)) != null) {
+      nSettings.qpackMaxTableCapacity(lval);
+    }
+    Boolean bval;
+    if ((bval = localSettings.get(HttpSettings.ENABLE_CONNECT_PROTOCOL)) != null) {
+      nSettings.enableConnectProtocol(bval);
     }
     return nSettings;
   }
@@ -249,6 +253,9 @@ public abstract class Http3Connection implements HttpConnection {
             break;
           case HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE:
             vSetting = Http3Settings.MAX_FIELD_SECTION_SIZE;
+            break;
+          case HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL:
+            vSetting = HttpSettings.ENABLE_CONNECT_PROTOCOL;
             break;
           default:
             continue;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ServerStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ServerStream.java
@@ -62,6 +62,7 @@ public class Http3ServerStream extends Http3Stream<Http3ServerStream, Http3Serve
         requestHeaders.scheme(),
         requestHeaders.method(),
         requestHeaders.path(),
+        requestHeaders.protocol(),
         requestHeaders,
         requestHeaders.authority(),
         null,

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpClientTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpClientTransport.java
@@ -356,7 +356,7 @@ public class TcpHttpClientTransport implements HttpClientTransport {
                 future.tryComplete(unwrap);
               });
               stream.exceptionHandler(future::tryFail);
-              HttpRequestHead request = new HttpRequestHead("http", OPTIONS, "/", HttpHeaders.headers(), HostAndPort.authority(server.host(), server.port()),
+              HttpRequestHead request = new HttpRequestHead("http", OPTIONS, "/", null, HttpHeaders.headers(), HostAndPort.authority(server.host(), server.port()),
                 "http://" + server + "/", null);
               stream.writeHead(request, false, null, true, null, false);
             } else {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpClientTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpClientTransport.java
@@ -416,7 +416,7 @@ public class TcpHttpClientTransport implements HttpClientTransport {
                 future.tryComplete(unwrap);
               });
               stream.exceptionHandler(future::tryFail);
-              HttpRequestHead request = new HttpRequestHead("http", OPTIONS, "/", HttpHeaders.headers(), HostAndPort.authority(server.host(), server.port()),
+              HttpRequestHead request = new HttpRequestHead("http", OPTIONS, "/", null, HttpHeaders.headers(), HostAndPort.authority(server.host(), server.port()),
                 "http://" + server + "/", null);
               stream.writeHead(request, false, null, true, null, false);
             } else {

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
@@ -106,6 +106,11 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
+  public String connectProtocol() {
+    return delegate.connectProtocol();
+  }
+
+  @Override
   public boolean isValidAuthority() {
     return delegate.isValidAuthority();
   }

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
@@ -107,6 +107,11 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
+  public String connectProtocol() {
+    return delegate.connectProtocol();
+  }
+
+  @Override
   public boolean isValidAuthority() {
     return delegate.isValidAuthority();
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
@@ -191,6 +191,19 @@ public class Http2ClientTest extends Http2TestBase {
   }
 
   @Test
+  public void testEnableConnectProtocolSetting() throws Exception {
+    io.vertx.core.http.Http2Settings settings = new io.vertx.core.http.Http2Settings();
+    settings.set(io.vertx.core.http.Http2Settings.ENABLE_CONNECT_PROTOCOL, true);
+    server = vertx.createHttpServer(new HttpServerOptions(serverOptions).setInitialSettings(settings));
+    server.requestHandler(req -> {
+    });
+    startServer();
+    HttpConnection connection = client.connect(requestOptions).await();
+    HttpSettings receivedSettings = connection.remoteSettings();
+    Assert.assertTrue(receivedSettings.get(Http2Settings.ENABLE_CONNECT_PROTOCOL));
+  }
+
+  @Test
   public void testReduceMaxConcurrentStreams() throws Exception {
     int initial = 10;
     int reduced = 5;
@@ -1655,6 +1668,30 @@ public class Http2ClientTest extends Http2TestBase {
         }));
     }));
     await();
+  }
+
+  @Test
+  public void testExtendedConnect() throws Exception {
+
+    HttpServerOptions options = createBaseServerOptions();
+    options.getInitialSettings().set(Http2Settings.ENABLE_CONNECT_PROTOCOL, true);
+
+    server.close();
+    server = vertx.createHttpServer(options);
+    server.requestHandler(request -> {
+      Assert.assertEquals("the-protocol", request.connectProtocol());
+      request.response().end();
+    });
+
+    startServer(testAddress);
+
+    client.request(new RequestOptions(requestOptions)
+        .setMethod(HttpMethod.CONNECT))
+      .compose(request -> request.connectProtocol("the-protocol")
+        .send()
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::end))
+      .await();
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2ServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2ServerTest.java
@@ -110,19 +110,19 @@ import static io.vertx.test.core.TestUtils.assertIllegalStateException;
  */
 public class Http2ServerTest extends Http2TestBase {
 
-  private static Http2Headers headers(String method, String scheme, String path) {
+  static Http2Headers headers(String method, String scheme, String path) {
     return new DefaultHttp2Headers().method(method).scheme(scheme).path(path);
   }
 
-  private static Http2Headers GET(String scheme, String path) {
+  static Http2Headers GET(String scheme, String path) {
     return headers("GET", scheme, path);
   }
 
-  private static Http2Headers GET(String path) {
+  static Http2Headers GET(String path) {
     return headers("GET", "https", path);
   }
 
-  private static Http2Headers POST(String path) {
+  static Http2Headers POST(String path) {
     return headers("POST", "https", path);
   }
 
@@ -447,6 +447,30 @@ public class Http2ServerTest extends Http2TestBase {
   }
 
   @Test
+  public void testEnableConnectProtocolSetting() throws Exception {
+    io.vertx.core.http.Http2Settings settings = new io.vertx.core.http.Http2Settings();
+    settings.set(io.vertx.core.http.Http2Settings.ENABLE_CONNECT_PROTOCOL, true);
+    server = vertx.createHttpServer(new HttpServerOptions(serverOptions).setInitialSettings(settings));
+    server.requestHandler(req -> {
+    });
+    startServer();
+    TestClient client = new TestClient();
+    client.connect(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, connection -> {
+      connection.decoder.frameListener(new Http2FrameAdapter() {
+        @Override
+        public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings newSettings) throws Http2Exception {
+          vertx.runOnContext(v -> {
+            Long val = newSettings.get((char) 0x08);
+            Assert.assertEquals((Long) 1L, val);
+            testComplete();
+          });
+        }
+      });
+    });
+    await();
+  }
+
+  @Test
   public void testGet() throws Exception {
     String expected = TestUtils.randomAlphaString(1000);
     AtomicBoolean requestEnded = new AtomicBoolean();
@@ -731,6 +755,38 @@ public class Http2ServerTest extends Http2TestBase {
       Http2Headers headers = new DefaultHttp2Headers().method("CONNECT").authority("whatever.com");
       request.encoder.writeHeaders(request.context, id, headers, 0, true, request.context.newPromise());
       request.context.flush();
+    });
+    await();
+  }
+
+  @Test
+  public void testExtendedConnect() throws Exception {
+    io.vertx.core.http.Http2Settings settings = new io.vertx.core.http.Http2Settings();
+    settings.set(io.vertx.core.http.Http2Settings.ENABLE_CONNECT_PROTOCOL, true);
+    server = vertx.createHttpServer(new HttpServerOptions(serverOptions).setInitialSettings(settings));
+    server.requestHandler(req -> {
+      Assert.assertEquals("the-protocol", req.connectProtocol());
+      req.response().end();
+    });
+    startServer();
+    TestClient client = new TestClient();
+    client.connect(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, connection -> {
+      int id = connection.nextStreamId();
+      connection.decoder.frameListener(new Http2EventAdapter() {
+        @Override
+        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) throws Http2Exception {
+          if (endStream) {
+            vertx.runOnContext(v -> {
+              testComplete();
+            });
+          }
+        }
+      });
+      Http2Headers headers = headers("CONNECT", "https", "/")
+        .authority(DEFAULT_HTTPS_HOST_AND_PORT)
+        .set(":protocol", "the-protocol");
+      connection.encoder.writeHeaders(connection.context, id, headers, 0, true, connection.context.newPromise());
+      connection.context.flush();
     });
     await();
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -3777,6 +3777,8 @@ public abstract class HttpTest extends SimpleHttpTest2 {
       public String getURI() { throw new UnsupportedOperationException(); }
       public HttpClientRequest setURI(String uri) { throw new UnsupportedOperationException(); }
       public String path() { throw new UnsupportedOperationException(); }
+      public String connectProtocol() { throw new UnsupportedOperationException(); }
+      public HttpClientRequest connectProtocol(String protocol) { return null; }
       public String query() { throw new UnsupportedOperationException(); }
       public MultiMap headers() { return headers; }
       public HttpClientRequest putHeader(String name, String value) { throw new UnsupportedOperationException(); }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -4004,6 +4004,8 @@ public abstract class HttpTest extends SimpleHttpTest2 {
       public String getURI() { throw new UnsupportedOperationException(); }
       public HttpClientRequest setURI(String uri) { throw new UnsupportedOperationException(); }
       public String path() { throw new UnsupportedOperationException(); }
+      public String connectProtocol() { throw new UnsupportedOperationException(); }
+      public HttpClientRequest connectProtocol(String protocol) { return null; }
       public String query() { throw new UnsupportedOperationException(); }
       public MultiMap headers() { return headers; }
       public HttpClientRequest putHeader(String name, String value) { throw new UnsupportedOperationException(); }

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ClientTest.java
@@ -401,7 +401,8 @@ public class Http3ClientTest extends VertxTestBase {
         .setInitialSettings(new Http3Settings()
           .setMaxFieldSectionSize(1024)
           .setQPackMaxTableCapacity(1024)
-          .setQPackBlockedStreams(1024)));
+          .setQPackBlockedStreams(1024)
+          .set(HttpSettings.ENABLE_CONNECT_PROTOCOL, true)));
 
     server.close();
     server = vertx.createHttpServer(serverConfig, serverSslOptions);
@@ -443,6 +444,7 @@ public class Http3ClientTest extends VertxTestBase {
     Assert.assertEquals(1024L, (long)settings.get(io.vertx.core.http.Http3Settings.MAX_FIELD_SECTION_SIZE));
     Assert.assertEquals(1024L, (long)settings.get(io.vertx.core.http.Http3Settings.QPACK_BLOCKED_STREAMS));
     Assert.assertEquals(1024L, (long)settings.get(io.vertx.core.http.Http3Settings.QPACK_MAX_TABLE_CAPACITY));
+    Assert.assertEquals(true, settings.get(HttpSettings.ENABLE_CONNECT_PROTOCOL));
   }
 
 //  @Test
@@ -518,5 +520,34 @@ public class Http3ClientTest extends VertxTestBase {
     } catch (Throwable e) {
       Assert.assertTrue(e instanceof TimeoutException);
     }
+  }
+
+  @Test
+  public void testExtendedConnect() {
+
+    server.close();
+    Http3ServerConfig cfg = new Http3ServerConfig()
+      .setInitialSettings(new io.vertx.core.http.Http3Settings()
+        .set(HttpSettings.ENABLE_CONNECT_PROTOCOL, true));
+    server = vertx.createHttpServer(new HttpServerConfig(serverOptions).setHttp3Config(cfg), serverSslOptions);
+
+    server.requestHandler(req -> {
+      Assert.assertEquals("the-protocol", req.connectProtocol());
+      req.response().end();
+    });
+    server.listen(8443, "localhost").await();
+
+    HttpClientConnection connection = client.connect(new HttpConnectOptions()
+      .setHost("localhost")
+      .setPort(8443)).await();
+
+    connection.request(HttpMethod.CONNECT, 8443, "localhost", "/")
+      .expecting(request -> request.version() == HttpVersion.HTTP_3)
+      .compose(request -> request
+        .connectProtocol("the-protocol")
+        .send()
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::end))
+      .await();
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ServerTest.java
@@ -411,7 +411,8 @@ public class Http3ServerTest extends VertxTestBase {
         .setInitialSettings(new io.vertx.core.http.Http3Settings()
           .setMaxFieldSectionSize(1024)
           .setQPackBlockedStreams(1024)
-          .setQPackMaxTableCapacity(1024)));
+          .setQPackMaxTableCapacity(1024)
+          .set(HttpSettings.ENABLE_CONNECT_PROTOCOL, true)));
     server = vertx.createHttpServer(config, sslOptions());
 
     server.connectionHandler(connection -> {
@@ -443,7 +444,8 @@ public class Http3ServerTest extends VertxTestBase {
     Http3Settings settings = connection.remoteSettings();
     Assert.assertEquals(1024L, (long)settings.maxFieldSectionSize());
     Assert.assertEquals(1024L, (long)settings.qpackMaxTableCapacity());
-    Assert.assertEquals(1024L, (long)settings.qpackBlockedStreams());
+    Assert.assertEquals(1024L, (long)settings.qpackMaxTableCapacity());
+    Assert.assertEquals(true, settings.connectProtocolEnabled());
   }
 
   @Test
@@ -464,6 +466,31 @@ public class Http3ServerTest extends VertxTestBase {
     Http3TestClient.Client.Connection connection = client.connect(new InetSocketAddress(NetUtil.LOCALHOST4, 8443));
     Http3TestClient.Client.Stream stream = connection.stream();
     stream.write(new DefaultHttp3Headers().method("CONNECT").authority("whatever.com"), true, false);
+    await();
+  }
+
+  @Test
+  public void testExtendedConnect() throws Exception {
+    server.close();
+    Http3ServerConfig cfg = new Http3ServerConfig()
+      .setInitialSettings(new io.vertx.core.http.Http3Settings()
+        .set(HttpSettings.ENABLE_CONNECT_PROTOCOL, true));
+    server = vertx.createHttpServer(serverConfig().setHttp3Config(cfg), sslOptions());
+    server.requestHandler(req -> {
+      Assert.assertEquals("the-protocol", req.connectProtocol());
+      testComplete();
+    });
+
+    server.listen(8443, "localhost").await();
+
+    Http3TestClient.Client.Connection connection = client.connect(new InetSocketAddress(NetUtil.LOCALHOST4, 8443));
+    Http3TestClient.Client.Stream stream = connection.stream();
+    stream.write(new DefaultHttp3Headers()
+      .method("CONNECT")
+      .authority("whatever.com")
+      .scheme("https")
+      .path("/")
+      .protocol("the-protocol"), true, false);
     await();
   }
 


### PR DESCRIPTION
Motivation:

RFC9220 and RFC8441 define an extended connect method for bootstrapping WebSocket and other protocols for HTTP/2 and HTTP/3.

Changes:

Implement _ENABLE_CONNECT_PROTOCOL_ setting for HTTP/2 and HTTP/3

Implement the `:protocol` pseudo header passing for the `CONNECT` method: this provides support for setting or obtaining the connect protocol value of the pseudo header.
