### PR TITLE
Add https proxy support

### DIFF
--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -2417,7 +2417,8 @@ used with binary frames that are no split over multiple frames.
 
 === Using a proxy for HTTP/HTTPS connections
 
-The {@link io.vertx.core.http.HttpClient} supports accessing HTTP/HTTPS URLs via an HTTP proxy (e.g. Squid), a _SOCKS4a_, or a _SOCKS5_ proxy.
+The {@link io.vertx.core.http.HttpClient} supports accessing HTTP/HTTPS URLs via an HTTP proxy (e.g. Squid), an HTTPS proxy
+(an HTTP proxy reached over SSL/TLS), a _SOCKS4a_, or a _SOCKS5_ proxy.
 The `CONNECT` protocol uses HTTP/1.x but can connect to HTTP/1.x and HTTP/2 servers.
 
 Connecting to `h2c` (unencrypted HTTP/2 servers) is likely not supported by http proxies since they will support HTTP/1.1 only.
@@ -2435,6 +2436,11 @@ Here's an example of using an HTTP proxy:
 When the client connects to an HTTP URL, it connects to the proxy server and provides the full URL in the HTTP request, like `GET http://www.somehost.com/path/file.html HTTP/1.1`.
 
 When the client connects to an HTTPS URL, it asks the proxy to create a tunnel to the remote host with the `CONNECT` method.
