### PR TITLE
Flush pending writes before closing the connection on caught exceptions

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/WebSocketConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/WebSocketConnectionImpl.java
@@ -36,7 +36,7 @@ import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
  */
 public final class WebSocketConnectionImpl extends VertxConnection {
 
-  private final long closingTimeoutMS;
+  private long closingTimeoutMS;
   private ScheduledFuture<?> closingTimeout;
   private final boolean server;
   private final WebSocketMetrics webSocketMetrics;
@@ -137,6 +137,7 @@ public final class WebSocketConnectionImpl extends VertxConnection {
 
   @Override
   public boolean handleException(Throwable t) {
+    closingTimeoutMS = 0L;
     WebSocketImplBase<?> ws = webSocket;
     if (ws != null) {
       ws.context().execute(t, ws::handleException);

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxHandler.java
@@ -151,9 +151,6 @@ public final class VertxHandler<C extends VertxConnection> extends ChannelDuplex
       close = true;
     }
     if (close) {
-      // Close through the channel so it traverses the pipeline tail into VertxHandler#close ->
-      // VertxConnection#writeClose, flushing pending writes before the channel closes -- the same
-      // path used by a regular connection close.
       chctx.channel().close();
     }
   }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxHandler.java
@@ -151,7 +151,15 @@ public final class VertxHandler<C extends VertxConnection> extends ChannelDuplex
       close = true;
     }
     if (close) {
-      chctx.close();
+      if (connection != null) {
+        // Route the close through the pipeline tail so VertxHandler#close -> VertxConnection#writeClose
+        // flushes any pending writes (e.g. a response written from the user's exception handler) before
+        // closing the channel. A bare chctx.close() would let Netty's ChannelOutboundBuffer discard the
+        // unflushed entries.
+        chctx.channel().close();
+      } else {
+        chctx.close();
+      }
     }
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/VertxHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/VertxHandler.java
@@ -151,15 +151,10 @@ public final class VertxHandler<C extends VertxConnection> extends ChannelDuplex
       close = true;
     }
     if (close) {
-      if (connection != null) {
-        // Route the close through the pipeline tail so VertxHandler#close -> VertxConnection#writeClose
-        // flushes any pending writes (e.g. a response written from the user's exception handler) before
-        // closing the channel. A bare chctx.close() would let Netty's ChannelOutboundBuffer discard the
-        // unflushed entries.
-        chctx.channel().close();
-      } else {
-        chctx.close();
-      }
+      // Close through the channel so it traverses the pipeline tail into VertxHandler#close ->
+      // VertxConnection#writeClose, flushing pending writes before the channel closes -- the same
+      // path used by a regular connection close.
+      chctx.channel().close();
     }
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -2876,50 +2876,6 @@ public class Http1xTest extends HttpTest {
   }
 
   @Test
