### PR TITLE
Remove follow alt-svc property in HttpClientOptions.

### DIFF
--- a/vertx-core/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -152,11 +152,6 @@ public class HttpClientOptionsConverter {
             obj.setName((String)member.getValue());
           }
           break;
-        case "followAlternativeServices":
-          if (member.getValue() instanceof Boolean) {
-            obj.setFollowAlternativeServices((Boolean)member.getValue());
-          }
-          break;
       }
     }
   }
@@ -207,6 +202,5 @@ public class HttpClientOptionsConverter {
     if (obj.getName() != null) {
       json.put("name", obj.getName());
     }
-    json.put("followAlternativeServices", obj.getFollowAlternativeServices());
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
@@ -29,6 +29,11 @@ import java.util.Objects;
 @Unstable
 public class HttpClientConfig {
 
+  /**
+   * Follow alternative service server advertisements = {@code false}
+   */
+  public static final boolean DEFAULT_FOLLOW_ALTERNATIVE_SERVICES = false;
+
   private static List<HttpVersion> toSupportedVersion(HttpVersion version) {
     switch (version) {
       case HTTP_1_0:
@@ -95,7 +100,7 @@ public class HttpClientConfig {
     this.observabilityConfig = null;
     this.shared = HttpClientOptions.DEFAULT_SHARED;
     this.name = HttpClientOptions.DEFAULT_NAME;
-    this.followAlternativeServices = HttpClientOptions.DEFAULT_FOLLOW_ALTERNATIVE_SERVICES;
+    this.followAlternativeServices = DEFAULT_FOLLOW_ALTERNATIVE_SERVICES;
   }
 
   public HttpClientConfig(HttpClientConfig other) {
@@ -141,7 +146,7 @@ public class HttpClientConfig {
     this.observabilityConfig = observabilityConfig;
     this.shared = options.isShared();
     this.name = options.getName();
-    this.followAlternativeServices = options.getFollowAlternativeServices();
+    this.followAlternativeServices = false;
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -13,7 +13,6 @@ package io.vertx.core.http;
 
 import io.netty.handler.logging.ByteBufFormat;
 import io.vertx.codegen.annotations.DataObject;
-import io.vertx.codegen.annotations.Unstable;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.impl.HttpUtils;
@@ -164,11 +163,6 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public static final boolean DEFAULT_HTTP_2_MULTIPLEX_IMPLEMENTATION = false;
 
-  /**
-   * Follow alternative service server advertisements = {@code false}
-   */
-  public static final boolean DEFAULT_FOLLOW_ALTERNATIVE_SERVICES = false;
-
   private Http1ClientConfig http1Config;
   private Http2ClientConfig http2Config;
   private boolean verifyHost;
@@ -183,8 +177,6 @@ public class HttpClientOptions extends ClientOptionsBase {
 
   private boolean shared;
   private String name;
-
-  private boolean followAlternativeServices;
 
   /**
    * Default constructor
@@ -260,7 +252,6 @@ public class HttpClientOptions extends ClientOptionsBase {
     tracingPolicy = DEFAULT_TRACING_POLICY;
     shared = DEFAULT_SHARED;
     name = DEFAULT_NAME;
-    followAlternativeServices = DEFAULT_FOLLOW_ALTERNATIVE_SERVICES;
   }
 
   public Http1ClientConfig getHttp1Config() {
@@ -1029,31 +1020,6 @@ public class HttpClientOptions extends ClientOptionsBase {
   public HttpClientOptions setName(String name) {
     Objects.requireNonNull(name, "Client name cannot be null");
     this.name = name;
-    return this;
-  }
-
-  /**
-   * @return whether the client follows alternative services advertisements
-   */
-  @Unstable
-  public boolean getFollowAlternativeServices() {
-    return followAlternativeServices;
-  }
-
-  /**
-   * <p>Configure whether the client follows alternative services advertisements, the default
-   * setting does not.</p>
-   *
-   * <p>Setting this to true, instructs the client to use most appropriate alternative services advertised by
-   * HTTP servers.</p>
-   *
-   * <p>The client only follows alternative services it can trust for a given origin, in practice this means
-   * this only the {@code https} scheme is supported and alternatives handshake uses the alternative origin.</p>
-   *
-   * @param followAlternativeServices the config value
-   */
-  public HttpClientOptions setFollowAlternativeServices(boolean followAlternativeServices) {
-    this.followAlternativeServices = followAlternativeServices;
     return this;
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpAlternativesTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpAlternativesTest.java
@@ -401,7 +401,7 @@ public class HttpAlternativesTest extends VertxTestBase {
         .end(request.authority().toString(false));
     });
     server.listen(8080).await();
-    client = vertx.createHttpClient(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_2).setFollowAlternativeServices(true));
+    client = vertx.createHttpClient(new HttpClientConfig(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_2)).setFollowAlternativeServices(true));
     Buffer body = client.request(HttpMethod.GET, 8080, "host2.com", "/")
       .compose(request -> request
         .send()


### PR DESCRIPTION
Motivation:

The alt-svc property is mostly useful with HTTP/3 and hardly makes sense in `HttpClientOptions`.

It could actually be misleading to think that this would enable HTTP/3.

Changes:

Remove `HttpClientOptions#followAlternativeServices` property
