### PR TITLE
Modify TestUtils#randomMultiMap to sanitize connection headers

### DIFF
--- a/src/test/java/io/vertx/test/core/TestUtils.java
+++ b/src/test/java/io/vertx/test/core/TestUtils.java
@@ -300,6 +300,13 @@ public class TestUtils {
       } while (multiMap.contains(key));
       multiMap.set(key, TestUtils.randomAlphaString(1 + (int) ((19) * Math.random())));
     }
+    // Sanitize connection headers
+    multiMap.remove("te");
+    multiMap.remove("upgrade");
+    multiMap.remove("connection");
+    multiMap.remove("keep-alive");
+    multiMap.remove("proxy-connection");
+    multiMap.remove("transfer-encoding");
     return multiMap;
   }
 


### PR DESCRIPTION
Motivation:

TestUtils#randomMultiMap sometimes generate invalid multimap containing connection headers which can fail the test, this has been observed regularly for the header "te" that can be sometimes generated.

Changes:

Filter the random multimap to remove connection headers.
