### PR TITLE
Introduce HTTP ClientRedirectConfig.

### DIFF
--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -1613,8 +1613,7 @@ The client can be configured to follow HTTP redirections provided by the `Locati
 * a `303` status code, in addition the directed request perform an HTTP GET method
 
 When redirecting a `QUERY` request, the request body is buffered in memory and resent to the redirected location.
-By default, the maximum size of this buffer is limited to `4KB` (configured via {@link io.vertx.core.http.HttpClientConfig#setMaxRedirectBufferSize(int)}).
-If the body size exceeds this limit, the redirection is not followed.
+By default, the maximum size of this buffer is limited to `4KB` (configured via {@link io.vertx.core.http.ClientRedirectConfig#setMaxBufferedSize(int)}). If the body size exceeds this limit, the redirection is not followed.
 
 Here's an example:
 
@@ -1623,7 +1622,7 @@ Here's an example:
 {@link examples.HttpExamples#clientRequestFollowRedirects}
 ----
 
-The maximum redirects is `16` by default and can be changed with {@link io.vertx.core.http.HttpClientConfig#setMaxRedirects(int)}.
+The maximum redirects is `16` by default and can be changed with {@link io.vertx.core.http.ClientRedirectConfig#setMaxRedirects(int)}.
 
 [source,$lang]
 ----

--- a/vertx-core/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -127,9 +127,9 @@ public class HttpClientOptionsConverter {
             obj.setMaxRedirects(((Number)member.getValue()).intValue());
           }
           break;
-        case "maxRedirectBufferSize":
+        case "maxRedirectBufferedSize":
           if (member.getValue() instanceof Number) {
-            obj.setMaxRedirectBufferSize(((Number)member.getValue()).intValue());
+            obj.setMaxRedirectBufferedSize(((Number)member.getValue()).intValue());
           }
           break;
         case "forceSni":
@@ -198,7 +198,7 @@ public class HttpClientOptionsConverter {
     json.put("http2ClearTextUpgrade", obj.isHttp2ClearTextUpgrade());
     json.put("http2ClearTextUpgradeWithPreflightRequest", obj.isHttp2ClearTextUpgradeWithPreflightRequest());
     json.put("maxRedirects", obj.getMaxRedirects());
-    json.put("maxRedirectBufferSize", obj.getMaxRedirectBufferSize());
+    json.put("maxRedirectBufferedSize", obj.getMaxRedirectBufferedSize());
     json.put("forceSni", obj.isForceSni());
     json.put("decoderInitialBufferSize", obj.getDecoderInitialBufferSize());
     if (obj.getTracingPolicy() != null) {

--- a/vertx-core/src/main/java/examples/HttpExamples.java
+++ b/vertx-core/src/main/java/examples/HttpExamples.java
@@ -1163,7 +1163,10 @@ public class HttpExamples {
 
     HttpClientAgent client = vertx.createHttpClient(
       new HttpClientConfig()
-        .setMaxRedirects(32));
+        .setRedirectConfig(new ClientRedirectConfig()
+          .setMaxRedirects(32)
+          .setMaxBufferedSize(8 * 1024))
+    );
 
     client
       .request(HttpMethod.GET, "some-uri")

--- a/vertx-core/src/main/java/io/vertx/core/http/ClientRedirectConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/ClientRedirectConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.Unstable;
+import io.vertx.core.impl.Arguments;
+
+/**
+ * HTTP client HTTP redirect config.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@DataObject
+@Unstable
+public class ClientRedirectConfig {
+
+  private int maxRedirects;
+  private int maxBufferedSize;
+
+  public ClientRedirectConfig() {
+    this.maxRedirects = HttpClientOptions.DEFAULT_MAX_REDIRECTS;
+    this.maxBufferedSize = HttpClientOptions.DEFAULT_MAX_REDIRECT_BUFFERED_SIZE;
+  }
+
+  public ClientRedirectConfig(ClientRedirectConfig other) {
+    this.maxRedirects = other.maxRedirects;
+    this.maxBufferedSize = other.maxBufferedSize;
+  }
+
+  /**
+   * @return the maximum number of redirection a request can follow
+   */
+  public int getMaxRedirects() {
+    return maxRedirects;
+  }
+
+  /**
+   * Set to {@code maxRedirects} the maximum number of redirection a request can follow.
+   *
+   * @param maxRedirects the maximum number of redirection
+   * @return a reference to this, so the API can be used fluently
+   */
+  public ClientRedirectConfig setMaxRedirects(int maxRedirects) {
+    this.maxRedirects = maxRedirects;
+    return this;
+  }
+
+  /**
+   * @return the maximum size in bytes of the redirect buffer when redirecting QUERY requests
+   */
+  public int getMaxBufferedSize() {
+    return maxBufferedSize;
+  }
+
+  /**
+   * Set the maximum size of the redirect buffer in bytes when redirecting QUERY requests.
+   *
+   * @param maxBufferedSize the maximum buffer size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public ClientRedirectConfig setMaxBufferedSize(int maxBufferedSize) {
+    Arguments.require(maxBufferedSize >= 0, "Max redirect buffer size must be >= 0");
+    this.maxBufferedSize = maxBufferedSize;
+    return this;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
@@ -10,7 +10,6 @@
  */
 package io.vertx.core.http;
 
-import io.vertx.core.impl.Arguments;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Unstable;
@@ -79,8 +78,7 @@ public class HttpClientConfig {
   private boolean decompressionEnabled;
   private String defaultHost;
   private int defaultPort;
-  private int maxRedirects;
-  private int maxRedirectBufferSize;
+  private ClientRedirectConfig redirectConfig;
   private ObservabilityConfig observabilityConfig;
   private boolean shared;
   private String name;
@@ -98,8 +96,7 @@ public class HttpClientConfig {
     this.decompressionEnabled = HttpClientOptions.DEFAULT_DECOMPRESSION_SUPPORTED;
     this.defaultHost = HttpClientOptions.DEFAULT_DEFAULT_HOST;
     this.defaultPort = HttpClientOptions.DEFAULT_DEFAULT_PORT;
-    this.maxRedirects = HttpClientOptions.DEFAULT_MAX_REDIRECTS;
-    this.maxRedirectBufferSize = HttpClientOptions.DEFAULT_MAX_REDIRECT_BUFFER_SIZE;
+    this.redirectConfig = null;
     this.observabilityConfig = null;
     this.shared = HttpClientOptions.DEFAULT_SHARED;
     this.name = HttpClientOptions.DEFAULT_NAME;
@@ -118,8 +115,7 @@ public class HttpClientConfig {
     this.decompressionEnabled = other.decompressionEnabled;
     this.defaultHost = other.defaultHost;
     this.defaultPort = other.defaultPort;
-    this.maxRedirects = other.maxRedirects;
-    this.maxRedirectBufferSize = other.maxRedirectBufferSize;
+    this.redirectConfig = other.redirectConfig != null ? new ClientRedirectConfig(other.redirectConfig) : null;
     this.observabilityConfig = other.observabilityConfig != null ? new ObservabilityConfig(other.observabilityConfig) : null;
     this.shared = other.shared;
     this.name = other.name;
@@ -135,6 +131,10 @@ public class HttpClientConfig {
         .setTracingPolicy(options.getTracingPolicy());
     }
 
+    ClientRedirectConfig redirectConfig = new ClientRedirectConfig();
+    redirectConfig.setMaxRedirects(options.getMaxRedirects());
+    redirectConfig.setMaxBufferedSize(options.getMaxRedirectBufferedSize());
+
     this.tcpConfig = new TcpClientConfig(options);
     this.quicConfig = defaultQuicConfig();
     this.ssl = options.isSsl();
@@ -146,8 +146,7 @@ public class HttpClientConfig {
     this.decompressionEnabled = options.isDecompressionSupported();
     this.defaultHost = options.getDefaultHost();
     this.defaultPort = options.getDefaultPort();
-    this.maxRedirects = options.getMaxRedirects();
-    this.maxRedirectBufferSize = options.getMaxRedirectBufferSize();
+    this.redirectConfig = redirectConfig;
     this.observabilityConfig = observabilityConfig;
     this.shared = options.isShared();
     this.name = options.getName();
@@ -442,7 +441,8 @@ public class HttpClientConfig {
    * @return the maximum number of redirection a request can follow
    */
   public int getMaxRedirects() {
-    return maxRedirects;
+    ClientRedirectConfig cfg = redirectConfig;
+    return cfg == null ? HttpClientOptions.DEFAULT_MAX_REDIRECTS : cfg.getMaxRedirects();
   }
 
   /**
@@ -452,26 +452,31 @@ public class HttpClientConfig {
    * @return a reference to this, so the API can be used fluently
    */
   public HttpClientConfig setMaxRedirects(int maxRedirects) {
-    this.maxRedirects = maxRedirects;
+    if (redirectConfig == null) {
+      if (maxRedirects == HttpClientOptions.DEFAULT_MAX_REDIRECTS) {
+        return this;
+      }
+      redirectConfig = new ClientRedirectConfig();
+    }
+    redirectConfig.setMaxRedirects(maxRedirects);
     return this;
   }
 
   /**
-   * @return the maximum size in bytes of the redirect buffer when redirecting QUERY requests
+   * @return the client redirect config, it can be {@code null} in which case the default settings are used.
    */
-  public int getMaxRedirectBufferSize() {
-    return maxRedirectBufferSize;
+  public ClientRedirectConfig getRedirectConfig() {
+    return redirectConfig;
   }
 
   /**
-   * Set the maximum size of the redirect buffer in bytes when redirecting QUERY requests.
+   * Set the client redirect config, set to {@code null} to use the default config.
    *
-   * @param maxRedirectBufferSize the maximum buffer size
+   * @param redirectConfig the redirect config
    * @return a reference to this, so the API can be used fluently
    */
-  public HttpClientConfig setMaxRedirectBufferSize(int maxRedirectBufferSize) {
-    Arguments.require(maxRedirectBufferSize >= 0, "Max redirect buffer size must be >= 0");
-    this.maxRedirectBufferSize = maxRedirectBufferSize;
+  public HttpClientConfig setRedirectConfig(ClientRedirectConfig redirectConfig) {
+    this.redirectConfig = redirectConfig;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -137,7 +137,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   /**
    * Default max redirect buffer size = 4 * 1024 bytes (4KB)
    */
-  public static final int DEFAULT_MAX_REDIRECT_BUFFER_SIZE = 4 * 1024;
+  public static final int DEFAULT_MAX_REDIRECT_BUFFERED_SIZE = 4 * 1024;
 
   /*
    * Default force SNI = {@code false}
@@ -177,7 +177,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   private int defaultPort;
   private HttpVersion protocolVersion;
   private int maxRedirects;
-  private int maxRedirectBufferSize;
+  private int maxRedirectBufferedSize;
   private boolean forceSni;
 
   private TracingPolicy tracingPolicy;
@@ -218,7 +218,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.defaultPort = other.defaultPort;
     this.protocolVersion = other.protocolVersion;
     this.maxRedirects = other.maxRedirects;
-    this.maxRedirectBufferSize = other.maxRedirectBufferSize;
+    this.maxRedirectBufferedSize = other.maxRedirectBufferedSize;
     this.forceSni = other.forceSni;
     this.tracingPolicy = other.tracingPolicy;
     this.shared = other.shared;
@@ -256,7 +256,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     defaultPort = DEFAULT_DEFAULT_PORT;
     protocolVersion = DEFAULT_PROTOCOL_VERSION;
     maxRedirects = DEFAULT_MAX_REDIRECTS;
-    maxRedirectBufferSize = DEFAULT_MAX_REDIRECT_BUFFER_SIZE;
+    maxRedirectBufferedSize = DEFAULT_MAX_REDIRECT_BUFFERED_SIZE;
     forceSni = DEFAULT_FORCE_SNI;
     tracingPolicy = DEFAULT_TRACING_POLICY;
     shared = DEFAULT_SHARED;
@@ -908,19 +908,19 @@ public class HttpClientOptions extends ClientOptionsBase {
   /**
    * @return the maximum size in bytes of the redirect buffer when redirecting QUERY requests
    */
-  public int getMaxRedirectBufferSize() {
-    return maxRedirectBufferSize;
+  public int getMaxRedirectBufferedSize() {
+    return maxRedirectBufferedSize;
   }
 
   /**
    * Set the maximum size of the redirect buffer in bytes when redirecting QUERY requests.
    *
-   * @param maxRedirectBufferSize the maximum buffer size
+   * @param maxRedirectBufferedSize the maximum buffer size
    * @return a reference to this, so the API can be used fluently
    */
-  public HttpClientOptions setMaxRedirectBufferSize(int maxRedirectBufferSize) {
-    Arguments.require(maxRedirectBufferSize >= 0, "Max redirect buffer size must be >= 0");
-    this.maxRedirectBufferSize = maxRedirectBufferSize;
+  public HttpClientOptions setMaxRedirectBufferedSize(int maxRedirectBufferedSize) {
+    Arguments.require(maxRedirectBufferedSize >= 0, "Max redirect buffer size must be >= 0");
+    this.maxRedirectBufferedSize = maxRedirectBufferedSize;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -167,6 +167,13 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
     HttpClientOptions options = HttpClientBuilderInternal.this.clientOptions;
     Handler<HttpConnection> connectHandler = connectionHandler(config);
     List<HttpVersion> versions = config.getVersions();
+    int maxRedirects = HttpClientOptions.DEFAULT_MAX_REDIRECTS;
+    int maxRedirectBufferedSize = HttpClientOptions.DEFAULT_MAX_REDIRECT_BUFFERED_SIZE;
+    ClientRedirectConfig redirectConfig = config.getRedirectConfig();
+    if (redirectConfig != null) {
+      maxRedirects = redirectConfig.getMaxRedirects();
+      maxRedirectBufferedSize = redirectConfig.getMaxBufferedSize();
+    }
     return new LegacyHttpClient(
       vertx,
       resolver,
@@ -182,8 +189,8 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       config.isSsl(),
       config.getDefaultHost(),
       config.getDefaultPort(),
-      config.getMaxRedirects(),
-      config.getMaxRedirectBufferSize(),
+      maxRedirects,
+      maxRedirectBufferedSize,
       versions,
       sslOptions,
       connectHandler,

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -69,7 +69,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   private final String defaultHost;
   private final int defaultPort;
   private final int maxRedirects;
-  private final int maxRedirectBufferSize;
+  private final int maxRedirectBufferedSize;
   private final List<HttpVersion> versions;
   private final Handler<HttpConnection> connectHandler;
   private volatile Handler<Throwable> exceptionHandler;
@@ -90,7 +90,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
                  String defaultHost,
                  int defaultPort,
                  int maxRedirects,
-                 int maxRedirectBufferSize,
+                 int maxRedirectBufferedSize,
                  List<HttpVersion> versions,
                  ClientSSLOptions sslOptions,
                  Handler<HttpConnection> connectHandler,
@@ -119,7 +119,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     this.defaultHost = defaultHost;
     this.defaultPort = defaultPort;
     this.maxRedirects = maxRedirects;
-    this.maxRedirectBufferSize = maxRedirectBufferSize;
+    this.maxRedirectBufferedSize = maxRedirectBufferedSize;
     this.versions = versions;
     this.sslOptions = sslOptions;
     this.connectHandler = connectHandler;
@@ -794,7 +794,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   HttpClientRequestImpl createRequest(HostAndPort authority, HttpConnection connection, HttpClientStream stream, RequestOptions options) {
     HttpClientRequestImpl request = new HttpClientRequestImpl(authority, connection, stream);
     request.init(options);
-    request.maxRedirectBufferSize(maxRedirectBufferSize);
+    request.maxRedirectBufferSize(maxRedirectBufferedSize);
     Function<HttpClientResponse, Future<RequestOptions>> rHandler = redirectHandler;
     if (rHandler != null) {
       request.setMaxRedirects(maxRedirects);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -61,7 +61,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   private StreamPriority priority;
   private boolean isConnect;
   private String traceOperation;
-  private int maxRedirectBufferSize = HttpClientOptions.DEFAULT_MAX_REDIRECT_BUFFER_SIZE;
+  private int maxRedirectBufferSize = HttpClientOptions.DEFAULT_MAX_REDIRECT_BUFFERED_SIZE;
   private List<Buffer> bodyBuffer;
 
   public HttpClientRequestImpl(HostAndPort authority, HttpConnection connection, HttpClientStream stream) {

--- a/vertx-core/src/test/java/io/vertx/test/http/HttpConfigurator.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/HttpConfigurator.java
@@ -112,7 +112,7 @@ public interface HttpConfigurator {
         }
         @Override
         public HttpClientConfigurator setMaxRedirectBufferSize(int maxRedirectBufferSize) {
-          options.setMaxRedirectBufferSize(maxRedirectBufferSize);
+          options.setMaxRedirectBufferedSize(maxRedirectBufferSize);
           return this;
         }
         @Override

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3Configurator.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3Configurator.java
@@ -222,7 +222,12 @@ public class Http3Configurator implements HttpConfigurator {
       }
       @Override
       public HttpClientConfigurator setMaxRedirectBufferSize(int maxRedirectBufferSize) {
-        config.setMaxRedirectBufferSize(maxRedirectBufferSize);
+        ClientRedirectConfig redirectConfig = config.getRedirectConfig();
+        if (redirectConfig == null) {
+          redirectConfig = new ClientRedirectConfig();
+          config.setRedirectConfig(redirectConfig);
+        }
+        redirectConfig.setMaxBufferedSize(maxRedirectBufferSize);
         return this;
       }
       @Override


### PR DESCRIPTION
Motivation:

The HTTP client has properties for HTTP client redirection configuration.

We should introduce a config object for this matter as we might have more configuration knobs in the future.

Changes:

Introduce `ClientRedirectConfig` holding both the max number of redirections and the max number of buffered bytes for HTTP QUERY.
