### PR TITLE
Sort DNS MX and SRV records by priority

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/dns/DnsClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/DnsClient.java
@@ -131,8 +131,9 @@ public interface DnsClient {
    * Try to resolve the SRV records for the given name.
    *
    * @param name  the name for which the SRV records should be resolved
-   * @return a future resolved with a List that contains all resolved {@link SrvRecord}s. If none was found it will
-   *                 get notified with an empty {@link java.util.List}. If an error occurs it will get failed.
+   * @return a future resolved with a List that contains all resolved {@link SrvRecord}s, sorted by
+   *                 their {@link SrvRecord#priority()}. If none was found it will get notified with an empty
+   *                 {@link java.util.List}.  If an error occurs it will get failed.
    */
   Future<List<SrvRecord>> resolveSRV(String name);
 

--- a/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
@@ -137,7 +137,7 @@ public class DnsClientImpl implements DnsClient {
 
   @Override
   public Future<List<MxRecord>> resolveMX(String name) {
-    return queryAll(name, DnsRecordType.MX, RecordDecoder.MX);
+    return queryAll(name, DnsRecordType.MX, RecordDecoder.MX, Comparator.comparingInt(MxRecord::priority));
   }
 
   @Override
@@ -163,7 +163,7 @@ public class DnsClientImpl implements DnsClient {
 
   @Override
   public Future<List<SrvRecord>> resolveSRV(String name) {
-    return queryAll(name, DnsRecordType.SRV, RecordDecoder.SRV);
+    return queryAll(name, DnsRecordType.SRV, RecordDecoder.SRV, Comparator.comparingInt(SrvRecord::priority));
   }
 
   private Future<List<String>> resolveAll(String name, InternetProtocolFamily ipFamily) {
@@ -198,6 +198,11 @@ public class DnsClientImpl implements DnsClient {
   }
 
   private <T> Future<List<T>> queryAll(String name, DnsRecordType recordType, Function<DnsRecord, T> mapper) {
+    return queryAll(name, recordType, mapper, null);
+  }
+
+  private <T> Future<List<T>> queryAll(String name, DnsRecordType recordType, Function<DnsRecord, T> mapper,
+                                       Comparator<T> comparator) {
     Objects.requireNonNull(name);
     ContextInternal ctx = vertx.getOrCreateContext();
     DnsNameResolver resolver = resolver(ctx, InternetProtocolFamily.IPv4);
@@ -238,6 +243,9 @@ public class DnsClientImpl implements DnsClient {
                 ret.add(mapped);
               }
             }
+          }
+          if (comparator != null) {
+            ret.sort(comparator);
           }
           return Future.succeededFuture(ret);
         } finally {

--- a/vertx-core/src/main/java/io/vertx/core/dns/impl/RecordDecoder.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/impl/RecordDecoder.java
@@ -44,7 +44,7 @@ class RecordDecoder {
     static Function<DnsRecord, MxRecord> MX = record -> {
       if (record.type() == DnsRecordType.MX) {
         ByteBuf packet = ((DnsRawRecord)record).content();
-        int priority = packet.readShort();
+        int priority = packet.readUnsignedShort();
         String name = RecordDecoder.readName(packet);
         long ttl = record.timeToLive();
         return new MxRecordImpl(ttl, priority, name);
@@ -86,8 +86,8 @@ class RecordDecoder {
     static Function<DnsRecord, SrvRecord> SRV = record -> {
       if (record.type() == DnsRecordType.SRV) {
         ByteBuf packet = ((DnsRawRecord)record).content();
-        int priority = packet.readShort();
-        int weight = packet.readShort();
+        int priority = packet.readUnsignedShort();
+        int weight = packet.readUnsignedShort();
         int port = packet.readUnsignedShort();
         long ttl = record.timeToLive();
         String target = RecordDecoder.readName(packet);

--- a/vertx-core/src/test/java/io/vertx/tests/dns/DNSTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/dns/DNSTest.java
@@ -28,6 +28,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.SortedMap;
@@ -194,6 +195,24 @@ public class DNSTest extends VertxTestBase {
   }
 
   @Test
+  public void testResolveMXSortedByPriority() throws Exception {
+    mockDnsServer.store(question -> Arrays.asList(
+      MockDnsServer.mx("vertx.io", 100, "mx-high.vertx.io", 40000),
+      MockDnsServer.mx("vertx.io", 100, "mx-low.vertx.io", 10)
+    ));
+    DnsClient dns = prepareDns();
+
+    List<MxRecord> result = dns.resolveMX("vertx.io").await();
+    Assert.assertEquals(2, result.size());
+    MxRecord first = result.get(0);
+    Assert.assertEquals(10, first.priority());
+    Assert.assertEquals("mx-low.vertx.io", first.name());
+    MxRecord second = result.get(1);
+    Assert.assertEquals(40000, second.priority());
+    Assert.assertEquals("mx-high.vertx.io", second.name());
+  }
+
+  @Test
   public void testResolveTXT() throws Exception {
     final String txt = "vertx is awesome";
     mockDnsServer.testResolveTXT(txt);
@@ -286,6 +305,25 @@ public class DNSTest extends VertxTestBase {
         testComplete();
       }));
     await();
+  }
+
+  @Test
+  public void testResolveSRVSortedByPriority() throws Exception {
+    mockDnsServer.store(question -> Arrays.asList(
+      MockDnsServer.srv("_svc._tcp.vertx.io", 100, 40000, 40000, 80, "svc-high.vertx.io"),
+      MockDnsServer.srv("_svc._tcp.vertx.io", 100, 10, 1, 81, "svc-low.vertx.io")
+    ));
+    DnsClient dns = prepareDns();
+
+    List<SrvRecord> result = dns.resolveSRV("_svc._tcp.vertx.io").await();
+    Assert.assertEquals(2, result.size());
+    SrvRecord first = result.get(0);
+    Assert.assertEquals(10, first.priority());
+    Assert.assertEquals("svc-low.vertx.io", first.target());
+    SrvRecord second = result.get(1);
+    Assert.assertEquals(40000, second.priority());
+    Assert.assertEquals(40000, second.weight());
+    Assert.assertEquals("svc-high.vertx.io", second.target());
   }
 
   @Test


### PR DESCRIPTION
Fixes #6205

Motivation:

MX and SRV lookups should return records in DNS priority order, with lower priority values first, instead of preserving the DNS answer order.

This change sorts MX and SRV results by priority and decodes MX/SRV numeric fields as unsigned 16-bit values. It also adds regression tests and updates the `resolveSRV()` Javadoc.

Conformance:

I Have signed the ECA