### PR TITLE
MetricsProvider#getMetrics() should return null on cleaned objects.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -61,7 +61,8 @@ public class CleanableHttpClient extends CleanableObject<HttpClientInternal> imp
 
   @Override
   public Metrics getMetrics() {
-    return getOrDie().getMetrics();
+    HttpClientInternal delegate = get();
+    return delegate == null ? null : delegate.getMetrics();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetClient.java
@@ -85,6 +85,7 @@ public class CleanableNetClient extends CleanableObject<NetClientInternal> imple
 
   @Override
   public Metrics getMetrics() {
-    return getOrDie().getMetrics();
+    NetClientInternal delegate = get();
+    return delegate == null ? null : delegate.getMetrics();
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/MetricsTest.java
@@ -29,6 +29,7 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.VertxMetricsFactory;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
+import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
@@ -1275,4 +1276,17 @@ public class MetricsTest extends VertxTestBase {
       assertNull(all.get("vert.x-virtual-thread"));
     }
   }
+
+  @Test
+  public void testGetMetricsOnClosedClient() {
+    HttpClientAgent httpClient = vertx.createHttpClient();
+    assertNotNull(((MetricsProvider)httpClient).getMetrics());
+    httpClient.close().await();
+    assertNull(((MetricsProvider)httpClient).getMetrics());
+    NetClient tcpClient = vertx.createNetClient();
+    assertNotNull(((MetricsProvider)tcpClient).getMetrics());
+    tcpClient.close().await();
+    assertNull(((MetricsProvider)tcpClient).getMetrics());
+  }
+
 }


### PR DESCRIPTION
Motivation:

`CleanableObject` throws an `IllegalStateException` when the actual delegate is already cleaned.

`CleanableObject` implementing `MetricsProvider` should instead check the delegate presence and return null when the delegate is absent.
