### PR TITLE
Consolidate VertxConnection flush during a drain.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
@@ -292,7 +292,7 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
         stream.trace = tracer.sendRequest(stream.context, SpanKind.RPC, tracingPolicy, new ObservableRequest(request), operation, headers, HttpUtils.CLIENT_HTTP_REQUEST_TAG_EXTRACTOR);
       }
     }
-    write(nettyRequest, false, promise);
+    unsafeWrite(nettyRequest, promise);
     if (end) {
       endRequest(stream);
     }
@@ -305,10 +305,10 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
     if (isConnect) {
       msg = buff != null ? buff : Unpooled.EMPTY_BUFFER;
       if (end) {
-        write(msg, false, listener)
+        unsafeWrite(msg, listener)
           .addListener(v -> closeInternal());
       } else {
-        write(msg, false);
+        unsafeWrite(msg, listener);
       }
     } else {
       if (end) {
@@ -320,7 +320,7 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
       } else {
         msg = new DefaultHttpContent(buff);
       }
-      write(msg, false, listener);
+      unsafeWrite(msg, listener);
       if (end) {
         endRequest(s);
       }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerConnection.java
@@ -267,7 +267,7 @@ public class Http1ServerConnection extends Http1Connection implements HttpServer
     writeToChannel(new MessageWrite() {
       @Override
       public void write() {
-        Http1ServerConnection.this.write(msg, false, promise);
+        Http1ServerConnection.this.unsafeWrite(msg, false, promise);
         if (msg.isEnded()) {
           responseComplete();
         }

--- a/vertx-core/src/main/java/io/vertx/core/internal/concurrent/OutboundMessageQueue.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/concurrent/OutboundMessageQueue.java
@@ -101,18 +101,23 @@ public class OutboundMessageQueue<M> implements Predicate<M> {
    */
   private int drainMessageQueue() {
     draining++;
+    startDraining();
     try {
-      int flags = mqp.drain();
-      overflow |= (flags & MessagePassingQueue.DRAIN_REQUIRED_MASK) != 0;
-      if ((flags & MessagePassingQueue.WRITABLE_MASK) != 0) {
-        handleDrained(numberOfUnwritableSignals(flags));
+      try {
+        int flags = mqp.drain();
+        overflow |= (flags & MessagePassingQueue.DRAIN_REQUIRED_MASK) != 0;
+        if ((flags & MessagePassingQueue.WRITABLE_MASK) != 0) {
+          handleDrained(numberOfUnwritableSignals(flags));
+        }
+        return flags;
+      } finally {
+        draining--;
+        if (draining == 0 && closed) {
+          releaseMessages();
+        }
       }
-      return flags;
     } finally {
-      draining--;
-      if (draining == 0 && closed) {
-        releaseMessages();
-      }
+      stopDraining();
     }
   }
 
@@ -121,9 +126,7 @@ public class OutboundMessageQueue<M> implements Predicate<M> {
       return;
     }
     assert(draining == 0);
-    startDraining();
     drainMessageQueue();
-    stopDraining();
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -397,19 +397,26 @@ public class VertxConnection extends ConnectionBase {
   }
 
   /**
-   * Like {@link #write(Object, boolean, ChannelPromise)}.
+   * Like {@link #unsafeWrite(Object, boolean, ChannelPromise)} with flush = false.
    */
-  public final ChannelPromise write(Object msg, boolean forceFlush, Promise<Void> promise) {
+  public final ChannelPromise unsafeWrite(Object msg, Promise<Void> promise) {
+    return unsafeWrite(msg, false, promise);
+  }
+
+  /**
+   * Like {@link #unsafeWrite(Object, boolean, ChannelPromise)}.
+   */
+  public final ChannelPromise unsafeWrite(Object msg, boolean flush, Promise<Void> promise) {
     ChannelPromise channelPromise = promise == null ? voidPromise : newChannelPromise(promise);
-    write(msg, forceFlush, channelPromise);
+    unsafeWrite(msg, flush, channelPromise);
     return channelPromise;
   }
 
   /**
-   * Like {@link #write(Object, boolean, ChannelPromise)}.
+   * Like {@link #unsafeWrite(Object, boolean, ChannelPromise)}.
    */
-  public final ChannelPromise write(Object msg, boolean forceFlush) {
-    return write(msg, forceFlush, voidPromise);
+  public final ChannelPromise unsafeWrite(Object msg, boolean flush) {
+    return unsafeWrite(msg, flush, voidPromise);
   }
 
   /**
@@ -418,15 +425,14 @@ public class VertxConnection extends ConnectionBase {
    * <p>This method directly writes to the channel pipeline and bypasses the outbound queue.</p>
    *
    * @param msg the message to write
-   * @param forceFlush flush when {@code true} or there is no read in progress
+   * @param flush flush when {@code true} or there is no read in progress
    * @param promise the promise receiving the completion event
    */
-  public final ChannelPromise write(Object msg, boolean forceFlush, ChannelPromise promise) {
+  public final ChannelPromise unsafeWrite(Object msg, boolean flush, ChannelPromise promise) {
     assert chctx.executor().inEventLoop();
     if (METRICS_ENABLED) {
       reportsBytesWritten(msg);
     }
-    boolean flush = (!read && !draining) || forceFlush;
     needsFlush = !flush;
     if (flush) {
       chctx.writeAndFlush(msg, promise);
@@ -452,7 +458,7 @@ public class VertxConnection extends ConnectionBase {
     return writeToChannel(new MessageWrite() {
       @Override
       public void write() {
-        VertxConnection.this.write(msg, forceFlush, promise);
+        unsafeWrite(msg, forceFlush, promise);
       }
 
       @Override
@@ -563,6 +569,9 @@ public class VertxConnection extends ConnectionBase {
     @Override
     public boolean write(MessageWrite msg) {
       msg.write();
+      if (!read) {
+        checkFlush();
+      }
       return true;
     }
 

--- a/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
@@ -396,10 +396,10 @@ public class VertxConnectionTest extends VertxTestBase {
       if (event == inbound1) {
         connection.pause();
         pipeline.fireChannelRead(inbound2);
-        connection.write(outbound1, false);
+        connection.unsafeWrite(outbound1, false);
         pipeline.fireChannelReadComplete();
       } else if (event == inbound2) {
-        connection.write(outbound2, false);
+        connection.unsafeWrite(outbound2, false);
       }
     };
     pipeline.fireChannelRead(inbound1);
@@ -496,7 +496,7 @@ public class VertxConnectionTest extends VertxTestBase {
     disableThreadChecks();
     connectHandler = conn -> {
       Promise<Void> promise = Promise.promise();
-      ChannelPromise channelPromise = ((VertxConnection) conn).write(Unpooled.copiedBuffer("outbound-1", StandardCharsets.UTF_8), false, promise);
+      ChannelPromise channelPromise = ((VertxConnection) conn).unsafeWrite(Unpooled.copiedBuffer("outbound-1", StandardCharsets.UTF_8), true, promise);
       Future<Void> future = promise.future();
       future.onComplete(onSuccess(v -> {
         new Thread(() -> {
@@ -765,7 +765,7 @@ public class VertxConnectionTest extends VertxTestBase {
     pipeline.fireChannelRead(factory.next());
     assertEquals(0, count.get());
     Object expected = new Object();
-    connection.write(expected, false);
+    connection.unsafeWrite(expected, false);
     connection.resume();
     assertEquals(0, count.get());
     assertTrue(ch.hasPendingTasks());


### PR DESCRIPTION
Motivation:

OutboundMessageQueue signals draining lifecycle only for drain initiated from a non consumer thread.

As consequence the VertxConnection flush is checked in the VertxConnection#write method (with a draining guard to avoid a flush per write when draining) and in the OutboundMessageQueue callbacks.

We can consolidate this signals drain lifecycle when a drain operation happens, therefore the VertxConnection#write implementation does not need to handle flush (except when it's forced by the message). Flush now happens in the stopDraining callbacks and only happens when no read operation is in progress.

Changes:

Move OutboundMessageQueue startDraining/stopDraining call to its drainMessageQueue method.

Rename VertxConnection direct write method to unsafeWrite
