### PR TITLE
Fix WebSocketClient ignoring setSslEngineOptions

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -449,6 +449,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     NetClientInternal tcpClient = new NetClientBuilder(this, config.getTcpConfig())
       .protocol("http")
       .sslOptions(options.getSslOptions())
+      .sslEngineOptions(options.getSslEngineOptions())
       .build();
     TcpHttpClientTransport channelConnector = TcpHttpClientTransport.create(tcpClient, config, false, httpMetrics);
     return new WebSocketClientImpl(this, o, options, channelConnector, httpMetrics);

--- a/vertx-core/src/test/java/io/vertx/it/tls/SSLEngineTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/tls/SSLEngineTest.java
@@ -15,14 +15,16 @@ import io.netty.handler.ssl.OpenSslSessionContext;
 import io.netty.handler.ssl.SslContext;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.net.NetServerInternal;
 import io.vertx.core.internal.tls.ServerSslContextProvider;
 import io.vertx.core.net.JdkSSLEngineOptions;
 import io.vertx.core.net.OpenSSLEngineOptions;
 import io.vertx.core.net.SSLEngineOptions;
-import io.vertx.core.internal.net.NetServerInternal;
 import io.vertx.test.http.HttpTestBase;
 import io.vertx.test.tls.Cert;
 import org.junit.Test;
+
+import javax.net.ssl.SSLSessionContext;
 
 import static io.vertx.test.core.AssertExpectations.that;
 
@@ -35,7 +37,7 @@ public class SSLEngineTest extends HttpTestBase {
     return JdkSSLEngineOptions.isAlpnAvailable();
   }
 
-  private static boolean OPEN_SSL = Boolean.getBoolean("vertx-test-alpn-openssl");
+  private static final boolean OPEN_SSL = Boolean.getBoolean("vertx-test-alpn-openssl");
 
   public SSLEngineTest() {
   }
@@ -70,22 +72,106 @@ public class SSLEngineTest extends HttpTestBase {
     doTest(new OpenSSLEngineOptions(), false, HttpVersion.HTTP_1_1, OPEN_SSL ? null : "OpenSSL is not available", "openssl", true);
   }
 
