### PR TITLE
Fix incorrect Buffer#setBytes(ByteBuffer) length calculation

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -502,7 +502,7 @@ public class BufferImpl implements BufferInternal {
   }
 
   public BufferImpl setBytes(int pos, ByteBuffer b) {
-    ensureLength(pos + b.limit());
+    ensureLength(pos + b.remaining());
     buffer.setBytes(pos, b);
     return this;
   }

--- a/vertx-core/src/test/java/io/vertx/tests/buffer/BufferTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/buffer/BufferTest.java
@@ -915,6 +915,19 @@ public class BufferTest {
     assertNullPointerException(() -> Buffer.buffer(150).setBytes(0, (ByteBuffer) null));
   }
 
+  @Test
+  public void testSetBytesByteBufferUsesRemaining() {
+    ByteBuffer src = ByteBuffer.wrap(new byte[] { 10, 20, 30, 40, 50 });
+    src.position(2);
+
+    Buffer dst = Buffer.buffer();
+    dst.setBytes(1, src);
+
+    assertEquals(4, dst.length());
+    assertTrue(TestUtils.byteArraysEqual(new byte[] { 0, 30, 40, 50 }, dst.getBytes()));
+    assertEquals(src.limit(), src.position());
+  }
+
   private void testSetBytesBuffer(Buffer buff, Function<byte[], Buffer> bufferFactory) throws Exception {
     Buffer b = bufferFactory.apply(TestUtils.randomByteArray(100));
     buff.setBuffer(50, b);


### PR DESCRIPTION
Motivation:

Fixes #6181

BufferImpl#setBytes(int, ByteBuffer) expands the buffer using ByteBuffer#limit(), while ByteBuf#setBytes(int, ByteBuffer) copies only remaining() bytes.

When the source buffer has a non-zero position, the Vert.x buffer length can become larger than the bytes actually copied.

Changes:

Use ByteBuffer#remaining() when ensuring the buffer length.

Conformance:

I have signed the ECA