### PR TITLE
WebSocketBaseImpl closeStatusCode can throw an NPE

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/WebSocketImplBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/WebSocketImplBase.java
@@ -204,7 +204,10 @@ public abstract class WebSocketImplBase<S extends WebSocket> implements WebSocke
       sc = closeStatusCode;
       isClosed = closed;
     }
-    return isClosed ? (sc == null ? 1006 : sc) : sc;
+    if (isClosed && sc == null) {
+      return 1006;
+    }
+    return sc;
   }
 
   @Override


### PR DESCRIPTION
See #6144

A single test is not less clear and avoids the NPE.