### PR TITLE
Improve a couple of tests

### DIFF
--- a/vertx-core/src/test/java/io/vertx/it/networklogging/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/networklogging/NetTest.java
@@ -10,38 +10,36 @@
  */
 package io.vertx.it.networklogging;
 
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.NetSocket;
-import io.vertx.test.core.TestUtils;
-import io.vertx.test.core.VertxTestBase;
+import io.vertx.test.core.*;
 import io.vertx.test.netty.TestLoggerFactory;
 import org.junit.Test;
 
 import java.util.function.Predicate;
 
 
-public class NetTest extends VertxTestBase {
+public class NetTest extends VertxTestBase2 {
 
   @Test
-  public void testNoLogging() throws Exception {
-    testLogging(new NetServerOptions(), new NetClientOptions(), factory -> !factory.hasName("io.netty.handler.logging.LoggingHandler"));
+  public void testNoLogging(Checkpoint checkpoint) throws Exception {
+    testLogging(checkpoint, new NetServerOptions(), new NetClientOptions(), factory -> !factory.hasName("io.netty.handler.logging.LoggingHandler"));
   }
 
   @Test
-  public void testServerLogging() throws Exception {
-    testLogging(new NetServerOptions().setLogActivity(true), new NetClientOptions(), factory -> factory.hasName("io.netty.handler.logging.LoggingHandler"));
+  public void testServerLogging(Checkpoint checkpoint) throws Exception {
+    testLogging(checkpoint, new NetServerOptions().setLogActivity(true), new NetClientOptions(), factory -> factory.hasName("io.netty.handler.logging.LoggingHandler"));
   }
 
   @Test
-  public void testClientLogging() throws Exception {
-    testLogging(new NetServerOptions(), new NetClientOptions().setLogActivity(true), factory -> factory.hasName("io.netty.handler.logging.LoggingHandler"));
+  public void testClientLogging(Checkpoint checkpoint) throws Exception {
+    testLogging(checkpoint, new NetServerOptions(), new NetClientOptions().setLogActivity(true), factory -> factory.hasName("io.netty.handler.logging.LoggingHandler"));
   }
 
-  public void testLogging(NetServerOptions serverOptions, NetClientOptions clientOptions, Predicate<TestLoggerFactory> checker) throws Exception {
+  public void testLogging(Checkpoint checkpoint, NetServerOptions serverOptions, NetClientOptions clientOptions, Predicate<TestLoggerFactory> checker) throws Exception {
     NetServer server;
     NetClient client;
     server = vertx.createNetServer(serverOptions);
@@ -51,13 +49,13 @@ public class NetTest extends VertxTestBase {
         so.endHandler(v -> {
           so.end();
         });
-        so.end(Buffer.buffer("fizzbuzz"));
       });
       server.listen(0, "localhost").await();
-      NetSocket so = client.connect(server.actualPort(), "localhost").await();
-      so.closeHandler(v2 -> testComplete());
+      NetSocket so = client
+        .connect(server.actualPort(), "localhost")
+        .await();
+      so.closeHandler(v2 -> checkpoint.succeed());
       so.end().await();
-      await();
     });
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -5533,7 +5533,9 @@ public class Http1xTest extends HttpTest {
       });
     server.listen(testAddress).await();
 
-    HttpClientAgent client = vertx.httpClientBuilder().withConnectHandler(conn -> {
+    client = vertx
+      .httpClientBuilder()
+      .withConnectHandler(conn -> {
       List<Object> invalidMessages = new ArrayList<>();
       ((HttpClientConnection) conn).invalidMessageHandler(invalidMessages::add);
       conn.exceptionHandler(err -> {

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ContextTest.java
@@ -19,36 +19,37 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.ServerSSLOptions;
-import io.vertx.test.core.VertxTestBase;
+import io.vertx.test.core.TestUtils;
+import io.vertx.test.core.VertxTestBase2;
 import io.vertx.test.tls.Cert;
 import io.vertx.test.tls.Trust;
-import org.junit.Assert;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
-public class Http3ContextTest extends VertxTestBase {
+import static org.junit.Assert.*;
+
+public class Http3ContextTest extends VertxTestBase2 {
 
   private HttpServer server;
   private HttpClientConfig clientConfig;
   private HttpClientAgent client;
 
   public Http3ContextTest() {
-    super(ReportMode.FORBIDDEN);
   }
 
-  @Override
+  @Before
   public void setUp() throws Exception {
-    super.setUp();
     clientConfig = new HttpClientConfig();
     clientConfig.setVersions(HttpVersion.HTTP_3);
     server = vertx.createHttpServer(new HttpServerConfig().setVersions(HttpVersion.HTTP_3), new ServerSSLOptions().setKeyCertOptions(Cert.SERVER_JKS.get()));
     client = vertx.createHttpClient(clientConfig, new ClientSSLOptions().setTrustOptions(Trust.SERVER_JKS.get()));
   }
 
-  @Override
-  protected void tearDown() throws Exception {
+  @After
+  public void tearDown() throws Exception {
     server.close().await();
     client.close().await();
-    super.tearDown();
   }
 
   @Test
@@ -65,17 +66,11 @@ public class Http3ContextTest extends VertxTestBase {
 
     server.requestHandler(req -> {
       Context ctx = Vertx.currentContext();
-      Assert.assertEquals(threadingModel, ctx.threadingModel());
+      assertEquals(threadingModel, ctx.threadingModel());
       assertIsDuplicate(req, ctx);
-      Buffer body = Buffer.buffer();
-      req.handler(chunk -> {
-        Assert.assertSame(ctx, Vertx.currentContext());
-        body.appendBuffer(chunk);
-      });
-      req.endHandler(v -> {
-        Assert.assertSame(ctx, Vertx.currentContext());
+      req.body().onComplete(TestUtils.onSuccess(body -> {
         req.response().end(body);
-      });
+      }));
     });
 
     ContextInternal serverCtx = ((VertxInternal) vertx).createContext(threadingModel);
@@ -85,10 +80,10 @@ public class Http3ContextTest extends VertxTestBase {
       .compose(request -> request
         .send(Buffer.buffer("payload"))
         .expecting(HttpResponseExpectation.SC_OK)
-      )
-      .compose(HttpClientResponse::body).await();
+        .compose(HttpClientResponse::body)
+      ).await();
 
-    Assert.assertEquals("payload", response.toString());
+    assertEquals("payload", response.toString());
   }
 
   @Test
@@ -115,19 +110,19 @@ public class Http3ContextTest extends VertxTestBase {
     HttpClientRequest request1 = Future.<HttpClientRequest>future(p -> connectionCtx.runOnContext(v -> client.request(HttpMethod.POST, 8443, "localhost", "/").onComplete(p))).await();
 
     Buffer body = request1.send().compose(response -> {
-      Assert.assertSame(connectionCtx, Vertx.currentContext());
+      assertSame(connectionCtx, Vertx.currentContext());
       return response.body();
     }).await();
-    Assert.assertEquals("Hello World", body.toString());
+    assertEquals("Hello World", body.toString());
 
     HttpClientRequest request2 = Future.<HttpClientRequest>future(p -> streamCtx.runOnContext(v -> client.request(HttpMethod.POST, 8443, "localhost", "/").onComplete(p))).await();
     body = request2.send().compose(response -> {
-      Assert.assertSame(streamCtx, Vertx.currentContext());
+      assertSame(streamCtx, Vertx.currentContext());
       return response.body();
     }).await();
-    Assert.assertEquals("Hello World", body.toString());
+    assertEquals("Hello World", body.toString());
 
-    Assert.assertSame(request1.connection(), request2.connection());
+    assertSame(request1.connection(), request2.connection());
   }
 
   private void assertIsDuplicate(HttpServerRequest request, Context context) {
@@ -135,8 +130,8 @@ public class Http3ContextTest extends VertxTestBase {
   }
 
   private void assertIsDuplicate(HttpServerRequest request, ContextInternal context) {
-    Assert.assertTrue(context.isDuplicate());
+    assertTrue(context.isDuplicate());
     HttpServerConnection connection = (HttpServerConnection) request.connection();
-    Assert.assertSame(connection.context(), context.unwrap());
+    assertSame(connection.context(), context.unwrap());
   }
 }


### PR DESCRIPTION
- **Http1xTest#testUnsolicitedMessagesAreTreatedAsInvalid does not keep a reference on the HttpClient, as consequence the client can be collected and fail the test with a false negative.**
- **Improve io.vertx.it.networklogging.NetTest : contains a race + modernize it.**
- **Improve Http3ContextTest**
