### PR TITLE
VertxConnection should forcibly close the channel when the endpoint is shutting down.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -73,7 +73,8 @@ public class VertxConnection extends ConnectionBase {
   // State accessed exclusively from the event loop thread
   private ScheduledFuture<?> shutdownTimeout;
   private ChannelPromise shutdown;
-  private boolean closeSent;
+  private boolean closeForcibly;
+  private ChannelPromise closeSent;
 
   public VertxConnection(ContextInternal context, ChannelHandlerContext chctx) {
     this(context, chctx, false);
@@ -113,6 +114,7 @@ public class VertxConnection extends ConnectionBase {
       if (shutdown == null) {
         ChannelPromise promise = chctx.newPromise();
         shutdown = promise;
+        closeForcibly = true;
         handleShutdown(shutdownEvent.timeout(), promise);
       } else {
         log.debug("Client shutdown after connection shutdown, ignoring ShutdownEvent");
@@ -230,9 +232,11 @@ public class VertxConnection extends ConnectionBase {
   }
 
   private void terminateClose(ChannelPromise promise) {
-    if (!closeSent) {
-      closeSent = true;
-      writeClose(promise);
+    if (closeSent == null) {
+      closeSent = promise;
+      if (!draining) {
+        writeClose(promise);
+      }
     } else {
       completeWhenChannelIsClosed(promise);
     }
@@ -248,13 +252,18 @@ public class VertxConnection extends ConnectionBase {
    * This method is exclusively called on the event-loop thread and relays a channel user event.
    */
   protected void writeClose(ChannelPromise promise) {
+    assert !draining;
+    ChannelPromise channelPromise = chctx.newPromise();
+    // Give a chance of pending message to be written
+    outboundMessageQueue.close();
     // Make sure everything is flushed out on close
-    ChannelPromise channelPromise = chctx
-      .newPromise()
-      .addListener((ChannelFutureListener) f -> {
-        chctx.close(promise);
-      });
-    writeToChannel(Unpooled.EMPTY_BUFFER, true, channelPromise);
+    unsafeWrite(Unpooled.EMPTY_BUFFER, true, channelPromise);
+    //
+    if (channelPromise.isDone() || closeForcibly) {
+      chctx.close(promise);
+    } else {
+      channelPromise.addListener((ChannelFutureListener) f -> chctx.close(promise));
+    }
   }
 
   protected void handleClosed() {
@@ -591,6 +600,8 @@ public class VertxConnection extends ConnectionBase {
    */
   private class InternalMessageChannel extends OutboundMessageQueue<MessageWrite> implements Predicate<MessageWrite>, OutboundWriteQueue {
 
+    private boolean notClosing;
+
     public InternalMessageChannel(io.vertx.core.internal.EventExecutor eventLoop) {
       super(eventLoop);
     }
@@ -607,18 +618,27 @@ public class VertxConnection extends ConnectionBase {
 
     @Override
     protected void handleDispose(MessageWrite write) {
-      write.cancel(CLOSED_EXCEPTION);
+      if (channel.isActive()) {
+        write.write();
+      } else {
+        write.cancel(CLOSED_EXCEPTION);
+      }
     }
 
     @Override
     protected void startDraining() {
+      notClosing = closeSent == null;
       draining = true;
     }
 
     @Override
     protected void stopDraining() {
       draining = false;
-      if (!read) {
+      ChannelPromise closePromise = closeSent;
+      boolean close = closePromise != null && notClosing;
+      if (close) {
+        writeClose(closePromise);
+      } else if (!read) {
         checkFlush();
       }
     }

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -4496,4 +4496,73 @@ public class NetTest {
     assertEquals("127.0.0.1", remove.hostAddress());
     assertWaitUntil(() -> connects.get() == 1);
   }
+
+  private void untilFull(NetSocket so, Runnable action, Runnable done) {
+    int count = 0;
+    while (so.writeQueueFull()) {
+      action.run();
+      count++;
+    }
+    if (count > 0) {
+      vertx.setTimer(1, v -> {
+        untilFull(so, action, done);
+      });
+    } else {
+      done.run();
+    }
+  }
+
+  @Test
+  public void testCloseUnwritableSocket(Checkpoint checkpoint1, Checkpoint checkpoint2) throws Exception {
+    AtomicBoolean closing = new AtomicBoolean();
+    AtomicBoolean closed = new AtomicBoolean();
+    server.connectHandler(so -> {
+      so.handler(chunk -> {
+        untilFull(so, () -> so.write(TestUtils.randomAlphaString(1024)), () -> {
+          so.closeHandler(v -> {
+            closed.set(true);
+            checkpoint1.succeed();
+          });
+          closing.set(true);
+          so
+            .close()
+            .onComplete(checkpoint2);
+        });
+      });
+    });
+    startServer();
+    NetSocket socket = client.connect(testAddress).await();
+    socket.pause();
+    socket.write("test").await();
+    TestUtils.assertWaitUntil(closing::get);
+    assertWaitUntil(closed::get);
+    socket.resume();
+  }
+
+  @Test
+  public void testCloseServerUnwritableSocket(Checkpoint checkpoint1, Checkpoint checkpoint2, Checkpoint checkpoint3) throws Exception {
+    AtomicBoolean closing = new AtomicBoolean();
+    AtomicBoolean closed = new AtomicBoolean();
+    server.connectHandler(so -> {
+      so.handler(chunk -> {
+        untilFull(so, () -> so.write(TestUtils.randomAlphaString(1024)), () -> {
+          so.write("LAST").onComplete(ar -> checkpoint3.succeed());
+          so.closeHandler(v -> {
+            closed.set(true);
+            checkpoint1.succeed();
+          });
+          closing.set(true);
+          server
+            .close()
+            .onComplete(checkpoint2);
+        });
+      });
+    });
+    startServer();
+    NetSocket socket = client.connect(testAddress).await();
+    socket.pause();
+    socket.write("test").await();
+    TestUtils.assertWaitUntil(closing::get);
+    TestUtils.assertWaitUntil(closed::get);
+  }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
@@ -14,10 +14,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.*;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
@@ -26,6 +23,7 @@ import io.vertx.core.internal.net.NetSocketInternal;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.impl.MessageWrite;
 import io.vertx.core.net.impl.ShutdownEvent;
 import io.vertx.core.net.impl.VertxConnection;
 import io.vertx.core.net.impl.VertxHandler;
@@ -44,6 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 public class VertxConnectionTest extends VertxTestBase {
@@ -618,6 +617,151 @@ public class VertxConnectionTest extends VertxTestBase {
     assertEquals(1L, shutdown.get());
     // The broadcaster of the event controls the channel close
     assertEquals(0L, closed.get());
+  }
+
+  @Test
+  public void testCloseWhenNotWritable() {
+    AtomicBoolean channelClosed = new AtomicBoolean();
+    AtomicBoolean written = new AtomicBoolean();
+    AtomicBoolean cancelled = new AtomicBoolean();
+    AtomicBoolean opClosed = new AtomicBoolean();
+    EmbeddedChannel channel = channel((ctx, chctx) -> new VertxConnection(ctx, chctx) {
+      @Override
+      protected void handleEvent(Object event) {
+        if ("test".equals(event)) {
+          while (channel.isWritable()) {
+            chctx.write(Unpooled.copiedBuffer(TestUtils.randomAlphaString(1024), StandardCharsets.UTF_8));
+          }
+          writeToChannel(new MessageWrite() {
+            @Override
+            public void write() {
+              written.set(true);
+            }
+            @Override
+            public void cancel(Throwable cause) {
+              cancelled.set(true);
+            }
+          });
+          close().onComplete(ar -> opClosed.set(true));
+        } else {
+          super.handleEvent(event);
+        }
+      }
+      @Override
+      protected void handleClosed() {
+        channelClosed.set(true);
+        super.handleClosed();
+      }
+    });
+    AtomicReference<ChannelHandlerContext> flushOp = new AtomicReference<>();
+    channel.pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
+      @Override
+      public void flush(ChannelHandlerContext ctx) throws Exception {
+        flushOp.set(ctx);
+      }
+    });
+    channel.pipeline().fireUserEventTriggered("test");
+    assertFalse(channelClosed.get());
+    assertFalse(opClosed.get());
+    assertTrue(written.get());
+    assertFalse(cancelled.get());
+    assertTrue(channel.isActive());
+    flushOp.get().flush();
+    assertTrue(channelClosed.get());
+    assertTrue(opClosed.get());
+    assertTrue(written.get());
+    assertFalse(cancelled.get());
+    assertFalse(channel.isActive());
+  }
+
+  @Test
+  public void testCloseForciblyWhenNotWritable() {
+    AtomicBoolean channelClosed = new AtomicBoolean();
+    AtomicBoolean written = new AtomicBoolean();
+    AtomicBoolean cancelled = new AtomicBoolean();
+    AtomicBoolean last = new AtomicBoolean();
+    EmbeddedChannel channel = channel((ctx, chctx) -> new VertxConnection(ctx, chctx) {
+      @Override
+      protected void handleEvent(Object event) {
+        if ("test".equals(event)) {
+          while (channel.isWritable()) {
+            chctx.write(Unpooled.copiedBuffer(TestUtils.randomAlphaString(1024), StandardCharsets.UTF_8));
+          }
+          VertxConnection connection = this;
+          writeToChannel(new MessageWrite() {
+            @Override
+            public void write() {
+              written.set(true);
+              ChannelPromise cp = connection.channel().newPromise();
+              cp.addListener((ChannelFutureListener) future -> last.set(future.isSuccess()));
+              connection.unsafeWrite("LAST", false, cp);
+            }
+            @Override
+            public void cancel(Throwable cause) {
+              cancelled.set(true);
+            }
+          });
+        } else {
+          super.handleEvent(event);
+        }
+      }
+      @Override
+      protected void handleClosed() {
+        channelClosed.set(true);
+        super.handleClosed();
+      }
+    });
+    channel.pipeline().fireUserEventTriggered("test");
+    channel.pipeline().fireUserEventTriggered(new ShutdownEvent(Duration.ZERO));
+    assertTrue(channelClosed.get());
+    assertTrue(written.get());
+    assertFalse(cancelled.get());
+    assertFalse(channel.isActive());
+    assertTrue(last.get());
+  }
+
+  @Test
+  public void testCloseForciblyWhenDraining() {
+    AtomicBoolean written = new AtomicBoolean();
+    AtomicBoolean cancelled = new AtomicBoolean();
+    AtomicBoolean channelClosed = new AtomicBoolean();
+    AtomicBoolean last = new AtomicBoolean();
+    EmbeddedChannel channel = channel((ctx, chctx) -> new VertxConnection(ctx, chctx) {
+      @Override
+      protected void handleEvent(Object event) {
+        VertxConnection connection = this;
+        if ("test".equals(event)) {
+          writeToChannel(new MessageWrite() {
+            @Override
+            public void write() {
+              written.set(true);
+              ChannelPromise cp = connection.channel().newPromise();
+              cp.addListener((ChannelFutureListener) future -> last.set(future.isSuccess()));
+              connection.unsafeWrite("LAST", false, cp);
+              connection.close();
+            }
+            @Override
+            public void cancel(Throwable cause) {
+              cancelled.set(true);
+              MessageWrite.super.cancel(cause);
+            }
+          });
+        } else {
+          super.handleEvent(event);
+        }
+      }
+      @Override
+      protected void handleClosed() {
+        channelClosed.set(true);
+        super.handleClosed();
+      }
+    });
+    channel.pipeline().fireUserEventTriggered("test");
+    assertTrue(channelClosed.get());
+    assertTrue(written.get());
+    assertFalse(cancelled.get());
+    assertFalse(channel.isActive());
+    assertTrue(last.get());
   }
 
   private <C extends VertxConnection> EmbeddedChannel channel(BiFunction<ContextInternal, ChannelHandlerContext, C> connectionFactory) {


### PR DESCRIPTION
Motivation:

`VertxConnection` flushes the connection before closing the channel to ensure all pending messages are written.

When an endpoint is shutting down, we should close the connection forcibly and avoid flushing the channel instead.

Changes:

`VertxConnection#writeClose` behaviour is changed to:

1/ close the outbound message queue, writting the pending messages to the channel giving a chance to the messages to be written or failed by the channel.
2/ when a channel is closed forcibly (endpoint close) the channel is closed immediately, otherwise the channel is closed after flush

`VertxConnection` pending message disposal now writes messages when the channel is open otherwise cancels them.