-  // Regression test: when an inbound request body fails to decompress, the application's
-  // exception handler must still be able to deliver an error response to the client. Before
-  // the VertxHandler#exceptionCaught flush-before-close fix, the response written from the
-  // exception handler was discarded and the client only saw a connection reset.
-  public void testRequestDecompressionInvalidBodyDeliversErrorResponse() throws Exception {
-    server = vertx.createHttpServer(new HttpServerOptions().setDecompressionSupported(true));
-    // A valid gzip header (the first 10 bytes) followed by a corrupted deflate payload, so that
-    // Netty's HttpContentDecompressor accepts the stream as gzip and then fails while decoding it.
-    byte[] corrupted = TestUtils.compressGzip(TestUtils.randomAlphaString(256));
-    for (int i = 10; i < corrupted.length; i++) {
-      corrupted[i] = (byte) ~corrupted[i];
-    }
-    server.requestHandler(req -> {
-      req.exceptionHandler(err -> {
-        if (!req.response().ended()) {
-          req.response().setStatusCode(400).end("decode-failed");
-        }
-      });
-      // Should not be reached for a malformed body.
-      req.bodyHandler(body -> req.response().end());
-    });
-    startServer(testAddress);
-    NetClient netClient = vertx.createNetClient();
-    CompletableFuture<String> result = new CompletableFuture<>();
-    netClient.connect(testAddress).onComplete(TestUtils.onSuccess(so -> {
-      Buffer respBuff = Buffer.buffer();
-      so.handler(respBuff::appendBuffer);
-      so.closeHandler(v -> result.complete(respBuff.toString()));
-      so.exceptionHandler(result::completeExceptionally);
-      Buffer request = Buffer.buffer()
-        .appendString("PUT /somepath HTTP/1.1\r\n")
-        .appendString("Host: localhost\r\n")
-        .appendString("Content-Encoding: gzip\r\n")
-        .appendString("Content-Length: " + corrupted.length + "\r\n")
-        .appendString("\r\n")
-        .appendBytes(corrupted);
-      so.write(request);
-    }));
-    String resp = result.get(20, TimeUnit.SECONDS);
-    assertTrue("Expected the response to start with \"HTTP/1.1 400\" but got: [" + resp + "]", resp.startsWith("HTTP/1.1 400"));
-    assertTrue("Expected the error body in the response but got: [" + resp + "]", resp.contains("decode-failed"));
-  }
-
-  @Test
   public void testResetClientRequestNotYetSent(Checkpoint checkpoint) throws Exception {
     testResetClientRequestNotYetSent(checkpoint, false, false);
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -2876,6 +2876,50 @@ public class Http1xTest extends HttpTest {
   }
 
   @Test
+  // Regression test: when an inbound request body fails to decompress, the application's
+  // exception handler must still be able to deliver an error response to the client. Before
+  // the VertxHandler#exceptionCaught flush-before-close fix, the response written from the
+  // exception handler was discarded and the client only saw a connection reset.
+  public void testRequestDecompressionInvalidBodyDeliversErrorResponse() throws Exception {
+    server = vertx.createHttpServer(new HttpServerOptions().setDecompressionSupported(true));
+    // A valid gzip header (the first 10 bytes) followed by a corrupted deflate payload, so that
+    // Netty's HttpContentDecompressor accepts the stream as gzip and then fails while decoding it.
+    byte[] corrupted = TestUtils.compressGzip(TestUtils.randomAlphaString(256));
+    for (int i = 10; i < corrupted.length; i++) {
+      corrupted[i] = (byte) ~corrupted[i];
+    }
+    server.requestHandler(req -> {
+      req.exceptionHandler(err -> {
+        if (!req.response().ended()) {
+          req.response().setStatusCode(400).end("decode-failed");
+        }
+      });
+      // Should not be reached for a malformed body.
+      req.bodyHandler(body -> req.response().end());
+    });
+    startServer(testAddress);
+    NetClient netClient = vertx.createNetClient();
+    CompletableFuture<String> result = new CompletableFuture<>();
+    netClient.connect(testAddress).onComplete(TestUtils.onSuccess(so -> {
+      Buffer respBuff = Buffer.buffer();
+      so.handler(respBuff::appendBuffer);
+      so.closeHandler(v -> result.complete(respBuff.toString()));
+      so.exceptionHandler(result::completeExceptionally);
+      Buffer request = Buffer.buffer()
+        .appendString("PUT /somepath HTTP/1.1\r\n")
+        .appendString("Host: localhost\r\n")
+        .appendString("Content-Encoding: gzip\r\n")
+        .appendString("Content-Length: " + corrupted.length + "\r\n")
+        .appendString("\r\n")
+        .appendBytes(corrupted);
+      so.write(request);
+    }));
+    String resp = result.get(20, TimeUnit.SECONDS);
+    assertTrue("Expected the response to start with \"HTTP/1.1 400\" but got: [" + resp + "]", resp.startsWith("HTTP/1.1 400"));
+    assertTrue("Expected the error body in the response but got: [" + resp + "]", resp.contains("decode-failed"));
+  }
+
+  @Test
   public void testResetClientRequestNotYetSent(Checkpoint checkpoint) throws Exception {
     testResetClientRequestNotYetSent(checkpoint, false, false);
   }

--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -40,6 +40,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
 import io.vertx.core.net.impl.HAProxyMessageCompletionHandler;
+import io.vertx.core.net.impl.VertxConnection;
 import io.vertx.core.net.impl.VertxHandler;
 import io.vertx.core.net.impl.tcp.CleanableNetClient;
 import io.vertx.core.internal.net.NetServerInternal;
@@ -4640,5 +4641,31 @@ public class NetTest {
     socket.write("test").await();
     TestUtils.assertWaitUntil(closing::get);
     TestUtils.assertWaitUntil(closed::get);
+  }
+
+  @Test
+  public void testFlushPendingWriteOnExceptionClose() throws Exception {
+    server.connectHandler(so -> {
+      so.exceptionHandler(err -> {});
+      so.handler(data -> {
+        VertxConnection conn = (VertxConnection) so;
+        // A response queued on the connection but not yet flushed (the state produced when a
+        // response is written while a read is in progress), then a pipeline failure that tears
+        // the connection down.
+        conn.unsafeWrite(Unpooled.copiedBuffer("pending-response", StandardCharsets.UTF_8), false);
+        conn.channelHandlerContext().pipeline().fireExceptionCaught(new RuntimeException("boom"));
+      });
+    });
+    startServer();
+    Buffer received = Buffer.buffer();
+    CompletableFuture<String> result = new CompletableFuture<>();
+    NetSocket socket = client.connect(testAddress).await();
+    socket.handler(received::appendBuffer);
+    socket.closeHandler(v -> result.complete(received.toString()));
+    socket.exceptionHandler(result::completeExceptionally);
+    socket.write("ping").await();
+    // With the fix the pending response is flushed before the connection closes; without it the
+    // client only sees the close (Netty discards the unflushed entry).
+    assertEquals("pending-response", result.get(20, TimeUnit.SECONDS));
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
@@ -922,4 +922,27 @@ public class VertxConnectionTest extends VertxTestBase {
     outbound = ch.readOutbound();
     assertSame(expected, outbound);
   }
+
+  @Test
+  public void testFlushPendingWriteOnExceptionClose() {
+    EmbeddedChannel ch = new EmbeddedChannel();
+    ChannelPipeline pipeline = ch.pipeline();
+    pipeline.addLast(VertxHandler.create(chctx -> new TestConnection(chctx)));
+    TestConnection connection = (TestConnection) pipeline.get(VertxHandler.class).getConnection();
+    connection.exceptionHandler(err -> {});
+    // Queue a write without flushing it: this is the state produced when a response is written
+    // while a read is in progress (e.g. an inbound codec failing mid-decode, which is how a
+    // request-body decompression failure surfaces). The message sits in the channel outbound
+    // buffer as an unflushed entry.
+    Object response = new Object();
+    connection.unsafeWrite(response, false);
+    assertNull(ch.readOutbound());
+    // The failure surfaces as a caught exception that asks the connection to close. The close
+    // must flush the pending write before closing the channel, otherwise Netty's
+    // ChannelOutboundBuffer discards the unflushed entry and the peer never sees the response.
+    pipeline.fireExceptionCaught(new RuntimeException());
+    ch.runPendingTasks();
+    assertSame(response, ch.readOutbound());
+    assertFalse(ch.isOpen());
+  }
 }


### PR DESCRIPTION
- **Flush pending writes before closing the connection on caught exceptions**
- **Add a VertxConnectionTest reproducing the flush before close on exception**
- **Move the flush-before-close-on-exception regression test to NetTest**
- **Always close through the channel in VertxHandler.exceptionCaught**
- **Remove comment**
- **Skip the WebSocket closing handshake timeout on exception**
