### PR TITLE
Correctly propagate the client request authority.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -65,17 +65,27 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   HttpClientRequest drainHandler(Handler<Void> handler);
 
   /**
-   * Override the request authority, when using HTTP/1.x this overrides the request {@code host} header, when using
-   * HTTP/2 this sets the {@code authority} pseudo header. When the port is a negative value, the default
-   * scheme port will be used.
+   * Override the request authority initially set by the client.
    *
-   * <p>The default request authority is the server host and port when connecting to the server.
+   * <ul>
+   *   <li>when using HTTP/1.x this overrides the request {@code host} header</li>
+   *   <li>when using HTTP/2 this sets the {@code authority} pseudo header</li>
+   *
+   * When the port is a negative value, the default scheme port will be used.
+   *
+   * <p>According to the protocol, it can set to {@code null} (although it is not common), e.g. an HTTP/2 request
+   * can have a null authority when it carries an {@code host} header.</p>
    *
    * @param authority override the request authority
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
   HttpClientRequest authority(HostAndPort authority);
+
+  /**
+   * @return the current request authority
+   */
+  HostAndPort authority();
 
   /**
    * Set the request to follow HTTP redirects up to {@link HttpClientOptions#getMaxRedirects()}.

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -527,7 +527,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
         });
       });
     });
-    return wrap(httpMethod, requestURI, headers, traceOperation, idleTimeout, followRedirects, proxyOptions, fut2);
+    return wrap(authority, httpMethod, requestURI, headers, traceOperation, idleTimeout, followRedirects, proxyOptions, fut2);
   }
 
   private Future<HttpClientRequest> doRequest(
@@ -698,7 +698,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
       // I think this is not possible - so remove it
       return streamCtx.failedFuture("Cannot resolve address " + server);
     } else {
-      return wrap(method, requestURI, headers, traceOperation, idleTimeout, followRedirects, null, future);
+      return wrap(authority, method, requestURI, headers, traceOperation, idleTimeout, followRedirects, null, future);
     }
   }
 
@@ -738,7 +738,8 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     return resourceManager.withResourceAsync(key, provider, (group, created) -> function.apply(group));
   }
 
-  private Future<HttpClientRequest> wrap(HttpMethod method,
+  private Future<HttpClientRequest> wrap(HostAndPort authority,
+                                         HttpMethod method,
                                          String requestURI,
                                          MultiMap headers,
                                          String traceOperation,
@@ -756,7 +757,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
       options.setFollowRedirects(followRedirects);
       options.setTraceOperation(traceOperation);
       HttpClientStream stream = res.stream;
-      HttpClientRequestImpl request = createRequest(stream.connection(), stream, options);
+      HttpClientRequestImpl request = createRequest(authority, stream.connection(), stream, options);
       if (res.alternative != null) {
         String altUsedValue;
         int defaultPort = stream.connection().isSsl() ? 443 : 80;
@@ -787,8 +788,8 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     }
   }
 
-  HttpClientRequestImpl createRequest(HttpConnection connection, HttpClientStream stream, RequestOptions options) {
-    HttpClientRequestImpl request = new HttpClientRequestImpl(connection, stream);
+  HttpClientRequestImpl createRequest(HostAndPort authority, HttpConnection connection, HttpClientStream stream, RequestOptions options) {
+    HttpClientRequestImpl request = new HttpClientRequestImpl(authority, connection, stream);
     request.init(options);
     Function<HttpClientResponse, Future<RequestOptions>> rHandler = redirectHandler;
     if (rHandler != null) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientPush.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientPush.java
@@ -48,6 +48,10 @@ public class HttpClientPush implements HttpRequest {
     return stream;
   }
 
+  public HostAndPort authority() {
+    return authority;
+  }
+
   @Override
   public long id() {
     return stream.id();
@@ -82,5 +86,4 @@ public class HttpClientPush implements HttpRequest {
   public HttpMethod method() {
     return method;
   }
-
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -45,14 +45,14 @@ public abstract class HttpClientRequestBase implements HttpClientRequestInternal
   private long lastDataReceived;
   protected Throwable reset;
 
-  HttpClientRequestBase(HttpConnection connection, HttpClientStream stream, PromiseInternal<HttpClientResponse> responsePromise, HttpMethod method, String uri) {
+  HttpClientRequestBase(HostAndPort authority, HttpConnection connection, HttpClientStream stream, PromiseInternal<HttpClientResponse> responsePromise, HttpMethod method, String uri) {
     this.connection = connection;
     this.stream = stream;
     this.responsePromise = responsePromise;
     this.context = responsePromise.context();
     this.uri = uri;
     this.method = method;
-    this.authority = stream.connection().authority();
+    this.authority = authority;
     this.ssl = stream.connection().isSsl();
 
     //
@@ -70,7 +70,7 @@ public abstract class HttpClientRequestBase implements HttpClientRequestInternal
     });
   }
 
-  protected HostAndPort authority() {
+  public HostAndPort authority() {
     return authority;
   }
 
@@ -171,7 +171,12 @@ public abstract class HttpClientRequestBase implements HttpClientRequestInternal
   }
 
   void handlePush(HttpClientPush push) {
-    HttpClientRequestPushPromise pushReq = new HttpClientRequestPushPromise(connection, push.stream(), push.method(), push.uri(), push.headers());
+    HttpClientRequestPushPromise pushReq = new HttpClientRequestPushPromise(connection,
+      push.stream(),
+      push.authority(),
+      push.method(),
+      push.uri(),
+      push.headers());
     if (pushHandler != null) {
       pushHandler.handle(pushReq);
     } else {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -59,8 +59,8 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   private boolean isConnect;
   private String traceOperation;
 
-  public HttpClientRequestImpl(HttpConnection connection, HttpClientStream stream) {
-    super(connection, stream, stream.context().promise(), HttpMethod.GET, "/");
+  public HttpClientRequestImpl(HostAndPort authority, HttpConnection connection, HttpClientStream stream) {
+    super(authority, connection, stream, stream.context().promise(), HttpMethod.GET, "/");
     this.chunked = false;
     this.endPromise = context.promise();
     this.endFuture = endPromise.future();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -18,6 +18,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
+import io.vertx.core.net.HostAndPort;
 
 import java.util.function.Function;
 
@@ -32,10 +33,11 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   public HttpClientRequestPushPromise(
     HttpConnection connection,
     HttpClientStream stream,
+    HostAndPort authority,
     HttpMethod method,
     String uri,
     MultiMap headers) {
-    super(connection, stream, stream.connection().context().promise(), method, uri);
+    super(authority, connection, stream, stream.connection().context().promise(), method, uri);
     this.stream = stream;
     this.headers = headers;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/UnpooledHttpClientConnection.java
@@ -20,6 +20,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 
 import javax.net.ssl.SSLSession;
@@ -231,8 +232,16 @@ public class UnpooledHttpClientConnection implements io.vertx.core.http.HttpClie
         future = actual.createStream(context);
       }
     }
+    String host = options.getHost();
+    Integer port = options.getPort();
+    HostAndPort authority;
+    if (host != null && port != null) {
+      authority = HostAndPort.authority(host, port);
+    } else {
+      authority = actual.authority();
+    }
     return future.map(stream -> {
-      HttpClientRequestImpl request = new HttpClientRequestImpl(this, stream);
+      HttpClientRequestImpl request = new HttpClientRequestImpl(authority, this, stream);
       stream.closeHandler(this::checkPending);
       if (options != null) {
         request.init(options);

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -44,6 +44,7 @@ import io.vertx.test.http.SimpleHttpTest2;
 import io.vertx.tests.http.http3.Http3Test;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.*;
@@ -3771,6 +3772,7 @@ public abstract class HttpTest extends SimpleHttpTest2 {
       public HttpClientRequest setChunked(boolean chunked) { throw new UnsupportedOperationException(); }
       public boolean isChunked() { return false; }
       public HttpClientRequest authority(HostAndPort authority) { throw new UnsupportedOperationException(); }
+      public HostAndPort authority() { throw new UnsupportedOperationException(); }
       public HttpMethod getMethod() { return method; }
       public String absoluteURI() { return baseURI; }
       public HttpVersion version() { return HttpVersion.HTTP_1_1; }
@@ -6123,5 +6125,41 @@ public abstract class HttpTest extends SimpleHttpTest2 {
     System.out.println(delta);
     assertTrue(delta >= 500);
     assertTrue(delta <= 1000);
+  }
+
+  @Test
+  public void testNoAuthority() throws Exception {
+    Assume.assumeTrue(testAddress.isInetSocket());
+    assertEquals(testAddress.toString(), testNoAuthority(false).toString());
+  }
+
+  @Test
+  public void testForceNoAuthority() throws Exception {
+    Assume.assumeTrue(testAddress.isInetSocket() && config.version() != HttpVersion.HTTP_3);
+    assertEquals("null", testNoAuthority(true).toString());
+  }
+
+  public Buffer testNoAuthority(boolean force) throws Exception {
+    server.requestHandler(request -> {
+      request
+        .response()
+        .end("" + request.authority());
+    });
+
+    startServer(testAddress);
+
+    return client
+      .request(new RequestOptions().setServer(testAddress))
+      .compose(request -> {
+        assertEquals(testAddress.toString(), request.authority().toString());
+        if (force) {
+          request.authority(null);
+        }
+        return request
+          .send()
+          .expecting(HttpResponseExpectation.SC_OK)
+          .compose(HttpClientResponse::body);
+      })
+      .await();
   }
 }


### PR DESCRIPTION
Motivation:

The `HttpClientRequest` authority should be properly set instead of being inherited from the connection authority.

In addition we should let the client request to have no authority when desired (which can be desired to craft HTTP/2 without an authority).

Changes:

Correctly create the initial request authority from the options authority or the push authority pseudo header.

Add test for these cases.
