### PR TITLE
HttpServerOptions should initialize the default compression level.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -293,6 +293,7 @@ public class HttpServerOptions extends NetServerOptions {
     maxFormFields = DEFAULT_MAX_FORM_FIELDS;
     maxFormBufferedBytes = DEFAULT_MAX_FORM_BUFFERED_SIZE;
     strictThreadMode = DEFAULT_STRICT_THREAD_MODE_STRICT;
+    compressionLevel = DEFAULT_COMPRESSION_LEVEL;
     compression = new CompressionConfig();
     handle100ContinueAutomatically = DEFAULT_HANDLE_100_CONTINE_AUTOMATICALLY;
     http1Config = new Http1ServerConfig();

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpServerConfigTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpServerConfigTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.http;
+
+import io.netty.handler.codec.compression.CompressionOptions;
+import io.netty.handler.codec.compression.DeflateOptions;
+import io.netty.handler.codec.compression.GzipOptions;
+import io.vertx.core.http.CompressionConfig;
+import io.vertx.core.http.HttpServerConfig;
+import io.vertx.core.http.HttpServerOptions;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class HttpServerConfigTest {
+
+  @Test
+  public void testCompressionFromDefaultOptions() {
+    HttpServerConfig config = new HttpServerConfig(new HttpServerOptions().setCompressionSupported(true));
+    CompressionConfig compressionConfig = config.getCompressionConfig();
+    List<CompressionOptions> compressors = compressionConfig.getCompressors();
+    assertEquals(2, compressors.size());
+    for (CompressionOptions compressor : compressors) {
+      if (compressor instanceof GzipOptions) {
+        GzipOptions gzipCompressor = (GzipOptions) compressor;
+        assertEquals(HttpServerOptions.DEFAULT_COMPRESSION_LEVEL, gzipCompressor.compressionLevel());
+      } else if (compressor instanceof DeflateOptions) {
+        DeflateOptions deflateCompressor = (DeflateOptions) compressor;
+        assertEquals(HttpServerOptions.DEFAULT_COMPRESSION_LEVEL, deflateCompressor.compressionLevel());
+      } else {
+        fail();
+      }
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

During the update to the new HTTP server configuration object, the `HttpServerOptions` lost the initialization of the compression level.

Changes:

Configure the default compression level in `HttpServerOptions#init`
