### PR TITLE
Performance improvement for Future.await()

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/Future.java
+++ b/vertx-core/src/main/java/io/vertx/core/Future.java
@@ -736,18 +736,12 @@ public interface Future<T> extends AsyncResult<T> {
   }
 
   /**
-   * Park the current thread until the {@code future} is completed, when the future
-   * is completed the thread is un-parked and
+   * If this {@link Future} is already completed or failed, then this method immediately returns the result or throws the failure, respectively.
+   * <p>
+   * Otherwise, the current thread is parked until this {@link Future} is completed or failed.
    *
-   * <ul>
-   *   <li>the result value is returned when the future was completed with a result</li>
-   *   <li>otherwise, the failure is thrown</li>
-   * </ul>
-   *
-   * This method must be called from a vertx virtual thread or a non vertx thread.
-   *
-   * @return the result
-   * @throws IllegalStateException when called from a vertx event-loop or worker thread
+   * @return the result when this {@link Future} is completed
+   * @throws IllegalStateException when the current thread must be parked and this method is called from a Vert.x event-loop or worker thread.
    */
   default T await() {
     CountDownLatch continuation = trySuspend();
@@ -766,9 +760,9 @@ public interface Future<T> extends AsyncResult<T> {
    * Like {@link #await()} but with a timeout.
    *
    * @param timeout the timeout
-   * @return the result
+   * @return the result when this {@link Future} is completed
    * @throws TimeoutException when the timeout fires before the future completes
-   * @throws IllegalStateException when called from a vertx event-loop or worker thread
+   * @throws IllegalStateException when the current thread must be parked and this method is called from a Vert.x event-loop or worker thread.
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   default T await(Duration timeout) throws TimeoutException {
@@ -780,9 +774,9 @@ public interface Future<T> extends AsyncResult<T> {
    *
    * @param timeout the timeout
    * @param unit the timeout unit
-   * @return the result
+   * @return the result when this {@link Future} is completed
    * @throws TimeoutException when the timeout fires before the future completes
-   * @throws IllegalStateException when called from a vertx event-loop or worker thread
+   * @throws IllegalStateException when the current thread must be parked and this method is called from a Vert.x event-loop or worker thread.
    */
   default T await(long timeout, TimeUnit unit) throws TimeoutException {
     if (unit == null) {

--- a/vertx-core/src/main/java/io/vertx/core/Future.java
+++ b/vertx-core/src/main/java/io/vertx/core/Future.java
@@ -12,12 +12,12 @@
 package io.vertx.core;
 
 import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.core.impl.WorkerExecutor;
-import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.impl.Utils;
+import io.vertx.core.impl.WorkerExecutor;
 import io.vertx.core.impl.future.CompositeFutureImpl;
 import io.vertx.core.impl.future.FailedFuture;
 import io.vertx.core.impl.future.SucceededFuture;
+import io.vertx.core.internal.ContextInternal;
 
 import java.time.Duration;
 import java.util.List;
@@ -707,6 +707,9 @@ public interface Future<T> extends AsyncResult<T> {
   }
 
   private CountDownLatch trySuspend() {
+    if (isComplete()) {
+      return null;
+    }
     io.vertx.core.impl.WorkerExecutor executor = io.vertx.core.impl.WorkerExecutor.unwrapWorkerExecutor();
     CountDownLatch latch;
     if (executor != null) {

--- a/vertx-core/src/main/java/io/vertx/core/impl/future/FailedFuture.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/future/FailedFuture.java
@@ -14,9 +14,13 @@ package io.vertx.core.impl.future;
 import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.impl.NoStackTraceThrowable;
+import io.vertx.core.impl.Utils;
+import io.vertx.core.internal.ContextInternal;
 
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 /**
@@ -123,6 +127,24 @@ public final class FailedFuture<T> extends FutureBase<T> {
   @Override
   public Future<T> otherwise(T value) {
     return new SucceededFuture<>(context, value);
+  }
+
+  @Override
+  public T await() {
+    Utils.throwAsUnchecked(cause());
+    return null;
+  }
+
+  @Override
+  public T await(Duration timeout) throws TimeoutException {
+    Utils.throwAsUnchecked(cause());
+    return null;
+  }
+
+  @Override
+  public T await(long timeout, TimeUnit unit) throws TimeoutException {
+    Utils.throwAsUnchecked(cause());
+    return null;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/future/SucceededFuture.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/future/SucceededFuture.java
@@ -16,7 +16,10 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.internal.ContextInternal;
 
+import java.time.Duration;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 /**
@@ -114,6 +117,21 @@ public final class SucceededFuture<T> extends FutureBase<T> {
   @Override
   public Future<T> otherwise(T value) {
     return this;
+  }
+
+  @Override
+  public T await() {
+    return result();
+  }
+
+  @Override
+  public T await(Duration timeout) throws TimeoutException {
+    return result();
+  }
+
+  @Override
+  public T await(long timeout, TimeUnit unit) throws TimeoutException {
+    return result();
   }
 
   @Override

--- a/vertx-core/src/test/java/io/vertx/benchmarks/FutureAwaitBenchmark.java
+++ b/vertx-core/src/test/java/io/vertx/benchmarks/FutureAwaitBenchmark.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.benchmarks;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@Threads(1)
+@Fork(5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class FutureAwaitBenchmark {
+
+  private final Future<String> succeededFuture = Future.succeededFuture("foo");
+  private final Future<String> failedFuture = Future.failedFuture("foo");
+  private final Future<String> ofCompletedPromise;
+  private final Future<String> ofFailedPromise;
+
+  public FutureAwaitBenchmark() {
+    Promise<String> p1 = Promise.promise();
+    p1.complete("foo");
+    ofCompletedPromise = p1.future();
+
+    Promise<String> p2 = Promise.promise();
+    p2.fail("foo");
+    ofFailedPromise = p2.future();
+  }
+
+  @Benchmark
+  public String succeededFuture() {
+    return succeededFuture.await();
+  }
+
+  @Benchmark
+  public Exception failedFuture() {
+    try {
+      failedFuture.await();
+      throw new AssertionError("Should have thrown exception");
+    } catch (RuntimeException e) {
+      return e;
+    }
+  }
+
+  @Benchmark
+  public String completedPromise() {
+    return ofCompletedPromise.await();
+  }
+
+  @Benchmark
+  public Exception failedPromise() {
+    try {
+      ofFailedPromise.await();
+      throw new AssertionError("Should have thrown exception");
+    } catch (RuntimeException e) {
+      return e;
+    }
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/benchmarks/FutureAwaitVirtualBenchmark.java
+++ b/vertx-core/src/test/java/io/vertx/benchmarks/FutureAwaitVirtualBenchmark.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.benchmarks;
+
+import org.openjdk.jmh.annotations.Fork;
+
+@Fork(value = 1, jvmArgs = {
+  "-Djmh.executor=VIRTUAL"
+})
+public class FutureAwaitVirtualBenchmark extends FutureAwaitBenchmark {
+}

--- a/vertx-core/src/test/java/io/vertx/tests/future/FutureAwaitTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/future/FutureAwaitTest.java
@@ -11,52 +11,180 @@
 
 package io.vertx.tests.future;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.VertxInternal;
+import io.vertx.test.core.Checkpoint;
 import io.vertx.test.core.TestUtils;
-import io.vertx.test.core.VertxTestBase;
+import io.vertx.test.core.VertxTestBase2;
+import org.junit.After;
 import org.junit.Test;
 
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class FutureAwaitTest extends VertxTestBase {
+public class FutureAwaitTest extends VertxTestBase2 {
 
-  @Test
-  public void testAwaitFromEventLoopThread() {
-    Promise<String> promise = Promise.promise();
-    Future<String> future = promise.future();
-    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
-    ctx.nettyEventLoop().execute(() -> {
+  private static final Future<String> SUCCEEDED_FUTURE = Future.succeededFuture("foo");
+  private static final Future<String> FAILED_FUTURE = Future.failedFuture(new Exception());
+
+  private ContextInternal context;
+
+  @After
+  public void tearDown() throws Exception {
+    if (context != null) {
+      context.close().await();
+    }
+  }
+
+  private static ContextInternal createEventLoopContext(Vertx vertx) {
+    VertxInternal vertxInternal = (VertxInternal) vertx;
+    return vertxInternal.createEventLoopContext();
+  }
+
+  private static ContextInternal createWorkerContext(Vertx vertx) {
+    VertxInternal vertxInternal = (VertxInternal) vertx;
+    return vertxInternal.createWorkerContext();
+  }
+
+  private static Runnable runTaskOnContext(Runnable task, ContextInternal ctx) {
+    return () -> ctx.runOnContext(v -> task.run());
+  }
+
+  private static Runnable runTaskOnNettyEventLoop(Runnable task, ContextInternal ctx) {
+    return () -> ctx.nettyEventLoop().execute(task);
+  }
+
+  private static Runnable runTaskOnNonVertxThread(Runnable task) {
+    return () -> {
+      Thread t = new Thread(task);
+      t.start();
+    };
+  }
+
+  private static void testAwaitBehavior(Future<String> future, Function<Runnable, Runnable> executorSetup, Handler<AsyncResult<String>> checks, Checkpoint checkpoint) {
+    Runnable testLogic = () -> {
+      String res;
+      Exception failure;
       try {
-        future.await();
-      } catch (IllegalStateException expected) {
-        testComplete();
+        res = future.await();
+        failure = null;
+      } catch (Exception e) {
+        res = null;
+        failure = e;
       }
-    });
-    await();
+      checks.handle(res != null ? Future.succeededFuture(res) : Future.failedFuture(failure));
+      checkpoint.succeed();
+    };
+    executorSetup.apply(testLogic).run();
+  }
+
+  private static Handler<AsyncResult<String>> assertSuccess() {
+    return ar -> {
+      assertEquals("Expected Future.await() to return the expected result", SUCCEEDED_FUTURE.result(), ar.result());
+    };
+  }
+
+  private static Handler<AsyncResult<String>> assertFailure() {
+    return ar -> {
+      assertSame("Expected Future.await() to throw the expected failure", FAILED_FUTURE.cause(), ar.cause());
+    };
+  }
+
+  private static Handler<AsyncResult<String>> assertIllegal() {
+    return ar -> {
+      assertTrue("Expected Future.await() to throw IllegalStateException", ar.cause() instanceof IllegalStateException);
+    };
   }
 
   @Test
-  public void testAwaitFromNonVertxThread() {
+  public void testSucceededFutureAwaitOnEventLoopContext(Checkpoint checkpoint) {
+    context = createEventLoopContext(vertx);
+    testAwaitBehavior(SUCCEEDED_FUTURE, task -> runTaskOnContext(task, context), assertSuccess(), checkpoint);
+  }
+
+  @Test
+  public void testSucceededFutureAwaitOnNettyEventLoop(Checkpoint checkpoint) {
+    context = createEventLoopContext(vertx);
+    testAwaitBehavior(SUCCEEDED_FUTURE, task -> runTaskOnNettyEventLoop(task, context), assertSuccess(), checkpoint);
+  }
+
+  @Test
+  public void testSucceededFutureAwaitOnWorkerContext(Checkpoint checkpoint) {
+    context = createWorkerContext(vertx);
+    testAwaitBehavior(SUCCEEDED_FUTURE, task -> runTaskOnContext(task, context), assertSuccess(), checkpoint);
+  }
+
+  @Test
+  public void testSucceededFutureAwaitOnNonVertxThread(Checkpoint checkpoint) {
+    testAwaitBehavior(SUCCEEDED_FUTURE, task -> runTaskOnNonVertxThread(task), assertSuccess(), checkpoint);
+  }
+
+  @Test
+  public void testFailedFutureAwaitOnEventLoopContext(Checkpoint checkpoint) {
+    context = createEventLoopContext(vertx);
+    testAwaitBehavior(FAILED_FUTURE, task -> runTaskOnContext(task, context), assertFailure(), checkpoint);
+  }
+
+  @Test
+  public void testFailedFutureAwaitOnNettyEventLoop(Checkpoint checkpoint) {
+    context = createEventLoopContext(vertx);
+    testAwaitBehavior(FAILED_FUTURE, task -> runTaskOnNettyEventLoop(task, context), assertFailure(), checkpoint);
+  }
+
+  @Test
+  public void testFailedFutureAwaitOnWorkerContext(Checkpoint checkpoint) {
+    context = createWorkerContext(vertx);
+    testAwaitBehavior(FAILED_FUTURE, task -> runTaskOnContext(task, context), assertFailure(), checkpoint);
+  }
+
+  @Test
+  public void testFailedFutureAwaitOnNonVertxThread(Checkpoint checkpoint) {
+    testAwaitBehavior(FAILED_FUTURE, task -> runTaskOnNonVertxThread(task), assertFailure(), checkpoint);
+  }
+
+  @Test
+  public void testFutureAwaitOnEventLoopContext(Checkpoint checkpoint) {
     Promise<String> promise = Promise.promise();
-    Future<String> future = promise.future();
-    Thread current = Thread.currentThread();
-    new Thread(() -> {
-      while (current.getState() != Thread.State.WAITING) {
-        try {
-          Thread.sleep(10);
-        } catch (InterruptedException ignore) {
-        }
-      }
-      promise.complete("the-result");
-    }).start();
-    String res = future.await();
-    assertEquals("the-result", res);
+    context = createEventLoopContext(vertx);
+    testAwaitBehavior(promise.future(), task -> runTaskOnContext(task, context), assertIllegal(), checkpoint);
+  }
+
+  @Test
+  public void testFutureAwaitOnNettyEventLoop(Checkpoint checkpoint) {
+    Promise<String> promise = Promise.promise();
+    context = createEventLoopContext(vertx);
+    testAwaitBehavior(promise.future(), task -> runTaskOnNettyEventLoop(task, context), assertIllegal(), checkpoint);
+  }
+
+  @Test
+  public void testFutureAwaitOnWorkerContext(Checkpoint checkpoint) {
+    Promise<String> promise = Promise.promise();
+    context = createWorkerContext(vertx);
+    testAwaitBehavior(promise.future(), task -> runTaskOnContext(task, context), assertIllegal(), checkpoint);
+  }
+
+  @Test
+  public void testEventuallySucceededFutureAwaitOnNonVertxThread(Checkpoint checkpoint) throws Exception {
+    Promise<String> promise = Promise.promise();
+    testAwaitBehavior(promise.future(), task -> runTaskOnNonVertxThread(task), assertSuccess(), checkpoint);
+    MILLISECONDS.sleep(500);
+    SUCCEEDED_FUTURE.onComplete(promise);
+  }
+
+  @Test
+  public void testEventuallyFailedFutureAwaitOnNonVertxThread(Checkpoint checkpoint) throws Exception {
+    Promise<String> promise = Promise.promise();
+    testAwaitBehavior(promise.future(), task -> runTaskOnNonVertxThread(task), assertFailure(), checkpoint);
+    MILLISECONDS.sleep(500);
+    FAILED_FUTURE.onComplete(promise);
   }
 
   @Test
@@ -65,11 +193,11 @@ public class FutureAwaitTest extends VertxTestBase {
     Future<String> future = promise.future();
     long now = System.currentTimeMillis();
     try {
-      future.await(100, TimeUnit.MILLISECONDS);
+      future.await(100, MILLISECONDS);
       fail();
     } catch (TimeoutException expected) {
     }
-    assertTrue((System.currentTimeMillis() - now) >= 100);
+    assertThat(System.currentTimeMillis() - now).isGreaterThanOrEqualTo(100);
   }
 
   @Test
@@ -80,17 +208,7 @@ public class FutureAwaitTest extends VertxTestBase {
       future.await();
       fail();
     } catch (Exception expected) {
-      assertSame(msg, expected.getMessage());
-    }
-  }
-
-  @Test
-  public void testAwaitThrowsTimeoutException() {
-    TimeoutException failure = new TimeoutException();
-    try {
-      Future.failedFuture(failure).await();
-      fail();
-    } catch (Exception expected) {
+      assertThat(msg).isSameAs(expected.getMessage());
     }
   }
 }


### PR DESCRIPTION
See #5402

Before this change, `Future.await()` always relied on a `CountDownLatch`, regardless of the `Future` type or its state.

This commit improves the implementation for:

- `SucceededFuture` (return result)
- `FailedFuture` (throw failure)
- `Future` (check state and use a `CountDownLatch` only when necessary)