### PR TITLE
Lazy create the singleton vertx cleaner instance.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/CleanerProvider.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/CleanerProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.impl;
+
+import java.lang.ref.Cleaner;
+
+/**
+ * Encapsulate a cleaner and provide a lazy instantiation policy.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class CleanerProvider {
+
+  public static CleanerProvider INSTANCE = new CleanerProvider();
+
+  private CleanerProvider() {
+  }
+
+  /**
+   * Default shared cleaner for Vert.x
+   */
+  private Cleaner cleaner;
+
+  /**
+   * @return the cleaner
+   */
+  synchronized Cleaner get() {
+    Cleaner ret = cleaner;
+    if (ret == null) {
+      ret = Cleaner.create();
+      cleaner = ret;
+    }
+    return ret;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -93,11 +93,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   private static String version;
 
   /**
-   * Default shared cleaner for Vert.x
-   */
-  private static final Cleaner cleaner = Cleaner.create();
-
-  /**
    * Context dispatch info for context running with non vertx threads (Loom).
    */
   static final ThreadLocal<ContextDispatch> nonVertxContextDispatch = new ThreadLocal<>();
@@ -371,14 +366,14 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       .build();
     CloseFuture fut = resolveCloseFuture();
     fut.add(netClient);
-    return new CleanableNetClient( cleaner, netClient);
+    return new CleanableNetClient(CleanerProvider.INSTANCE.get(), netClient);
   }
 
   public NetClient createNetClient(NetClientOptions options) {
     NetClientImpl netClient = new NetClientBuilder(this, options).build();
     CloseFuture fut = resolveCloseFuture();
     fut.add(netClient);
-    return new CleanableNetClient(cleaner, netClient);
+    return new CleanableNetClient(CleanerProvider.INSTANCE.get(), netClient);
   }
 
   @Override
@@ -388,7 +383,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public Cleaner cleaner() {
-    return cleaner;
+    return CleanerProvider.INSTANCE.get();
   }
 
   @Override
@@ -429,12 +424,12 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
         cf_.add(completion -> impl.close().onComplete(completion));
         return impl;
       });
-      client = new CleanableWebSocketClient(client, cleaner, (timeout) -> closeFuture.close());
+      client = new CleanableWebSocketClient(client, CleanerProvider.INSTANCE.get(), (timeout) -> closeFuture.close());
       closeable = closeFuture;
     } else {
       WebSocketClientImpl impl = createWebSocketClientImpl(options);
       closeable = impl;
-      client = new CleanableWebSocketClient(impl, cleaner, impl::shutdown);
+      client = new CleanableWebSocketClient(impl, CleanerProvider.INSTANCE.get(), impl::shutdown);
     }
     cf.add(closeable);
     return client;
@@ -1123,7 +1118,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     WorkerPool sharedWorkerPool = createSharedWorkerPool(execCf, name, poolSize, maxExecuteTime, maxExecuteTimeUnit);
     CloseFuture parentCf = resolveCloseFuture();
     parentCf.add(execCf);
-    return new WorkerExecutorImpl(this, cleaner, sharedWorkerPool);
+    return new WorkerExecutorImpl(this, CleanerProvider.INSTANCE.get(), sharedWorkerPool);
   }
 
   public WorkerPool createSharedWorkerPool(String name, int poolSize, long maxExecuteTime, TimeUnit maxExecuteTimeUnit) {


### PR DESCRIPTION
Motivation:

Vert.x relies on a Java cleaner to collect unused cleanable proxies, the cleaner is only needed when a cleanable object is created.

Statically instantiating a cleaner has an impact since it can create a thread.

Changes:

Encapsulate the cleaner in a provider that lazy creates the cleaner when it is actually needed.