+
+To connect to the proxy itself over SSL/TLS, set the proxy type to {@link io.vertx.core.net.ProxyType#HTTPS} and configure
+the proxy SSL options with {@link io.vertx.core.net.ProxyOptions#setSslOptions(io.vertx.core.net.ClientSSLOptions)}. The
+proxy SSL options are independent of the target server's SSL options, and hostname verification of the proxy certificate is
+enabled by default.
 
 For a SOCKS5 proxy:
 

--- a/vertx-core/src/main/asciidoc/tcp.adoc
+++ b/vertx-core/src/main/asciidoc/tcp.adoc
@@ -506,10 +506,18 @@ the update.
 
 === Using a proxy for client connections
 
-The {@link io.vertx.core.net.NetClient} supports either an HTTP/1.x _CONNECT_, _SOCKS4a_ or _SOCKS5_ proxy.
+The {@link io.vertx.core.net.NetClient} supports either an HTTP/1.x _CONNECT_, an HTTPS (HTTP _CONNECT_ over SSL/TLS),
+_SOCKS4a_ or _SOCKS5_ proxy.
 
 The proxy can be configured in the {@link io.vertx.core.net.TcpClientConfig} by setting a
 {@link io.vertx.core.net.ProxyOptions} object containing proxy type, hostname, port and optionally username and password.
+
+To reach the proxy itself over SSL/TLS, use the {@link io.vertx.core.net.ProxyType#HTTPS} proxy type and configure the
+SSL options for the proxy connection with {@link io.vertx.core.net.ProxyOptions#setSslOptions(io.vertx.core.net.ClientSSLOptions)}.
+These options (trust store, optional client certificate, hostname verification) apply to the connection to the proxy and
+are independent of the options used for the target server. Hostname verification of the proxy certificate is enabled by
+default. Note that {@link io.vertx.core.net.ProxyType#HTTPS} denotes a proxy that is itself reached over SSL/TLS, which is
+distinct from the `https_proxy` environment-variable convention of a proxy used for `https` traffic.
 
 Here's an example:
 

--- a/vertx-core/src/main/generated/io/vertx/core/net/ProxyOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/net/ProxyOptionsConverter.java
@@ -47,6 +47,11 @@ public class ProxyOptionsConverter {
             obj.setConnectTimeout(java.time.Duration.of(((Number)member.getValue()).longValue(), java.time.temporal.ChronoUnit.MILLIS));
           }
           break;
+        case "sslOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setSslOptions(new io.vertx.core.net.ClientSSLOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
       }
     }
   }
@@ -74,6 +79,9 @@ public class ProxyOptionsConverter {
     }
     if (obj.getConnectTimeout() != null) {
       json.put("connectTimeout", obj.getConnectTimeout().toMillis());
+    }
+    if (obj.getSslOptions() != null) {
+      json.put("sslOptions", obj.getSslOptions().toJson());
     }
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/EndpointKey.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/EndpointKey.java
@@ -79,14 +79,15 @@ public final class EndpointKey {
         Objects.equals(options1.getType(), options2.getType()) &&
         Objects.equals(options1.getUsername(), options2.getUsername()) &&
         Objects.equals(options1.getPassword(), options2.getPassword()) &&
-        Objects.equals(options1.getProxyAuthorization(), options2.getProxyAuthorization());
+        Objects.equals(options1.getProxyAuthorization(), options2.getProxyAuthorization()) &&
+        Objects.equals(options1.getSslOptions(), options2.getSslOptions());
     }
     return false;
   }
 
   private static int hashCode(ProxyOptions options) {
     return Objects.hash(options.getHost(), options.getPort(), options.getType(), options.getUsername(),
-      options.getPassword(), options.getProxyAuthorization());
+      options.getPassword(), options.getProxyAuthorization(), options.getSslOptions());
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -194,10 +194,13 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
       PoolMetrics poolMetrics = HttpClientImpl.this.httpMetrics != null ? vertx.metrics().createPoolMetrics("http", key.authority.toString(), maxPoolSize) : null;
       ProxyOptions proxyOptions = key.proxyOptions;
       ClientSSLOptions sslOptions = key.sslOptions;
-      if (proxyOptions != null && !key.ssl && proxyOptions.getType() == ProxyType.HTTP) {
+      boolean forwardProxy = false;
+      if (proxyOptions != null && !key.ssl && (proxyOptions.getType() == ProxyType.HTTP || proxyOptions.getType() == ProxyType.HTTPS)) {
         SocketAddress server = SocketAddress.inetSocketAddress(proxyOptions.getPort(), proxyOptions.getHost());
         key = new EndpointKey(key.ssl, key.protocol, sslOptions, proxyOptions, server, key.authority);
-        proxyOptions = null;
+        // Forward mode: the single socket connects to the proxy as the server while the logical
+        // origin stays plain HTTP (key.ssl == false).
+        forwardProxy = true;
       }
       HttpVersion protocol = key.protocol;
       List<HttpVersion> protocols;
@@ -206,7 +209,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
       } else {
         protocols = List.of(protocol);
       }
-      HttpConnectParams params = new HttpConnectParams(protocols, sslOptions, proxyOptions, key.ssl);
+      HttpConnectParams params = new HttpConnectParams(protocols, sslOptions, proxyOptions, key.ssl, forwardProxy);
       Function<SharedHttpClientConnectionGroup, SharedHttpClientConnectionGroup.Pool> p = group -> {
         int queueMaxSize = poolOptions.getMaxWaitQueueSize();
         if (transport instanceof TcpHttpClientTransport) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -94,7 +94,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
     Boolean followRedirects = options.getFollowRedirects();
     long idleTimeout = options.getIdleTimeout();
     ProxyOptions proxyOptions = options.getProxyOptions();
-    if (proxyOptions != null && !useSSL && proxyOptions.getType() == ProxyType.HTTP) {
+    if (proxyOptions != null && !useSSL && (proxyOptions.getType() == ProxyType.HTTP || proxyOptions.getType() == ProxyType.HTTPS)) {
       HostAndPort authority = conn.authority();
       if (!ABS_URI_START_PATTERN.matcher(requestURI).find()) {
         int defaultPort = 80;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpConnectParams.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpConnectParams.java
@@ -12,15 +12,27 @@ public class HttpConnectParams {
                            ClientSSLOptions sslOptions,
                            ProxyOptions proxyOptions,
                            boolean ssl) {
+    this(protocols, sslOptions, proxyOptions, ssl, false);
+  }
+
+  public HttpConnectParams(List<HttpVersion> protocols,
+                           ClientSSLOptions sslOptions,
+                           ProxyOptions proxyOptions,
+                           boolean ssl,
+                           boolean forwardProxy) {
     this.protocols = protocols;
     this.sslOptions = sslOptions;
     this.proxyOptions = proxyOptions;
     this.ssl = ssl;
+    this.forwardProxy = forwardProxy;
   }
 
   public final List<HttpVersion> protocols;
   public final ClientSSLOptions sslOptions;
   public final ProxyOptions proxyOptions;
+
   public final boolean ssl;
+
+  public final boolean forwardProxy;
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
@@ -150,11 +150,6 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
   }
 
   @Override
-  public boolean isSsl() {
-    return ssl;
-  }
-
-  @Override
   public io.vertx.core.http.impl.HttpClientConnection evictionHandler(Handler<Void> handler) {
     evictionHandler = handler;
     return this;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
@@ -150,6 +150,11 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
   }
 
   @Override
+  public boolean isSsl() {
+    return ssl;
+  }
+
+  @Override
   public io.vertx.core.http.impl.HttpClientConnection evictionHandler(Handler<Void> handler) {
     evictionHandler = handler;
     return this;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
@@ -150,6 +150,13 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
   }
 
   @Override
+  public boolean isSsl() {
+    // Report the origin ssl, not the pipeline: in forward-proxy mode the TLS leg to an HTTPS proxy is
+    // itself the pipeline "ssl" handler.
+    return ssl;
+  }
+
+  @Override
   public io.vertx.core.http.impl.HttpClientConnection evictionHandler(Handler<Void> handler) {
     evictionHandler = handler;
     return this;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpClientTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpClientTransport.java
@@ -143,26 +143,57 @@ public class TcpHttpClientTransport implements HttpClientTransport {
     }
   }
 
+  /**
+   * Whether this connection's transport TLS terminates at an HTTPS proxy (forward mode through an
+   * HTTPS proxy) — the only forward case that uses leg-1 TLS to the proxy.
+   */
+  private static boolean proxyHttps(HttpConnectParams params) {
+    return params.forwardProxy && params.proxyOptions != null && params.proxyOptions.getType() == ProxyType.HTTPS;
+  }
+
+  /** Whether the socket is encrypted: origin TLS, or leg-1 TLS to an HTTPS proxy (forward mode). */
+  private static boolean transportSsl(HttpConnectParams params) {
+    return params.ssl || proxyHttps(params);
+  }
+
   private void connect(ContextInternal context, HttpConnectParams params, HostAndPort authority, SocketAddress server, Promise<NetSocket> promise) {
+    boolean forward = params.forwardProxy;
+    boolean proxyHttps = proxyHttps(params);
+    boolean transportSsl = transportSsl(params);
+
     ConnectOptions connectOptions = new ConnectOptions();
     connectOptions.setRemoteAddress(server);
-    if (authority != null) {
+    if (proxyHttps) {
+      // Forward mode through an HTTPS proxy: the socket's TLS terminates at the proxy, so the peer /
+      // SNI is the proxy (the server), not the origin authority.
+      connectOptions.setHost(server.host());
+      connectOptions.setPort(server.port());
+      connectOptions.setSniServerName(server.host());
+    } else if (authority != null) {
       connectOptions.setHost(authority.host());
       connectOptions.setPort(authority.port());
-      if (params.ssl && forceSni) {
+      if (transportSsl && forceSni) {
         connectOptions.setSniServerName(authority.host());
       }
     }
-    connectOptions.setSsl(params.ssl);
-    if (params.ssl) {
+    connectOptions.setSsl(transportSsl);
+    if (transportSsl) {
+      // The TLS being configured terminates at the proxy (forward + HTTPS proxy) or at the origin
+      // (direct, or the leg-2 of a CONNECT tunnel); pick the matching options.
+      ClientSSLOptions transportSslOptions = proxyHttps ? params.proxyOptions.getSslOptions() : params.sslOptions;
       ClientSSLOptions copy;
-      if (params.sslOptions != null) {
-        copy = params.sslOptions.copy();
+      if (transportSslOptions != null) {
+        copy = transportSslOptions.copy();
       } else {
         // We might end up using javax.net.ssl.trustStore
         copy = new ClientSSLOptions().setHostnameVerificationAlgorithm("HTTPS");
       }
-      boolean useAlpn = params.protocols.contains(HttpVersion.HTTP_2);
+      if (proxyHttps && copy.getHostnameVerificationAlgorithm() == null) {
+        // Verify the proxy certificate against the proxy host by default (secure default).
+        copy.setHostnameVerificationAlgorithm("HTTPS");
+      }
+      // No ALPN on a leg-1 TLS connection to the proxy: ALPN belongs to the origin (leg 2).
+      boolean useAlpn = !proxyHttps && params.protocols.contains(HttpVersion.HTTP_2);
       copy.setUseAlpn(useAlpn);
       if (useAlpn) {
         List<String> list = params.protocols
@@ -174,7 +205,9 @@ public class TcpHttpClientTransport implements HttpClientTransport {
       }
       connectOptions.setSslOptions(copy);
     }
-    connectOptions.setProxyOptions(params.proxyOptions);
+    // Only CONNECT/SOCKS-tunnel through the proxy when NOT forwarding; in forward mode the socket
+    // connects straight to the proxy (the server) and issues absolute-URI requests.
+    connectOptions.setProxyOptions(forward ? null : params.proxyOptions);
     client.connectInternal(connectOptions, promise, context);
   }
 
@@ -197,7 +230,11 @@ public class TcpHttpClientTransport implements HttpClientTransport {
 
     //
     Channel ch = so.channelHandlerContext().channel();
-    if (params.ssl) {
+    // Transport TLS may be on because the origin is HTTPS or because leg-1 TLS to an HTTPS proxy is
+    // in use (forward mode). The connection's ssl flag, however, must reflect the logical origin
+    // (params.ssl), not the transport.
+    boolean transportSsl = transportSsl(params);
+    if (transportSsl) {
       String protocol = so.applicationLayerProtocol();
       if (protocol == null) {
         protocol = "";
@@ -241,7 +278,7 @@ public class TcpHttpClientTransport implements HttpClientTransport {
           }
           if (version != null) {
             applyHttp1xConnectionOptions(ch.pipeline());
-            http1xConnected(version, false, server, authority, true, context, transportMetrics, metric, ch, clientMetrics, promise);
+            http1xConnected(version, false, server, authority, params.ssl, context, transportMetrics, metric, ch, clientMetrics, promise);
           } else {
             so.close();
             promise.tryFail(new IllegalStateException("HTTP/1.1 not supported"));

--- a/vertx-core/src/main/java/io/vertx/core/net/ProxyOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/ProxyOptions.java
@@ -264,7 +264,7 @@ public class ProxyOptions {
   }
 
   /**
-   * Get the SSL options used for the connection to the proxy itself.
+   * Get the SSL options used between the client and the proxy.
    * <p>
    * Only relevant when {@link #getType()} is {@link ProxyType#HTTPS}.
    *

--- a/vertx-core/src/main/java/io/vertx/core/net/ProxyOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/ProxyOptions.java
@@ -56,6 +56,7 @@ public class ProxyOptions {
   private String proxyAuthorization;
   private ProxyType type;
   private Duration connectTimeout;
+  private ClientSSLOptions sslOptions;
 
   /**
    * Default constructor.
@@ -80,6 +81,7 @@ public class ProxyOptions {
     proxyAuthorization = other.getProxyAuthorization();
     type = other.getType();
     connectTimeout = other.getConnectTimeout();
+    sslOptions = other.sslOptions != null ? other.sslOptions.copy() : null;
   }
 
   /**
@@ -258,6 +260,34 @@ public class ProxyOptions {
    */
   public ProxyOptions setConnectTimeout(Duration connectTimeout) {
     this.connectTimeout = connectTimeout;
+    return this;
+  }
+
+  /**
+   * Get the SSL options used for the connection to the proxy itself.
+   * <p>
+   * Only relevant when {@link #getType()} is {@link ProxyType#HTTPS}.
+   *
+   * @return the proxy SSL options, or {@code null}
+   */
+  public ClientSSLOptions getSslOptions() {
+    return sslOptions;
+  }
+
+  /**
+   * Set the SSL options used for the connection to the proxy itself, when the proxy is reached over
+   * SSL/TLS ({@link ProxyType#HTTPS}).
+   * <p>
+   * These options are resolved independently of the origin SSL options, so the proxy presents and
+   * is validated against its own certificate and trust store. When left unset for an
+   * {@link ProxyType#HTTPS} proxy, the connection is still established over SSL/TLS using the default
+   * trust source, with hostname verification enabled against the proxy host.
+   *
+   * @param sslOptions the proxy SSL options
+   * @return a reference to this, so the API can be used fluently
+   */
+  public ProxyOptions setSslOptions(ClientSSLOptions sslOptions) {
+    this.sslOptions = sslOptions;
     return this;
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/ProxyType.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/ProxyType.java
@@ -25,6 +25,16 @@ public enum ProxyType {
    */
   HTTP,
   /**
+   * HTTP proxy reached over SSL/TLS, i.e. the client opens an {@code https} connection to the proxy
+   * itself before issuing {@code CONNECT} or absolute-URI requests. The proxying semantics are
+   * identical to {@link #HTTP}; only the connection to the proxy is encrypted, configured via
+   * {@link ProxyOptions#setSslOptions(ClientSSLOptions)}.
+   * <p>
+   * Note this is distinct from the {@code https_proxy} environment-variable convention, which
+   * denotes the proxy used <em>for</em> {@code https} traffic rather than a proxy reached over SSL/TLS.
+   */
+  HTTPS,
+  /**
    * SOCKS4/4a tcp proxy
    */
   SOCKS4,

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -301,7 +301,9 @@ public abstract class ConnectionBase {
   }
 
   public boolean isSsl() {
-    return chctx.pipeline().get(SslHandler.class) != null;
+    // Check if the origin ssl handler (named "ssl") is in the pipeline. We don't check for the presence
+    // of an SslHandler as that could be an instance of the handler for the https proxy.
+    return chctx.pipeline().get("ssl") != null;
   }
 
   public boolean isTrafficShaped() {

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -301,9 +301,18 @@ public abstract class ConnectionBase {
   }
 
   public boolean isSsl() {
-    // Check if the origin ssl handler (named "ssl") is in the pipeline. We don't check for the presence
-    // of an SslHandler as that could be an instance of the handler for the https proxy.
-    return chctx.pipeline().get("ssl") != null;
+    // Ignore a TLS leg to an HTTPS proxy ("proxy-ssl"): report whether the origin connection is encrypted.
+    ChannelHandler proxySsl = chctx.pipeline().get("proxy-ssl");
+    if (proxySsl == null) {
+      return chctx.pipeline().get(SslHandler.class) != null;
+    }
+    for (String name : chctx.pipeline().names()) {
+      ChannelHandler handler = chctx.pipeline().get(name);
+      if (handler != proxySsl && handler instanceof SslHandler) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public boolean isTrafficShaped() {

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxConnection.java
@@ -12,6 +12,7 @@ package io.vertx.core.net.impl;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.*;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
@@ -141,7 +142,8 @@ public class VertxConnection extends ConnectionBase {
   }
 
   protected boolean supportsFileRegion() {
-    return vertx.transport().supportFileRegion() && !isSsl() &&!isTrafficShaped();
+    boolean sslChannel = chctx.pipeline().get(SslHandler.class) != null;
+    return vertx.transport().supportFileRegion() && !sslChannel && !isTrafficShaped();
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/ChannelProvider.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/ChannelProvider.java
@@ -35,6 +35,7 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.net.SslChannelProvider;
 import io.vertx.core.net.impl.SslEngineUtils;
+import io.vertx.core.internal.tls.ClientSslContextManager;
 import io.vertx.core.internal.tls.SslContextProvider;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.HostAndPort;
@@ -59,16 +60,19 @@ public final class ChannelProvider {
 
   private final Bootstrap bootstrap;
   private final SslContextProvider sslContextProvider;
+  private final ClientSslContextManager sslContextManager;
   private final ContextInternal context;
   private ProxyOptions proxyOptions;
   private String applicationProtocol;
 
   public ChannelProvider(Bootstrap bootstrap,
                          SslContextProvider sslContextProvider,
+                         ClientSslContextManager sslContextManager,
                          ContextInternal context) {
     this.bootstrap = bootstrap;
     this.context = context;
     this.sslContextProvider = sslContextProvider;
+    this.sslContextManager = sslContextManager;
   }
 
   /**
@@ -204,6 +208,7 @@ public final class ChannelProvider {
         switch (proxyType) {
           default:
           case HTTP:
+          case HTTPS:
             proxy = createHttpProxyHandler(proxyAddr, proxyUsername, proxyPassword, proxyAuthorization);
             break;
           case SOCKS5:
@@ -224,41 +229,82 @@ public final class ChannelProvider {
         bootstrap.resolver(NoopAddressResolverGroup.INSTANCE);
         java.net.SocketAddress targetAddress = vertx.transport().convert(remoteAddress);
 
-        bootstrap.handler(new ChannelInitializer<Channel>() {
-          @Override
-          protected void initChannel(Channel ch) throws Exception {
-            ChannelPipeline pipeline = ch.pipeline();
-            pipeline.addFirst("proxy", proxy);
-            pipeline.addLast(new ChannelInboundHandlerAdapter() {
-              @Override
-              public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
-                if (evt instanceof ProxyConnectionEvent) {
-                  pipeline.remove(proxy);
-                  pipeline.remove(this);
-                  initSSL(peerAddress, serverName, ssl, sslOptions, ch, channelHandler);
-                  connected(ch, ssl, channelHandler);
+        final ClientSSLOptions proxySslOptions;
+        final io.vertx.core.Future<SslChannelProvider> proxySslProviderFuture;
+        if (proxyType == ProxyType.HTTPS) {
+          proxySslOptions = resolveProxySslOptions();
+          List<String> resolvedGroups = SslEngineUtils.resolveKeyExchangeGroups(proxySslOptions.getKeyExchangeGroups(), proxySslOptions.getPqcEnforcementPolicy());
+          proxySslProviderFuture = sslContextManager.resolveSslContextProvider(proxySslOptions, context)
+            .map(p -> new SslChannelProvider(vertx, p, false, resolvedGroups));
+        } else {
+          proxySslOptions = null;
+          proxySslProviderFuture = context.succeededFuture(null);
+        }
+
+        proxySslProviderFuture.onComplete(ar -> {
+          if (ar.failed()) {
+            channelHandler.setFailure(ar.cause());
+            return;
+          }
+          SslChannelProvider proxySslChannelProvider = ar.result();
+          bootstrap.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) {
+              ChannelPipeline pipeline = ch.pipeline();
+              ChannelInboundHandlerAdapter proxyConnected = new ChannelInboundHandlerAdapter() {
+                @Override
+                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                  if (evt instanceof ProxyConnectionEvent) {
+                    pipeline.remove(proxy);
+                    pipeline.remove(this);
+                    initSSL(peerAddress, serverName, ssl, sslOptions, ch, channelHandler);
+                    connected(ch, ssl, channelHandler);
+                  }
+                  ctx.fireUserEventTriggered(evt);
                 }
-                ctx.fireUserEventTriggered(evt);
-              }
 
-              @Override
-              public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-                channelHandler.setFailure(cause);
+                @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                  channelHandler.setFailure(cause);
+                }
+              };
+              if (proxySslChannelProvider != null) {
+                SslHandler proxySslHandler = proxySslChannelProvider.createClientSslHandler(
+                  HostAndPort.create(proxyHost, proxyPort), proxyHost, null,
+                  proxySslOptions.getSslHandshakeTimeout(), proxySslOptions.getSslHandshakeTimeoutUnit());
+                pipeline.addFirst("proxy-ssl", proxySslHandler);
+                pipeline.addAfter("proxy-ssl", "proxy", proxy);
+              } else {
+                pipeline.addFirst("proxy", proxy);
               }
-            });
-          }
-        });
-        ChannelFuture future = bootstrap.connect(targetAddress);
+              pipeline.addLast(proxyConnected);
+            }
+          });
+          ChannelFuture future = bootstrap.connect(targetAddress);
 
-        future.addListener(res -> {
-          if (!res.isSuccess()) {
-            channelHandler.setFailure(res.cause());
-          }
+          future.addListener(res -> {
+            if (!res.isSuccess()) {
+              channelHandler.setFailure(res.cause());
+            }
+          });
         });
       } else {
         channelHandler.setFailure(dnsRes.cause());
       }
     });
+  }
+
+
+  private ClientSSLOptions resolveProxySslOptions() {
+    ClientSSLOptions proxySslOptions = proxyOptions.getSslOptions();
+    proxySslOptions = proxySslOptions != null ? proxySslOptions.copy() : new ClientSSLOptions();
+    if (proxySslOptions.getHostnameVerificationAlgorithm() == null) {
+      proxySslOptions.setHostnameVerificationAlgorithm("HTTPS");
+    }
+    // ALPN is negotiated for the origin (leg 2), never for the proxy connection.
+    proxySslOptions.setUseAlpn(false);
+    proxySslOptions.setApplicationLayerProtocols(null);
+    return proxySslOptions;
   }
 
   private static ProxyHandler createHttpProxyHandler(InetSocketAddress proxyAddr, String proxyUsername, String proxyPassword,

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/ChannelProvider.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/ChannelProvider.java
@@ -229,71 +229,74 @@ public final class ChannelProvider {
         bootstrap.resolver(NoopAddressResolverGroup.INSTANCE);
         java.net.SocketAddress targetAddress = vertx.transport().convert(remoteAddress);
 
-        final ClientSSLOptions proxySslOptions;
-        final io.vertx.core.Future<SslChannelProvider> proxySslProviderFuture;
         if (proxyType == ProxyType.HTTPS) {
-          proxySslOptions = resolveProxySslOptions();
+          ClientSSLOptions proxySslOptions = resolveProxySslOptions();
           List<String> resolvedGroups = SslEngineUtils.resolveKeyExchangeGroups(proxySslOptions.getKeyExchangeGroups(), proxySslOptions.getPqcEnforcementPolicy());
-          proxySslProviderFuture = sslContextManager.resolveSslContextProvider(proxySslOptions, context)
-            .map(p -> new SslChannelProvider(vertx, p, false, resolvedGroups));
-        } else {
-          proxySslOptions = null;
-          proxySslProviderFuture = context.succeededFuture(null);
-        }
-
-        proxySslProviderFuture.onComplete(ar -> {
-          if (ar.failed()) {
-            channelHandler.setFailure(ar.cause());
-            return;
-          }
-          SslChannelProvider proxySslChannelProvider = ar.result();
-          bootstrap.handler(new ChannelInitializer<Channel>() {
-            @Override
-            protected void initChannel(Channel ch) {
-              ChannelPipeline pipeline = ch.pipeline();
-              ChannelInboundHandlerAdapter proxyConnected = new ChannelInboundHandlerAdapter() {
-                @Override
-                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
-                  if (evt instanceof ProxyConnectionEvent) {
-                    pipeline.remove(proxy);
-                    pipeline.remove(this);
-                    initSSL(peerAddress, serverName, ssl, sslOptions, ch, channelHandler);
-                    connected(ch, ssl, channelHandler);
-                  }
-                  ctx.fireUserEventTriggered(evt);
-                }
-
-                @Override
-                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-                  channelHandler.setFailure(cause);
-                }
-              };
-              if (proxySslChannelProvider != null) {
-                SslHandler proxySslHandler = proxySslChannelProvider.createClientSslHandler(
-                  HostAndPort.create(proxyHost, proxyPort), proxyHost, null,
-                  proxySslOptions.getSslHandshakeTimeout(), proxySslOptions.getSslHandshakeTimeoutUnit());
-                pipeline.addFirst("proxy-ssl", proxySslHandler);
-                pipeline.addAfter("proxy-ssl", "proxy", proxy);
-              } else {
-                pipeline.addFirst("proxy", proxy);
+          sslContextManager.resolveSslContextProvider(proxySslOptions, context)
+            .map(p -> new SslChannelProvider(vertx, p, false, resolvedGroups))
+            .onComplete(ar -> {
+              if (ar.failed()) {
+                channelHandler.setFailure(ar.cause());
+                return;
               }
-              pipeline.addLast(proxyConnected);
-            }
-          });
-          ChannelFuture future = bootstrap.connect(targetAddress);
-
-          future.addListener(res -> {
-            if (!res.isSuccess()) {
-              channelHandler.setFailure(res.cause());
-            }
-          });
-        });
+              connectViaProxy(ar.result(), proxySslOptions, proxy, proxyHost, proxyPort, targetAddress,
+                peerAddress, serverName, ssl, sslOptions, channelHandler);
+            });
+        } else {
+          connectViaProxy(null, null, proxy, proxyHost, proxyPort, targetAddress,
+            peerAddress, serverName, ssl, sslOptions, channelHandler);
+        }
       } else {
         channelHandler.setFailure(dnsRes.cause());
       }
     });
   }
 
+  private void connectViaProxy(SslChannelProvider proxySslChannelProvider, ClientSSLOptions proxySslOptions,
+                               ProxyHandler proxy, String proxyHost, int proxyPort, java.net.SocketAddress targetAddress,
+                               HostAndPort peerAddress, String serverName, boolean ssl, ClientSSLOptions sslOptions,
+                               Promise<Channel> channelHandler) {
+    bootstrap.handler(new ChannelInitializer<Channel>() {
+      @Override
+      protected void initChannel(Channel ch) {
+        ChannelPipeline pipeline = ch.pipeline();
+        ChannelInboundHandlerAdapter proxyConnected = new ChannelInboundHandlerAdapter() {
+          @Override
+          public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            if (evt instanceof ProxyConnectionEvent) {
+              pipeline.remove(proxy);
+              pipeline.remove(this);
+              initSSL(peerAddress, serverName, ssl, sslOptions, ch, channelHandler);
+              connected(ch, ssl, channelHandler);
+            }
+            ctx.fireUserEventTriggered(evt);
+          }
+
+          @Override
+          public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            channelHandler.setFailure(cause);
+          }
+        };
+        if (proxySslChannelProvider != null) {
+          SslHandler proxySslHandler = proxySslChannelProvider.createClientSslHandler(
+            HostAndPort.create(proxyHost, proxyPort), proxyHost, null,
+            proxySslOptions.getSslHandshakeTimeout(), proxySslOptions.getSslHandshakeTimeoutUnit());
+          pipeline.addFirst("proxy-ssl", proxySslHandler);
+          pipeline.addAfter("proxy-ssl", "proxy", proxy);
+        } else {
+          pipeline.addFirst("proxy", proxy);
+        }
+        pipeline.addLast(proxyConnected);
+      }
+    });
+    ChannelFuture future = bootstrap.connect(targetAddress);
+
+    future.addListener(res -> {
+      if (!res.isSuccess()) {
+        channelHandler.setFailure(res.cause());
+      }
+    });
+  }
 
   private ClientSSLOptions resolveProxySslOptions() {
     ClientSSLOptions proxySslOptions = proxyOptions.getSslOptions();

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
@@ -354,7 +354,7 @@ public class NetClientImpl implements NetClientInternal, CleanableResource<NetCl
         }
       }
 
-      ChannelProvider channelProvider = new ChannelProvider(bootstrap, sslContextProvider, context)
+      ChannelProvider channelProvider = new ChannelProvider(bootstrap, sslContextProvider, sslContextManager, context)
         .proxyOptions(proxyOptions);
 
       SocketAddress captured = remoteAddress;

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
@@ -16,6 +16,7 @@ import io.netty.channel.*;
 import io.netty.channel.Channel;
 import io.netty.handler.logging.ByteBufFormat;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -106,7 +107,8 @@ public class NetClientImpl implements NetClientInternal, CleanableResource<NetCl
     if (logging != null) {
       pipeline.addLast("logging", new LoggingHandler(logging));
     }
-    if (ssl || !vertx.transport().supportFileRegion()) {
+    boolean sslChannel = pipeline.get(SslHandler.class) != null;
+    if (sslChannel || !vertx.transport().supportFileRegion()) {
       // only add ChunkedWriteHandler when SSL is enabled otherwise it is not needed as FileRegion is used.
       pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());       // For large file / sendfile support
     }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
@@ -103,10 +103,12 @@ public class NetClientImpl implements NetClientInternal, CleanableResource<NetCl
     this.protocol = protocol;
   }
 
-  protected void initChannel(ChannelPipeline pipeline, boolean ssl) {
+  protected void initChannel(ChannelPipeline pipeline) {
     if (logging != null) {
       pipeline.addLast("logging", new LoggingHandler(logging));
     }
+    // The origin can be plaintext while the channel is still TLS wrapped, e.g. when tunnelling through an
+    // HTTPS proxy, so the file region support is decided from the pipeline rather than from the origin.
     boolean sslChannel = pipeline.get(SslHandler.class) != null;
     if (sslChannel || !vertx.transport().supportFileRegion()) {
       // only add ChunkedWriteHandler when SSL is enabled otherwise it is not needed as FileRegion is used.
@@ -375,7 +377,6 @@ public class NetClientImpl implements NetClientInternal, CleanableResource<NetCl
             future.getNow(),
             connectHandler,
             captured,
-            connectOptions.isSsl(),
             registerWriteHandlers);
         } else {
           failed(context, null, future.cause(), connectHandler);
@@ -391,10 +392,9 @@ public class NetClientImpl implements NetClientInternal, CleanableResource<NetCl
                          Channel ch,
                          Promise<NetSocket> connectHandler,
                          SocketAddress remoteAddress,
-                         boolean ssl,
                          boolean registerWriteHandlers) {
     channelGroup.add(ch);
-    initChannel(ch.pipeline(), ssl);
+    initChannel(ch.pipeline());
     VertxHandler<NetSocketImpl> handler = VertxHandler.create(ctx -> new NetSocketImpl(
       context,
       ctx,

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetSocketImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetSocketImpl.java
@@ -38,6 +38,7 @@ import io.vertx.core.net.impl.StreamChannelBase;
 import io.vertx.core.spi.metrics.TransportMetrics;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -151,7 +152,7 @@ public class NetSocketImpl extends StreamChannelBase<NetSocketImpl> implements N
           chctx.channel().config().setAutoRead(true);
           if (res.isSuccess()) {
             ChannelPromise channelPromise = chctx.newPromise();
-            chctx.pipeline().addFirst("handshaker", new SslHandshakeCompletionHandler(channelPromise));
+            SslHandshakeCompletionHandler handshaker = new SslHandshakeCompletionHandler(channelPromise);
             ChannelHandler sslHandler;
             if (sslOptions instanceof ClientSSLOptions) {
               ClientSSLOptions clientSSLOptions = (ClientSSLOptions) sslOptions;
@@ -161,7 +162,13 @@ public class NetSocketImpl extends StreamChannelBase<NetSocketImpl> implements N
               sslHandler = provider.createServerHandler(applicationProtocols, sslOptions.getSslHandshakeTimeout(),
                 sslOptions.getSslHandshakeTimeoutUnit(), HttpUtils.socketAddressToHostAndPort(chctx.channel().remoteAddress()));
             }
-            chctx.pipeline().addFirst("ssl", sslHandler);
+            if (chctx.pipeline().get("proxy-ssl") != null) {
+              chctx.pipeline().addAfter("proxy-ssl", "ssl", sslHandler);
+              chctx.pipeline().addAfter("ssl", "handshaker", handshaker);
+            } else {
+              chctx.pipeline().addFirst("handshaker", handshaker);
+              chctx.pipeline().addFirst("ssl", sslHandler);
+            }
             channelPromise.addListener(p);
             doPause();
           } else {
@@ -180,7 +187,15 @@ public class NetSocketImpl extends StreamChannelBase<NetSocketImpl> implements N
 
   @Override
   public String applicationLayerProtocol() {
-    SslHandler handler = channel.pipeline().get(SslHandler.class);
+    // Use the innermost (last) SslHandler: when tunnelling through an HTTPS proxy the pipeline holds
+    // two SslHandlers (leg-1 to the proxy at the head, leg-2 to the origin after it), and the
+    // application protocol is negotiated on the origin (leg-2) handshake.
+    SslHandler handler = null;
+    for (Map.Entry<String, ChannelHandler> entry : channel.pipeline()) {
+      if (entry.getValue() instanceof SslHandler) {
+        handler = (SslHandler) entry.getValue();
+      }
+    }
     if (handler != null) {
       return handler.engine().getApplicationProtocol();
     } else {

--- a/vertx-core/src/test/java/io/vertx/test/proxy/HttpProxy.java
+++ b/vertx-core/src/test/java/io/vertx/test/proxy/HttpProxy.java
@@ -17,8 +17,10 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
+import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.TrustOptions;
 import io.vertx.test.http.HttpTestBase;
 
 import java.net.UnknownHostException;
@@ -60,9 +62,34 @@ public class HttpProxy extends ProxyBase<HttpProxy> {
   private MultiMap lastRequestHeaders = null;
   private HttpMethod lastMethod;
 
+  private KeyCertOptions serverCert = null;
+  private TrustOptions clientAuthTrust = null;
+
   @Override
   public int defaultPort() {
     return DEFAULT_PORT;
+  }
+
+  /**
+   * Make the proxy itself listen over TLS, so the client establishes an HTTPS connection to the
+   * proxy (leg 1). This is used to test {@link io.vertx.core.net.ProxyType#HTTPS}.
+   *
+   * @param serverCert the key/cert the proxy presents to the client
+   */
+  public HttpProxy ssl(KeyCertOptions serverCert) {
+    this.serverCert = serverCert;
+    return this;
+  }
+
+  /**
+   * Additionally require and validate a client certificate (mutual TLS on leg 1). Implies
+   * {@link #ssl(KeyCertOptions)} having been set.
+   *
+   * @param clientAuthTrust trust used to validate the client certificate
+   */
+  public HttpProxy requireClientAuth(TrustOptions clientAuthTrust) {
+    this.clientAuthTrust = clientAuthTrust;
+    return this;
   }
 
   /**
@@ -75,6 +102,12 @@ public class HttpProxy extends ProxyBase<HttpProxy> {
   public HttpProxy start(Vertx vertx) throws Exception {
     HttpServerOptions options = new HttpServerOptions();
     options.setHost("localhost").setPort(port);
+    if (serverCert != null) {
+      options.setSsl(true).setKeyCertOptions(serverCert);
+      if (clientAuthTrust != null) {
+        options.setClientAuth(ClientAuth.REQUIRED).setTrustOptions(clientAuthTrust);
+      }
+    }
     client = vertx.createNetClient();
     server = vertx.createHttpServer(options);
     server.requestHandler(request -> {

--- a/vertx-core/src/test/java/io/vertx/test/proxy/Proxy.java
+++ b/vertx-core/src/test/java/io/vertx/test/proxy/Proxy.java
@@ -16,8 +16,11 @@ import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
+import io.vertx.test.tls.Cert;
+import io.vertx.test.tls.Trust;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -63,12 +66,14 @@ public class Proxy implements TestRule {
 
     private final String username;
     private final ProxyKind kind;
+    private final boolean requireSslClientAuth;
     private final Statement statement;
     private final String hosts;
 
-    public ProxyLifecycle(String username, ProxyKind kind, String hosts, Statement statement) {
+    public ProxyLifecycle(String username, ProxyKind kind, boolean requireSslClientAuth, String hosts, Statement statement) {
       this.username = username;
       this.kind = kind;
+      this.requireSslClientAuth = requireSslClientAuth;
       this.statement = statement;
       this.hosts = hosts;
     }
@@ -83,9 +88,19 @@ public class Proxy implements TestRule {
       Vertx vertx = Vertx.vertx(vertxOptions);
       ProxyType type;
       ProxyBase<?> proxy;
+      ClientSSLOptions sslOptions = null;
       if (kind == ProxyKind.HTTP) {
         type = ProxyType.HTTP;
         proxy = new HttpProxy();
+      } else if (kind == ProxyKind.HTTPS) {
+        // TLS requires the proxy to present a certificate, so an HTTPS proxy always has a server cert.
+        type = ProxyType.HTTPS;
+        HttpProxy httpProxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
+        if (requireSslClientAuth) {
+          httpProxy.requireClientAuth(Trust.CLIENT_JKS.get());
+        }
+        proxy = httpProxy;
+        sslOptions = new ClientSSLOptions().setTrustOptions(Trust.SERVER_JKS.get());
       } else if (kind == ProxyKind.SOCKS5) {
         type = ProxyType.SOCKS5;
         proxy = new SocksProxy();
@@ -99,7 +114,8 @@ public class Proxy implements TestRule {
       ProxyOptions proxyOptions = new ProxyOptions()
         .setHost("localhost")
         .setPort(proxy.port())
-        .setType(type);
+        .setType(type)
+        .setSslOptions(sslOptions);
       proxy.start(vertx);
       Proxy.this.proxy = proxy;
       Proxy.this.options = proxyOptions;
@@ -124,7 +140,7 @@ public class Proxy implements TestRule {
         }
         hosts.append("127.0.0.1 ").append(host);
       }
-      result = new ProxyLifecycle(repeat.username(), repeat.kind(), hosts.toString(), statement);
+      result = new ProxyLifecycle(repeat.username(), repeat.kind(), repeat.requireSslClientAuth(), hosts.toString(), statement);
     }
     return result;
   }

--- a/vertx-core/src/test/java/io/vertx/test/proxy/ProxyKind.java
+++ b/vertx-core/src/test/java/io/vertx/test/proxy/ProxyKind.java
@@ -18,6 +18,11 @@ public enum ProxyKind {
   HTTP,
 
   /**
+   * HTTP proxy whose own connection (leg 1) is established over TLS
+   */
+  HTTPS,
+
+  /**
    * SOCKS4/4a tcp proxy
    */
   SOCKS4,

--- a/vertx-core/src/test/java/io/vertx/test/proxy/WithProxy.java
+++ b/vertx-core/src/test/java/io/vertx/test/proxy/WithProxy.java
@@ -22,6 +22,13 @@ public @interface WithProxy {
 
   ProxyKind kind();
 
+  /**
+   * Only meaningful for {@link ProxyKind#HTTPS}: when {@code true} the proxy requires and validates a
+   * client certificate (mutual TLS on leg 1). This is a server-side knob only; the client presenting a
+   * certificate remains the responsibility of the test's own {@code ProxyOptions.sslOptions}.
+   */
+  boolean requireSslClientAuth() default false;
+
   String[] localhosts() default {};
 
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpsProxyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpsProxyTest.java
@@ -19,9 +19,14 @@ import io.vertx.core.http.HttpResponseExpectation;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.ClientSSLOptions;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.NetServer;
+import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.test.core.TestUtils;
 import io.vertx.test.http.HttpTestBase;
 import io.vertx.test.proxy.Proxy;
 import io.vertx.test.proxy.ProxyKind;
@@ -32,6 +37,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import javax.net.ssl.SSLHandshakeException;
+import java.io.File;
+import java.nio.file.Files;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -171,6 +178,40 @@ public class HttpsProxyTest extends HttpTestBase {
       .await();
 
     assertEquals("Hello from origin", body.toString());
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
+  public void testHttpsProxy_sendFileThroughTunnel() throws Exception {
+    // A client NetSocket.sendFile() to a plain origin through the HTTPS proxy: the file must travel
+    // through the leg-1 TLS (the "proxy-ssl" SslHandler on the client pipeline). Because the origin is
+    // plain, the connection's isSsl() is false, so the old !isSsl() zero-copy check would send the raw
+    // file bytes bypassing the SslHandler and break the TLS tunnel. supportsFileRegion() must instead
+    // detect the SslHandler and fall back to chunked writes.
+    String content = TestUtils.randomUnicodeString(10000);
+    File file = Files.createTempFile("vertx", ".txt").toFile();
+    file.deleteOnExit();
+    Files.write(file.toPath(), content.getBytes("UTF-8"));
+    Buffer expected = Buffer.buffer(content);
+
+    // Plain origin. Not DEFAULT_HTTP_PORT: the proxy denies CONNECT to that port.
+    Buffer received = Buffer.buffer();
+    NetServer origin = vertx.createNetServer();
+    origin.connectHandler(sock -> sock.handler(buff -> {
+      received.appendBuffer(buff);
+      if (received.length() == expected.length()) {
+        assertEquals(expected, received);
+        testComplete();
+      }
+    }));
+    origin.listen(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST).await();
+
+    NetClient netClient = vertx.createNetClient(new NetClientOptions().setProxyOptions(proxy.options()));
+    NetSocket sock = netClient.connect(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST).await();
+    sock.sendFile(file.getAbsolutePath()).await();
+
+    await();
+    assertEquals(HttpMethod.CONNECT, proxy.lastMethod());
   }
 
   // --- Security / failure cases ---------------------------------------------

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpsProxyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpsProxyTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.http;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpResponseExpectation;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.net.ClientSSLOptions;
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.ProxyType;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.test.http.HttpTestBase;
+import io.vertx.test.proxy.HttpProxy;
+import io.vertx.test.tls.Cert;
+import io.vertx.test.tls.Trust;
+import org.junit.Test;
+
+/**
+ * Tests for {@link ProxyType#HTTPS}: the connection to the proxy itself (leg 1) is established over
+ * TLS. The proxying semantics (absolute-URI {@code GET} forwarding for plain origins, {@code CONNECT}
+ * tunnel for TLS origins) are unchanged from {@link ProxyType#HTTP}.
+ */
+public class HttpsProxyTest extends HttpTestBase {
+
+  private Vertx proxyVertx;
+  private HttpProxy proxy;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    // The proxy runs on its own Vertx instance so that closing it in tearDown awaits the release of
+    // its listen socket. HttpProxy.stop() alone does not wait for the close to complete, which leaks
+    // the port into the following tests.
+    proxyVertx = Vertx.vertx();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    try {
+      if (proxy != null) {
+        proxy.stop();
+      }
+    } finally {
+      if (proxyVertx != null) {
+        proxyVertx.close().await();
+      }
+    }
+    super.tearDown();
+  }
+
+  private void startHttpOrigin() throws Exception {
+    server.requestHandler(req -> req.response().end("Hello from origin"));
+    startServer();
+  }
+
+  private void startHttpsOrigin(HttpVersion version) throws Exception {
+    server = vertx.createHttpServer(createBaseServerOptions()
+      .setSsl(true)
+      .setUseAlpn(version == HttpVersion.HTTP_2)
+      .setKeyCertOptions(Cert.SERVER_JKS.get()));
+    server.requestHandler(req -> req.response().end("Hello from origin"));
+    startServer(SocketAddress.inetSocketAddress(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST));
+  }
+
+  /** Default proxy SSL options trusting the proxy's (localhost) certificate. */
+  private static ClientSSLOptions trustingProxySsl() {
+    return new ClientSSLOptions().setTrustOptions(Trust.SERVER_JKS.get());
+  }
+
+  private static ProxyOptions httpsProxy(int port) {
+    return new ProxyOptions()
+      .setType(ProxyType.HTTPS)
+      .setHost("localhost")
+      .setPort(port)
+      .setSslOptions(trustingProxySsl());
+  }
+
+  // --- Happy paths ----------------------------------------------------------
+
+  @Test
+  public void testHttpsProxy_HttpOrigin_forwarded() throws Exception {
+    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
+    proxy.start(proxyVertx);
+    startHttpOrigin();
+
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions().setProxyOptions(httpsProxy(proxy.port())));
+
+    Buffer body = client.request(new RequestOptions().setMethod(HttpMethod.GET)
+        .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
+      .compose(req -> req.send().expecting(HttpResponseExpectation.SC_OK))
+      .compose(HttpClientResponse::body)
+      .await();
+
+    assertEquals("Hello from origin", body.toString());
+    // Plain origin: the proxy GET-forwards (it sees the absolute URI), it does not CONNECT.
+    assertEquals(HttpMethod.GET, proxy.getLastMethod());
+    assertNotNull(proxy.getLastUri());
+  }
+
+  @Test
+  public void testHttpsProxy_HttpsOrigin_tunnelled() throws Exception {
+    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
+    proxy.start(proxyVertx);
+    startHttpsOrigin(HttpVersion.HTTP_1_1);
+
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setSsl(true)
+      .setTrustOptions(Trust.SERVER_JKS.get())
+      .setProxyOptions(httpsProxy(proxy.port())));
+
+    Buffer body = client.request(new RequestOptions().setMethod(HttpMethod.GET)
+        .setHost(DEFAULT_HTTPS_HOST).setPort(DEFAULT_HTTPS_PORT).setURI("/"))
+      .compose(req -> req.send().expecting(HttpResponseExpectation.SC_OK))
+      .compose(HttpClientResponse::body)
+      .await();
+
+    assertEquals("Hello from origin", body.toString());
+    // TLS origin: nested TLS through the CONNECT tunnel (the proxy never sees the encrypted request).
+    assertEquals(HttpMethod.CONNECT, proxy.getLastMethod());
+  }
+
+  @Test
+  public void testHttpsProxy_Http2Origin_tunnelled() throws Exception {
+    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
+    proxy.start(proxyVertx);
+    startHttpsOrigin(HttpVersion.HTTP_2);
+
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setProtocolVersion(HttpVersion.HTTP_2)
+      .setSsl(true)
+      .setUseAlpn(true)
+      .setTrustOptions(Trust.SERVER_JKS.get())
+      .setProxyOptions(httpsProxy(proxy.port())));
+
+    String result = client.request(new RequestOptions().setMethod(HttpMethod.GET)
+        .setHost(DEFAULT_HTTPS_HOST).setPort(DEFAULT_HTTPS_PORT).setURI("/"))
+      .compose(req -> req.send().expecting(HttpResponseExpectation.SC_OK))
+      .compose(resp -> resp.body().map(body -> resp.version() + ":" + body))
+      .await();
+
+    // h2 rides the CONNECT tunnel for free; ALPN negotiates h2 end-to-end with the origin.
+    assertEquals(HttpVersion.HTTP_2 + ":Hello from origin", result);
+    assertEquals(HttpMethod.CONNECT, proxy.getLastMethod());
+  }
+
+  @Test
+  public void testHttpsProxy_proxyAuthentication() throws Exception {
+    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get()).username("user1");
+    proxy.start(proxyVertx);
+    startHttpOrigin();
+
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setProxyOptions(httpsProxy(proxy.port()).setUsername("user1").setPassword("user1")));
+
+    Buffer body = client.request(new RequestOptions().setMethod(HttpMethod.GET)
+        .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
+      .compose(req -> req.send().expecting(HttpResponseExpectation.SC_OK))
+      .compose(HttpClientResponse::body)
+      .await();
+
+    // SC_OK proves the Basic Proxy-Authorization (sent inside the established leg-1 TLS) was accepted;
+    // the proxy returns 407 on missing/incorrect credentials.
+    assertEquals("Hello from origin", body.toString());
+  }
+
+  @Test
+  public void testHttpsProxy_mutualTls() throws Exception {
+    proxy = new HttpProxy()
+      .ssl(Cert.SERVER_JKS.get())
+      .requireClientAuth(Trust.CLIENT_JKS.get());
+    proxy.start(proxyVertx);
+    startHttpOrigin();
+
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions().setProxyOptions(httpsProxy(proxy.port())
+      .setSslOptions(new ClientSSLOptions()
+        .setTrustOptions(Trust.SERVER_JKS.get())
+        .setKeyCertOptions(Cert.CLIENT_JKS.get()))));
+
+    Buffer body = client.request(new RequestOptions().setMethod(HttpMethod.GET)
+        .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
+      .compose(req -> req.send().expecting(HttpResponseExpectation.SC_OK))
+      .compose(HttpClientResponse::body)
+      .await();
+
+    assertEquals("Hello from origin", body.toString());
+  }
+
+  // --- Security / failure cases ---------------------------------------------
+
+  @Test
+  public void testHttpsProxy_untrustedProxyCertRejected() throws Exception {
+    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
+    proxy.start(proxyVertx);
+    startHttpOrigin();
+
+    client.close();
+    // No sslOptions => default trust source (no self-signed cert): the proxy cert is not trusted and
+    // there is no plaintext fallback for an HTTPS proxy.
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTPS).setHost("localhost").setPort(proxy.port())));
+
+    try {
+      client.request(new RequestOptions().setMethod(HttpMethod.GET)
+          .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
+        .compose(req -> req.send())
+        .await();
+      fail("Expected the connection to the untrusted HTTPS proxy to fail");
+    } catch (Exception expected) {
+      // connect failed rather than hanging or silently downgrading
+    }
+  }
+
+  @Test
+  public void testHttpsProxy_hostnameMismatchRejected() throws Exception {
+    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
+    proxy.start(proxyVertx);
+    startHttpOrigin();
+
+    client.close();
+    // Proxy cert is CN=localhost; connecting via 127.0.0.1 must fail hostname verification (on by default).
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTPS).setHost("127.0.0.1").setPort(proxy.port())
+        .setSslOptions(trustingProxySsl())));
+
+    try {
+      client.request(new RequestOptions().setMethod(HttpMethod.GET)
+          .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
+        .compose(req -> req.send())
+        .await();
+      fail("Expected hostname verification against the proxy to fail");
+    } catch (Exception expected) {
+      // verification rejected the mismatched proxy hostname
+    }
+  }
+
+  @Test
+  public void testHttpsProxy_againstPlaintextProxyFailsCleanly() throws Exception {
+    proxy = new HttpProxy(); // plaintext proxy
+    proxy.start(proxyVertx);
+    startHttpOrigin();
+
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions().setProxyOptions(httpsProxy(proxy.port())));
+
+    try {
+      client.request(new RequestOptions().setMethod(HttpMethod.GET)
+          .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
+        .compose(req -> req.send())
+        .await();
+      fail("Expected the TLS handshake against a plaintext proxy to fail");
+    } catch (Exception expected) {
+      // no silent downgrade: a HTTPS proxy type never falls back to plaintext
+    }
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpsProxyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpsProxyTest.java
@@ -29,6 +29,10 @@ import io.vertx.test.tls.Cert;
 import io.vertx.test.tls.Trust;
 import org.junit.Test;
 
+import javax.net.ssl.SSLHandshakeException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 /**
  * Tests for {@link ProxyType#HTTPS}: the connection to the proxy itself (leg 1) is established over
  * TLS. The proxying semantics (absolute-URI {@code GET} forwarding for plain origins, {@code CONNECT}
@@ -218,15 +222,13 @@ public class HttpsProxyTest extends HttpTestBase {
     client = vertx.createHttpClient(new HttpClientOptions()
       .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTPS).setHost("localhost").setPort(proxy.port())));
 
-    try {
-      client.request(new RequestOptions().setMethod(HttpMethod.GET)
-          .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
-        .compose(req -> req.send())
-        .await();
-      fail("Expected the connection to the untrusted HTTPS proxy to fail");
-    } catch (Exception expected) {
-      // connect failed rather than hanging or silently downgrading
-    }
+    // connect must fail rather than hanging or silently downgrading
+    assertThatThrownBy(() -> client.request(new RequestOptions().setMethod(HttpMethod.GET)
+        .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
+      .compose(req -> req.send())
+      .await())
+      .isInstanceOf(SSLHandshakeException.class)
+      .hasStackTraceContaining("unable to find valid certification path");
   }
 
   @Test
@@ -241,15 +243,13 @@ public class HttpsProxyTest extends HttpTestBase {
       .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTPS).setHost("127.0.0.1").setPort(proxy.port())
         .setSslOptions(trustingProxySsl())));
 
-    try {
-      client.request(new RequestOptions().setMethod(HttpMethod.GET)
-          .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
-        .compose(req -> req.send())
-        .await();
-      fail("Expected hostname verification against the proxy to fail");
-    } catch (Exception expected) {
-      // verification rejected the mismatched proxy hostname
-    }
+    // verification must reject the mismatched proxy hostname
+    assertThatThrownBy(() -> client.request(new RequestOptions().setMethod(HttpMethod.GET)
+        .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
+      .compose(req -> req.send())
+      .await())
+      .isInstanceOf(SSLHandshakeException.class)
+      .hasStackTraceContaining("No subject alternative names present");
   }
 
   @Test
@@ -261,14 +261,12 @@ public class HttpsProxyTest extends HttpTestBase {
     client.close();
     client = vertx.createHttpClient(new HttpClientOptions().setProxyOptions(httpsProxy(proxy.port())));
 
-    try {
-      client.request(new RequestOptions().setMethod(HttpMethod.GET)
-          .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
-        .compose(req -> req.send())
-        .await();
-      fail("Expected the TLS handshake against a plaintext proxy to fail");
-    } catch (Exception expected) {
-      // no silent downgrade: a HTTPS proxy type never falls back to plaintext
-    }
+    // no silent downgrade: a HTTPS proxy type never falls back to plaintext
+    assertThatThrownBy(() -> client.request(new RequestOptions().setMethod(HttpMethod.GET)
+        .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
+      .compose(req -> req.send())
+      .await())
+      .isInstanceOf(SSLHandshakeException.class)
+      .hasStackTraceContaining("not an SSL/TLS record");
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpsProxyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpsProxyTest.java
@@ -10,7 +10,6 @@
  */
 package io.vertx.tests.http;
 
-import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 
 import io.vertx.core.http.HttpClientOptions;
@@ -24,9 +23,12 @@ import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.test.http.HttpTestBase;
-import io.vertx.test.proxy.HttpProxy;
+import io.vertx.test.proxy.Proxy;
+import io.vertx.test.proxy.ProxyKind;
+import io.vertx.test.proxy.WithProxy;
 import io.vertx.test.tls.Cert;
 import io.vertx.test.tls.Trust;
+import org.junit.Rule;
 import org.junit.Test;
 
 import javax.net.ssl.SSLHandshakeException;
@@ -40,31 +42,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 public class HttpsProxyTest extends HttpTestBase {
 
-  private Vertx proxyVertx;
-  private HttpProxy proxy;
-
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    // The proxy runs on its own Vertx instance so that closing it in tearDown awaits the release of
-    // its listen socket. HttpProxy.stop() alone does not wait for the close to complete, which leaks
-    // the port into the following tests.
-    proxyVertx = Vertx.vertx();
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-    try {
-      if (proxy != null) {
-        proxy.stop();
-      }
-    } finally {
-      if (proxyVertx != null) {
-        proxyVertx.close().await();
-      }
-    }
-    super.tearDown();
-  }
+  @Rule
+  public Proxy proxy = new Proxy();
 
   private void startHttpOrigin() throws Exception {
     server.requestHandler(req -> req.response().end("Hello from origin"));
@@ -85,24 +64,15 @@ public class HttpsProxyTest extends HttpTestBase {
     return new ClientSSLOptions().setTrustOptions(Trust.SERVER_JKS.get());
   }
 
-  private static ProxyOptions httpsProxy(int port) {
-    return new ProxyOptions()
-      .setType(ProxyType.HTTPS)
-      .setHost("localhost")
-      .setPort(port)
-      .setSslOptions(trustingProxySsl());
-  }
-
   // --- Happy paths ----------------------------------------------------------
 
   @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
   public void testHttpsProxy_HttpOrigin_forwarded() throws Exception {
-    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
-    proxy.start(proxyVertx);
     startHttpOrigin();
 
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setProxyOptions(httpsProxy(proxy.port())));
+    client = vertx.createHttpClient(new HttpClientOptions().setProxyOptions(proxy.options()));
 
     Buffer body = client.request(new RequestOptions().setMethod(HttpMethod.GET)
         .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
@@ -112,21 +82,20 @@ public class HttpsProxyTest extends HttpTestBase {
 
     assertEquals("Hello from origin", body.toString());
     // Plain origin: the proxy GET-forwards (it sees the absolute URI), it does not CONNECT.
-    assertEquals(HttpMethod.GET, proxy.getLastMethod());
-    assertNotNull(proxy.getLastUri());
+    assertEquals(HttpMethod.GET, proxy.lastMethod());
+    assertNotNull(proxy.lastUri());
   }
 
   @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
   public void testHttpsProxy_HttpsOrigin_tunnelled() throws Exception {
-    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
-    proxy.start(proxyVertx);
     startHttpsOrigin(HttpVersion.HTTP_1_1);
 
     client.close();
     client = vertx.createHttpClient(new HttpClientOptions()
       .setSsl(true)
       .setTrustOptions(Trust.SERVER_JKS.get())
-      .setProxyOptions(httpsProxy(proxy.port())));
+      .setProxyOptions(proxy.options()));
 
     Buffer body = client.request(new RequestOptions().setMethod(HttpMethod.GET)
         .setHost(DEFAULT_HTTPS_HOST).setPort(DEFAULT_HTTPS_PORT).setURI("/"))
@@ -136,13 +105,12 @@ public class HttpsProxyTest extends HttpTestBase {
 
     assertEquals("Hello from origin", body.toString());
     // TLS origin: nested TLS through the CONNECT tunnel (the proxy never sees the encrypted request).
-    assertEquals(HttpMethod.CONNECT, proxy.getLastMethod());
+    assertEquals(HttpMethod.CONNECT, proxy.lastMethod());
   }
 
   @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
   public void testHttpsProxy_Http2Origin_tunnelled() throws Exception {
-    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
-    proxy.start(proxyVertx);
     startHttpsOrigin(HttpVersion.HTTP_2);
 
     client.close();
@@ -151,7 +119,7 @@ public class HttpsProxyTest extends HttpTestBase {
       .setSsl(true)
       .setUseAlpn(true)
       .setTrustOptions(Trust.SERVER_JKS.get())
-      .setProxyOptions(httpsProxy(proxy.port())));
+      .setProxyOptions(proxy.options()));
 
     String result = client.request(new RequestOptions().setMethod(HttpMethod.GET)
         .setHost(DEFAULT_HTTPS_HOST).setPort(DEFAULT_HTTPS_PORT).setURI("/"))
@@ -161,18 +129,17 @@ public class HttpsProxyTest extends HttpTestBase {
 
     // h2 rides the CONNECT tunnel for free; ALPN negotiates h2 end-to-end with the origin.
     assertEquals(HttpVersion.HTTP_2 + ":Hello from origin", result);
-    assertEquals(HttpMethod.CONNECT, proxy.getLastMethod());
+    assertEquals(HttpMethod.CONNECT, proxy.lastMethod());
   }
 
   @Test
+  @WithProxy(kind = ProxyKind.HTTPS, username = "user1")
   public void testHttpsProxy_proxyAuthentication() throws Exception {
-    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get()).username("user1");
-    proxy.start(proxyVertx);
     startHttpOrigin();
 
     client.close();
     client = vertx.createHttpClient(new HttpClientOptions()
-      .setProxyOptions(httpsProxy(proxy.port()).setUsername("user1").setPassword("user1")));
+      .setProxyOptions(proxy.options().setUsername("user1").setPassword("user1")));
 
     Buffer body = client.request(new RequestOptions().setMethod(HttpMethod.GET)
         .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
@@ -186,15 +153,13 @@ public class HttpsProxyTest extends HttpTestBase {
   }
 
   @Test
+  @WithProxy(kind = ProxyKind.HTTPS, requireSslClientAuth = true)
   public void testHttpsProxy_mutualTls() throws Exception {
-    proxy = new HttpProxy()
-      .ssl(Cert.SERVER_JKS.get())
-      .requireClientAuth(Trust.CLIENT_JKS.get());
-    proxy.start(proxyVertx);
     startHttpOrigin();
 
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setProxyOptions(httpsProxy(proxy.port())
+    // The proxy requires a client certificate (server-side); the client presents one here (client-side).
+    client = vertx.createHttpClient(new HttpClientOptions().setProxyOptions(proxy.options()
       .setSslOptions(new ClientSSLOptions()
         .setTrustOptions(Trust.SERVER_JKS.get())
         .setKeyCertOptions(Cert.CLIENT_JKS.get()))));
@@ -211,9 +176,8 @@ public class HttpsProxyTest extends HttpTestBase {
   // --- Security / failure cases ---------------------------------------------
 
   @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
   public void testHttpsProxy_untrustedProxyCertRejected() throws Exception {
-    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
-    proxy.start(proxyVertx);
     startHttpOrigin();
 
     client.close();
@@ -232,9 +196,8 @@ public class HttpsProxyTest extends HttpTestBase {
   }
 
   @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
   public void testHttpsProxy_hostnameMismatchRejected() throws Exception {
-    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
-    proxy.start(proxyVertx);
     startHttpOrigin();
 
     client.close();
@@ -253,15 +216,16 @@ public class HttpsProxyTest extends HttpTestBase {
   }
 
   @Test
+  @WithProxy(kind = ProxyKind.HTTP)
   public void testHttpsProxy_againstPlaintextProxyFailsCleanly() throws Exception {
-    proxy = new HttpProxy(); // plaintext proxy
-    proxy.start(proxyVertx);
     startHttpOrigin();
 
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setProxyOptions(httpsProxy(proxy.port())));
+    // A HTTPS proxy type pointed at a plaintext proxy: no silent downgrade, the TLS handshake must fail.
+    client = vertx.createHttpClient(new HttpClientOptions()
+      .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTPS).setHost("localhost").setPort(proxy.port())
+        .setSslOptions(trustingProxySsl())));
 
-    // no silent downgrade: a HTTPS proxy type never falls back to plaintext
     assertThatThrownBy(() -> client.request(new RequestOptions().setMethod(HttpMethod.GET)
         .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
       .compose(req -> req.send())

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpsProxyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpsProxyTest.java
@@ -52,8 +52,12 @@ public class HttpsProxyTest extends HttpTestBase {
   @Rule
   public Proxy proxy = new Proxy();
 
+  // The origin echoes the TLS status of its own (leg 2) connection, so that tests assert the origin view
+  // and not only the client one: leg 1 being TLS must not make a plain origin look encrypted, and a
+  // tunnelled TLS origin must still see its own TLS.
+
   private void startHttpOrigin() throws Exception {
-    server.requestHandler(req -> req.response().end("Hello from origin"));
+    server.requestHandler(req -> req.response().end("Hello from origin ssl=" + req.isSSL()));
     startServer();
   }
 
@@ -62,7 +66,7 @@ public class HttpsProxyTest extends HttpTestBase {
       .setSsl(true)
       .setUseAlpn(version == HttpVersion.HTTP_2)
       .setKeyCertOptions(Cert.SERVER_JKS.get()));
-    server.requestHandler(req -> req.response().end("Hello from origin"));
+    server.requestHandler(req -> req.response().end("Hello from origin ssl=" + req.isSSL()));
     startServer(SocketAddress.inetSocketAddress(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST));
   }
 
@@ -87,7 +91,7 @@ public class HttpsProxyTest extends HttpTestBase {
       .compose(HttpClientResponse::body)
       .await();
 
-    assertEquals("Hello from origin", body.toString());
+    assertEquals("Hello from origin ssl=false", body.toString());
     // Plain origin: the proxy GET-forwards (it sees the absolute URI), it does not CONNECT.
     assertEquals(HttpMethod.GET, proxy.lastMethod());
     assertNotNull(proxy.lastUri());
@@ -110,7 +114,7 @@ public class HttpsProxyTest extends HttpTestBase {
       .compose(HttpClientResponse::body)
       .await();
 
-    assertEquals("Hello from origin", body.toString());
+    assertEquals("Hello from origin ssl=true", body.toString());
     // TLS origin: nested TLS through the CONNECT tunnel (the proxy never sees the encrypted request).
     assertEquals(HttpMethod.CONNECT, proxy.lastMethod());
   }
@@ -135,7 +139,7 @@ public class HttpsProxyTest extends HttpTestBase {
       .await();
 
     // h2 rides the CONNECT tunnel for free; ALPN negotiates h2 end-to-end with the origin.
-    assertEquals(HttpVersion.HTTP_2 + ":Hello from origin", result);
+    assertEquals(HttpVersion.HTTP_2 + ":Hello from origin ssl=true", result);
     assertEquals(HttpMethod.CONNECT, proxy.lastMethod());
   }
 
@@ -156,7 +160,7 @@ public class HttpsProxyTest extends HttpTestBase {
 
     // SC_OK proves the Basic Proxy-Authorization (sent inside the established leg-1 TLS) was accepted;
     // the proxy returns 407 on missing/incorrect credentials.
-    assertEquals("Hello from origin", body.toString());
+    assertEquals("Hello from origin ssl=false", body.toString());
   }
 
   @Test
@@ -177,7 +181,7 @@ public class HttpsProxyTest extends HttpTestBase {
       .compose(HttpClientResponse::body)
       .await();
 
-    assertEquals("Hello from origin", body.toString());
+    assertEquals("Hello from origin ssl=false", body.toString());
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpsProxyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpsProxyTest.java
@@ -10,24 +10,27 @@
  */
 package io.vertx.tests.http;
 
+import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 
-import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientConfig;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpResponseExpectation;
+import io.vertx.core.http.HttpServerConfig;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.NetClient;
-import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
+import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.TcpClientConfig;
 import io.vertx.test.core.TestUtils;
-import io.vertx.test.http.HttpTestBase;
+import io.vertx.test.http.HttpTestBase2;
 import io.vertx.test.proxy.Proxy;
 import io.vertx.test.proxy.ProxyKind;
 import io.vertx.test.proxy.WithProxy;
@@ -41,16 +44,32 @@ import java.io.File;
 import java.nio.file.Files;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests for {@link ProxyType#HTTPS}: the connection to the proxy itself (leg 1) is established over
  * TLS. The proxying semantics (absolute-URI {@code GET} forwarding for plain origins, {@code CONNECT}
  * tunnel for TLS origins) are unchanged from {@link ProxyType#HTTP}.
  */
-public class HttpsProxyTest extends HttpTestBase {
+public class HttpsProxyTest extends HttpTestBase2 {
 
   @Rule
   public Proxy proxy = new Proxy();
+
+  private NetServer netOrigin;
+
+  @Override
+  protected void tearDown() throws Exception {
+    if (netOrigin != null) {
+      netOrigin.close().await();
+      netOrigin = null;
+    }
+    if (server != null) {
+      server.close().await();
+    }
+    super.tearDown();
+  }
 
   // The origin echoes the TLS status of its own (leg 2) connection, so that tests assert the origin view
   // and not only the client one: leg 1 being TLS must not make a plain origin look encrypted, and a
@@ -62,10 +81,11 @@ public class HttpsProxyTest extends HttpTestBase {
   }
 
   private void startHttpsOrigin(HttpVersion version) throws Exception {
-    server = vertx.createHttpServer(createBaseServerOptions()
-      .setSsl(true)
-      .setUseAlpn(version == HttpVersion.HTTP_2)
-      .setKeyCertOptions(Cert.SERVER_JKS.get()));
+    server = vertx.createHttpServer(
+      new HttpServerConfig().setPort(DEFAULT_HTTPS_PORT).setHost(DEFAULT_HTTPS_HOST),
+      new ServerSSLOptions()
+        .setKeyCertOptions(Cert.SERVER_JKS.get())
+        .setUseAlpn(version == HttpVersion.HTTP_2));
     server.requestHandler(req -> req.response().end("Hello from origin ssl=" + req.isSSL()));
     startServer(SocketAddress.inetSocketAddress(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST));
   }
@@ -73,6 +93,13 @@ public class HttpsProxyTest extends HttpTestBase {
   /** Default proxy SSL options trusting the proxy's (localhost) certificate. */
   private static ClientSSLOptions trustingProxySsl() {
     return new ClientSSLOptions().setTrustOptions(Trust.SERVER_JKS.get());
+  }
+
+  /** A client config whose transport routes through {@code proxyOptions}. */
+  private static HttpClientConfig proxiedConfig(ProxyOptions proxyOptions) {
+    HttpClientConfig config = new HttpClientConfig();
+    config.getTcpConfig().setProxyOptions(proxyOptions);
+    return config;
   }
 
   // --- Happy paths ----------------------------------------------------------
@@ -83,7 +110,7 @@ public class HttpsProxyTest extends HttpTestBase {
     startHttpOrigin();
 
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions().setProxyOptions(proxy.options()));
+    client = vertx.createHttpClient(proxiedConfig(proxy.options()));
 
     Buffer body = client.request(new RequestOptions().setMethod(HttpMethod.GET)
         .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
@@ -103,10 +130,9 @@ public class HttpsProxyTest extends HttpTestBase {
     startHttpsOrigin(HttpVersion.HTTP_1_1);
 
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions()
-      .setSsl(true)
-      .setTrustOptions(Trust.SERVER_JKS.get())
-      .setProxyOptions(proxy.options()));
+    client = vertx.createHttpClient(
+      proxiedConfig(proxy.options()).setSsl(true),
+      new ClientSSLOptions().setTrustOptions(Trust.SERVER_JKS.get()));
 
     Buffer body = client.request(new RequestOptions().setMethod(HttpMethod.GET)
         .setHost(DEFAULT_HTTPS_HOST).setPort(DEFAULT_HTTPS_PORT).setURI("/"))
@@ -125,12 +151,9 @@ public class HttpsProxyTest extends HttpTestBase {
     startHttpsOrigin(HttpVersion.HTTP_2);
 
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions()
-      .setProtocolVersion(HttpVersion.HTTP_2)
-      .setSsl(true)
-      .setUseAlpn(true)
-      .setTrustOptions(Trust.SERVER_JKS.get())
-      .setProxyOptions(proxy.options()));
+    client = vertx.createHttpClient(
+      proxiedConfig(proxy.options()).setVersions(HttpVersion.HTTP_2).setSsl(true),
+      new ClientSSLOptions().setTrustOptions(Trust.SERVER_JKS.get()).setUseAlpn(true));
 
     String result = client.request(new RequestOptions().setMethod(HttpMethod.GET)
         .setHost(DEFAULT_HTTPS_HOST).setPort(DEFAULT_HTTPS_PORT).setURI("/"))
@@ -149,8 +172,7 @@ public class HttpsProxyTest extends HttpTestBase {
     startHttpOrigin();
 
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions()
-      .setProxyOptions(proxy.options().setUsername("user1").setPassword("user1")));
+    client = vertx.createHttpClient(proxiedConfig(proxy.options().setUsername("user1").setPassword("user1")));
 
     Buffer body = client.request(new RequestOptions().setMethod(HttpMethod.GET)
         .setHost(DEFAULT_HTTP_HOST).setPort(DEFAULT_HTTP_PORT).setURI("/"))
@@ -170,7 +192,7 @@ public class HttpsProxyTest extends HttpTestBase {
 
     client.close();
     // The proxy requires a client certificate (server-side); the client presents one here (client-side).
-    client = vertx.createHttpClient(new HttpClientOptions().setProxyOptions(proxy.options()
+    client = vertx.createHttpClient(proxiedConfig(proxy.options()
       .setSslOptions(new ClientSSLOptions()
         .setTrustOptions(Trust.SERVER_JKS.get())
         .setKeyCertOptions(Cert.CLIENT_JKS.get()))));
@@ -200,21 +222,22 @@ public class HttpsProxyTest extends HttpTestBase {
 
     // Plain origin. Not DEFAULT_HTTP_PORT: the proxy denies CONNECT to that port.
     Buffer received = Buffer.buffer();
-    NetServer origin = vertx.createNetServer();
-    origin.connectHandler(sock -> sock.handler(buff -> {
+    Promise<Void> allReceived = Promise.promise();
+    netOrigin = vertx.createNetServer();
+    netOrigin.connectHandler(sock -> sock.handler(buff -> {
       received.appendBuffer(buff);
       if (received.length() == expected.length()) {
-        assertEquals(expected, received);
-        testComplete();
+        allReceived.complete();
       }
     }));
-    origin.listen(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST).await();
+    netOrigin.listen(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST).await();
 
-    NetClient netClient = vertx.createNetClient(new NetClientOptions().setProxyOptions(proxy.options()));
+    NetClient netClient = vertx.createNetClient(new TcpClientConfig().setProxyOptions(proxy.options()));
     NetSocket sock = netClient.connect(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST).await();
     sock.sendFile(file.getAbsolutePath()).await();
 
-    await();
+    allReceived.future().await();
+    assertEquals(expected, received);
     assertEquals(HttpMethod.CONNECT, proxy.lastMethod());
   }
 
@@ -228,8 +251,8 @@ public class HttpsProxyTest extends HttpTestBase {
     client.close();
     // No sslOptions => default trust source (no self-signed cert): the proxy cert is not trusted and
     // there is no plaintext fallback for an HTTPS proxy.
-    client = vertx.createHttpClient(new HttpClientOptions()
-      .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTPS).setHost("localhost").setPort(proxy.port())));
+    client = vertx.createHttpClient(proxiedConfig(
+      new ProxyOptions().setType(ProxyType.HTTPS).setHost("localhost").setPort(proxy.port())));
 
     // connect must fail rather than hanging or silently downgrading
     assertThatThrownBy(() -> client.request(new RequestOptions().setMethod(HttpMethod.GET)
@@ -247,8 +270,8 @@ public class HttpsProxyTest extends HttpTestBase {
 
     client.close();
     // Proxy cert is CN=localhost; connecting via 127.0.0.1 must fail hostname verification (on by default).
-    client = vertx.createHttpClient(new HttpClientOptions()
-      .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTPS).setHost("127.0.0.1").setPort(proxy.port())
+    client = vertx.createHttpClient(proxiedConfig(
+      new ProxyOptions().setType(ProxyType.HTTPS).setHost("127.0.0.1").setPort(proxy.port())
         .setSslOptions(trustingProxySsl())));
 
     // verification must reject the mismatched proxy hostname
@@ -267,8 +290,8 @@ public class HttpsProxyTest extends HttpTestBase {
 
     client.close();
     // A HTTPS proxy type pointed at a plaintext proxy: no silent downgrade, the TLS handshake must fail.
-    client = vertx.createHttpClient(new HttpClientOptions()
-      .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTPS).setHost("localhost").setPort(proxy.port())
+    client = vertx.createHttpClient(proxiedConfig(
+      new ProxyOptions().setType(ProxyType.HTTPS).setHost("localhost").setPort(proxy.port())
         .setSslOptions(trustingProxySsl())));
 
     assertThatThrownBy(() -> client.request(new RequestOptions().setMethod(HttpMethod.GET)

--- a/vertx-core/src/test/java/io/vertx/tests/http/ProxyIsSslConsistencyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/ProxyIsSslConsistencyTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.http;
+
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.WebSocketClientOptions;
+import io.vertx.core.http.WebSocketConnectOptions;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.test.http.HttpTestBase;
+import io.vertx.test.proxy.Proxy;
+import io.vertx.test.proxy.ProxyKind;
+import io.vertx.test.proxy.WithProxy;
+import io.vertx.test.tls.Cert;
+import io.vertx.test.tls.Trust;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * The invariant: {@code connection.isSsl()} must be identical whether a connection is direct, via an
+ * HTTP proxy, or via an HTTPS proxy. The proxy is a transport detail and must not change
+ * {@code isSsl()} — it reports whether the ORIGIN connection is encrypted.
+ *
+ * <p>Each test starts one origin, then opens a connection direct and a connection through the proxy of
+ * the method's {@link WithProxy} kind, and asserts the two {@code isSsl()} values are equal.
+ * {@code @WithProxy} selects one proxy kind per method, so there are two tests per case (HTTP proxy and
+ * HTTPS proxy). Origins are cleaned up by {@code tearDown} (vertx close), like other {@link HttpTestBase}
+ * tests; the per-type client logic ({@link #connectNetSocket}, {@link #connectHttp},
+ * {@link #connectWebSocket}) is reused across cases.
+ *
+ * <p>Covers the four main proxy-capable connection types (NetSocket, HTTP/1, HTTP/2, WebSocket)
+ * against a plain and a TLS origin.
+ */
+public class ProxyIsSslConsistencyTest extends HttpTestBase {
+
+  // CONNECT-safe origin port: >= 1024 and != DEFAULT_HTTP_PORT (8080), which HttpProxy denies for CONNECT.
+  private static final int ORIGIN_PORT = DEFAULT_HTTPS_PORT;
+  private static final String ORIGIN_HOST = "localhost";
+
+  @Rule
+  public Proxy proxy = new Proxy();
+
+  // --- Origins (one per test; closed by tearDown) ---------------------------
+
+  private void startNetOrigin(boolean originTls) throws Exception {
+    NetServerOptions options = new NetServerOptions().setPort(ORIGIN_PORT).setHost(ORIGIN_HOST);
+    if (originTls) {
+      options.setSsl(true).setKeyCertOptions(Cert.SERVER_JKS.get());
+    }
+    vertx.createNetServer(options).connectHandler(so -> {}).listen().await();
+  }
+
+  private void startHttpOrigin(HttpVersion version, boolean originTls) throws Exception {
+    HttpServerOptions options = new HttpServerOptions().setPort(ORIGIN_PORT).setHost(ORIGIN_HOST);
+    if (originTls) {
+      options.setSsl(true).setKeyCertOptions(Cert.SERVER_JKS.get()).setUseAlpn(version == HttpVersion.HTTP_2);
+    }
+    createHttpServer(options).requestHandler(req -> req.response().end("ok")).listen().await();
+  }
+
+  private void startWebSocketOrigin(boolean originTls) throws Exception {
+    HttpServerOptions options = new HttpServerOptions().setPort(ORIGIN_PORT).setHost(ORIGIN_HOST);
+    if (originTls) {
+      options.setSsl(true).setKeyCertOptions(Cert.SERVER_JKS.get());
+    }
+    createHttpServer(options).webSocketHandler(ws -> ws.handler(buff -> {})).listen().await();
+  }
+
+  // --- Reusable per-type client logic: connect (direct if proxyOptions is null, else through the
+  //     proxy) and return connection.isSsl() ------------------------------------------------------
+
+  private boolean connectNetSocket(boolean originTls, ProxyOptions proxyOptions) throws Exception {
+    NetClientOptions options = new NetClientOptions();
+    if (originTls) {
+      options.setSsl(true).setTrustOptions(Trust.SERVER_JKS.get()).setHostnameVerificationAlgorithm("HTTPS");
+    }
+    if (proxyOptions != null) {
+      options.setProxyOptions(proxyOptions);
+    }
+    NetClient client = vertx.createNetClient(options);
+    try {
+      NetSocket so = client.connect(ORIGIN_PORT, ORIGIN_HOST).await();
+      return so.isSsl();
+    } finally {
+      client.close().await();
+    }
+  }
+
+  private boolean connectHttp(HttpVersion version, boolean originTls, ProxyOptions proxyOptions) throws Exception {
+    HttpClientOptions options = new HttpClientOptions().setProtocolVersion(version);
+    if (originTls) {
+      options.setSsl(true).setTrustOptions(Trust.SERVER_JKS.get()).setUseAlpn(version == HttpVersion.HTTP_2);
+    }
+    if (proxyOptions != null) {
+      options.setProxyOptions(proxyOptions);
+    }
+    HttpClient client = createHttpClient(options);
+    try {
+      return client.request(new RequestOptions().setHost(ORIGIN_HOST).setPort(ORIGIN_PORT).setURI("/"))
+        .compose(req -> req.send().map(resp -> resp.request().connection().isSsl()))
+        .await();
+    } finally {
+      client.close().await();
+    }
+  }
+
+  private boolean connectWebSocket(boolean originTls, ProxyOptions proxyOptions) throws Exception {
+    WebSocketClientOptions options = new WebSocketClientOptions();
+    if (originTls) {
+      options.setSsl(true).setTrustOptions(Trust.SERVER_JKS.get());
+    }
+    if (proxyOptions != null) {
+      options.setProxyOptions(proxyOptions);
+    }
+    WebSocketClient client = vertx.createWebSocketClient(options);
+    try {
+      WebSocket ws = client.connect(new WebSocketConnectOptions()
+        .setHost(ORIGIN_HOST).setPort(ORIGIN_PORT).setURI("/").setSsl(originTls)).await();
+      return ws.isSsl();
+    } finally {
+      client.close().await();
+    }
+  }
+
+  // --- NetSocket ------------------------------------------------------------
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTP)
+  public void netSocket_plainOrigin_httpProxy() throws Exception {
+    startNetOrigin(false);
+    boolean isSslDirect = connectNetSocket(false, null);
+    boolean isSslViaProxy = connectNetSocket(false, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
+  public void netSocket_plainOrigin_httpsProxy() throws Exception {
+    startNetOrigin(false);
+    boolean isSslDirect = connectNetSocket(false, null);
+    boolean isSslViaProxy = connectNetSocket(false, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTP)
+  public void netSocket_tlsOrigin_httpProxy() throws Exception {
+    startNetOrigin(true);
+    boolean isSslDirect = connectNetSocket(true, null);
+    boolean isSslViaProxy = connectNetSocket(true, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
+  public void netSocket_tlsOrigin_httpsProxy() throws Exception {
+    startNetOrigin(true);
+    boolean isSslDirect = connectNetSocket(true, null);
+    boolean isSslViaProxy = connectNetSocket(true, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  // --- HTTP/1 ---------------------------------------------------------------
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTP)
+  public void http1_plainOrigin_httpProxy() throws Exception {
+    startHttpOrigin(HttpVersion.HTTP_1_1, false);
+    boolean isSslDirect = connectHttp(HttpVersion.HTTP_1_1, false, null);
+    boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_1_1, false, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
+  public void http1_plainOrigin_httpsProxy() throws Exception {
+    startHttpOrigin(HttpVersion.HTTP_1_1, false);
+    boolean isSslDirect = connectHttp(HttpVersion.HTTP_1_1, false, null);
+    boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_1_1, false, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTP)
+  public void http1_tlsOrigin_httpProxy() throws Exception {
+    startHttpOrigin(HttpVersion.HTTP_1_1, true);
+    boolean isSslDirect = connectHttp(HttpVersion.HTTP_1_1, true, null);
+    boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_1_1, true, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
+  public void http1_tlsOrigin_httpsProxy() throws Exception {
+    startHttpOrigin(HttpVersion.HTTP_1_1, true);
+    boolean isSslDirect = connectHttp(HttpVersion.HTTP_1_1, true, null);
+    boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_1_1, true, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  // --- HTTP/2 ---------------------------------------------------------------
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTP)
+  public void http2_plainOrigin_httpProxy() throws Exception {
+    startHttpOrigin(HttpVersion.HTTP_2, false);
+    boolean isSslDirect = connectHttp(HttpVersion.HTTP_2, false, null);
+    boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_2, false, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
+  public void http2_plainOrigin_httpsProxy() throws Exception {
+    startHttpOrigin(HttpVersion.HTTP_2, false);
+    boolean isSslDirect = connectHttp(HttpVersion.HTTP_2, false, null);
+    boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_2, false, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTP)
+  public void http2_tlsOrigin_httpProxy() throws Exception {
+    startHttpOrigin(HttpVersion.HTTP_2, true);
+    boolean isSslDirect = connectHttp(HttpVersion.HTTP_2, true, null);
+    boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_2, true, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
+  public void http2_tlsOrigin_httpsProxy() throws Exception {
+    startHttpOrigin(HttpVersion.HTTP_2, true);
+    boolean isSslDirect = connectHttp(HttpVersion.HTTP_2, true, null);
+    boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_2, true, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  // --- WebSocket ------------------------------------------------------------
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTP)
+  public void webSocket_plainOrigin_httpProxy() throws Exception {
+    startWebSocketOrigin(false);
+    boolean isSslDirect = connectWebSocket(false, null);
+    boolean isSslViaProxy = connectWebSocket(false, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
+  public void webSocket_plainOrigin_httpsProxy() throws Exception {
+    startWebSocketOrigin(false);
+    boolean isSslDirect = connectWebSocket(false, null);
+    boolean isSslViaProxy = connectWebSocket(false, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTP)
+  public void webSocket_tlsOrigin_httpProxy() throws Exception {
+    startWebSocketOrigin(true);
+    boolean isSslDirect = connectWebSocket(true, null);
+    boolean isSslViaProxy = connectWebSocket(true, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+
+  @Test
+  @WithProxy(kind = ProxyKind.HTTPS)
+  public void webSocket_tlsOrigin_httpsProxy() throws Exception {
+    startWebSocketOrigin(true);
+    boolean isSslDirect = connectWebSocket(true, null);
+    boolean isSslViaProxy = connectWebSocket(true, proxy.options());
+    assertEquals(isSslDirect, isSslViaProxy);
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/tests/http/ProxyIsSslConsistencyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/ProxyIsSslConsistencyTest.java
@@ -34,16 +34,18 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * The invariant: {@code connection.isSsl()} must be identical whether a connection is direct, via an
- * HTTP proxy, or via an HTTPS proxy. The proxy is a transport detail and must not change
- * {@code isSsl()} — it reports whether the ORIGIN connection is encrypted.
+ * The invariant: {@code connection.isSsl()} reports whether the ORIGIN connection is encrypted, so it
+ * must equal the origin's TLS setting whether the connection is direct, via an HTTP proxy, or via an
+ * HTTPS proxy. The proxy is a transport detail and must not change {@code isSsl()} — in particular the
+ * TLS leg to an HTTPS proxy must not make a plaintext origin look encrypted.
  *
  * <p>Each test starts one origin, then opens a connection direct and a connection through the proxy of
- * the method's {@link WithProxy} kind, and asserts the two {@code isSsl()} values are equal.
- * {@code @WithProxy} selects one proxy kind per method, so there are two tests per case (HTTP proxy and
- * HTTPS proxy). Origins are cleaned up by {@code tearDown} (vertx close), like other {@link HttpTestBase}
- * tests; the per-type client logic ({@link #connectNetSocket}, {@link #connectHttp},
- * {@link #connectWebSocket}) is reused across cases.
+ * the method's {@link WithProxy} kind, and asserts that both report the origin's TLS setting. The direct
+ * connection is the control: on failure it tells a proxy regression apart from one that was already
+ * broken without a proxy. {@code @WithProxy} selects one proxy kind per method, so there are two tests
+ * per case (HTTP proxy and HTTPS proxy). Origins are cleaned up by {@code tearDown} (vertx close), like
+ * other {@link HttpTestBase} tests; the per-type client logic ({@link #connectNetSocket},
+ * {@link #connectHttp}, {@link #connectWebSocket}) is reused across cases.
  *
  * <p>Covers the four main proxy-capable connection types (NetSocket, HTTP/1, HTTP/2, WebSocket)
  * against a plain and a TLS origin.
@@ -147,7 +149,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startNetOrigin(false);
     boolean isSslDirect = connectNetSocket(false, null);
     boolean isSslViaProxy = connectNetSocket(false, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertFalse(isSslDirect);
+    assertFalse(isSslViaProxy);
   }
 
   @Test
@@ -156,7 +159,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startNetOrigin(false);
     boolean isSslDirect = connectNetSocket(false, null);
     boolean isSslViaProxy = connectNetSocket(false, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertFalse(isSslDirect);
+    assertFalse(isSslViaProxy);
   }
 
   @Test
@@ -165,7 +169,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startNetOrigin(true);
     boolean isSslDirect = connectNetSocket(true, null);
     boolean isSslViaProxy = connectNetSocket(true, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertTrue(isSslDirect);
+    assertTrue(isSslViaProxy);
   }
 
   @Test
@@ -174,7 +179,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startNetOrigin(true);
     boolean isSslDirect = connectNetSocket(true, null);
     boolean isSslViaProxy = connectNetSocket(true, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertTrue(isSslDirect);
+    assertTrue(isSslViaProxy);
   }
 
   // --- HTTP/1 ---------------------------------------------------------------
@@ -185,7 +191,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startHttpOrigin(HttpVersion.HTTP_1_1, false);
     boolean isSslDirect = connectHttp(HttpVersion.HTTP_1_1, false, null);
     boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_1_1, false, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertFalse(isSslDirect);
+    assertFalse(isSslViaProxy);
   }
 
   @Test
@@ -194,7 +201,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startHttpOrigin(HttpVersion.HTTP_1_1, false);
     boolean isSslDirect = connectHttp(HttpVersion.HTTP_1_1, false, null);
     boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_1_1, false, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertFalse(isSslDirect);
+    assertFalse(isSslViaProxy);
   }
 
   @Test
@@ -203,7 +211,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startHttpOrigin(HttpVersion.HTTP_1_1, true);
     boolean isSslDirect = connectHttp(HttpVersion.HTTP_1_1, true, null);
     boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_1_1, true, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertTrue(isSslDirect);
+    assertTrue(isSslViaProxy);
   }
 
   @Test
@@ -212,7 +221,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startHttpOrigin(HttpVersion.HTTP_1_1, true);
     boolean isSslDirect = connectHttp(HttpVersion.HTTP_1_1, true, null);
     boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_1_1, true, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertTrue(isSslDirect);
+    assertTrue(isSslViaProxy);
   }
 
   // --- HTTP/2 ---------------------------------------------------------------
@@ -223,7 +233,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startHttpOrigin(HttpVersion.HTTP_2, false);
     boolean isSslDirect = connectHttp(HttpVersion.HTTP_2, false, null);
     boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_2, false, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertFalse(isSslDirect);
+    assertFalse(isSslViaProxy);
   }
 
   @Test
@@ -232,7 +243,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startHttpOrigin(HttpVersion.HTTP_2, false);
     boolean isSslDirect = connectHttp(HttpVersion.HTTP_2, false, null);
     boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_2, false, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertFalse(isSslDirect);
+    assertFalse(isSslViaProxy);
   }
 
   @Test
@@ -241,7 +253,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startHttpOrigin(HttpVersion.HTTP_2, true);
     boolean isSslDirect = connectHttp(HttpVersion.HTTP_2, true, null);
     boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_2, true, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertTrue(isSslDirect);
+    assertTrue(isSslViaProxy);
   }
 
   @Test
@@ -250,7 +263,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startHttpOrigin(HttpVersion.HTTP_2, true);
     boolean isSslDirect = connectHttp(HttpVersion.HTTP_2, true, null);
     boolean isSslViaProxy = connectHttp(HttpVersion.HTTP_2, true, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertTrue(isSslDirect);
+    assertTrue(isSslViaProxy);
   }
 
   // --- WebSocket ------------------------------------------------------------
@@ -261,7 +275,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startWebSocketOrigin(false);
     boolean isSslDirect = connectWebSocket(false, null);
     boolean isSslViaProxy = connectWebSocket(false, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertFalse(isSslDirect);
+    assertFalse(isSslViaProxy);
   }
 
   @Test
@@ -270,7 +285,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startWebSocketOrigin(false);
     boolean isSslDirect = connectWebSocket(false, null);
     boolean isSslViaProxy = connectWebSocket(false, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertFalse(isSslDirect);
+    assertFalse(isSslViaProxy);
   }
 
   @Test
@@ -279,7 +295,8 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startWebSocketOrigin(true);
     boolean isSslDirect = connectWebSocket(true, null);
     boolean isSslViaProxy = connectWebSocket(true, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertTrue(isSslDirect);
+    assertTrue(isSslViaProxy);
   }
 
   @Test
@@ -288,6 +305,7 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     startWebSocketOrigin(true);
     boolean isSslDirect = connectWebSocket(true, null);
     boolean isSslViaProxy = connectWebSocket(true, proxy.options());
-    assertEquals(isSslDirect, isSslViaProxy);
+    assertTrue(isSslDirect);
+    assertTrue(isSslViaProxy);
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/ProxyIsSslConsistencyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/ProxyIsSslConsistencyTest.java
@@ -11,20 +11,24 @@
 package io.vertx.tests.http;
 
 import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpClientConfig;
+import io.vertx.core.http.HttpServerConfig;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.WebSocket;
 import io.vertx.core.http.WebSocketClient;
 import io.vertx.core.http.WebSocketClientOptions;
 import io.vertx.core.http.WebSocketConnectOptions;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.NetClient;
-import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.ProxyOptions;
-import io.vertx.test.http.HttpTestBase;
+import io.vertx.core.net.ServerSSLOptions;
+import io.vertx.core.net.TcpClientConfig;
+import io.vertx.core.net.TcpServerConfig;
+import io.vertx.test.http.HttpTestBase2;
 import io.vertx.test.proxy.Proxy;
 import io.vertx.test.proxy.ProxyKind;
 import io.vertx.test.proxy.WithProxy;
@@ -32,6 +36,9 @@ import io.vertx.test.tls.Cert;
 import io.vertx.test.tls.Trust;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * The invariant: {@code connection.isSsl()} reports whether the ORIGIN connection is encrypted, so it
@@ -43,14 +50,14 @@ import org.junit.Test;
  * the method's {@link WithProxy} kind, and asserts that both report the origin's TLS setting. The direct
  * connection is the control: on failure it tells a proxy regression apart from one that was already
  * broken without a proxy. {@code @WithProxy} selects one proxy kind per method, so there are two tests
- * per case (HTTP proxy and HTTPS proxy). Origins are cleaned up by {@code tearDown} (vertx close), like
- * other {@link HttpTestBase} tests; the per-type client logic ({@link #connectNetSocket},
- * {@link #connectHttp}, {@link #connectWebSocket}) is reused across cases.
+ * per case (HTTP proxy and HTTPS proxy). Origins are cleaned up by {@code tearDown} (vertx close); the
+ * per-type client logic ({@link #connectNetSocket}, {@link #connectHttp}, {@link #connectWebSocket}) is
+ * reused across cases.
  *
  * <p>Covers the four main proxy-capable connection types (NetSocket, HTTP/1, HTTP/2, WebSocket)
  * against a plain and a TLS origin.
  */
-public class ProxyIsSslConsistencyTest extends HttpTestBase {
+public class ProxyIsSslConsistencyTest extends HttpTestBase2 {
 
   // CONNECT-safe origin port: >= 1024 and != DEFAULT_HTTP_PORT (8080), which HttpProxy denies for CONNECT.
   private static final int ORIGIN_PORT = DEFAULT_HTTPS_PORT;
@@ -59,44 +66,70 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
   @Rule
   public Proxy proxy = new Proxy();
 
+  private NetServer netOrigin;
+  private HttpServer httpOrigin;
+
+  @Override
+  protected void tearDown() throws Exception {
+    if (netOrigin != null) {
+      netOrigin.close().await();
+      netOrigin = null;
+    }
+    if (httpOrigin != null) {
+      httpOrigin.close().await();
+      httpOrigin = null;
+    }
+    super.tearDown();
+  }
+
   // --- Origins (one per test; closed by tearDown) ---------------------------
 
   private void startNetOrigin(boolean originTls) throws Exception {
-    NetServerOptions options = new NetServerOptions().setPort(ORIGIN_PORT).setHost(ORIGIN_HOST);
-    if (originTls) {
-      options.setSsl(true).setKeyCertOptions(Cert.SERVER_JKS.get());
-    }
-    vertx.createNetServer(options).connectHandler(so -> {}).listen().await();
+    TcpServerConfig config = new TcpServerConfig()
+      .setPort(ORIGIN_PORT)
+      .setHost(ORIGIN_HOST)
+      .setSsl(originTls);
+    ServerSSLOptions sslOptions = originTls
+      ? new ServerSSLOptions().setKeyCertOptions(Cert.SERVER_JKS.get())
+      : null;
+    netOrigin = vertx.createNetServer(config, sslOptions).connectHandler(so -> {});
+    netOrigin.listen().await();
   }
 
   private void startHttpOrigin(HttpVersion version, boolean originTls) throws Exception {
-    HttpServerOptions options = new HttpServerOptions().setPort(ORIGIN_PORT).setHost(ORIGIN_HOST);
-    if (originTls) {
-      options.setSsl(true).setKeyCertOptions(Cert.SERVER_JKS.get()).setUseAlpn(version == HttpVersion.HTTP_2);
-    }
-    createHttpServer(options).requestHandler(req -> req.response().end("ok")).listen().await();
+    HttpServerConfig config = new HttpServerConfig().setPort(ORIGIN_PORT).setHost(ORIGIN_HOST);
+    ServerSSLOptions sslOptions = originTls
+      ? new ServerSSLOptions()
+      .setKeyCertOptions(Cert.SERVER_JKS.get())
+      .setUseAlpn(version == HttpVersion.HTTP_2)
+      : null;
+    httpOrigin = vertx.createHttpServer(config, sslOptions).requestHandler(req -> req.response().end("ok"));
+    httpOrigin.listen().await();
   }
 
   private void startWebSocketOrigin(boolean originTls) throws Exception {
-    HttpServerOptions options = new HttpServerOptions().setPort(ORIGIN_PORT).setHost(ORIGIN_HOST);
-    if (originTls) {
-      options.setSsl(true).setKeyCertOptions(Cert.SERVER_JKS.get());
-    }
-    createHttpServer(options).webSocketHandler(ws -> ws.handler(buff -> {})).listen().await();
+    HttpServerConfig config = new HttpServerConfig().setPort(ORIGIN_PORT).setHost(ORIGIN_HOST);
+    ServerSSLOptions sslOptions = originTls
+      ? new ServerSSLOptions().setKeyCertOptions(Cert.SERVER_JKS.get())
+      : null;
+    httpOrigin = vertx.createHttpServer(config, sslOptions).webSocketHandler(ws -> ws.handler(buff -> {}));
+    httpOrigin.listen().await();
   }
 
   // --- Reusable per-type client logic: connect (direct if proxyOptions is null, else through the
   //     proxy) and return connection.isSsl() ------------------------------------------------------
 
   private boolean connectNetSocket(boolean originTls, ProxyOptions proxyOptions) throws Exception {
-    NetClientOptions options = new NetClientOptions();
-    if (originTls) {
-      options.setSsl(true).setTrustOptions(Trust.SERVER_JKS.get()).setHostnameVerificationAlgorithm("HTTPS");
-    }
+    TcpClientConfig config = new TcpClientConfig().setSsl(originTls);
     if (proxyOptions != null) {
-      options.setProxyOptions(proxyOptions);
+      config.setProxyOptions(proxyOptions);
     }
-    NetClient client = vertx.createNetClient(options);
+    ClientSSLOptions sslOptions = originTls
+      ? new ClientSSLOptions()
+      .setTrustOptions(Trust.SERVER_JKS.get())
+      .setHostnameVerificationAlgorithm("HTTPS")
+      : null;
+    NetClient client = vertx.createNetClient(config, sslOptions);
     try {
       NetSocket so = client.connect(ORIGIN_PORT, ORIGIN_HOST).await();
       return so.isSsl();
@@ -106,14 +139,22 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
   }
 
   private boolean connectHttp(HttpVersion version, boolean originTls, ProxyOptions proxyOptions) throws Exception {
-    HttpClientOptions options = new HttpClientOptions().setProtocolVersion(version);
-    if (originTls) {
-      options.setSsl(true).setTrustOptions(Trust.SERVER_JKS.get()).setUseAlpn(version == HttpVersion.HTTP_2);
+    HttpClientConfig config = new HttpClientConfig().setSsl(originTls);
+    if (version == HttpVersion.HTTP_2 && !originTls) {
+      // h2c starts as an HTTP/1.1 upgrade, so the client must support HTTP/1.1 as well
+      config.setVersions(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1);
+    } else {
+      config.setVersions(version);
     }
     if (proxyOptions != null) {
-      options.setProxyOptions(proxyOptions);
+      config.getTcpConfig().setProxyOptions(proxyOptions);
     }
-    HttpClient client = createHttpClient(options);
+    ClientSSLOptions sslOptions = originTls
+      ? new ClientSSLOptions()
+      .setTrustOptions(Trust.SERVER_JKS.get())
+      .setUseAlpn(version == HttpVersion.HTTP_2)
+      : null;
+    HttpClient client = vertx.createHttpClient(config, sslOptions);
     try {
       return client.request(new RequestOptions().setHost(ORIGIN_HOST).setPort(ORIGIN_PORT).setURI("/"))
         .compose(req -> req.send().map(resp -> resp.request().connection().isSsl()))
@@ -123,6 +164,7 @@ public class ProxyIsSslConsistencyTest extends HttpTestBase {
     }
   }
 
+  // WebSocketClient has no config counterpart yet, so this one stays on the options class.
   private boolean connectWebSocket(boolean originTls, ProxyOptions proxyOptions) throws Exception {
     WebSocketClientOptions options = new WebSocketClientOptions();
     if (originTls) {

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -3151,6 +3151,39 @@ public class NetTest {
   }
 
   /**
+   * Same as {@link #testUpgradeSSLWithSocks5Proxy()} but through an HTTPS proxy: the connection to
+   * the proxy itself (leg 1) is TLS, and {@code upgradeToSsl} then establishes a second, nested TLS
+   * to the origin (leg 2). Guards the relative ordering of the two SslHandlers in the pipeline.
+   */
+  @Test
+  public void testUpgradeSSLWithHttpsConnectProxy() throws Exception {
+    NetServerOptions options = new NetServerOptions()
+        .setPort(1234)
+        .setHost("localhost")
+        .setSsl(true)
+        .setKeyCertOptions(Cert.SERVER_JKS_ROOT_CA.get());
+    server = vertx.createNetServer(options);
+    server.connectHandler(sock -> {
+
+    });
+
+    NetClientOptions clientOptions = new NetClientOptions()
+        .setHostnameVerificationAlgorithm("HTTPS")
+        .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTPS).setHost("localhost").setPort(13128)
+          .setSslOptions(new ClientSSLOptions().setTrustOptions(Trust.SERVER_JKS.get())))
+        .setTrustOptions(Trust.SERVER_JKS_ROOT_CA.get());
+    client = vertx.createNetClient(clientOptions);
+    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
+    proxy.start(vertx);
+    server.listen().await();
+    client.connect(1234, "localhost")
+      .compose(NetSocket::upgradeToSsl)
+      .await();
+    // make sure we have gone through the proxy
+    assertEquals("localhost:1234", proxy.getLastUri());
+  }
+
+  /**
    * test http connect proxy for accessing a arbitrary server port
    * note that this may not work with a "real" proxy since there are usually access rules defined
    * that limit the target host and ports (e.g. connecting to localhost or to port 25 may not be allowed)
@@ -3164,6 +3197,27 @@ public class NetTest {
 
     });
     proxy = new HttpProxy();
+    proxy.start(vertx);
+    server.listen(1234, "localhost").await();
+    client.connect(1234, "localhost").await();
+    // make sure we have gone through the proxy
+    assertEquals("localhost:1234", proxy.getLastUri());
+  }
+
+  /**
+   * Same as {@link #testWithHttpConnectProxy()} but the connection to the proxy itself is over TLS
+   * (an {@link ProxyType#HTTPS} proxy).
+   */
+  @Test
+  public void testWithHttpsConnectProxy() throws Exception {
+    NetClientOptions clientOptions = new NetClientOptions()
+        .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTPS).setHost("localhost").setPort(13128)
+          .setSslOptions(new ClientSSLOptions().setTrustOptions(Trust.SERVER_JKS.get())));
+    NetClient client = vertx.createNetClient(clientOptions);
+    server.connectHandler(sock -> {
+
+    });
+    proxy = new HttpProxy().ssl(Cert.SERVER_JKS.get());
     proxy.start(vertx);
     server.listen(1234, "localhost").await();
     client.connect(1234, "localhost").await();

--- a/vertx-core/src/test/java/io/vertx/tests/net/ProxyOptionsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/ProxyOptionsTest.java
@@ -12,6 +12,7 @@
 package io.vertx.tests.net;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 import io.vertx.test.core.TestUtils;
@@ -75,6 +76,31 @@ public class ProxyOptionsTest {
     assertEquals(null, options.getProxyAuthorization());
     assertEquals(options, options.setProxyAuthorization(randProxyAuthorization));
     assertEquals(randProxyAuthorization, options.getProxyAuthorization());
+
+    assertEquals(null, options.getSslOptions());
+    ClientSSLOptions sslOptions = new ClientSSLOptions();
+    assertEquals(options, options.setSslOptions(sslOptions));
+    assertSame(sslOptions, options.getSslOptions());
+  }
+
+  @Test
+  public void testCopyAndJsonSslOptions() {
+    ProxyOptions options = new ProxyOptions()
+      .setType(ProxyType.HTTPS)
+      .setSslOptions(new ClientSSLOptions().setHostnameVerificationAlgorithm("HTTPS"));
+
+    // copy
+    ProxyOptions copy = new ProxyOptions(options);
+    assertEquals(ProxyType.HTTPS, copy.getType());
+    assertNotNull(copy.getSslOptions());
+    assertNotSame(options.getSslOptions(), copy.getSslOptions());
+    assertEquals("HTTPS", copy.getSslOptions().getHostnameVerificationAlgorithm());
+
+    // json round-trip
+    ProxyOptions fromJson = new ProxyOptions(options.toJson());
+    assertEquals(ProxyType.HTTPS, fromJson.getType());
+    assertNotNull(fromJson.getSslOptions());
+    assertEquals("HTTPS", fromJson.getSslOptions().getHostnameVerificationAlgorithm());
   }
 
   @Test


### PR DESCRIPTION
Motivation:

Closes: #6207

# Add HTTPS proxy support (`ProxyType.HTTPS`)

## What this adds

Support for connecting to a forward proxy **over TLS** — i.e. the connection to
the proxy itself (leg 1) is encrypted. Enabled via:

```java
new ProxyOptions()
  .setType(ProxyType.HTTPS)
  .setHost(...).setPort(...)
  .setSslOptions(new ClientSSLOptions()...);   // TLS options for the proxy connection
```

The proxying semantics are unchanged from `ProxyType.HTTP`:

- **Plain origin → forward mode** (absolute-URI `GET`, single TLS leg to the
  proxy).
- **TLS origin → `CONNECT` tunnel** (leg-1 TLS to the proxy, then a second
  nested TLS to the origin). HTTP/2 over the tunnel negotiates via ALPN
  end-to-end. Works for both `HttpClient` and `NetClient` (`upgradeToSsl`).

## Key design decisions

1. **`ConnectionBase.isSsl()` keeps meaning "the origin is TLS", not "the wire
   is TLS".** Existing code and the public contract rely on
   `ConnectionBase.isSsl()` reflecting the origin. Rather than overload it,
   transport-level TLS (TLS to an HTTPS proxy) is computed separately via the
   `transportSsl`/`proxyHttps` helpers in `TcpHttpClientTransport`. The new
   override `Http1ClientConnection.isSsl()` returns the origin flag.

2. **Transport-level "how to connect" calculations live in the transport.**
   `HttpConnectParams` carries intent (`forwardProxy` flag, origin `ssl`,
   original `proxyOptions`); `TcpHttpClientTransport` derives peer/SNI, TLS
   options, ALPN eligibility, and proxy hostname verification at the point of
   use. The forward-vs-CONNECT decision stays at endpoint-creation time because
   it selects the pooling/connect target (`EndpointKey`).

3. **Zero-copy file region is gated on the actual pipeline, not
   `ConnectionBase.isSsl()`.** Because `ConnectionBase.isSsl()` now strictly
   means "origin", `VertxConnection.supportsFileRegion()` checks for an
   `SslHandler` in the pipeline instead of calling the inherited
   `ConnectionBase.isSsl()` — zero-copy must be disabled whenever the wire is
   encrypted (e.g. leg-1 TLS to the proxy), regardless of the logical origin
   flag.

4. **Two `SslHandler`s in the CONNECT-tunnel pipeline.** `NetSocketImpl` inserts
   the origin (leg-2) handler after the proxy (leg-1) handler (`proxy-ssl` →
   `ssl`), and `applicationLayerProtocol()` reads the **innermost**
   `SslHandler`, since ALPN is negotiated on the origin handshake.

5. **Secure defaults for the proxy leg.** Hostname verification defaults to
   `"HTTPS"` for the proxy connection; ALPN is never offered on the leg-1
   (proxy) handshake — it belongs to the origin; there is **no plaintext
   fallback** for an HTTPS proxy (a TLS handshake failure against a plaintext
   proxy fails cleanly rather than downgrading). Mutual TLS to the proxy is
   supported.

6. **Proxy SSL options participate in pool identity.** `EndpointKey` includes
   `ProxyOptions.getSslOptions()` in `equals`/`hashCode` so connections with
   different proxy TLS config aren't pooled together.

## Tests

- New `HttpsProxyTest`: forward (plain origin), `CONNECT` tunnel (HTTP/1 and
  HTTP/2 origins), proxy auth, mutual TLS, and negative cases (untrusted proxy
  cert, hostname mismatch, plaintext-proxy no-downgrade).
- New `NetTest` cases for `CONNECT` over a TLS proxy (`NetClient` +
  `upgradeToSsl`).
- `ProxyOptionsTest` for the new `sslOptions` field.

## Issues encountered & how they were resolved

- **Flaky empty body on the HTTP/2-over-CONNECT test**
  (`testHttpsProxy_Http2Origin_tunnelled`): the response body was read across
  the `await()` boundary, so body chunks could arrive with no handler attached.
  Fixed by reading the body inside the same future composition
  (`resp.body().map(...)`), which also folds the negotiated version into the
  asserted value. (Commit `2b8895f51`.)
- **Port leak in `HttpsProxyTest`**: fixed (commit `93b7ef36b`).

## Note on CI failures

CI runs on this branch intermittently failed on tests that I have seen failing
also in unrelated PRs suggesting these are flaky tests.

- `HttpSendFileTest.testSendOpenRangeFileFromClasspath` (empty HTTP body), and
- `NetTest.testListenDomainSocketAddress` (empty receive, `-PNativeEpoll`).


Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
