### PR TITLE
Copy followAlternativeServices in HttpClientOptions

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -223,6 +223,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.tracingPolicy = other.tracingPolicy;
     this.shared = other.shared;
     this.name = other.name;
+    this.followAlternativeServices = other.followAlternativeServices;
   }
 
   /**

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -477,6 +477,7 @@ public class Http1xTest extends HttpTest {
     int http2ConnectionWindowSize = TestUtils.randomPositiveInt();
     int http2UpgradeMaxContentLength = TestUtils.randomPositiveInt();
     boolean decompressionSupported = rand.nextBoolean();
+    boolean followAlternativeServices = true;
     HttpVersion protocolVersion = HttpVersion.HTTP_1_0;
     int maxChunkSize = TestUtils.randomPositiveInt();
     int maxInitialLineLength = TestUtils.randomPositiveInt();
@@ -515,6 +516,7 @@ public class Http1xTest extends HttpTest {
     options.setHttp2MultiplexingLimit(http2MultiplexingLimit);
     options.setHttp2ConnectionWindowSize(http2ConnectionWindowSize);
     options.setDecompressionSupported(decompressionSupported);
+    options.setFollowAlternativeServices(followAlternativeServices);
     options.setProtocolVersion(protocolVersion);
     options.setMaxChunkSize(maxChunkSize);
     options.setMaxInitialLineLength(maxInitialLineLength);


### PR DESCRIPTION
Motivation:

The HttpClientOptions copy constructor did not copy followAlternativeServices, so copied options could lose that setting.

Conformance:

I have signed the ECA
