### PR TITLE
Add missing HttpServerOptions#useSemicolonAsQueryParamDelimiter

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerConfig.java
@@ -124,8 +124,16 @@ public class HttpServerConfig {
       .setMaxFields(options.getMaxFormFields())
       .setMaxBufferedBytes(options.getMaxFormBufferedBytes());
 
+    QueryParamDecoderConfig queryParamDecoderConfig;
+    if (options.isUseSemicolonAsQueryParamDelimiter() == QueryParamDecoderConfig.DEFAULT_USE_SEMICOLON_AS_DELIMITER) {
+      queryParamDecoderConfig = null;
+    } else {
+      queryParamDecoderConfig = new QueryParamDecoderConfig().setUseSemicolonAsDelimiter(!QueryParamDecoderConfig.DEFAULT_USE_SEMICOLON_AS_DELIMITER);
+    }
+
     this.versions = versions;
     this.formDecoderConfig = formDecoderConfig;
+    this.queryParamDecoderConfig = queryParamDecoderConfig;
     this.handle100ContinueAutomatically = options.isHandle100ContinueAutomatically();
     this.strictThreadMode = options.getStrictThreadMode();
     this.observabilityConfig = observabilityConfig;

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -231,6 +231,7 @@ public class HttpServerOptions extends NetServerOptions {
   private TimeUnit http2RstFloodWindowDurationTimeUnit;
   private boolean strictThreadMode;
   private boolean http2ClearTextEnabled;
+  private boolean useSemicolonAsQueryParamDelimiter;
 
   /**
    * Default constructor
@@ -263,6 +264,7 @@ public class HttpServerOptions extends NetServerOptions {
     this.http2RstFloodWindowDurationTimeUnit = other.http2RstFloodWindowDurationTimeUnit;
     this.strictThreadMode = other.strictThreadMode;
     this.http2ClearTextEnabled = other.http2ClearTextEnabled;
+    this.useSemicolonAsQueryParamDelimiter = other.useSemicolonAsQueryParamDelimiter;
   }
 
   /**
@@ -304,6 +306,7 @@ public class HttpServerOptions extends NetServerOptions {
     registerWebSocketWriteHandlers = DEFAULT_REGISTER_WEBSOCKET_WRITE_HANDLERS;
     http2RstFloodWindowDurationTimeUnit = DEFAULT_HTTP2_RST_FLOOD_WINDOW_DURATION_TIME_UNIT;
     http2ClearTextEnabled = DEFAULT_HTTP2_CLEAR_TEXT_ENABLED;
+    useSemicolonAsQueryParamDelimiter = QueryParamDecoderConfig.DEFAULT_USE_SEMICOLON_AS_DELIMITER;
   }
 
   /**
@@ -924,6 +927,24 @@ public class HttpServerOptions extends NetServerOptions {
    */
   public HttpServerOptions setHttp2ClearTextEnabled(boolean http2ClearTextEnabled) {
     this.http2ClearTextEnabled = http2ClearTextEnabled;
+    return this;
+  }
+
+  /**
+   * @return whether to use the semicolon char {@code ;} as a delimiter for query string parameters.
+   */
+  public boolean isUseSemicolonAsQueryParamDelimiter() {
+    return useSemicolonAsQueryParamDelimiter;
+  }
+
+  /**
+   * Configure whether to use the semicolon char {@code ;} as a delimiter for query string parameters.
+   *
+   * @param useSemicolonAsDelimiter whether to allow semicolon to be used as a delimiter or it is a an actual parameter name or value
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setUseSemicolonAsQueryParamDelimiter(boolean useSemicolonAsDelimiter) {
+    this.useSemicolonAsQueryParamDelimiter = useSemicolonAsDelimiter;
     return this;
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpServerConfigTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpServerConfigTest.java
@@ -42,4 +42,15 @@ public class HttpServerConfigTest {
       }
     }
   }
+
+  @Test
+  public void testUseSemicolonAsQueryParamDelimiter() {
+    HttpServerConfig cfg = new HttpServerConfig(new HttpServerOptions());
+    assertNull(cfg.getQueryParamConfig());
+    cfg = new HttpServerConfig(new HttpServerOptions().setUseSemicolonAsQueryParamDelimiter(true));
+    assertNull(cfg.getQueryParamConfig());
+    cfg = new HttpServerConfig(new HttpServerOptions().setUseSemicolonAsQueryParamDelimiter(false));
+    assertNotNull(cfg.getQueryParamConfig());
+    assertFalse(cfg.getQueryParamConfig().isUseSemicolonAsDelimiter());
+  }
 }


### PR DESCRIPTION
Motivation:

The new `useSemicolonAsQueryParamDelimiter` was implemented differently in 5.1 and 4.5.x in terms of configuration.

5.1 was implemented directly in `HttpServerConfig` and 4.5.x was done on `HttpServerOptions`.

We need to port the `HttpServerOptions` property to 5.1 and emulate it with the `HttpServerConfig`.

Changes:

Add `HttpServerOptions#useSemicolonAsQueryParamDelimiter` and configure `HttpServerConfig#queryParamDecoderConfig` accordingly.
