### PR TITLE
fix(dns): support bare IPv6 resolver addresses

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsAddressResolverProvider.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsAddressResolverProvider.java
@@ -23,6 +23,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.net.impl.UriParser;
 import io.vertx.core.spi.dns.AddressResolverProvider;
 
 import java.io.File;
@@ -62,9 +63,12 @@ public class DnsAddressResolverProvider implements AddressResolverProvider, Host
     if (dnsServers != null && !dnsServers.isEmpty()) {
       for (String dnsServer : dnsServers) {
         int sep = dnsServer.lastIndexOf(':');
+        boolean hasPort = sep != -1 &&
+          (!isIPLiteral(dnsServer) ||
+            (isIPLiteral(dnsServer.substring(0, sep)) && UriParser.parseAndEvalPort(dnsServer, sep) != -1));
         String ipAddress;
         int port;
-        if (sep != -1) {
+        if (hasPort) {
           ipAddress = dnsServer.substring(0, sep);
           port = Integer.parseInt(dnsServer.substring(sep + 1));
         } else {
@@ -142,6 +146,11 @@ public class DnsAddressResolverProvider implements AddressResolverProvider, Host
         return addressResolver;
       }
     };
+  }
+
+  private static boolean isIPLiteral(String address) {
+    String literal = "[" + address + "]";
+    return UriParser.parseIPLiteral(literal, 0, literal.length()) == literal.length();
   }
 
   @Override

--- a/vertx-core/src/test/java/io/vertx/tests/dns/NameResolverTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/dns/NameResolverTest.java
@@ -184,6 +184,22 @@ public class NameResolverTest extends VertxTestBase {
   }
 
   @Test
+  public void testBareIpv6NameServerUsesDefaultPort() {
+    assertNameServerAccepted(new AddressResolverOptions().addServer("2001:4860:4860::8888"));
+    assertNameServerAccepted(new AddressResolverOptions().setServers(Collections.singletonList("2001:db8::1:abcd")));
+  }
+
+  @Test
+  public void testIpv6NameServerWithPortRemainsSupported() {
+    assertNameServerAccepted(new AddressResolverOptions().addServer("2001:db8::1:5353"));
+  }
+
+  private void assertNameServerAccepted(AddressResolverOptions options) {
+    Vertx configuredVertx = vertx(new VertxOptions().setAddressResolverOptions(options));
+    configuredVertx.createDnsClient().close();
+  }
+
+  @Test
   public void testOptions() {
     AddressResolverOptions options = new AddressResolverOptions();
     assertEquals(AddressResolverOptions.DEFAULT_OPT_RESOURCE_ENABLED, options.isOptResourceEnabled());


### PR DESCRIPTION
Motivation:

Fixes #6194

Fixes parsing of configured DNS resolver addresses so bare IPv6 literals are accepted without being mistaken for `host:port` values.

IPv6 DNS server addresses contain `:` characters, so the previous `lastIndexOf(':')` parsing treated bare IPv6 literals as if they included a port. That could reject valid resolver addresses or parse them incorrectly.

## How

- Detects whether a configured DNS server string actually includes a port.
- Uses Vert.x URI parsing helpers to distinguish IP literals from `host:port` values.
- Preserves support for IPv6 resolver addresses that explicitly include a port.
- Adds regression coverage for bare IPv6 resolver addresses and IPv6 addresses with ports.

## Testing

- Added `NameResolverTest` coverage for bare IPv6 DNS servers.
- Added coverage for IPv6 DNS server entries with explicit ports.