### PR TITLE
Allow zero HTTP/2 keep-alive timeout

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/Http2ClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/Http2ClientConfig.java
@@ -119,7 +119,7 @@ public class Http2ClientConfig {
    * @return a reference to this, so the API can be used fluently
    */
   public Http2ClientConfig setKeepAliveTimeout(Duration keepAliveTimeout) {
-    if (keepAliveTimeout != null && (keepAliveTimeout.isNegative() || keepAliveTimeout.isZero())) {
+    if (keepAliveTimeout != null && (keepAliveTimeout.isNegative())) {
       throw new IllegalArgumentException("HTTP/2 keepAliveTimeout must be >= 0");
     }
     this.keepAliveTimeout = keepAliveTimeout;

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpClientConfigTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpClientConfigTest.java
@@ -12,8 +12,10 @@ package io.vertx.tests.http;
 
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientConfig;
+import io.vertx.core.http.Http2ClientConfig;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.List;
 
 import static io.vertx.core.http.HttpVersion.*;
@@ -59,5 +61,13 @@ public class HttpClientConfigTest {
     assertNotNull(config.getHttp3Config());
     assertFalse(config.isSsl());
     assertEquals(List.of(HTTP_1_0), config.getVersions());
+  }
+
+  @Test
+  public void testHttp2KeepAliveTimeoutValidation() {
+    Http2ClientConfig config = new Http2ClientConfig();
+    assertSame(config, config.setKeepAliveTimeout(Duration.ZERO));
+    assertEquals(Duration.ZERO, config.getKeepAliveTimeout());
+    assertThrows(IllegalArgumentException.class, () -> config.setKeepAliveTimeout(Duration.ofMillis(-1)));
   }
 }


### PR DESCRIPTION
Motivation:

`Http2ClientConfig#setKeepAliveTimeout(Duration.ZERO)` currently throws.
The method documents zero and `null` as no timeout, and HTTP/1 and HTTP/3
client configs already accept zero.  

This change allows zero for HTTP/2 keep-alive timeout while still rejecting
negative durations, and adds a regression test.

Conformance:

I have signed the ECA.