-  private void doTest(SSLEngineOptions engine,
-                      boolean useAlpn, HttpVersion version, String error, String expectedSslContext, boolean expectCause) {
+  private void doTest(SSLEngineOptions sslEngineOptions,
+                      boolean useAlpn, HttpVersion version, String error, String expectedEngine, boolean expectCause) {
+    doSslEngineTest(
+      sslEngineOptions,
+      error,
+      expectedEngine,
+      expectCause,
+      opts -> opts.setUseAlpn(useAlpn),
+      srv -> srv.requestHandler(req -> {
+        assertEquals(req.version(), version);
+        assertTrue(req.isSSL());
+        req.response().end();
+      }),
+      (engineOptions, expectedEng) -> {
+        client = vertx.createHttpClient(new HttpClientOptions()
+          .setSslEngineOptions(engineOptions)
+          .setSsl(true)
+          .setUseAlpn(useAlpn)
+          .setTrustAll(true)
+          .setProtocolVersion(version));
+        client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath")
+          .compose(req -> req
+            .send()
+            .expecting(that(resp -> assertEquals(200, resp.statusCode())))
+            .compose(HttpClientResponse::end))
+          .onComplete(onSuccess(v -> testComplete()));
+        await();
+      }
+    );
+  }
+
+  @Test
+  public void testWebSocketDefaultEngine() {
+    doWebSocketTest(null, null, "jdk");
+  }
+
+  @Test
+  public void testWebSocketJdkEngine() {
+    doWebSocketTest(new JdkSSLEngineOptions(), null, "jdk");
+  }
+
+  @Test
+  public void testWebSocketOpenSSLEngine() {
+    doWebSocketTest(new OpenSSLEngineOptions(), OPEN_SSL ? null : "OpenSSL is not available", "openssl");
+  }
+
+  private void doWebSocketTest(SSLEngineOptions sslEngineOptions, String error, String expectedEngine) {
+    doSslEngineTest(
+      sslEngineOptions,
+      error,
+      expectedEngine,
+      false,
+      opts -> {
+      },
+      srv -> srv.webSocketHandler(ws -> {
+        assertTrue(ws.isSsl());
+        ws.textMessageHandler(msg -> ws.writeTextMessage(msg));
+      }),
+      (engineOptions, expectedEng) -> {
+        WebSocketClient wsClient = vertx.createWebSocketClient(new WebSocketClientOptions()
+          .setSslEngineOptions(engineOptions)
+          .setSsl(true)
+          .setTrustAll(true));
+        wsClient.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/")
+          .onComplete(onSuccess(ws -> {
+            assertSslSessionContextType(expectedEng, ws.sslSession().getSessionContext());
+            ws.writeTextMessage("test");
+            ws.textMessageHandler(msg -> {
+              assertEquals("test", msg);
+              testComplete();
+            });
+          }));
+        await();
+      }
+    );
+  }
+
+  private void doSslEngineTest(
+    SSLEngineOptions sslEngineOptions,
+    String error,
+    String expectedEngine,
+    boolean expectCause,
+    java.util.function.Consumer<HttpServerOptions> serverOptionsConfigurator,
+    java.util.function.Consumer<HttpServer> serverHandlerSetup,
+    java.util.function.BiConsumer<SSLEngineOptions, String> clientTestLogic
+  ) {
     server.close();
     HttpServerOptions options = new HttpServerOptions()
-        .setSslEngineOptions(engine)
-        .setPort(DEFAULT_HTTP_PORT)
-        .setHost(DEFAULT_HTTP_HOST)
-        .setKeyCertOptions(Cert.SERVER_PEM.get())
-        .setSsl(true)
-        .setUseAlpn(useAlpn);
+      .setSslEngineOptions(sslEngineOptions)
+      .setPort(DEFAULT_HTTP_PORT)
+      .setHost(DEFAULT_HTTP_HOST)
+      .setKeyCertOptions(Cert.SERVER_PEM.get())
+      .setSsl(true);
+
+    serverOptionsConfigurator.accept(options);
+
     server = vertx.createHttpServer(options);
-    server.requestHandler(req -> {
-      assertEquals(req.version(), version);
-      assertTrue(req.isSSL());
-      req.response().end();
-    });
+
+    serverHandlerSetup.accept(server);
+
     try {
       startServer();
       if (error != null) {
@@ -106,26 +192,29 @@ public class SSLEngineTest extends HttpTestBase {
     assertEquals(tcpServer.actualPort(), server.actualPort());
     ServerSslContextProvider provider = tcpServer.sslContextProvider();
     SslContext ctx = provider.createServerContext(null);
-    switch (expectedSslContext != null ? expectedSslContext : "jdk") {
+
+    assertSslSessionContextType(expectedEngine != null ? expectedEngine : "jdk", ctx.sessionContext());
+
+    clientTestLogic.accept(sslEngineOptions, expectedEngine != null ? expectedEngine : "jdk");
+  }
+
+  private void assertSslSessionContextType(String engine, SSLSessionContext sessionContext) {
+    String className = sessionContext.getClass().getName();
+    switch (engine) {
       case "jdk":
-        assertTrue(ctx.sessionContext().getClass().getName().equals("sun.security.ssl.SSLSessionContextImpl"));
+        assertTrue(
+          "Expected JDK SSL session context but got: " + className,
+          className.equals("sun.security.ssl.SSLSessionContextImpl")
+        );
         break;
       case "openssl":
-        assertTrue(ctx.sessionContext() instanceof OpenSslSessionContext);
+        assertTrue(
+          "Expected OpenSSL session context but got: " + className,
+          sessionContext instanceof OpenSslSessionContext
+        );
         break;
+      default:
+        fail("Unknown SSL context type: " + engine);
     }
-    client = vertx.createHttpClient(new HttpClientOptions()
-      .setSslEngineOptions(engine)
-      .setSsl(true)
-      .setUseAlpn(useAlpn)
-      .setTrustAll(true)
-      .setProtocolVersion(version));
-    client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath")
-      .compose(req -> req
-        .send()
-        .expecting(that(resp -> assertEquals(200, resp.statusCode())))
-        .compose(HttpClientResponse::end))
-      .onComplete(onSuccess(v -> testComplete()));
-    await();
   }
 }


### PR DESCRIPTION
Backport #6154 