### PR TITLE
Add RFC 10008 (QUERY Method) Support

### DIFF
--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -1609,8 +1609,12 @@ Alternatively you can just parse the `Set-Cookie` headers yourself in the respon
 
 The client can be configured to follow HTTP redirections provided by the `Location` response header when the client receives:
 
-* a `301`, `302`, `307` or `308` status code along with an HTTP GET or HEAD method
+* a `301`, `302`, `307` or `308` status code along with an HTTP GET, HEAD, or QUERY method
 * a `303` status code, in addition the directed request perform an HTTP GET method
+
+When redirecting a `QUERY` request, the request body is buffered in memory and resent to the redirected location.
+By default, the maximum size of this buffer is limited to `4KB` (configured via {@link io.vertx.core.http.HttpClientConfig#setMaxRedirectBufferSize(int)}).
+If the body size exceeds this limit, the redirection is not followed.
 
 Here's an example:
 

--- a/vertx-core/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -127,6 +127,11 @@ public class HttpClientOptionsConverter {
             obj.setMaxRedirects(((Number)member.getValue()).intValue());
           }
           break;
+        case "maxRedirectBufferSize":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxRedirectBufferSize(((Number)member.getValue()).intValue());
+          }
+          break;
         case "forceSni":
           if (member.getValue() instanceof Boolean) {
             obj.setForceSni((Boolean)member.getValue());
@@ -193,6 +198,7 @@ public class HttpClientOptionsConverter {
     json.put("http2ClearTextUpgrade", obj.isHttp2ClearTextUpgrade());
     json.put("http2ClearTextUpgradeWithPreflightRequest", obj.isHttp2ClearTextUpgradeWithPreflightRequest());
     json.put("maxRedirects", obj.getMaxRedirects());
+    json.put("maxRedirectBufferSize", obj.getMaxRedirectBufferSize());
     json.put("forceSni", obj.isForceSni());
     json.put("decoderInitialBufferSize", obj.getDecoderInitialBufferSize());
     if (obj.getTracingPolicy() != null) {

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
@@ -79,6 +79,7 @@ public class HttpClientConfig {
   private String defaultHost;
   private int defaultPort;
   private int maxRedirects;
+  private int maxRedirectBufferSize;
   private ObservabilityConfig observabilityConfig;
   private boolean shared;
   private String name;
@@ -97,6 +98,7 @@ public class HttpClientConfig {
     this.defaultHost = HttpClientOptions.DEFAULT_DEFAULT_HOST;
     this.defaultPort = HttpClientOptions.DEFAULT_DEFAULT_PORT;
     this.maxRedirects = HttpClientOptions.DEFAULT_MAX_REDIRECTS;
+    this.maxRedirectBufferSize = HttpClientOptions.DEFAULT_MAX_REDIRECT_BUFFER_SIZE;
     this.observabilityConfig = null;
     this.shared = HttpClientOptions.DEFAULT_SHARED;
     this.name = HttpClientOptions.DEFAULT_NAME;
@@ -116,6 +118,7 @@ public class HttpClientConfig {
     this.defaultHost = other.defaultHost;
     this.defaultPort = other.defaultPort;
     this.maxRedirects = other.maxRedirects;
+    this.maxRedirectBufferSize = other.maxRedirectBufferSize;
     this.observabilityConfig = other.observabilityConfig != null ? new ObservabilityConfig(other.observabilityConfig) : null;
     this.shared = other.shared;
     this.name = other.name;
@@ -143,6 +146,7 @@ public class HttpClientConfig {
     this.defaultHost = options.getDefaultHost();
     this.defaultPort = options.getDefaultPort();
     this.maxRedirects = options.getMaxRedirects();
+    this.maxRedirectBufferSize = options.getMaxRedirectBufferSize();
     this.observabilityConfig = observabilityConfig;
     this.shared = options.isShared();
     this.name = options.getName();
@@ -448,6 +452,24 @@ public class HttpClientConfig {
    */
   public HttpClientConfig setMaxRedirects(int maxRedirects) {
     this.maxRedirects = maxRedirects;
+    return this;
+  }
+
+  /**
+   * @return the maximum size of the redirect buffer when redirecting QUERY requests
+   */
+  public int getMaxRedirectBufferSize() {
+    return maxRedirectBufferSize;
+  }
+
+  /**
+   * Set the maximum size of the redirect buffer in bytes when redirecting QUERY requests.
+   *
+   * @param maxRedirectBufferSize the maximum buffer size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientConfig setMaxRedirectBufferSize(int maxRedirectBufferSize) {
+    this.maxRedirectBufferSize = maxRedirectBufferSize;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.http;
 
+import io.vertx.core.impl.Arguments;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Unstable;
@@ -456,7 +457,7 @@ public class HttpClientConfig {
   }
 
   /**
-   * @return the maximum size of the redirect buffer when redirecting QUERY requests
+   * @return the maximum size in bytes of the redirect buffer when redirecting QUERY requests
    */
   public int getMaxRedirectBufferSize() {
     return maxRedirectBufferSize;
@@ -469,6 +470,7 @@ public class HttpClientConfig {
    * @return a reference to this, so the API can be used fluently
    */
   public HttpClientConfig setMaxRedirectBufferSize(int maxRedirectBufferSize) {
+    Arguments.require(maxRedirectBufferSize >= 0, "Max redirect buffer size must be >= 0");
     this.maxRedirectBufferSize = maxRedirectBufferSize;
     return this;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.http;
 
+import io.vertx.core.impl.Arguments;
 import io.netty.handler.logging.ByteBufFormat;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
@@ -134,9 +135,9 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final int DEFAULT_MAX_REDIRECTS = 16;
 
   /**
-   * Default max redirect buffer size = 1024 * 1024 bytes (1MB)
+   * Default max redirect buffer size = 4 * 1024 bytes (4KB)
    */
-  public static final int DEFAULT_MAX_REDIRECT_BUFFER_SIZE = 1024 * 1024;
+  public static final int DEFAULT_MAX_REDIRECT_BUFFER_SIZE = 4 * 1024;
 
   /*
    * Default force SNI = {@code false}
@@ -905,7 +906,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   /**
-   * @return the maximum size of the redirect buffer when redirecting QUERY requests
+   * @return the maximum size in bytes of the redirect buffer when redirecting QUERY requests
    */
   public int getMaxRedirectBufferSize() {
     return maxRedirectBufferSize;
@@ -918,6 +919,7 @@ public class HttpClientOptions extends ClientOptionsBase {
    * @return a reference to this, so the API can be used fluently
    */
   public HttpClientOptions setMaxRedirectBufferSize(int maxRedirectBufferSize) {
+    Arguments.require(maxRedirectBufferSize >= 0, "Max redirect buffer size must be >= 0");
     this.maxRedirectBufferSize = maxRedirectBufferSize;
     return this;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -133,6 +133,11 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public static final int DEFAULT_MAX_REDIRECTS = 16;
 
+  /**
+   * Default max redirect buffer size = 1024 * 1024 bytes (1MB)
+   */
+  public static final int DEFAULT_MAX_REDIRECT_BUFFER_SIZE = 1024 * 1024;
+
   /*
    * Default force SNI = {@code false}
    */
@@ -171,6 +176,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   private int defaultPort;
   private HttpVersion protocolVersion;
   private int maxRedirects;
+  private int maxRedirectBufferSize;
   private boolean forceSni;
 
   private TracingPolicy tracingPolicy;
@@ -211,6 +217,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.defaultPort = other.defaultPort;
     this.protocolVersion = other.protocolVersion;
     this.maxRedirects = other.maxRedirects;
+    this.maxRedirectBufferSize = other.maxRedirectBufferSize;
     this.forceSni = other.forceSni;
     this.tracingPolicy = other.tracingPolicy;
     this.shared = other.shared;
@@ -248,6 +255,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     defaultPort = DEFAULT_DEFAULT_PORT;
     protocolVersion = DEFAULT_PROTOCOL_VERSION;
     maxRedirects = DEFAULT_MAX_REDIRECTS;
+    maxRedirectBufferSize = DEFAULT_MAX_REDIRECT_BUFFER_SIZE;
     forceSni = DEFAULT_FORCE_SNI;
     tracingPolicy = DEFAULT_TRACING_POLICY;
     shared = DEFAULT_SHARED;
@@ -893,6 +901,24 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public HttpClientOptions setMaxRedirects(int maxRedirects) {
     this.maxRedirects = maxRedirects;
+    return this;
+  }
+
+  /**
+   * @return the maximum size of the redirect buffer when redirecting QUERY requests
+   */
+  public int getMaxRedirectBufferSize() {
+    return maxRedirectBufferSize;
+  }
+
+  /**
+   * Set the maximum size of the redirect buffer in bytes when redirecting QUERY requests.
+   *
+   * @param maxRedirectBufferSize the maximum buffer size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientOptions setMaxRedirectBufferSize(int maxRedirectBufferSize) {
+    this.maxRedirectBufferSize = maxRedirectBufferSize;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -119,7 +119,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   /**
    * @return the maximum size in bytes of the redirect buffer when redirecting QUERY requests
    */
-  int getMaxRedirectBufferSize();
+  int maxRedirectBufferSize();
 
   /**
    * Set the maximum size of the redirect buffer in bytes when redirecting QUERY requests.
@@ -128,7 +128,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  HttpClientRequest setMaxRedirectBufferSize(int maxRedirectBufferSize);
+  HttpClientRequest maxRedirectBufferSize(int maxRedirectBufferSize);
 
   /**
    * @return the number of followed redirections for the current HTTP request

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -117,6 +117,20 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   int getMaxRedirects();
 
   /**
+   * @return the maximum size of the redirect buffer in bytes when redirecting QUERY requests
+   */
+  int getMaxRedirectBufferSize();
+
+  /**
+   * Set the maximum size of the redirect buffer in bytes when redirecting QUERY requests.
+   *
+   * @param maxRedirectBufferSize the maximum buffer size
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpClientRequest setMaxRedirectBufferSize(int maxRedirectBufferSize);
+
+  /**
    * @return the number of followed redirections for the current HTTP request
    */
   int numberOfRedirections();

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -117,7 +117,7 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   int getMaxRedirects();
 
   /**
-   * @return the maximum size of the redirect buffer in bytes when redirecting QUERY requests
+   * @return the maximum size in bytes of the redirect buffer when redirecting QUERY requests
    */
   int getMaxRedirectBufferSize();
 

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -73,6 +73,8 @@ public interface HttpHeaders {
 
   /**
    * Accept-Query header name
+   * <p>
+   * TODO: Use {@code HttpHeaderNames.ACCEPT_QUERY} when bumping to the next Netty release
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   CharSequence ACCEPT_QUERY = createOptimized("accept-query");

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpHeaders.java
@@ -72,6 +72,12 @@ public interface HttpHeaders {
   CharSequence ACCEPT_PATCH = HttpHeaderNames.ACCEPT_PATCH;
 
   /**
+   * Accept-Query header name
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  CharSequence ACCEPT_QUERY = createOptimized("accept-query");
+
+  /**
    * Access-Control-Allow-Credentials header name
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpMethod.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpMethod.java
@@ -203,6 +203,7 @@ public class HttpMethod {
     TRACE = new HttpMethod(io.netty.handler.codec.http.HttpMethod.TRACE);
     CONNECT = new HttpMethod(io.netty.handler.codec.http.HttpMethod.CONNECT);
     PATCH = new HttpMethod(io.netty.handler.codec.http.HttpMethod.PATCH);
+    // TODO: Use Netty HttpMethod.QUERY in the next Netty bump
     QUERY = new HttpMethod(io.netty.handler.codec.http.HttpMethod.valueOf("QUERY"));
     PROPFIND = new HttpMethod(io.netty.handler.codec.http.HttpMethod.valueOf("PROPFIND"));
     PROPPATCH = new HttpMethod(io.netty.handler.codec.http.HttpMethod.valueOf("PROPPATCH"));

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpMethod.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpMethod.java
@@ -74,6 +74,11 @@ public class HttpMethod {
   public static final HttpMethod PATCH;
 
   /**
+   * The RFC 10008 {@code QUERY} method, this instance is interned and uniquely used.
+   */
+  public static final HttpMethod QUERY;
+
+  /**
    * The RFC 2518/4918 {@code PROPFIND} method, this instance is interned and uniquely used.
    */
   public static final HttpMethod PROPFIND;
@@ -198,6 +203,7 @@ public class HttpMethod {
     TRACE = new HttpMethod(io.netty.handler.codec.http.HttpMethod.TRACE);
     CONNECT = new HttpMethod(io.netty.handler.codec.http.HttpMethod.CONNECT);
     PATCH = new HttpMethod(io.netty.handler.codec.http.HttpMethod.PATCH);
+    QUERY = new HttpMethod(io.netty.handler.codec.http.HttpMethod.valueOf("QUERY"));
     PROPFIND = new HttpMethod(io.netty.handler.codec.http.HttpMethod.valueOf("PROPFIND"));
     PROPPATCH = new HttpMethod(io.netty.handler.codec.http.HttpMethod.valueOf("PROPPATCH"));
     MKCOL = new HttpMethod(io.netty.handler.codec.http.HttpMethod.valueOf("MKCOL"));
@@ -252,7 +258,8 @@ public class HttpMethod {
       HttpMethod.MKACTIVITY,
       HttpMethod.ORDERPATCH,
       HttpMethod.ACL,
-      HttpMethod.SEARCH
+      HttpMethod.SEARCH,
+      HttpMethod.QUERY
     ));
   }
 
@@ -303,6 +310,8 @@ public class HttpMethod {
         return CONNECT;
       case "PATCH":
         return PATCH;
+      case "QUERY":
+        return QUERY;
       case "PROPFIND":
         return PROPFIND;
       case "PROPPATCH":
@@ -386,6 +395,8 @@ public class HttpMethod {
         return CONNECT;
       case "PATCH":
         return PATCH;
+      case "QUERY":
+        return QUERY;
       case "PROPFIND":
         return PROPFIND;
       case "PROPPATCH":

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/DefaultRedirectHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/DefaultRedirectHandler.java
@@ -72,6 +72,7 @@ public class DefaultRedirectHandler implements Function<HttpClientResponse, Futu
         options.setURI(requestURI);
         options.setHeaders(resp.request().headers());
         options.removeHeader(CONTENT_LENGTH);
+        options.removeHeader(HttpHeaders.TRANSFER_ENCODING);
         return Future.succeededFuture(options);
       }
       return null;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/DefaultRedirectHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/DefaultRedirectHandler.java
@@ -35,7 +35,7 @@ public class DefaultRedirectHandler implements Function<HttpClientResponse, Futu
         HttpMethod m = resp.request().getMethod();
         if (statusCode == 303) {
           m = HttpMethod.GET;
-        } else if (m != HttpMethod.GET && m != HttpMethod.HEAD) {
+        } else if (m != HttpMethod.GET && m != HttpMethod.HEAD && m != HttpMethod.QUERY) {
           return null;
         }
         URI uri = HttpUtils.resolveURIReference(resp.request().absoluteURI(), location);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/DefaultRedirectHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/DefaultRedirectHandler.java
@@ -35,7 +35,7 @@ public class DefaultRedirectHandler implements Function<HttpClientResponse, Futu
         HttpMethod m = resp.request().getMethod();
         if (statusCode == 303) {
           m = HttpMethod.GET;
-        } else if (m != HttpMethod.GET && m != HttpMethod.HEAD && m != HttpMethod.QUERY) {
+        } else if (m != HttpMethod.GET && m != HttpMethod.HEAD) {
           return null;
         }
         URI uri = HttpUtils.resolveURIReference(resp.request().absoluteURI(), location);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -183,6 +183,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       config.getDefaultHost(),
       config.getDefaultPort(),
       config.getMaxRedirects(),
+      config.getMaxRedirectBufferSize(),
       versions,
       sslOptions,
       connectHandler,
@@ -210,6 +211,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       String defaultHost,
       int defaultPort,
       int maxRedirects,
+      int maxRedirectBufferSize,
       List<HttpVersion> versions,
       ClientSSLOptions sslOptions,
       Handler<HttpConnection> connectHandler,
@@ -217,7 +219,7 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       HttpClientTransport quicTransport,
       HttpClientConfig config,
       HttpClientOptions options) {
-      super(vertx, resolver, redirectHandler, httpMetrics, poolOptions, defaultProxyOptions, nonProxyHosts, loadBalancer, followAlternativeServices, resolverIdeTimeout, verifyHost, defaultSsl, defaultHost, defaultPort, maxRedirects, versions, sslOptions, connectHandler, tcpTransport, quicTransport);
+      super(vertx, resolver, redirectHandler, httpMetrics, poolOptions, defaultProxyOptions, nonProxyHosts, loadBalancer, followAlternativeServices, resolverIdeTimeout, verifyHost, defaultSsl, defaultHost, defaultPort, maxRedirects, maxRedirectBufferSize, versions, sslOptions, connectHandler, tcpTransport, quicTransport);
       this.config = config;
       this.options = options;
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -69,6 +69,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   private final String defaultHost;
   private final int defaultPort;
   private final int maxRedirects;
+  private final int maxRedirectBufferSize;
   private final List<HttpVersion> versions;
   private final Handler<HttpConnection> connectHandler;
   private volatile Handler<Throwable> exceptionHandler;
@@ -89,6 +90,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
                  String defaultHost,
                  int defaultPort,
                  int maxRedirects,
+                 int maxRedirectBufferSize,
                  List<HttpVersion> versions,
                  ClientSSLOptions sslOptions,
                  Handler<HttpConnection> connectHandler,
@@ -117,6 +119,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     this.defaultHost = defaultHost;
     this.defaultPort = defaultPort;
     this.maxRedirects = maxRedirects;
+    this.maxRedirectBufferSize = maxRedirectBufferSize;
     this.versions = versions;
     this.sslOptions = sslOptions;
     this.connectHandler = connectHandler;
@@ -791,6 +794,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   HttpClientRequestImpl createRequest(HostAndPort authority, HttpConnection connection, HttpClientStream stream, RequestOptions options) {
     HttpClientRequestImpl request = new HttpClientRequestImpl(authority, connection, stream);
     request.init(options);
+    request.setMaxRedirectBufferSize(maxRedirectBufferSize);
     Function<HttpClientResponse, Future<RequestOptions>> rHandler = redirectHandler;
     if (rHandler != null) {
       request.setMaxRedirects(maxRedirects);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -794,7 +794,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   HttpClientRequestImpl createRequest(HostAndPort authority, HttpConnection connection, HttpClientStream stream, RequestOptions options) {
     HttpClientRequestImpl request = new HttpClientRequestImpl(authority, connection, stream);
     request.init(options);
-    request.setMaxRedirectBufferSize(maxRedirectBufferSize);
+    request.maxRedirectBufferSize(maxRedirectBufferSize);
     Function<HttpClientResponse, Future<RequestOptions>> rHandler = redirectHandler;
     if (rHandler != null) {
       request.setMaxRedirects(maxRedirects);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -41,6 +41,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
 
   static final Logger log = LoggerFactory.getLogger(HttpClientRequestImpl.class);
 
+  private static final int MAX_REDIRECT_BUFFER_SIZE = 1024 * 1024;
   private final Promise<Void> endPromise;
   private final Future<Void> endFuture;
   private boolean chunked;
@@ -58,6 +59,8 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   private StreamPriority priority;
   private boolean isConnect;
   private String traceOperation;
+  private Buffer bodyBuffer;
+  private boolean bodyBufferCopied;
 
   public HttpClientRequestImpl(HostAndPort authority, HttpConnection connection, HttpClientStream stream) {
     super(authority, connection, stream, stream.context().promise(), HttpMethod.GET, "/");
@@ -384,13 +387,19 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
     next.pushHandler(pushHandler());
     next.setFollowRedirects(true);
     next.setMaxRedirects(maxRedirects);
-    ((HttpClientRequestImpl)next).numberOfRedirections = numberOfRedirections + 1;
+    HttpClientRequestImpl nextImpl = (HttpClientRequestImpl) next;
+    nextImpl.numberOfRedirections = numberOfRedirections + 1;
+    nextImpl.bodyBuffer = bodyBuffer;
     endFuture.onComplete(ar -> {
       if (ar.succeeded()) {
         if (timeoutMs > 0) {
           next.idleTimeout(timeoutMs);
         }
-        next.end();
+        if (next.getMethod() == HttpMethod.QUERY && bodyBuffer != null) {
+          next.end(bodyBuffer);
+        } else {
+          next.end();
+        }
       } else {
         next.reset(0);
       }
@@ -504,6 +513,28 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
       }
       if (trailersSent) {
         return context.failedFuture(new IllegalStateException("Request already complete"));
+      }
+      if (followRedirects && getMethod() == HttpMethod.QUERY) {
+        if (buff != null) {
+          if (bodyBuffer == null) {
+            if (buff.length() > MAX_REDIRECT_BUFFER_SIZE) {
+              followRedirects = false;
+            } else {
+              bodyBuffer = buff;
+            }
+          } else {
+            if (bodyBuffer.length() + buff.length() > MAX_REDIRECT_BUFFER_SIZE) {
+              followRedirects = false;
+              bodyBuffer = null;
+            } else {
+              if (!bodyBufferCopied) {
+                bodyBuffer = Buffer.buffer().appendBuffer(bodyBuffer);
+                bodyBufferCopied = true;
+              }
+              bodyBuffer.appendBuffer(buff);
+            }
+          }
+        }
       }
       if (!headersSent) {
         if (!connect) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -168,14 +168,14 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   }
 
   @Override
-  public synchronized HttpClientRequest setMaxRedirectBufferSize(int maxRedirectBufferSize) {
+  public synchronized HttpClientRequest maxRedirectBufferSize(int maxRedirectBufferSize) {
     Arguments.require(maxRedirectBufferSize >= 0, "Max redirect buffer size must be >= 0");
     this.maxRedirectBufferSize = maxRedirectBufferSize;
     return this;
   }
 
   @Override
-  public synchronized int getMaxRedirectBufferSize() {
+  public synchronized int maxRedirectBufferSize() {
     return maxRedirectBufferSize;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -555,7 +555,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
             if (bodyBuffer == null) {
               bodyBuffer = new ArrayList<>();
             }
-            bodyBuffer.add(buff);
+            bodyBuffer.add(buff.copy());
           }
         }
       }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -26,6 +26,10 @@ import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 
+import java.util.ArrayList;
+import java.util.List;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.CompositeByteBuf;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
@@ -59,8 +63,8 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   private StreamPriority priority;
   private boolean isConnect;
   private String traceOperation;
-  private Buffer bodyBuffer;
-  private boolean bodyBufferCopied;
+  private int maxRedirectBufferSize = HttpClientOptions.DEFAULT_MAX_REDIRECT_BUFFER_SIZE;
+  private List<Buffer> bodyBuffer;
 
   public HttpClientRequestImpl(HostAndPort authority, HttpConnection connection, HttpClientStream stream) {
     super(authority, connection, stream, stream.context().promise(), HttpMethod.GET, "/");
@@ -161,6 +165,18 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   @Override
   public synchronized int getMaxRedirects() {
     return maxRedirects;
+  }
+
+  @Override
+  public synchronized HttpClientRequest setMaxRedirectBufferSize(int maxRedirectBufferSize) {
+    Arguments.require(maxRedirectBufferSize >= 0, "Max redirect buffer size must be >= 0");
+    this.maxRedirectBufferSize = maxRedirectBufferSize;
+    return this;
+  }
+
+  @Override
+  public synchronized int getMaxRedirectBufferSize() {
+    return maxRedirectBufferSize;
   }
 
   @Override
@@ -395,8 +411,18 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
         if (timeoutMs > 0) {
           next.idleTimeout(timeoutMs);
         }
-        if (next.getMethod() == HttpMethod.QUERY && bodyBuffer != null) {
-          next.end(bodyBuffer);
+        if (next.getMethod() == HttpMethod.QUERY && bodyBuffer != null && !bodyBuffer.isEmpty()) {
+          Buffer redirectBody;
+          if (bodyBuffer.size() == 1) {
+            redirectBody = bodyBuffer.get(0);
+          } else {
+            CompositeByteBuf composite = Unpooled.compositeBuffer();
+            for (Buffer b : bodyBuffer) {
+              composite.addComponent(true, ((BufferInternal) b).getByteBuf());
+            }
+            redirectBody = BufferInternal.buffer(composite);
+          }
+          next.end(redirectBody);
         } else {
           next.end();
         }
@@ -516,23 +542,20 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
       }
       if (followRedirects && getMethod() == HttpMethod.QUERY) {
         if (buff != null) {
-          if (bodyBuffer == null) {
-            if (buff.length() > MAX_REDIRECT_BUFFER_SIZE) {
-              followRedirects = false;
-            } else {
-              bodyBuffer = buff;
+          int currentLen = 0;
+          if (bodyBuffer != null) {
+            for (Buffer b : bodyBuffer) {
+              currentLen += b.length();
             }
+          }
+          if (currentLen + buff.length() > maxRedirectBufferSize) {
+            followRedirects = false;
+            bodyBuffer = null;
           } else {
-            if (bodyBuffer.length() + buff.length() > MAX_REDIRECT_BUFFER_SIZE) {
-              followRedirects = false;
-              bodyBuffer = null;
-            } else {
-              if (!bodyBufferCopied) {
-                bodyBuffer = Buffer.buffer().appendBuffer(bodyBuffer);
-                bodyBufferCopied = true;
-              }
-              bodyBuffer.appendBuffer(buff);
+            if (bodyBuffer == null) {
+              bodyBuffer = new ArrayList<>();
             }
+            bodyBuffer.add(buff);
           }
         }
       }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -44,8 +44,6 @@ import static io.vertx.core.http.impl.HttpClientImpl.ABS_URI_START_PATTERN;
 public class HttpClientRequestImpl extends HttpClientRequestBase implements HttpClientRequest {
 
   static final Logger log = LoggerFactory.getLogger(HttpClientRequestImpl.class);
-
-  private static final int MAX_REDIRECT_BUFFER_SIZE = 1024 * 1024;
   private final Promise<Void> endPromise;
   private final Future<Void> endFuture;
   private boolean chunked;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -108,6 +108,16 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
+  public int getMaxRedirectBufferSize() {
+    return 0;
+  }
+
+  @Override
+  public HttpClientRequest setMaxRedirectBufferSize(int maxRedirectBufferSize) {
+    throw new IllegalStateException();
+  }
+
+  @Override
   public HttpClientRequest redirectHandler(@Nullable Function<HttpClientResponse, Future<HttpClientRequest>> handler) {
     throw new IllegalStateException();
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -108,12 +108,12 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
-  public int getMaxRedirectBufferSize() {
+  public int maxRedirectBufferSize() {
     return 0;
   }
 
   @Override
-  public HttpClientRequest setMaxRedirectBufferSize(int maxRedirectBufferSize) {
+  public HttpClientRequest maxRedirectBufferSize(int maxRedirectBufferSize) {
     throw new IllegalStateException();
   }
 

--- a/vertx-core/src/test/java/io/vertx/test/http/HttpClientConfigurator.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/HttpClientConfigurator.java
@@ -23,6 +23,7 @@ public interface HttpClientConfigurator {
   HttpClientConfigurator setLogActivity(boolean logActivity);
   HttpClientConfigurator setMetricsName(String name);
   HttpClientConfigurator configureSsl(Consumer<ClientSSLOptions> configurator);
+  HttpClientConfigurator setMaxRedirectBufferSize(int maxRedirectBufferSize);
   default HttpClientAgent create(Vertx vertx, PoolOptions poolOptions) {
     return builder(vertx).with(poolOptions).build();
   }

--- a/vertx-core/src/test/java/io/vertx/test/http/HttpConfigurator.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/HttpConfigurator.java
@@ -111,6 +111,11 @@ public interface HttpConfigurator {
           return this;
         }
         @Override
+        public HttpClientConfigurator setMaxRedirectBufferSize(int maxRedirectBufferSize) {
+          options.setMaxRedirectBufferSize(maxRedirectBufferSize);
+          return this;
+        }
+        @Override
         public HttpClientBuilder builder(Vertx vertx) {
           return vertx.httpClientBuilder().with(options);
         }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpMethodTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpMethodTest.java
@@ -59,6 +59,7 @@ public class HttpMethodTest {
     assertEquals("ORDERPATCH", HttpMethod.ORDERPATCH.name());
     assertEquals("ACL", HttpMethod.ACL.name());
     assertEquals("SEARCH", HttpMethod.SEARCH.name());
+    assertEquals("QUERY", HttpMethod.QUERY.name());
   }
 
   @Test
@@ -94,7 +95,8 @@ public class HttpMethodTest {
       HttpMethod.MKACTIVITY,
       HttpMethod.ORDERPATCH,
       HttpMethod.ACL,
-      HttpMethod.SEARCH
+      HttpMethod.SEARCH,
+      HttpMethod.QUERY
       )) {
       assertSame(HttpMethod.valueOf(method.name()), method);
       assertSame(method.name(), method.toString());
@@ -162,6 +164,7 @@ public class HttpMethodTest {
     assertSame(HttpMethod.fromNetty(io.netty.handler.codec.http.HttpMethod.OPTIONS), HttpMethod.OPTIONS);
     assertSame(HttpMethod.fromNetty(io.netty.handler.codec.http.HttpMethod.PATCH), HttpMethod.PATCH);
     assertSame(HttpMethod.fromNetty(io.netty.handler.codec.http.HttpMethod.TRACE), HttpMethod.TRACE);
+    assertSame(HttpMethod.fromNetty(io.netty.handler.codec.http.HttpMethod.valueOf("QUERY")), HttpMethod.QUERY);
     assertEquals(HttpMethod.valueOf("foo").toNetty().name(), "foo");
     assertEquals(HttpMethod.fromNetty(io.netty.handler.codec.http.HttpMethod.valueOf("foo")).name(), "foo");
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -3485,6 +3485,35 @@ public abstract class HttpTest extends SimpleHttpTest2 {
   }
 
   @Test
+  public void testFollowRedirectQueryWithConfiguredBodyExceedingLimit() throws Exception {
+    Buffer expected = TestUtils.randomBuffer(2048);
+    AtomicBoolean redirected = new AtomicBoolean();
+    server.requestHandler(req -> {
+      if (redirected.compareAndSet(false, true)) {
+        assertEquals(HttpMethod.QUERY, req.method());
+        req.bodyHandler(body -> {
+          assertEquals(body, expected);
+          String scheme = req.connection().isSsl() ? "https" : "http";
+          req.response().setStatusCode(307).putHeader(HttpHeaders.LOCATION, scheme + "://" + config.host() + ":" + config.port() + "/whatever").end();
+        });
+      } else {
+        fail("Should not redirect");
+      }
+    });
+    startServer(testAddress);
+    client = config.forClient().setMaxRedirectBufferSize(1024).create(vertx);
+    RequestOptions opts = new RequestOptions()
+      .setMethod(QUERY)
+      .setHost(config.host())
+      .setPort(config.port());
+    client.request(opts).compose(req -> req
+        .setFollowRedirects(true)
+        .send(expected)
+        .expecting(HttpResponseExpectation.status(307)))
+      .await();
+  }
+
+  @Test
   public void testFollowRedirectWithBody() throws Exception {
     testFollowRedirectWithBody(Function.identity());
   }
@@ -3887,6 +3916,8 @@ public abstract class HttpTest extends SimpleHttpTest2 {
       public HttpClientRequest continueHandler(@Nullable Handler<Void> handler) { throw new UnsupportedOperationException(); }
       public boolean isFollowRedirects() { throw new UnsupportedOperationException(); }
       public int getMaxRedirects() { throw new UnsupportedOperationException(); }
+      public int getMaxRedirectBufferSize() { throw new UnsupportedOperationException(); }
+      public HttpClientRequest setMaxRedirectBufferSize(int maxRedirectBufferSize) { throw new UnsupportedOperationException(); }
       public int numberOfRedirections() { throw new UnsupportedOperationException(); }
       public HttpClientRequest redirectHandler(@Nullable Function<HttpClientResponse, Future<HttpClientRequest>> handler) { throw new UnsupportedOperationException(); }
       public HttpClientRequest earlyHintsHandler(@Nullable Handler<MultiMap> handler) { throw new UnsupportedOperationException(); }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -3427,21 +3427,22 @@ public abstract class HttpTest extends SimpleHttpTest2 {
   @Test
   public void testFollowRedirectQueryWithBody() throws Exception {
     Buffer expected = TestUtils.randomBuffer(2048);
-    AtomicBoolean redirected = new AtomicBoolean();
     server.requestHandler(req -> {
-      if (redirected.compareAndSet(false, true)) {
+      if ("/".equals(req.path())) {
         assertEquals(HttpMethod.QUERY, req.method());
-        req.bodyHandler(body -> {
-          assertEquals(body, expected);
+        req.body().onComplete(TestUtils.onSuccess(body -> {
+          assertEquals(expected, body);
           String scheme = req.connection().isSsl() ? "https" : "http";
           req.response().setStatusCode(307).putHeader(HttpHeaders.LOCATION, scheme + "://" + config.host() + ":" + config.port() + "/whatever").end();
-        });
-      } else {
+        }));
+      } else if ("/whatever".equals(req.path())) {
         assertEquals(HttpMethod.QUERY, req.method());
-        req.bodyHandler(body -> {
-          assertEquals(body, expected);
+        req.body().onComplete(TestUtils.onSuccess(body -> {
+          assertEquals(expected, body);
           req.response().end();
-        });
+        }));
+      } else {
+        req.response().setStatusCode(404).end();
       }
     });
     startServer(testAddress);
@@ -3458,16 +3459,15 @@ public abstract class HttpTest extends SimpleHttpTest2 {
 
   @Test
   public void testFollowRedirectQueryWithBodyExceedingLimit() throws Exception {
-    Buffer expected = TestUtils.randomBuffer(1024 * 1024 + 1); // 1MB + 1B
-    AtomicBoolean redirected = new AtomicBoolean();
+    Buffer expected = TestUtils.randomBuffer(4 * 1024 + 1); // 4KB + 1B
     server.requestHandler(req -> {
-      if (redirected.compareAndSet(false, true)) {
+      if ("/".equals(req.path())) {
         assertEquals(HttpMethod.QUERY, req.method());
-        req.bodyHandler(body -> {
-          assertEquals(body, expected);
+        req.body().onComplete(TestUtils.onSuccess(body -> {
+          assertEquals(expected, body);
           String scheme = req.connection().isSsl() ? "https" : "http";
           req.response().setStatusCode(307).putHeader(HttpHeaders.LOCATION, scheme + "://" + config.host() + ":" + config.port() + "/whatever").end();
-        });
+        }));
       } else {
         fail("Should not redirect");
       }
@@ -3487,15 +3487,14 @@ public abstract class HttpTest extends SimpleHttpTest2 {
   @Test
   public void testFollowRedirectQueryWithConfiguredBodyExceedingLimit() throws Exception {
     Buffer expected = TestUtils.randomBuffer(2048);
-    AtomicBoolean redirected = new AtomicBoolean();
     server.requestHandler(req -> {
-      if (redirected.compareAndSet(false, true)) {
+      if ("/".equals(req.path())) {
         assertEquals(HttpMethod.QUERY, req.method());
-        req.bodyHandler(body -> {
-          assertEquals(body, expected);
+        req.body().onComplete(TestUtils.onSuccess(body -> {
+          assertEquals(expected, body);
           String scheme = req.connection().isSsl() ? "https" : "http";
           req.response().setStatusCode(307).putHeader(HttpHeaders.LOCATION, scheme + "://" + config.host() + ":" + config.port() + "/whatever").end();
-        });
+        }));
       } else {
         fail("Should not redirect");
       }
@@ -3511,6 +3510,82 @@ public abstract class HttpTest extends SimpleHttpTest2 {
         .send(expected)
         .expecting(HttpResponseExpectation.status(307)))
       .await();
+  }
+
+  @Test
+  public void testFollowRedirectQueryWithMultipleBuffers() throws Exception {
+    Buffer chunk1 = TestUtils.randomBuffer(1024);
+    Buffer chunk2 = TestUtils.randomBuffer(1024);
+    Buffer expected = Buffer.buffer().appendBuffer(chunk1).appendBuffer(chunk2);
+    server.requestHandler(req -> {
+      if ("/".equals(req.path())) {
+        assertEquals(HttpMethod.QUERY, req.method());
+        req.body().onComplete(TestUtils.onSuccess(body -> {
+          assertEquals(expected, body);
+          String scheme = req.connection().isSsl() ? "https" : "http";
+          req.response().setStatusCode(307).putHeader(HttpHeaders.LOCATION, scheme + "://" + config.host() + ":" + config.port() + "/whatever").end();
+        }));
+      } else if ("/whatever".equals(req.path())) {
+        assertEquals(HttpMethod.QUERY, req.method());
+        req.body().onComplete(TestUtils.onSuccess(body -> {
+          assertEquals(expected, body);
+          req.response().end();
+        }));
+      } else {
+        req.response().setStatusCode(404).end();
+      }
+    });
+    startServer(testAddress);
+    RequestOptions opts = new RequestOptions()
+      .setMethod(QUERY)
+      .setHost(config.host())
+      .setPort(config.port());
+    client.request(opts).compose(req -> {
+      req.setFollowRedirects(true);
+      req.write(chunk1);
+      req.end(chunk2);
+      return req.response().expecting(HttpResponseExpectation.SC_OK);
+    }).await();
+  }
+
+  @Test
+  public void testFollowRedirectQueryWithStream() throws Exception {
+    Buffer chunk1 = TestUtils.randomBuffer(1024);
+    Buffer chunk2 = TestUtils.randomBuffer(1024);
+    Buffer expected = Buffer.buffer().appendBuffer(chunk1).appendBuffer(chunk2);
+    server.requestHandler(req -> {
+      if ("/".equals(req.path())) {
+        assertEquals(HttpMethod.QUERY, req.method());
+        req.body().onComplete(TestUtils.onSuccess(body -> {
+          assertEquals(expected, body);
+          String scheme = req.connection().isSsl() ? "https" : "http";
+          req.response().setStatusCode(307).putHeader(HttpHeaders.LOCATION, scheme + "://" + config.host() + ":" + config.port() + "/whatever").end();
+        }));
+      } else if ("/whatever".equals(req.path())) {
+        assertEquals(HttpMethod.QUERY, req.method());
+        req.body().onComplete(TestUtils.onSuccess(body -> {
+          assertEquals(expected, body);
+          req.response().end();
+        }));
+      } else {
+        req.response().setStatusCode(404).end();
+      }
+    });
+    startServer(testAddress);
+    FakeStream<Buffer> stream = new FakeStream<>();
+    stream.pause();
+    RequestOptions opts = new RequestOptions()
+      .setMethod(QUERY)
+      .setHost(config.host())
+      .setPort(config.port());
+    Future<HttpClientResponse> responseFuture = client.request(opts).compose(req -> {
+      req.setFollowRedirects(true);
+      return req.send(stream);
+    });
+    stream.write(chunk1);
+    stream.write(chunk2);
+    stream.end();
+    responseFuture.compose(HttpClientResponse::end).await();
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -3236,16 +3236,16 @@ public abstract class HttpTest extends SimpleHttpTest2 {
 
   @Test
   public void testFollowRedirectQueryOn301() throws Exception {
-    testFollowRedirect(HttpMethod.QUERY, HttpMethod.QUERY, 301, 200, 2,
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.GET, 301, 301, 1,
       "http://" + config.host() + ":" + config.port() + "/redirected",
-      "http://" + config.host() + ":" + config.port() + "/redirected");
+      "http://" + config.host() + ":" + config.port() + "/somepath");
   }
 
   @Test
   public void testFollowRedirectQueryOn302() throws Exception {
-    testFollowRedirect(HttpMethod.QUERY, HttpMethod.QUERY, 302, 200, 2,
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.GET, 302, 302, 1,
       "http://" + config.host() + ":" + config.port() + "/redirected",
-      "http://" + config.host() + ":" + config.port() + "/redirected");
+      "http://" + config.host() + ":" + config.port() + "/somepath");
   }
 
   @Test
@@ -3257,16 +3257,16 @@ public abstract class HttpTest extends SimpleHttpTest2 {
 
   @Test
   public void testFollowRedirectQueryOn307() throws Exception {
-    testFollowRedirect(HttpMethod.QUERY, HttpMethod.QUERY, 307, 200, 2,
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.GET, 307, 307, 1,
       "http://" + config.host() + ":" + config.port() + "/redirected",
-      "http://" + config.host() + ":" + config.port() + "/redirected");
+      "http://" + config.host() + ":" + config.port() + "/somepath");
   }
 
   @Test
   public void testFollowRedirectQueryOn308() throws Exception {
-    testFollowRedirect(HttpMethod.QUERY, HttpMethod.QUERY, 308, 200, 2,
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.GET, 308, 308, 1,
       "http://" + config.host() + ":" + config.port() + "/redirected",
-      "http://" + config.host() + ":" + config.port() + "/redirected");
+      "http://" + config.host() + ":" + config.port() + "/somepath");
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -3991,8 +3991,8 @@ public abstract class HttpTest extends SimpleHttpTest2 {
       public HttpClientRequest continueHandler(@Nullable Handler<Void> handler) { throw new UnsupportedOperationException(); }
       public boolean isFollowRedirects() { throw new UnsupportedOperationException(); }
       public int getMaxRedirects() { throw new UnsupportedOperationException(); }
-      public int getMaxRedirectBufferSize() { throw new UnsupportedOperationException(); }
-      public HttpClientRequest setMaxRedirectBufferSize(int maxRedirectBufferSize) { throw new UnsupportedOperationException(); }
+      public int maxRedirectBufferSize() { throw new UnsupportedOperationException(); }
+      public HttpClientRequest maxRedirectBufferSize(int maxRedirectBufferSize) { throw new UnsupportedOperationException(); }
       public int numberOfRedirections() { throw new UnsupportedOperationException(); }
       public HttpClientRequest redirectHandler(@Nullable Function<HttpClientResponse, Future<HttpClientRequest>> handler) { throw new UnsupportedOperationException(); }
       public HttpClientRequest earlyHintsHandler(@Nullable Handler<MultiMap> handler) { throw new UnsupportedOperationException(); }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -3235,6 +3235,41 @@ public abstract class HttpTest extends SimpleHttpTest2 {
   }
 
   @Test
+  public void testFollowRedirectQueryOn301() throws Exception {
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.QUERY, 301, 200, 2,
+      "http://" + config.host() + ":" + config.port() + "/redirected",
+      "http://" + config.host() + ":" + config.port() + "/redirected");
+  }
+
+  @Test
+  public void testFollowRedirectQueryOn302() throws Exception {
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.QUERY, 302, 200, 2,
+      "http://" + config.host() + ":" + config.port() + "/redirected",
+      "http://" + config.host() + ":" + config.port() + "/redirected");
+  }
+
+  @Test
+  public void testFollowRedirectQueryOn303() throws Exception {
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.GET, 303, 200, 2,
+      "http://" + config.host() + ":" + config.port() + "/redirected",
+      "http://" + config.host() + ":" + config.port() + "/redirected");
+  }
+
+  @Test
+  public void testFollowRedirectQueryOn307() throws Exception {
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.QUERY, 307, 200, 2,
+      "http://" + config.host() + ":" + config.port() + "/redirected",
+      "http://" + config.host() + ":" + config.port() + "/redirected");
+  }
+
+  @Test
+  public void testFollowRedirectQueryOn308() throws Exception {
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.QUERY, 308, 200, 2,
+      "http://" + config.host() + ":" + config.port() + "/redirected",
+      "http://" + config.host() + ":" + config.port() + "/redirected");
+  }
+
+  @Test
   public void testFollowRedirectGetOn301() throws Exception {
     testFollowRedirect(HttpMethod.GET, HttpMethod.GET, 301, 200, 2, "http://" + config.host() + ":" + config.port() + "/redirected", "http://" + config.host() + ":" + config.port() + "/redirected");
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -3236,16 +3236,16 @@ public abstract class HttpTest extends SimpleHttpTest2 {
 
   @Test
   public void testFollowRedirectQueryOn301() throws Exception {
-    testFollowRedirect(HttpMethod.QUERY, HttpMethod.GET, 301, 301, 1,
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.QUERY, 301, 200, 2,
       "http://" + config.host() + ":" + config.port() + "/redirected",
-      "http://" + config.host() + ":" + config.port() + "/somepath");
+      "http://" + config.host() + ":" + config.port() + "/redirected");
   }
 
   @Test
   public void testFollowRedirectQueryOn302() throws Exception {
-    testFollowRedirect(HttpMethod.QUERY, HttpMethod.GET, 302, 302, 1,
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.QUERY, 302, 200, 2,
       "http://" + config.host() + ":" + config.port() + "/redirected",
-      "http://" + config.host() + ":" + config.port() + "/somepath");
+      "http://" + config.host() + ":" + config.port() + "/redirected");
   }
 
   @Test
@@ -3257,16 +3257,16 @@ public abstract class HttpTest extends SimpleHttpTest2 {
 
   @Test
   public void testFollowRedirectQueryOn307() throws Exception {
-    testFollowRedirect(HttpMethod.QUERY, HttpMethod.GET, 307, 307, 1,
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.QUERY, 307, 200, 2,
       "http://" + config.host() + ":" + config.port() + "/redirected",
-      "http://" + config.host() + ":" + config.port() + "/somepath");
+      "http://" + config.host() + ":" + config.port() + "/redirected");
   }
 
   @Test
   public void testFollowRedirectQueryOn308() throws Exception {
-    testFollowRedirect(HttpMethod.QUERY, HttpMethod.GET, 308, 308, 1,
+    testFollowRedirect(HttpMethod.QUERY, HttpMethod.QUERY, 308, 200, 2,
       "http://" + config.host() + ":" + config.port() + "/redirected",
-      "http://" + config.host() + ":" + config.port() + "/somepath");
+      "http://" + config.host() + ":" + config.port() + "/redirected");
   }
 
   @Test
@@ -3422,6 +3422,66 @@ public abstract class HttpTest extends SimpleHttpTest2 {
           });
         })
       ).await();
+  }
+
+  @Test
+  public void testFollowRedirectQueryWithBody() throws Exception {
+    Buffer expected = TestUtils.randomBuffer(2048);
+    AtomicBoolean redirected = new AtomicBoolean();
+    server.requestHandler(req -> {
+      if (redirected.compareAndSet(false, true)) {
+        assertEquals(HttpMethod.QUERY, req.method());
+        req.bodyHandler(body -> {
+          assertEquals(body, expected);
+          String scheme = req.connection().isSsl() ? "https" : "http";
+          req.response().setStatusCode(307).putHeader(HttpHeaders.LOCATION, scheme + "://" + config.host() + ":" + config.port() + "/whatever").end();
+        });
+      } else {
+        assertEquals(HttpMethod.QUERY, req.method());
+        req.bodyHandler(body -> {
+          assertEquals(body, expected);
+          req.response().end();
+        });
+      }
+    });
+    startServer(testAddress);
+    RequestOptions opts = new RequestOptions()
+      .setMethod(QUERY)
+      .setHost(config.host())
+      .setPort(config.port());
+    client.request(opts).compose(req -> req
+        .setFollowRedirects(true)
+        .send(expected)
+        .expecting(HttpResponseExpectation.SC_OK))
+      .await();
+  }
+
+  @Test
+  public void testFollowRedirectQueryWithBodyExceedingLimit() throws Exception {
+    Buffer expected = TestUtils.randomBuffer(1024 * 1024 + 1); // 1MB + 1B
+    AtomicBoolean redirected = new AtomicBoolean();
+    server.requestHandler(req -> {
+      if (redirected.compareAndSet(false, true)) {
+        assertEquals(HttpMethod.QUERY, req.method());
+        req.bodyHandler(body -> {
+          assertEquals(body, expected);
+          String scheme = req.connection().isSsl() ? "https" : "http";
+          req.response().setStatusCode(307).putHeader(HttpHeaders.LOCATION, scheme + "://" + config.host() + ":" + config.port() + "/whatever").end();
+        });
+      } else {
+        fail("Should not redirect");
+      }
+    });
+    startServer(testAddress);
+    RequestOptions opts = new RequestOptions()
+      .setMethod(QUERY)
+      .setHost(config.host())
+      .setPort(config.port());
+    client.request(opts).compose(req -> req
+        .setFollowRedirects(true)
+        .send(expected)
+        .expecting(HttpResponseExpectation.status(307)))
+      .await();
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3Configurator.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3Configurator.java
@@ -221,6 +221,11 @@ public class Http3Configurator implements HttpConfigurator {
         return this;
       }
       @Override
+      public HttpClientConfigurator setMaxRedirectBufferSize(int maxRedirectBufferSize) {
+        config.setMaxRedirectBufferSize(maxRedirectBufferSize);
+        return this;
+      }
+      @Override
       public HttpClientBuilder builder(Vertx vertx) {
         return vertx.httpClientBuilder().with(config).with(sslOptions);
       }


### PR DESCRIPTION
Motivation:

In order to add RFC 10008 support elsewhere in vert.x, these are the basic blocs required to support the QUERY Method.

Conformance:

- [x] You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md

- [x] Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
