### PR TITLE
Copy routingKey in RequestOptions copy constructor

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/RequestOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/RequestOptions.java
@@ -118,6 +118,7 @@ public class RequestOptions extends HttpConnectOptions {
       setHeaders(MultiMap.caseInsensitiveMultiMap().setAll(other.headers));
     }
     setTraceOperation(other.traceOperation);
+    setRoutingKey(other.routingKey);
   }
 
   /**

--- a/vertx-core/src/test/java/io/vertx/tests/http/RequestOptionsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/RequestOptionsTest.java
@@ -48,12 +48,14 @@ public class RequestOptionsTest {
       .setMethod(HttpMethod.PUT)
       .setPort(8443)
       .setSsl(true)
-      .setFollowRedirects(true);
+      .setFollowRedirects(true)
+      .setRoutingKey("user-123");
     RequestOptions copy = new RequestOptions(options);
     assertEquals(options.getMethod(), copy.getMethod());
     assertEquals(options.getPort(), copy.getPort());
     assertEquals(options.isSsl(), copy.isSsl());
     assertEquals(options.getFollowRedirects(), copy.getFollowRedirects());
+    assertEquals(options.getRoutingKey(), copy.getRoutingKey());
   }
 
   @Test


### PR DESCRIPTION
Motivation:

Fixes #6202

`RequestOptions(RequestOptions other)` should preserve `routingKey` when copying request options.
This change adds the missing copy and covers it in `RequestOptionsTest.testCopy`.

Conformance:

I have signed the ECA
