### PR TITLE
feat: add per-connection attachment storage to HttpConnectionInternal

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -15,8 +15,8 @@ import io.netty.channel.ChannelHandlerContext;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpConnection;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.http.HttpConnectionInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.HostAndPort;
@@ -24,7 +24,7 @@ import io.vertx.core.net.HostAndPort;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public interface HttpClientConnection extends HttpConnection {
+public interface HttpClientConnection extends HttpConnectionInternal {
 
   Logger log = LoggerFactory.getLogger(HttpClientConnection.class);
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerConnection.java
@@ -13,13 +13,13 @@ package io.vertx.core.http.impl;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.Headers;
 import io.vertx.core.Handler;
-import io.vertx.core.http.HttpConnection;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.http.HttpConnectionInternal;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public interface HttpServerConnection extends HttpConnection {
+public interface HttpServerConnection extends HttpConnectionInternal {
 
   HttpServerConnection streamHandler(Handler<HttpServerStream> handler);
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1Connection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1Connection.java
@@ -26,6 +26,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.http.HttpConnectionInternal;
 import io.vertx.core.net.impl.VertxConnection;
 
 import java.time.Duration;
@@ -33,7 +34,7 @@ import java.time.Duration;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-abstract class Http1Connection extends VertxConnection implements io.vertx.core.http.HttpConnection {
+abstract class Http1Connection extends VertxConnection implements HttpConnectionInternal {
 
   protected boolean closeInitiated;
   protected Duration shutdownInitiated;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1Connection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1Connection.java
@@ -26,21 +26,23 @@ import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.http.HttpConnectionInternal;
 import io.vertx.core.net.impl.VertxConnection;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-abstract class Http1Connection extends VertxConnection implements HttpConnectionInternal {
+abstract class Http1Connection extends VertxConnection implements HttpConnection {
 
   protected boolean closeInitiated;
   protected Duration shutdownInitiated;
   protected ChannelPromise closePromise;
 
   private Handler<Void> shutdownHandler;
+  private Map<Object, Object> attachments;
 
   Http1Connection(ContextInternal context, ChannelHandlerContext chctx) {
     this(context, chctx, false);
@@ -141,6 +143,26 @@ abstract class Http1Connection extends VertxConnection implements HttpConnection
   @Override
   public Future<Buffer> ping(Buffer data) {
     throw new UnsupportedOperationException("HTTP/1.x connections don't support PING");
+  }
+
+  @Override
+  protected void handleClosed() {
+    synchronized (this) {
+      attachments = null;
+    }
+    super.handleClosed();
+  }
+
+  @SuppressWarnings("unchecked")
+  public synchronized <T> T attachment(Object key) {
+    return attachments != null ? (T) attachments.get(key) : null;
+  }
+
+  public synchronized void attach(Object key, Object value) {
+    if (attachments == null) {
+      attachments = new HashMap<>();
+    }
+    attachments.put(key, value);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
@@ -36,7 +36,6 @@ import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.impl.buffer.VertxByteBufAllocator;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
-import io.vertx.core.internal.http.HttpConnectionInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.impl.ConnectionBase;
@@ -44,13 +43,14 @@ import io.vertx.core.net.impl.ConnectionBase;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameListener, HttpConnectionInternal, Http2Connection {
+abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameListener, HttpConnection, Http2Connection {
 
   private static final Logger log = LoggerFactory.getLogger(Http2ConnectionImpl.class);
 
@@ -75,6 +75,7 @@ abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameL
   private GoAway goAwayStatus;
   private int windowSize;
   private long maxConcurrentStreams;
+  private Map<Object, Object> attachments;
 
   public Http2ConnectionImpl(ContextInternal context, VertxHttp2ConnectionHandler handler) {
     super(context, handler.context());
@@ -88,7 +89,22 @@ abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameL
 
   @Override
   public void handleClosed() {
+    synchronized (this) {
+      attachments = null;
+    }
     super.handleClosed();
+  }
+
+  @SuppressWarnings("unchecked")
+  public synchronized <T> T attachment(Object key) {
+    return attachments != null ? (T) attachments.get(key) : null;
+  }
+
+  public synchronized void attach(Object key, Object value) {
+    if (attachments == null) {
+      attachments = new HashMap<>();
+    }
+    attachments.put(key, value);
   }
 
   protected void handleIdle(IdleStateEvent event) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
@@ -36,6 +36,7 @@ import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.impl.buffer.VertxByteBufAllocator;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
+import io.vertx.core.internal.http.HttpConnectionInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.impl.ConnectionBase;
@@ -49,7 +50,7 @@ import java.util.Objects;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameListener, HttpConnection, Http2Connection {
+abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameListener, HttpConnectionInternal, Http2Connection {
 
   private static final Logger log = LoggerFactory.getLogger(Http2ConnectionImpl.class);
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
@@ -43,7 +43,7 @@ import io.vertx.core.net.impl.ConnectionBase;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -75,7 +75,7 @@ abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameL
   private GoAway goAwayStatus;
   private int windowSize;
   private long maxConcurrentStreams;
-  private Map<Object, Object> attachments;
+  private final Map<Object, Object> attachments = new ConcurrentHashMap<>();
 
   public Http2ConnectionImpl(ContextInternal context, VertxHttp2ConnectionHandler handler) {
     super(context, handler.context());
@@ -89,21 +89,16 @@ abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameL
 
   @Override
   public void handleClosed() {
-    synchronized (this) {
-      attachments = null;
-    }
+    attachments.clear();
     super.handleClosed();
   }
 
   @SuppressWarnings("unchecked")
-  public synchronized <T> T attachment(Object key) {
-    return attachments != null ? (T) attachments.get(key) : null;
+  public <T> T attachment(Object key) {
+    return (T) attachments.get(key);
   }
 
-  public synchronized void attach(Object key, Object value) {
-    if (attachments == null) {
-      attachments = new HashMap<>();
-    }
+  public void attach(Object key, Object value) {
     attachments.put(key, value);
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
@@ -47,6 +47,7 @@ import io.vertx.core.impl.buffer.VertxByteBufAllocator;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.buffer.BufferInternal;
+import io.vertx.core.internal.http.HttpConnectionInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.spi.metrics.NetworkMetrics;
@@ -57,7 +58,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Objects;
 
-public abstract class Http2MultiplexConnection<S extends Http2Stream> extends ConnectionBase implements HttpConnection {
+public abstract class Http2MultiplexConnection<S extends Http2Stream> extends ConnectionBase implements HttpConnectionInternal {
 
   protected final Http2MultiplexHandler handler;
   protected final TransportMetrics<?> transportMetrics;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
@@ -47,7 +47,6 @@ import io.vertx.core.impl.buffer.VertxByteBufAllocator;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.buffer.BufferInternal;
-import io.vertx.core.internal.http.HttpConnectionInternal;
 import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.spi.metrics.NetworkMetrics;
@@ -56,9 +55,11 @@ import io.vertx.core.spi.metrics.TransportMetrics;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
-public abstract class Http2MultiplexConnection<S extends Http2Stream> extends ConnectionBase implements HttpConnectionInternal {
+public abstract class Http2MultiplexConnection<S extends Http2Stream> extends ConnectionBase implements HttpConnection {
 
   protected final Http2MultiplexHandler handler;
   protected final TransportMetrics<?> transportMetrics;
@@ -70,6 +71,7 @@ public abstract class Http2MultiplexConnection<S extends Http2Stream> extends Co
   private Handler<Void> shutdownHandler;
   private Handler<GoAway> goAwayHandler;
   private Handler<Buffer> pingHandler;
+  private Map<Object, Object> attachments;
 
   public Http2MultiplexConnection(Http2MultiplexHandler handler, TransportMetrics<?> transportMetrics, ChannelHandlerContext chctx, ContextInternal context) {
     super(context, chctx);
@@ -417,6 +419,26 @@ public abstract class Http2MultiplexConnection<S extends Http2Stream> extends Co
 
   void onClose() {
     handleClosed();
+  }
+
+  @Override
+  protected void handleClosed() {
+    synchronized (this) {
+      attachments = null;
+    }
+    super.handleClosed();
+  }
+
+  @SuppressWarnings("unchecked")
+  public synchronized <T> T attachment(Object key) {
+    return attachments != null ? (T) attachments.get(key) : null;
+  }
+
+  public synchronized void attach(Object key, Object value) {
+    if (attachments == null) {
+      attachments = new HashMap<>();
+    }
+    attachments.put(key, value);
   }
 
   void onException(Throwable err) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
@@ -55,7 +55,7 @@ import io.vertx.core.spi.metrics.TransportMetrics;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -71,7 +71,7 @@ public abstract class Http2MultiplexConnection<S extends Http2Stream> extends Co
   private Handler<Void> shutdownHandler;
   private Handler<GoAway> goAwayHandler;
   private Handler<Buffer> pingHandler;
-  private Map<Object, Object> attachments;
+  private final Map<Object, Object> attachments = new ConcurrentHashMap<>();
 
   public Http2MultiplexConnection(Http2MultiplexHandler handler, TransportMetrics<?> transportMetrics, ChannelHandlerContext chctx, ContextInternal context) {
     super(context, chctx);
@@ -423,21 +423,16 @@ public abstract class Http2MultiplexConnection<S extends Http2Stream> extends Co
 
   @Override
   protected void handleClosed() {
-    synchronized (this) {
-      attachments = null;
-    }
+    attachments.clear();
     super.handleClosed();
   }
 
   @SuppressWarnings("unchecked")
-  public synchronized <T> T attachment(Object key) {
-    return attachments != null ? (T) attachments.get(key) : null;
+  public <T> T attachment(Object key) {
+    return (T) attachments.get(key);
   }
 
-  public synchronized void attach(Object key, Object value) {
-    if (attachments == null) {
-      attachments = new HashMap<>();
-    }
+  public void attach(Object key, Object value) {
     attachments.put(key, value);
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Connection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Connection.java
@@ -303,12 +303,12 @@ public abstract class Http3Connection implements HttpConnectionInternal {
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> T get(Object key) {
+  public <T> T attachment(Object key) {
     return attachments != null ? (T) attachments.get(key) : null;
   }
 
   @Override
-  public void set(Object key, Object value) {
+  public void attach(Object key, Object value) {
     if (attachments == null) {
       attachments = new HashMap<>();
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Connection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Connection.java
@@ -26,6 +26,7 @@ import io.vertx.core.http.*;
 import io.vertx.core.http.Http3Settings;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
+import io.vertx.core.internal.http.HttpConnectionInternal;
 import io.vertx.core.internal.quic.QuicConnectionInternal;
 import io.vertx.core.internal.quic.QuicStreamInternal;
 import io.vertx.core.net.SocketAddress;
@@ -33,6 +34,7 @@ import io.vertx.core.net.SocketAddress;
 import javax.net.ssl.SSLSession;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +42,7 @@ import java.util.Map;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public abstract class Http3Connection implements HttpConnection {
+public abstract class Http3Connection implements HttpConnectionInternal {
 
   private final LongObjectMap<Http3Stream<?, ?>> streams;
   private final Http3FrameLogger frameLogger;
@@ -55,6 +57,7 @@ public abstract class Http3Connection implements HttpConnection {
   private Http3Settings localSettings;
   private Http3Settings remoteSettings;
   private Handler<HttpSettings> remoteSettingsHandler;
+  private Map<Object, Object> attachments;
 
   public Http3Connection(QuicConnectionInternal connection, Http3Settings localSettings, Http3FrameLogger frameLogger) {
     this.streams = new LongObjectHashMap<>();
@@ -291,10 +294,25 @@ public abstract class Http3Connection implements HttpConnection {
   }
 
   protected void handleClosed() {
+    attachments = null;
     Handler<Void> handler = closeHandler;
     if (handler != null) {
       context.emit(null, handler);
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> T get(Object key) {
+    return attachments != null ? (T) attachments.get(key) : null;
+  }
+
+  @Override
+  public void set(Object key, Object value) {
+    if (attachments == null) {
+      attachments = new HashMap<>();
+    }
+    attachments.put(key, value);
   }
 
   private void sendGoAway(QuicStreamChannel controlStream, long streamId, PromiseInternal<Void> promise) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Connection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Connection.java
@@ -26,7 +26,6 @@ import io.vertx.core.http.*;
 import io.vertx.core.http.Http3Settings;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
-import io.vertx.core.internal.http.HttpConnectionInternal;
 import io.vertx.core.internal.quic.QuicConnectionInternal;
 import io.vertx.core.internal.quic.QuicStreamInternal;
 import io.vertx.core.net.SocketAddress;
@@ -42,7 +41,7 @@ import java.util.Map;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public abstract class Http3Connection implements HttpConnectionInternal {
+public abstract class Http3Connection implements HttpConnection {
 
   private final LongObjectMap<Http3Stream<?, ?>> streams;
   private final Http3FrameLogger frameLogger;
@@ -294,7 +293,9 @@ public abstract class Http3Connection implements HttpConnectionInternal {
   }
 
   protected void handleClosed() {
-    attachments = null;
+    synchronized (this) {
+      attachments = null;
+    }
     Handler<Void> handler = closeHandler;
     if (handler != null) {
       context.emit(null, handler);
@@ -302,13 +303,11 @@ public abstract class Http3Connection implements HttpConnectionInternal {
   }
 
   @SuppressWarnings("unchecked")
-  @Override
-  public <T> T attachment(Object key) {
+  public synchronized <T> T attachment(Object key) {
     return attachments != null ? (T) attachments.get(key) : null;
   }
 
-  @Override
-  public void attach(Object key, Object value) {
+  public synchronized void attach(Object key, Object value) {
     if (attachments == null) {
       attachments = new HashMap<>();
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Connection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Connection.java
@@ -33,7 +33,7 @@ import io.vertx.core.net.SocketAddress;
 import javax.net.ssl.SSLSession;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +56,7 @@ public abstract class Http3Connection implements HttpConnection {
   private Http3Settings localSettings;
   private Http3Settings remoteSettings;
   private Handler<HttpSettings> remoteSettingsHandler;
-  private Map<Object, Object> attachments;
+  private final Map<Object, Object> attachments = new ConcurrentHashMap<>();
 
   public Http3Connection(QuicConnectionInternal connection, Http3Settings localSettings, Http3FrameLogger frameLogger) {
     this.streams = new LongObjectHashMap<>();
@@ -293,9 +293,7 @@ public abstract class Http3Connection implements HttpConnection {
   }
 
   protected void handleClosed() {
-    synchronized (this) {
-      attachments = null;
-    }
+    attachments.clear();
     Handler<Void> handler = closeHandler;
     if (handler != null) {
       context.emit(null, handler);
@@ -303,14 +301,11 @@ public abstract class Http3Connection implements HttpConnection {
   }
 
   @SuppressWarnings("unchecked")
-  public synchronized <T> T attachment(Object key) {
-    return attachments != null ? (T) attachments.get(key) : null;
+  public <T> T attachment(Object key) {
+    return (T) attachments.get(key);
   }
 
-  public synchronized void attach(Object key, Object value) {
-    if (attachments == null) {
-      attachments = new HashMap<>();
-    }
+  public void attach(Object key, Object value) {
     attachments.put(key, value);
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
@@ -38,6 +38,7 @@ import io.vertx.core.spi.metrics.ClientMetrics;
 
 import javax.net.ssl.SSLSession;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -56,6 +57,7 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
   private final ClientMetrics<?, ?, ?> clientMetrics;
   private io.vertx.core.http.impl.HttpClientConnection current;
   private boolean upgradeProcessed;
+  private Map<Object, Object> attachments;
 
   private Handler<Void> closeHandler;
   private Handler<Void> shutdownHandler;
@@ -73,6 +75,7 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
     this.current = connection;
     this.upgrade = upgrade;
     this.clientMetrics = clientMetrics;
+    connection.closeHandler(this::handleClosed);
   }
 
   public io.vertx.core.http.impl.HttpClientConnection unwrap() {
@@ -334,7 +337,7 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
       pushHandler = null;
       closeHandler = null;
       upgradedConnection.current = conn;
-      conn.closeHandler(upgradedConnection.closeHandler);
+      conn.closeHandler(upgradedConnection::handleClosed);
       conn.exceptionHandler(upgradedConnection.exceptionHandler);
       conn.pingHandler(upgradedConnection.pingHandler);
       conn.goAwayHandler(upgradedConnection.goAwayHandler);
@@ -776,11 +779,20 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
 
   @Override
   public HttpConnection closeHandler(Handler<Void> handler) {
-    if (current instanceof Http1ClientConnection) {
-      closeHandler = handler;
-    }
-    current.closeHandler(handler);
+    closeHandler = handler;
+    current.closeHandler(this::handleClosed);
     return this;
+  }
+
+  private void handleClosed(Void event) {
+    Handler<Void> handler;
+    synchronized (this) {
+      attachments = null;
+      handler = closeHandler;
+    }
+    if (handler != null) {
+      handler.handle(event);
+    }
   }
 
   @Override
@@ -911,6 +923,20 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
   @Override
   public String toString() {
     return getClass().getSimpleName() + "[current=" + current.getClass().getSimpleName() + "]";
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public synchronized <T> T attachment(Object key) {
+    return attachments != null ? (T) attachments.get(key) : null;
+  }
+
+  @Override
+  public synchronized void attach(Object key, Object value) {
+    if (attachments == null) {
+      attachments = new HashMap<>();
+    }
+    attachments.put(key, value);
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
@@ -38,7 +38,7 @@ import io.vertx.core.spi.metrics.ClientMetrics;
 
 import javax.net.ssl.SSLSession;
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +57,7 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
   private final ClientMetrics<?, ?, ?> clientMetrics;
   private io.vertx.core.http.impl.HttpClientConnection current;
   private boolean upgradeProcessed;
-  private Map<Object, Object> attachments;
+  private final Map<Object, Object> attachments = new ConcurrentHashMap<>();
 
   private Handler<Void> closeHandler;
   private Handler<Void> shutdownHandler;
@@ -785,9 +785,9 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
   }
 
   private void handleClosed(Void event) {
+    attachments.clear();
     Handler<Void> handler;
     synchronized (this) {
-      attachments = null;
       handler = closeHandler;
     }
     if (handler != null) {
@@ -927,15 +927,12 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
 
   @Override
   @SuppressWarnings("unchecked")
-  public synchronized <T> T attachment(Object key) {
-    return attachments != null ? (T) attachments.get(key) : null;
+  public <T> T attachment(Object key) {
+    return (T) attachments.get(key);
   }
 
   @Override
-  public synchronized void attach(Object key, Object value) {
-    if (attachments == null) {
-      attachments = new HashMap<>();
-    }
+  public void attach(Object key, Object value) {
     attachments.put(key, value);
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpConnectionInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpConnectionInternal.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.internal.http;
+
+import io.vertx.core.http.HttpConnection;
+
+/**
+ * Extends to expose internal methods that are necessary for integration.
+ */
+public interface HttpConnectionInternal extends HttpConnection {
+
+  /**
+   * Get an attachment previously stored with {@link #set(Object, Object)}.
+   * <p/>
+   * Attachments are scoped to the lifecycle of the connection: they are discarded when the
+   * connection closes and do not need to be cleaned up manually.
+   *
+   * @param key the attachment key
+   * @return the attachment value, or {@code null} if absent
+   */
+  <T> T get(Object key);
+
+  /**
+   * Store an attachment on this connection, associated with {@code key}.
+   *
+   * @param key the attachment key
+   * @param value the attachment value
+   */
+  void set(Object key, Object value);
+
+}

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpConnectionInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpConnectionInternal.java
@@ -18,7 +18,7 @@ import io.vertx.core.http.HttpConnection;
 public interface HttpConnectionInternal extends HttpConnection {
 
   /**
-   * Get an attachment previously stored with {@link #set(Object, Object)}.
+   * Get an attachment previously stored with {@link #attach(Object, Object)}.
    * <p/>
    * Attachments are scoped to the lifecycle of the connection: they are discarded when the
    * connection closes and do not need to be cleaned up manually.
@@ -26,7 +26,7 @@ public interface HttpConnectionInternal extends HttpConnection {
    * @param key the attachment key
    * @return the attachment value, or {@code null} if absent
    */
-  <T> T get(Object key);
+  <T> T attachment(Object key);
 
   /**
    * Store an attachment on this connection, associated with {@code key}.
@@ -34,6 +34,6 @@ public interface HttpConnectionInternal extends HttpConnection {
    * @param key the attachment key
    * @param value the attachment value
    */
-  void set(Object key, Object value);
+  void attach(Object key, Object value);
 
 }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -159,17 +159,17 @@ public abstract class ConnectionBase {
   }
 
   /**
-   * Get an attachment previously stored with {@link #set(Object, Object)}.
+   * Get an attachment previously stored with {@link #attach(Object, Object)}.
    */
   @SuppressWarnings("unchecked")
-  public final synchronized <T> T get(Object key) {
+  public final synchronized <T> T attachment(Object key) {
     return attachments != null ? (T) attachments.get(key) : null;
   }
 
   /**
    * Store an attachment on this connection, associated with {@code key}.
    */
-  public final synchronized void set(Object key, Object value) {
+  public final synchronized void attach(Object key, Object value) {
     if (attachments == null) {
       attachments = new HashMap<>();
     }

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -33,6 +33,7 @@ import io.vertx.core.spi.metrics.TransportMetrics;
 
 import javax.net.ssl.SSLSession;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,6 +75,7 @@ public abstract class ConnectionBase {
   private Future<Void> closeFuture;
   private long remainingBytesRead;
   private long remainingBytesWritten;
+  private Map<Object, Object> attachments;
 
   protected ConnectionBase(ContextInternal context, ChannelHandlerContext chctx) {
 
@@ -156,6 +158,24 @@ public abstract class ConnectionBase {
     return metric;
   }
 
+  /**
+   * Get an attachment previously stored with {@link #set(Object, Object)}.
+   */
+  @SuppressWarnings("unchecked")
+  public final synchronized <T> T get(Object key) {
+    return attachments != null ? (T) attachments.get(key) : null;
+  }
+
+  /**
+   * Store an attachment on this connection, associated with {@code key}.
+   */
+  public final synchronized void set(Object key, Object value) {
+    if (attachments == null) {
+      attachments = new HashMap<>();
+    }
+    attachments.put(key, value);
+  }
+
   public NetworkMetrics metrics() {
     return null;
   }
@@ -184,6 +204,9 @@ public abstract class ConnectionBase {
   }
 
   protected void handleClosed() {
+    synchronized (this) {
+      attachments = null;
+    }
     NetworkMetrics metrics = metrics();
     if (metrics != null) {
       flushBytesRead();

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -33,7 +33,6 @@ import io.vertx.core.spi.metrics.TransportMetrics;
 
 import javax.net.ssl.SSLSession;
 import java.net.InetSocketAddress;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,7 +74,6 @@ public abstract class ConnectionBase {
   private Future<Void> closeFuture;
   private long remainingBytesRead;
   private long remainingBytesWritten;
-  private Map<Object, Object> attachments;
 
   protected ConnectionBase(ContextInternal context, ChannelHandlerContext chctx) {
 
@@ -158,24 +156,6 @@ public abstract class ConnectionBase {
     return metric;
   }
 
-  /**
-   * Get an attachment previously stored with {@link #attach(Object, Object)}.
-   */
-  @SuppressWarnings("unchecked")
-  public final synchronized <T> T attachment(Object key) {
-    return attachments != null ? (T) attachments.get(key) : null;
-  }
-
-  /**
-   * Store an attachment on this connection, associated with {@code key}.
-   */
-  public final synchronized void attach(Object key, Object value) {
-    if (attachments == null) {
-      attachments = new HashMap<>();
-    }
-    attachments.put(key, value);
-  }
-
   public NetworkMetrics metrics() {
     return null;
   }
@@ -204,9 +184,6 @@ public abstract class ConnectionBase {
   }
 
   protected void handleClosed() {
-    synchronized (this) {
-      attachments = null;
-    }
     NetworkMetrics metrics = metrics();
     if (metrics != null) {
       flushBytesRead();

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
@@ -30,6 +30,7 @@ import io.vertx.core.http.*;
 import io.vertx.core.http.Http2Settings;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.buffer.BufferInternal;
+import io.vertx.core.internal.http.HttpConnectionInternal;
 import io.vertx.core.http.impl.tcp.Http2UpgradeClientConnection;
 import io.vertx.core.http.impl.HttpClientConnection;
 import io.vertx.core.net.NetServer;
@@ -1727,6 +1728,41 @@ public class Http2ClientTest extends Http2TestBase {
   public void testClearTextUpgrade() throws Exception {
     List<String> requests = testClearText(true, false);
     Assert.assertEquals(Arrays.asList("GET", "GET"), requests);
+  }
+
+  @Test
+  public void testClearTextUpgradePreservesConnectionAttachment() throws Exception {
+    Assume.assumeTrue(testAddress.isInetSocket());
+    Object key = new Object();
+    Object value = new Object();
+    ServerBootstrap bootstrap = createH2CServer((dec, enc) -> new Http2EventAdapter() {
+      @Override
+      public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) throws Http2Exception {
+        enc.writeHeaders(ctx, streamId, new DefaultHttp2Headers().status("200"), 0, true, ctx.newPromise());
+        ctx.flush();
+      }
+    }, upgrade -> {
+    }, true);
+    ChannelFuture channel = bootstrap.bind(DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT).sync();
+    try {
+      client.close();
+      client = vertx.createHttpClient(clientOptions
+        .setUseAlpn(false)
+        .setSsl(false)
+        .setHttp2ClearTextUpgrade(true));
+      client.request(requestOptions).onComplete(TestUtils.onSuccess(request -> {
+        HttpConnectionInternal connection = (HttpConnectionInternal) request.connection();
+        connection.attach(key, value);
+        request.send().onComplete(TestUtils.onSuccess(response -> {
+          Assert.assertSame(connection, response.request().connection());
+          Assert.assertSame(value, connection.attachment(key));
+          testComplete();
+        }));
+      }));
+      await();
+    } finally {
+      channel.channel().close().sync();
+    }
   }
 
   @Test


### PR DESCRIPTION
Motivation:

vert-x3/vertx-web#2910 needs per-connection state (announced Alt-Svc origins) scoped to the connection's lifecycle. The current workaround in vertx-web is a `WeakHashMap<HttpConnection, T>`, which can't reliably clean up stale connections (see discussion in that PR).

## Changes

New `HttpConnectionInternal` interface in `io.vertx.core.internal.http`, following the existing `HttpServerRequestInternal` / `HttpClientRequestInternal` pattern:
  ```java
  <T> T get(Object key);
  void set(Object key, Object value);
  ```
  
Backed by a lazily-created map stored directly on the connection object (not an external map keyed by connection), so entries are naturally scoped to the connection's own lifecycle — no leak risk, no weak references needed.

Wired into all four connection implementations:
ConnectionBase (shared by Http1Connection, Http2ConnectionImpl, Http2MultiplexConnection), cleared in handleClosed(). Http3Connection, which doesn't extend ConnectionBase, gets its own field and clears it in its own handleClosed().

Fixes [#6234](https://github.com/Harshal96/vert.x/issues/6234)
