### PR TITLE
Use endHandler in flaky NetTest.testListenDomainSocketAddress

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -2209,8 +2209,8 @@ public class NetTest {
           .onComplete(onSuccess(so -> {
             Buffer received = Buffer.buffer();
             so.handler(received::appendBuffer);
-            so.closeHandler(v -> {
-              assertEquals(received.toString(), sockAddress.path());
+            so.endHandler(v -> {
+              assertEquals(sockAddress.path(), received.toString());
               latch.countDown();
             });
           }));


### PR DESCRIPTION
This test is flaky and fails in CI builds(3/40 failed builds up to 25/6/2026). endHandler appears as a more appropriate function to ensure that all of the socket data are consumed because of two reasons:

* This pattern is used by io.vertx.core.streams.ReadStream#collect to read an entire read stream
* It might be a better option to increase our chances that all socket input is read. The documentation of endHandler mentions the following "This handler might be called after the close handler when the socket is paused and there are still buffers to deliver." While in the test we do not have a clear pause event happening but it suggests that closeEvent might be called before all buffers have been delivered in contrast to endHandler. 

Motivation:

While developing https://github.com/eclipse-vertx/vert.x/pull/6215 I encountered various failures and I have done an investigation of flaky builds. This was one of the top flaky tests and I investigated it further. This change does not guarantee that it will fix the flakyness but it is equivalent locally, the tests pass, so in my opinion this is a good change to try. 

I have also changed the order of expected  and actual in the assertion. The expected should be the input that was transfered through the socket and the actull what was read from the client. Before this change this was not true.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
