### PR TITLE
Increase timeout for NetTest.testEndHandlerCalledAfterAllEmissions

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -187,8 +187,8 @@ public class NetTest {
         });
       }
     });
-    assertWaitUntil(() -> received.get() == buffer.length());
-    assertWaitUntil(() -> ended.get() > 0);
+    assertWaitUntil(() -> received.get() == buffer.length(), 20_000);
+    assertWaitUntil(() -> ended.get() > 0, 20_000);
   }
 
   @Test


### PR DESCRIPTION
During an analysis of the last 60 CI failures upt to 28/6/2026 we have seen this test to be the cause of 9 failures(15%). This change assumes that the timeout is marginal and incresing it will reduce flaky CI failures. If this is due to a hang and not due to real execution time requirements it would hang anyway.

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
