### PR TITLE
Port new PQC API and tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "Ubuntu 26.04 Environment",
+  "image": "mcr.microsoft.com/devcontainers/base:dev-ubuntu26.04",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "25",
+      "installMaven": "true",
+      "mavenVersion": "latest"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack" // Installs Microsoft's Java Extension Pack (Debugger, Maven explorer, etc.)
+      ],
+      "settings": {
+        "redhat.telemetry.enabled": false
+      }
+    }
+  },
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y openssl libssl-dev libapr1t64"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -985,10 +985,11 @@
     </profile>
 
     <profile>
-      <id>linux</id>
+      <id>linux-x86_64</id>
       <activation>
         <os>
           <family>linux</family>
+          <arch>x86_64</arch>
         </os>
       </activation>
       <dependencies>
@@ -1002,6 +1003,31 @@
           <groupId>io.smallrye</groupId>
           <artifactId>smallrye-openssl</artifactId>
           <classifier>linux-x86_64</classifier>
+          <version>${smallrye.openssl.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>linux-aarch64</id>
+      <activation>
+        <os>
+          <family>linux</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <classifier>linux-aarch_64</classifier>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.smallrye</groupId>
+          <artifactId>smallrye-openssl</artifactId>
+          <classifier>linux-aarch_64</classifier>
           <version>${smallrye.openssl.version}</version>
           <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -985,11 +985,10 @@
     </profile>
 
     <profile>
-      <id>linux-x86_64</id>
+      <id>linux</id>
       <activation>
         <os>
           <family>linux</family>
-          <arch>x86_64</arch>
         </os>
       </activation>
       <dependencies>
@@ -1003,31 +1002,6 @@
           <groupId>io.smallrye</groupId>
           <artifactId>smallrye-openssl</artifactId>
           <classifier>linux-x86_64</classifier>
-          <version>${smallrye.openssl.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-
-    <profile>
-      <id>linux-aarch64</id>
-      <activation>
-        <os>
-          <family>linux</family>
-          <arch>aarch64</arch>
-        </os>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <classifier>linux-aarch_64</classifier>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>io.smallrye</groupId>
-          <artifactId>smallrye-openssl</artifactId>
-          <classifier>linux-aarch_64</classifier>
           <version>${smallrye.openssl.version}</version>
           <scope>test</scope>
         </dependency>

--- a/src/main/asciidoc/http.adoc
+++ b/src/main/asciidoc/http.adoc
@@ -41,16 +41,6 @@ To handle `h2` requests, TLS must be enabled along with {@link io.vertx.core.htt
 {@link examples.HTTP2Examples#example0}
 ----
 
-The rise of quantum computers will make key exchange protocols such as x25519 obsolete as they will be able to "crack" secret keys quickly.
-Vert.x proposes a quantum-safe key exchange protocol, x25519MLKEM768 (official recommendation of NIST) to ensure sessions over TLS are safe against quantum computers.
-
-Hybrid key exchange must be enabled with {@link io.vertx.core.net.SSLOptions#setUseHybridKeyExchangeProtocol(boolean)} and **requires OpenSSL** — it does not work with the JDK SSL engine. You must configure {@link io.vertx.core.net.OpenSSLEngineOptions} and add the following dependencies:
-
-- `io.netty:netty-tcnative-classes` (version managed by the Netty BOM)
-- An OpenSSL provider such as `io.smallrye:smallrye-openssl`
-
-If OpenSSL is not available at runtime, the TLS handshake will fail rather than silently falling back to a non-quantum-safe key exchange.
-
 ALPN is a TLS extension that negotiates the protocol before the client and the server start to exchange data.
 
 Clients that don't support ALPN will still be able to do a _classic_ SSL handshake.

--- a/src/main/asciidoc/net.adoc
+++ b/src/main/asciidoc/net.adoc
@@ -841,6 +841,50 @@ OpenSSL requires to configure {@link io.vertx.core.net.TCPSSLOptions#setOpenSslE
 and use http://netty.io/wiki/forked-tomcat-native.html[netty-tcnative] jar on the classpath. Using tcnative may require
 OpenSSL to be installed on your OS depending on the tcnative implementation.
 
+==== Post Quantum Cryptography
+
+The rise of quantum computers will make key exchange protocols such as x25519 obsolete as they will be able to "crack" secret keys quickly.
+Vert.x supports post-quantum cryptography (PQC) key exchange via X25519MLKEM768 (official recommendation of NIST) to ensure sessions over TLS are safe against quantum computers.
+
+PQC is configured with two properties:
+
+- {@link io.vertx.core.net.SSLOptions#setKeyExchangeGroups} — a list of key exchange group names (e.g. `["X25519MLKEM768", "X25519"]`)
+- {@link io.vertx.core.net.SSLOptions#setPqcEnforcementPolicy} — the enforcement policy: `RELAXED` (default), `CLIENT_NEGOTIATED`, or `STRICT`
+
+The three enforcement modes behave as follows:
+
+- **RELAXED**: uses the specified key exchange groups as-is; if none are specified, the SSL engine negotiates normally. No PQC enforcement.
+- **CLIENT_NEGOTIATED**: the server requires PQC support (X25519MLKEM768 is prepended to the groups if not present), but tolerates clients that do not support PQC.
+- **STRICT**: both server and client must support PQC. The key exchange groups are replaced with only X25519MLKEM768. Non-PQC clients will fail the TLS handshake.
+
+For both `STRICT` and `CLIENT_NEGOTIATED`, the application fails with either "PQC enforcement policy requires X25519MLKEM768 but the configured SSL engine does not support it" or "PQC enforcement policy requires X25519MLKEM768 but neither JDK nor OpenSSL support it" if pqc is not supported by the SSL engine.
+
+For `STRICT` and `CLIENT_NEGOTIATED` modes, you need an SslEngine supporting X25519MLKEM768. `JdkSslEngine` supports it starting with JDK 27 (preview feature), and OpenSsl supports it starting with OpenSsl 3.5. If no `SslEngine` is specified by the user, the first engine supporting pqc will be selected, starting with `JdkSslEngine`
+
+Using OpenSsl >= 3.5 requires the following dependencies:
+
+- `io.netty:netty-tcnative-classes` (version managed by the Netty BOM)
+- An OpenSSL provider such as `io.smallrye:smallrye-openssl`
+
+**PQC enforcement policy summary:**
+[cols="1,1,1,2", options="header"]
+|===
+| pqc-enforcement-policy | server-pqc-supports | client-pqc-supports | Result
+.3+| strict
+| false | required / true / false | **app fails** with error "PQC enforcement policy STRICT requires X25519MLKEM768 but the configured SSL engine does not support it"
+| true  | true / required         | app starts and ssl handshake succeeds
+| true  | false                   | app starts but **ssl handshake fails**
+
+.2+| client_negotiated
+| false | required / true / false | **app fails** with error "PQC enforcement policy STRICT requires X25519MLKEM768 but the configured SSL engine does not support it"
+| true  | required / true / false | app starts and ssl handshake succeeds
+
+.3+| relaxed
+| true  | required / true / false | app starts and ssl handshake succeeds
+| false | true / false            | app starts and ssl handshake succeeds
+| false | required                | app starts but **ssl handshake fails**
+|===
+
 === Using a proxy for client connections
 
 The {@link io.vertx.core.net.NetClient} supports either a HTTP/1.x _CONNECT_, _SOCKS4a_ or _SOCKS5_ proxy.

--- a/src/main/generated/io/vertx/core/eventbus/EventBusOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/eventbus/EventBusOptionsConverter.java
@@ -279,11 +279,6 @@ public class EventBusOptionsConverter {
             obj.setUseAlpn((Boolean)member.getValue());
           }
           break;
-        case "useHybridKeyExchangeProtocol":
-          if (member.getValue() instanceof Boolean) {
-            obj.setUseHybridKeyExchangeProtocol((Boolean)member.getValue());
-          }
-          break;
         case "writeIdleTimeout":
           if (member.getValue() instanceof Number) {
             obj.setWriteIdleTimeout(((Number)member.getValue()).intValue());
@@ -393,7 +388,6 @@ public class EventBusOptionsConverter {
       json.put("trustStoreOptions", obj.getTrustStoreOptions().toJson());
     }
     json.put("useAlpn", obj.isUseAlpn());
-    json.put("useHybridKeyExchangeProtocol", obj.isUseHybridKeyExchangeProtocol());
     json.put("writeIdleTimeout", obj.getWriteIdleTimeout());
   }
 }

--- a/src/main/generated/io/vertx/core/net/SSLOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/net/SSLOptionsConverter.java
@@ -54,6 +54,21 @@ public class SSLOptionsConverter {
             obj.setEnabledSecureTransportProtocols(list);
           }
           break;
+        case "keyExchangeGroups":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add((String)item);
+            });
+            obj.setKeyExchangeGroups(list);
+          }
+          break;
+        case "pqcEnforcementPolicy":
+          if (member.getValue() instanceof String) {
+            obj.setPqcEnforcementPolicy(io.vertx.core.net.PqcEnforcementPolicy.valueOf((String)member.getValue()));
+          }
+          break;
         case "sslHandshakeTimeout":
           if (member.getValue() instanceof Number) {
             obj.setSslHandshakeTimeout(((Number)member.getValue()).longValue());
@@ -67,11 +82,6 @@ public class SSLOptionsConverter {
         case "useAlpn":
           if (member.getValue() instanceof Boolean) {
             obj.setUseAlpn((Boolean)member.getValue());
-          }
-          break;
-        case "useHybridKeyExchangeProtocol":
-          if (member.getValue() instanceof Boolean) {
-            obj.setUseHybridKeyExchangeProtocol((Boolean)member.getValue());
           }
           break;
       }
@@ -103,11 +113,18 @@ public class SSLOptionsConverter {
       obj.getEnabledSecureTransportProtocols().forEach(item -> array.add(item));
       json.put("enabledSecureTransportProtocols", array);
     }
+    if (obj.getKeyExchangeGroups() != null) {
+      JsonArray array = new JsonArray();
+      obj.getKeyExchangeGroups().forEach(item -> array.add(item));
+      json.put("keyExchangeGroups", array);
+    }
+    if (obj.getPqcEnforcementPolicy() != null) {
+      json.put("pqcEnforcementPolicy", obj.getPqcEnforcementPolicy().name());
+    }
     json.put("sslHandshakeTimeout", obj.getSslHandshakeTimeout());
     if (obj.getSslHandshakeTimeoutUnit() != null) {
       json.put("sslHandshakeTimeoutUnit", obj.getSslHandshakeTimeoutUnit().name());
     }
     json.put("useAlpn", obj.isUseAlpn());
-    json.put("useHybridKeyExchangeProtocol", obj.isUseHybridKeyExchangeProtocol());
   }
 }

--- a/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
@@ -179,11 +179,6 @@ public class TCPSSLOptionsConverter {
             obj.setUseAlpn((Boolean)member.getValue());
           }
           break;
-        case "useHybridKeyExchangeProtocol":
-          if (member.getValue() instanceof Boolean) {
-            obj.setUseHybridKeyExchangeProtocol((Boolean)member.getValue());
-          }
-          break;
         case "writeIdleTimeout":
           if (member.getValue() instanceof Number) {
             obj.setWriteIdleTimeout(((Number)member.getValue()).intValue());
@@ -263,7 +258,6 @@ public class TCPSSLOptionsConverter {
       json.put("trustStoreOptions", obj.getTrustStoreOptions().toJson());
     }
     json.put("useAlpn", obj.isUseAlpn());
-    json.put("useHybridKeyExchangeProtocol", obj.isUseHybridKeyExchangeProtocol());
     json.put("writeIdleTimeout", obj.getWriteIdleTimeout());
   }
 }

--- a/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
@@ -476,11 +476,6 @@ public class EventBusOptions extends TCPSSLOptions {
   }
 
   @Override
-  public EventBusOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
-    return (EventBusOptions) super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
-  }
-
-  @Override
   public EventBusOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     return (EventBusOptions) super.setSslEngineOptions(sslEngineOptions);
   }

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -1155,11 +1155,6 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   @Override
-  public HttpClientOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
-    return (HttpClientOptions) super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
-  }
-
-  @Override
   public HttpClientOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     return (HttpClientOptions) super.setSslEngineOptions(sslEngineOptions);
   }

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -438,13 +438,6 @@ public class HttpServerOptions extends NetServerOptions {
   }
 
   @Override
-  public HttpServerOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
-    super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
-    return this;
-  }
-
-
-  @Override
   public HttpServerOptions setKeyCertOptions(KeyCertOptions options) {
     super.setKeyCertOptions(options);
     return this;

--- a/src/main/java/io/vertx/core/http/WebSocketClientOptions.java
+++ b/src/main/java/io/vertx/core/http/WebSocketClientOptions.java
@@ -553,11 +553,6 @@ public class WebSocketClientOptions extends ClientOptionsBase {
   }
 
   @Override
-  public WebSocketClientOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
-    return (WebSocketClientOptions)super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
-  }
-
-  @Override
   public WebSocketClientOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     return (WebSocketClientOptions)super.setSslEngineOptions(sslEngineOptions);
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
@@ -57,7 +57,7 @@ public class HttpChannelConnector {
   private final ClientMetrics metrics;
   private final boolean ssl;
   private final boolean useAlpn;
-  private final boolean useHybridKeyExchangeProtocol;
+  private final List<String> resolvedKeyExchangeGroups;
   private final HttpVersion version;
   private final SocketAddress peerAddress;
   private final SocketAddress server;
@@ -69,7 +69,7 @@ public class HttpChannelConnector {
                               HttpVersion version,
                               boolean ssl,
                               boolean useAlpn,
-                              boolean useHybridKeyExchangeProtocol,
+                              List<String> resolvedKeyExchangeGroups,
                               SocketAddress peerAddress,
                               SocketAddress server) {
     this.client = client;
@@ -79,7 +79,7 @@ public class HttpChannelConnector {
     this.proxyOptions = proxyOptions;
     this.ssl = ssl;
     this.useAlpn = useAlpn;
-    this.useHybridKeyExchangeProtocol = useHybridKeyExchangeProtocol;
+    this.resolvedKeyExchangeGroups = resolvedKeyExchangeGroups;
     this.version = version;
     this.peerAddress = peerAddress;
     this.server = server;
@@ -90,7 +90,7 @@ public class HttpChannelConnector {
   }
 
   private void connect(ContextInternal context, Promise<NetSocket> promise) {
-    netClient.connectInternal(proxyOptions, server, peerAddress, this.options.isForceSni() ? peerAddress.host() : null, ssl, useAlpn, useHybridKeyExchangeProtocol, false, promise, context, 0);
+    netClient.connectInternal(proxyOptions, server, peerAddress, this.options.isForceSni() ? peerAddress.host() : null, ssl, useAlpn, resolvedKeyExchangeGroups, false, promise, context, 0);
   }
 
   public Future<HttpClientConnection> wrap(ContextInternal context, NetSocket so_) {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -21,6 +21,7 @@ import io.vertx.core.net.*;
 import io.vertx.core.net.impl.NetClientBuilder;
 import io.vertx.core.net.impl.NetClientImpl;
 import io.vertx.core.net.impl.ProxyFilter;
+import io.vertx.core.net.impl.SslEngineUtils;
 import io.vertx.core.net.impl.pool.*;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
@@ -43,6 +44,7 @@ public class HttpClientBase implements MetricsProvider, Closeable {
   protected final VertxInternal vertx;
   protected final HttpClientOptions options;
   private final ConnectionManager<EndpointKey, HttpClientConnection> webSocketCM;
+  protected final List<String> resolvedKeyExchangeGroups;
   protected final NetClientImpl netClient;
   protected final HttpClientMetrics metrics;
   private final boolean keepAlive;
@@ -53,9 +55,16 @@ public class HttpClientBase implements MetricsProvider, Closeable {
   final boolean useH2UniformStreamByteDistributor;
 
   public HttpClientBase(VertxInternal vertx, HttpClientOptions options, CloseFuture closeFuture) {
+
+    List<String> resolvedKeyExchangeGroups = SslEngineUtils.resolveKeyExchangeGroups(
+      options.getSslOptions().getKeyExchangeGroups(),
+      options.getSslOptions().getPqcEnforcementPolicy()
+    );
+
     this.vertx = vertx;
     this.metrics = vertx.metricsSPI() != null ? vertx.metricsSPI().createHttpClientMetrics(options) : null;
     this.options = new HttpClientOptions(options);
+    this.resolvedKeyExchangeGroups = resolvedKeyExchangeGroups;
     this.closeFuture = closeFuture;
     List<HttpVersion> alpnVersions = options.getAlpnVersions();
     if (alpnVersions == null || alpnVersions.isEmpty()) {
@@ -190,7 +199,7 @@ public class HttpClientBase implements MetricsProvider, Closeable {
       public Endpoint<HttpClientConnection> create(ContextInternal ctx, Runnable dispose) {
         int maxPoolSize = options.getMaxWebSockets();
         ClientMetrics metrics = HttpClientBase.this.metrics != null ? HttpClientBase.this.metrics.createEndpointMetrics(key.serverAddr, maxPoolSize) : null;
-        HttpChannelConnector connector = new HttpChannelConnector(HttpClientBase.this, netClient, proxyOptions, metrics, HttpVersion.HTTP_1_1, key.ssl, false, false, key.peerAddr, key.serverAddr);
+        HttpChannelConnector connector = new HttpChannelConnector(HttpClientBase.this, netClient, proxyOptions, metrics, HttpVersion.HTTP_1_1, key.ssl, false, null, key.peerAddr, key.serverAddr);
         return new WebSocketEndpoint(null, maxPoolSize, connector, dispose);
       }
     };

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -172,7 +172,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
   public Future<HttpClientConnection> connect(SocketAddress server, SocketAddress peer) {
     ContextInternal context = vertx.getOrCreateContext();
     Promise<HttpClientConnection> promise = context.promise();
-    HttpChannelConnector connector = new HttpChannelConnector(this, netClient, null, null, options.getProtocolVersion(), options.isSsl(), options.isUseAlpn(), options.isUseHybridKeyExchangeProtocol(), peer, server);
+    HttpChannelConnector connector = new HttpChannelConnector(this, netClient, null, null, options.getProtocolVersion(), options.isSsl(), options.isUseAlpn(), resolvedKeyExchangeGroups, peer, server);
     connector.httpConnect(context, promise);
     return promise.future();
   }
@@ -353,7 +353,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
       public Endpoint<Lease<HttpClientConnection>> create(ContextInternal ctx, Runnable dispose) {
         int maxPoolSize = Math.max(poolOptions.getHttp1MaxSize(), poolOptions.getHttp2MaxSize());
         ClientMetrics metrics = HttpClientImpl.this.metrics != null ? HttpClientImpl.this.metrics.createEndpointMetrics(key.serverAddr, maxPoolSize) : null;
-        HttpChannelConnector connector = new HttpChannelConnector(HttpClientImpl.this, netClient, proxyOptions, metrics, options.getProtocolVersion(), key.ssl, options.isUseAlpn(), options.isUseHybridKeyExchangeProtocol(), key.peerAddr, key.serverAddr);
+        HttpChannelConnector connector = new HttpChannelConnector(HttpClientImpl.this, netClient, proxyOptions, metrics, options.getProtocolVersion(), key.ssl, options.isUseAlpn(), resolvedKeyExchangeGroups, key.peerAddr, key.serverAddr);
         return new SharedClientHttpStreamEndpoint(
           HttpClientImpl.this,
           metrics,

--- a/src/main/java/io/vertx/core/net/ClientOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/ClientOptionsBase.java
@@ -341,11 +341,6 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
   }
 
   @Override
-  public ClientOptionsBase setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
-    return (ClientOptionsBase) super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
-  }
-
-  @Override
   public ClientOptionsBase setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     return (ClientOptionsBase) super.setSslEngineOptions(sslEngineOptions);
   }

--- a/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
@@ -55,6 +55,15 @@ public class JdkSSLEngineOptions extends SSLEngineOptions {
     return jdkAlpnAvailable;
   }
 
+  /**
+   * @return if PQC key exchange (X25519MLKEM768) is available via the JDK SSL engine
+   * @implNote currently this returns {@code false} but implementation will change in the future when JDK support evolves
+   */
+  public static synchronized boolean isPqcAvailable() {
+    // Todo: implement it when JDK add supports
+    return false;
+  }
+
   private boolean pooledHeapBuffers = false;
 
   public JdkSSLEngineOptions() {

--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -264,11 +264,6 @@ public class NetClientOptions extends ClientOptionsBase {
   }
 
   @Override
-  public NetClientOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
-    return (NetClientOptions) super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
-  }
-
-  @Override
   public NetClientOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     return (NetClientOptions) super.setSslEngineOptions(sslEngineOptions);
   }

--- a/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -227,12 +227,6 @@ public class NetServerOptions extends TCPSSLOptions {
   }
 
   @Override
-  public NetServerOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
-    super.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
-    return this;
-  }
-
-  @Override
   public NetServerOptions setSslEngineOptions(SSLEngineOptions sslEngineOptions) {
     super.setSslEngineOptions(sslEngineOptions);
     return this;

--- a/src/main/java/io/vertx/core/net/OpenSSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/OpenSSLEngineOptions.java
@@ -11,8 +11,10 @@
 
 package io.vertx.core.net;
 
-import io.netty.handler.ssl.OpenSsl;
-import io.netty.handler.ssl.SslProvider;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.ssl.*;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.internal.tcnative.SSL;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
@@ -28,6 +30,8 @@ import io.vertx.core.spi.tls.SslContextFactory;
 @JsonGen(publicConverter = false)
 public class OpenSSLEngineOptions extends SSLEngineOptions {
 
+  private static Boolean opensslPqcAvailable;
+
   /**
    * @return when OpenSSL is available
    */
@@ -40,6 +44,33 @@ public class OpenSSLEngineOptions extends SSLEngineOptions {
    */
   public static boolean isAlpnAvailable() {
     return OpenSsl.isAlpnSupported();
+  }
+
+  /**
+   * @return if PQC key exchange (X25519MLKEM768) is available via the OpenSSL engine
+   */
+  public static synchronized boolean isPqcAvailable() {
+    if (opensslPqcAvailable == null) {
+      boolean available = false;
+      if (OpenSsl.isAvailable()) {
+        try {
+          SslContext ctx = SslContextBuilder.forClient()
+            .sslProvider(SslProvider.OPENSSL)
+            .trustManager(InsecureTrustManagerFactory.INSTANCE)
+            .build();
+          SslHandler handler = ctx.newHandler(ByteBufAllocator.DEFAULT);
+          try {
+            long sslPtr = ((ReferenceCountedOpenSslEngine) handler.engine()).sslPointer();
+            available = SSL.setCurvesList(sslPtr, "X25519MLKEM768");
+          } finally {
+            handler.engine().closeOutbound();
+          }
+        } catch (Exception ignore) {
+        }
+      }
+      opensslPqcAvailable = available;
+    }
+    return opensslPqcAvailable;
   }
 
   /**

--- a/src/main/java/io/vertx/core/net/PqcEnforcementPolicy.java
+++ b/src/main/java/io/vertx/core/net/PqcEnforcementPolicy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.core.net;
+
+import io.vertx.codegen.annotations.Unstable;
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * Policy for enforcing post-quantum cryptography (PQC) key exchange.
+ */
+@VertxGen
+@Unstable
+public enum PqcEnforcementPolicy {
+  /**
+   * No PQC enforcement. Key exchange groups are used as-is if specified.
+   * If no groups are specified, the SSL engine negotiates normally.
+   */
+  RELAXED,
+  /**
+   * PQC is enforced on the server side but clients that do not support PQC are tolerated.
+   * X25519MLKEM768 is prepended to the key exchange groups if not already present.
+   * If PQC is not available at runtime, the application fails to start with a VertxException:
+   * "PQC enforcement policy CLIENT_NEGOTIATED requires X25519MLKEM768 but the configured SSL engine does not support it"
+   */
+  CLIENT_NEGOTIATED,
+  /**
+   * PQC is strictly enforced. Both server and client must support PQC.
+   * The key exchange groups are replaced with only X25519MLKEM768.
+   * If PQC is not available at runtime, the application fails to start with a VertxException:
+   * "PQC enforcement policy STRICT requires X25519MLKEM768 but the configured SSL engine does not support it"
+   * Non-PQC clients will fail the TLS handshake.
+   */
+  STRICT
+}

--- a/src/main/java/io/vertx/core/net/SSLOptions.java
+++ b/src/main/java/io/vertx/core/net/SSLOptions.java
@@ -40,9 +40,9 @@ public class SSLOptions {
   public static final boolean DEFAULT_USE_ALPN = false;
 
   /**
-   * Default use hybrid = false
+   * Default PQC enforcement policy = RELAXED
    */
-  public static final boolean DEFAULT_USE_HYBRID = false;
+  public static final PqcEnforcementPolicy DEFAULT_PQC_ENFORCEMENT_POLICY = PqcEnforcementPolicy.RELAXED;
 
   /**
    * The default value of SSL handshake timeout = 10
@@ -71,7 +71,8 @@ public class SSLOptions {
   private ArrayList<String> crlPaths;
   private ArrayList<Buffer> crlValues;
   private boolean useAlpn;
-  private boolean useHybridKeyExchangeProtocol;
+  private List<String> keyExchangeGroups;
+  private PqcEnforcementPolicy pqcEnforcementPolicy;
   private Set<String> enabledSecureTransportProtocols;
 
   /**
@@ -105,7 +106,8 @@ public class SSLOptions {
     this.crlPaths = new ArrayList<>(other.getCrlPaths());
     this.crlValues = new ArrayList<>(other.getCrlValues());
     this.useAlpn = other.useAlpn;
-    this.useHybridKeyExchangeProtocol = other.useHybridKeyExchangeProtocol;
+    this.keyExchangeGroups = other.keyExchangeGroups != null ? new ArrayList<>(other.keyExchangeGroups) : null;
+    this.pqcEnforcementPolicy = other.pqcEnforcementPolicy;
     this.enabledSecureTransportProtocols = other.getEnabledSecureTransportProtocols() == null ? new LinkedHashSet<>() : new LinkedHashSet<>(other.getEnabledSecureTransportProtocols());
   }
 
@@ -117,7 +119,8 @@ public class SSLOptions {
     crlPaths = new ArrayList<>();
     crlValues = new ArrayList<>();
     useAlpn = DEFAULT_USE_ALPN;
-    useHybridKeyExchangeProtocol = DEFAULT_USE_HYBRID;
+    keyExchangeGroups = null;
+    pqcEnforcementPolicy = DEFAULT_PQC_ENFORCEMENT_POLICY;
     enabledSecureTransportProtocols = new LinkedHashSet<>(DEFAULT_ENABLED_SECURE_TRANSPORT_PROTOCOLS);
   }
 
@@ -255,32 +258,63 @@ public class SSLOptions {
   }
 
   /**
-   * @return whether the hybrid key exchange protocol X25519MLKEM768 is enabled
+   * @return the list of key exchange group names, or {@code null} if not set
    */
-  public boolean isUseHybridKeyExchangeProtocol() {
-    return useHybridKeyExchangeProtocol;
+  public List<String> getKeyExchangeGroups() {
+    return keyExchangeGroups;
   }
 
   /**
-   * Enable or disable the hybrid post-quantum key exchange protocol X25519MLKEM768.
+   * Set the list of key exchange group names to use for TLS connections.
    * <p>
-   * When enabled, TLS connections will use X25519MLKEM768 for key exchange, providing
-   * protection against quantum computer attacks.
-   * <p>
-   * This feature requires OpenSSL and will not work with the JDK SSL engine. You must:
+   * The effective groups used during the TLS handshake depend on the {@link #getPqcEnforcementPolicy()}:
    * <ul>
-   *   <li>Use {@link OpenSSLEngineOptions} as the SSL engine</li>
-   *   <li>Have {@code io.netty:netty-tcnative-classes} on the classpath</li>
-   *   <li>Have an OpenSSL provider (e.g. {@code io.smallrye:smallrye-openssl}) on the classpath</li>
+   *   <li>{@link PqcEnforcementPolicy#RELAXED}: uses the specified groups as-is, or engine defaults if {@code null}</li>
+   *   <li>{@link PqcEnforcementPolicy#CLIENT_NEGOTIATED}: prepends {@code X25519MLKEM768} if not already present</li>
+   *   <li>{@link PqcEnforcementPolicy#STRICT}: replaces the list with only {@code X25519MLKEM768}</li>
    * </ul>
-   * If OpenSSL is not available, the TLS handshake will fail rather than silently falling back
-   * to a non-quantum-safe key exchange.
    *
-   * @param useHybridKeyExchangeProtocol {@code true} to enable hybrid key exchange
+   * @param keyExchangeGroups the key exchange group names
    * @return a reference to this, so the API can be used fluently
    */
-  public SSLOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
-    this.useHybridKeyExchangeProtocol = useHybridKeyExchangeProtocol;
+  public SSLOptions setKeyExchangeGroups(List<String> keyExchangeGroups) {
+    this.keyExchangeGroups = keyExchangeGroups;
+    return this;
+  }
+
+  /**
+   * Add a key exchange group name.
+   *
+   * @param group the group name to add
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SSLOptions addKeyExchangeGroup(String group) {
+    Objects.requireNonNull(group, "group");
+    if (keyExchangeGroups == null) {
+      keyExchangeGroups = new ArrayList<>();
+    }
+    keyExchangeGroups.add(group);
+    return this;
+  }
+
+  /**
+   * @return the PQC enforcement policy
+   */
+  public PqcEnforcementPolicy getPqcEnforcementPolicy() {
+    return pqcEnforcementPolicy;
+  }
+
+  /**
+   * Set the post-quantum cryptography enforcement policy.
+   * <p>
+   * When set to {@link PqcEnforcementPolicy#STRICT} or {@link PqcEnforcementPolicy#CLIENT_NEGOTIATED},
+   * the SSL engine will be automatically switched to OpenSSL if not already configured.
+   *
+   * @param pqcEnforcementPolicy the enforcement policy
+   * @return a reference to this, so the API can be used fluently
+   */
+  public SSLOptions setPqcEnforcementPolicy(PqcEnforcementPolicy pqcEnforcementPolicy) {
+    this.pqcEnforcementPolicy = Objects.requireNonNull(pqcEnforcementPolicy, "pqcEnforcementPolicy");
     return this;
   }
 
@@ -378,7 +412,8 @@ public class SSLOptions {
          Objects.equals(crlPaths, that.crlPaths) &&
          Objects.equals(crlValues, that.crlValues) &&
          useAlpn == that.useAlpn &&
-         useHybridKeyExchangeProtocol == that.useHybridKeyExchangeProtocol &&
+         Objects.equals(keyExchangeGroups, that.keyExchangeGroups) &&
+         pqcEnforcementPolicy == that.pqcEnforcementPolicy &&
          Objects.equals(enabledSecureTransportProtocols, that.enabledSecureTransportProtocols);
     }
     return false;

--- a/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -723,24 +723,6 @@ public abstract class TCPSSLOptions extends NetworkOptions {
   }
 
   /**
-   * @return whether to use or not Hybrid key exchange protocol x25519MLKEM768
-   */
-  public boolean isUseHybridKeyExchangeProtocol() {
-    SSLOptions o = sslOptions;
-    return o != null && o.isUseHybridKeyExchangeProtocol();
-  }
-
-  /**
-   * Set the ALPN usage.
-   *
-   * @param useHybridKeyExchangeProtocol true when hybrid key exchange protocol should be used
-   */
-  public TCPSSLOptions setUseHybridKeyExchangeProtocol(boolean useHybridKeyExchangeProtocol) {
-    sslOptions.setUseHybridKeyExchangeProtocol(useHybridKeyExchangeProtocol);
-    return this;
-  }
-
-  /**
    * @return the SSL engine implementation to use
    */
   public SSLEngineOptions getSslEngineOptions() {

--- a/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
@@ -38,6 +38,7 @@ import io.vertx.core.net.SocketAddress;
 import javax.net.ssl.SSLHandshakeException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.List;
 
 /**
  * The logic for connecting to an host, this implementations performs a connection
@@ -93,13 +94,15 @@ public final class ChannelProvider {
     return applicationProtocol;
   }
 
-  public Future<Channel> connect(SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, boolean useHybridKeyExchangeProtocol) {
+  public Future<Channel> connect(SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl,
+                                 boolean useAlpn, List<String> resolvedKeyExchangeGroups) {
     Promise<Channel> p = context.nettyEventLoop().newPromise();
-    connect(handler, remoteAddress, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, p);
+    connect(handler, remoteAddress, peerAddress, serverName, ssl, useAlpn, resolvedKeyExchangeGroups, p);
     return p;
   }
 
-  private void connect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, boolean useHybridKeyExchangeProtocol, Promise<Channel> p) {
+  private void connect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress, String serverName,
+                       boolean ssl, boolean useAlpn, List<String> resolvedKeyExchangeGroups, Promise<Channel> p) {
     try {
       bootstrap.channelFactory(context.owner().transport().channelFactory(remoteAddress.isDomainSocket()));
     } catch (Exception e) {
@@ -107,15 +110,16 @@ public final class ChannelProvider {
       return;
     }
     if (proxyOptions != null) {
-      handleProxyConnect(handler, remoteAddress, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, p);
+      handleProxyConnect(handler, remoteAddress, peerAddress, serverName, ssl, useAlpn, resolvedKeyExchangeGroups, p);
     } else {
-      handleConnect(handler, remoteAddress, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, p);
+      handleConnect(handler, remoteAddress, peerAddress, serverName, ssl, useAlpn, resolvedKeyExchangeGroups, p);
     }
   }
 
-  private void initSSL(Handler<Channel> handler, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, boolean useHybridKeyExchangeProtocol, Channel ch, Promise<Channel> channelHandler) {
+  private void initSSL(Handler<Channel> handler, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn,
+                       List<String> resolvedKeyExchangeGroups, Channel ch, Promise<Channel> channelHandler) {
     if (ssl) {
-      SslHandler sslHandler = sslContextProvider.createClientSslHandler(peerAddress, serverName, useAlpn, useHybridKeyExchangeProtocol);
+      SslHandler sslHandler = sslContextProvider.createClientSslHandler(peerAddress, serverName, useAlpn, resolvedKeyExchangeGroups);
       ChannelPipeline pipeline = ch.pipeline();
       pipeline.addLast("ssl", sslHandler);
       pipeline.addLast(new ChannelInboundHandlerAdapter() {
@@ -149,13 +153,13 @@ public final class ChannelProvider {
   }
 
 
-  private void handleConnect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, boolean useHybridKeyExchangeProtocol, Promise<Channel> channelHandler) {
+  private void handleConnect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, List<String> resolvedKeyExchangeGroups, Promise<Channel> channelHandler) {
     VertxInternal vertx = context.owner();
     bootstrap.resolver(vertx.nettyAddressResolverGroup());
     bootstrap.handler(new ChannelInitializer<Channel>() {
       @Override
       protected void initChannel(Channel ch) {
-        initSSL(handler, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, ch, channelHandler);
+        initSSL(handler, peerAddress, serverName, ssl, useAlpn, resolvedKeyExchangeGroups, ch, channelHandler);
       }
     });
     ChannelFuture fut = bootstrap.connect(vertx.transport().convert(remoteAddress));
@@ -187,7 +191,8 @@ public final class ChannelProvider {
   /**
    * A channel provider that connects via a Proxy : HTTP or SOCKS
    */
-  private void handleProxyConnect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress, String serverName, boolean ssl, boolean useAlpn, boolean useHybridKeyExchangeProtocol, Promise<Channel> channelHandler) {
+  private void handleProxyConnect(Handler<Channel> handler, SocketAddress remoteAddress, SocketAddress peerAddress,
+                                  String serverName, boolean ssl, boolean useAlpn, List<String> resolvedKeyExchangeGroups, Promise<Channel> channelHandler) {
 
     final VertxInternal vertx = context.owner();
     final String proxyHost = proxyOptions.getHost();
@@ -237,7 +242,7 @@ public final class ChannelProvider {
                 if (evt instanceof ProxyConnectionEvent) {
                   pipeline.remove(proxy);
                   pipeline.remove(this);
-                  initSSL(handler, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, ch, channelHandler);
+                  initSSL(handler, peerAddress, serverName, ssl, useAlpn, resolvedKeyExchangeGroups, ch, channelHandler);
                   connected(handler, ch, ssl, channelHandler);
                 }
                 ctx.fireUserEventTriggered(evt);

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -46,6 +46,7 @@ import io.vertx.core.spi.metrics.TCPMetrics;
 
 import java.io.FileNotFoundException;
 import java.net.ConnectException;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -67,6 +68,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
 
   private final VertxInternal vertx;
   private final NetClientOptions options;
+  private final List<String> resolvedKeyExchangeGroups;
   private final SSLHelper sslHelper;
   private Future<SslContextUpdate> sslChannelProvider;
   private final ChannelGroup channelGroup;
@@ -75,9 +77,16 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
   private final Predicate<SocketAddress> proxyFilter;
 
   public NetClientImpl(VertxInternal vertx, TCPMetrics metrics, NetClientOptions options, CloseFuture closeFuture) {
+
+    List<String> resolvedKeyExchangeGroups = SslEngineUtils.resolveKeyExchangeGroups(
+      options.getSslOptions().getKeyExchangeGroups(),
+      options.getSslOptions().getPqcEnforcementPolicy()
+    );
+
     this.vertx = vertx;
     this.channelGroup = new DefaultChannelGroup(vertx.getAcceptorEventLoopGroup().next(), true);
     this.options = new NetClientOptions(options);
+    this.resolvedKeyExchangeGroups = resolvedKeyExchangeGroups;
     this.sslHelper = new SSLHelper(options, options.getApplicationLayerProtocols());
     this.metrics = metrics;
     this.logEnabled = options.getLogActivity();
@@ -225,7 +234,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
         proxyOptions = null;
       }
     }
-    connectInternal(proxyOptions, remoteAddress, peerAddress, serverName, options.isSsl(), options.isUseAlpn(), options.isUseHybridKeyExchangeProtocol(),  options.isRegisterWriteHandler(), connectHandler, ctx, options.getReconnectAttempts());
+    connectInternal(proxyOptions, remoteAddress, peerAddress, serverName, options.isSsl(), options.isUseAlpn(), resolvedKeyExchangeGroups,  options.isRegisterWriteHandler(), connectHandler, ctx, options.getReconnectAttempts());
   }
 
   /**
@@ -237,7 +246,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
    * @param serverName the SNI server name (along with SSL)
    * @param ssl whether to use SSL
    * @param useAlpn wether to use ALPN (along with SSL)
-   * @param useHybridKeyExchangeProtocol wether to use Hybrid Key Exchange Protocol (along with SSL)
+   * @param resolvedKeyExchangeGroups the resolved key exchange groups
    * @param registerWriteHandlers whether to register event-bus write handlers
    * @param connectHandler the promise to resolve with the connect result
    * @param context the socket context
@@ -249,7 +258,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
                                 String serverName,
                                 boolean ssl,
                                 boolean useAlpn,
-                                boolean useHybridKeyExchangeProtocol,
+                                List<String> resolvedKeyExchangeGroups,
                                 boolean registerWriteHandlers,
                                 Promise<NetSocket> connectHandler,
                                 ContextInternal context,
@@ -272,7 +281,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
       }
       fut.onComplete(ar -> {
         if (ar.succeeded()) {
-          connectInternal2(proxyOptions, remoteAddress, peerAddress, ar.result().sslChannelProvider(), serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, registerWriteHandlers, connectHandler, context, remainingAttempts);
+          connectInternal2(proxyOptions, remoteAddress, peerAddress, ar.result().sslChannelProvider(), serverName, ssl, useAlpn, resolvedKeyExchangeGroups, registerWriteHandlers, connectHandler, context, remainingAttempts);
         } else {
           connectHandler.fail(ar.cause());
         }
@@ -287,7 +296,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
                               String serverName,
                               boolean ssl,
                               boolean useAlpn,
-                              boolean useHybridKeyExchangeProtocol,
+                              List<String> resolvedKeyExchangeGroups,
                               boolean registerWriteHandlers,
                               Promise<NetSocket> connectHandler,
                               ContextInternal context,
@@ -308,7 +317,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
 
       channelProvider.handler(ch -> connected(context, ch, connectHandler, remoteAddress, sslChannelProvider, channelProvider.applicationProtocol(), registerWriteHandlers));
 
-      io.netty.util.concurrent.Future<Channel> fut = channelProvider.connect(remoteAddress, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol);
+      io.netty.util.concurrent.Future<Channel> fut = channelProvider.connect(remoteAddress, peerAddress, serverName, ssl, useAlpn, resolvedKeyExchangeGroups);
       fut.addListener((GenericFutureListener<io.netty.util.concurrent.Future<Channel>>) future -> {
         if (!future.isSuccess()) {
           Throwable cause = future.cause();
@@ -319,7 +328,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
               log.debug("Failed to create connection. Will retry in " + options.getReconnectInterval() + " milliseconds");
               //Set a timer to retry connection
               vertx.setTimer(options.getReconnectInterval(), tid ->
-                connectInternal(proxyOptions, remoteAddress, peerAddress, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, registerWriteHandlers, connectHandler, context, remainingAttempts == -1 ? remainingAttempts : remainingAttempts - 1)
+                connectInternal(proxyOptions, remoteAddress, peerAddress, serverName, ssl, useAlpn, resolvedKeyExchangeGroups, registerWriteHandlers, connectHandler, context, remainingAttempts == -1 ? remainingAttempts : remainingAttempts - 1)
               );
             });
           } else {
@@ -328,7 +337,7 @@ public class NetClientImpl implements MetricsProvider, NetClient, Closeable {
         }
       });
     } else {
-      eventLoop.execute(() -> connectInternal2(proxyOptions, remoteAddress, peerAddress, sslChannelProvider, serverName, ssl, useAlpn, useHybridKeyExchangeProtocol, registerWriteHandlers, connectHandler, context, remainingAttempts));
+      eventLoop.execute(() -> connectInternal2(proxyOptions, remoteAddress, peerAddress, sslChannelProvider, serverName, ssl, useAlpn, resolvedKeyExchangeGroups, registerWriteHandlers, connectHandler, context, remainingAttempts));
     }
   }
 

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -336,7 +336,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
           channelPromise.addListener(promise);
           ChannelHandler sslHandler;
           if (remoteAddress != null) {
-            sslHandler = sslChannelProvider.createClientSslHandler(remoteAddress, serverName, false, false);
+            sslHandler = sslChannelProvider.createClientSslHandler(remoteAddress, serverName, false, null);
           } else {
             sslHandler = sslChannelProvider.createServerHandler(HttpUtils.socketAddressToHostAndPort(chctx.channel().remoteAddress()));
           }

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -22,16 +22,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.buffer.impl.PartialPooledByteBufAllocator;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.net.ClientOptionsBase;
-import io.vertx.core.net.JdkSSLEngineOptions;
-import io.vertx.core.net.KeyCertOptions;
-import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.NetServerOptions;
-import io.vertx.core.net.OpenSSLEngineOptions;
-import io.vertx.core.net.SSLEngineOptions;
-import io.vertx.core.net.SSLOptions;
-import io.vertx.core.net.TCPSSLOptions;
-import io.vertx.core.net.TrustOptions;
+import io.vertx.core.net.*;
 import io.vertx.core.spi.tls.DefaultSslContextFactory;
 import io.vertx.core.spi.tls.SslContextFactory;
 
@@ -85,6 +76,37 @@ public class SSLHelper {
    * Resolve the ssl engine options to use for properly running the configured options.
    */
   public static SSLEngineOptions resolveEngineOptions(SSLEngineOptions engineOptions, boolean useAlpn) {
+    return resolveEngineOptions(engineOptions, useAlpn, PqcEnforcementPolicy.RELAXED);
+  }
+
+  /**
+   * Resolve the ssl engine options to use for properly running the configured options.
+   */
+  public static SSLEngineOptions resolveEngineOptions(SSLEngineOptions engineOptions, boolean useAlpn, PqcEnforcementPolicy pqcPolicy) {
+    if (pqcPolicy == null) {
+      pqcPolicy = PqcEnforcementPolicy.RELAXED;
+    }
+    if (pqcPolicy == PqcEnforcementPolicy.STRICT || pqcPolicy == PqcEnforcementPolicy.CLIENT_NEGOTIATED) {
+      if (engineOptions != null) {
+        boolean pqcSupported;
+        if (engineOptions instanceof JdkSSLEngineOptions) {
+          pqcSupported = JdkSSLEngineOptions.isPqcAvailable();
+        } else {
+          pqcSupported = OpenSSLEngineOptions.isPqcAvailable();
+        }
+        if (!pqcSupported) {
+          throw new VertxException("PQC enforcement policy " + pqcPolicy + " requires X25519MLKEM768 but the configured SSL engine does not support it");
+        }
+      } else {
+        if (JdkSSLEngineOptions.isPqcAvailable()) {
+          engineOptions = new JdkSSLEngineOptions();
+        } else if (OpenSSLEngineOptions.isPqcAvailable()) {
+          engineOptions = new OpenSSLEngineOptions();
+        } else {
+          throw new VertxException("PQC enforcement policy " + pqcPolicy + " requires X25519MLKEM768 but neither JDK nor OpenSSL support it");
+        }
+      }
+    }
     if (engineOptions == null) {
       if (useAlpn) {
         if (JdkSSLEngineOptions.isAlpnAvailable()) {
@@ -128,7 +150,8 @@ public class SSLHelper {
   private final ClientAuth clientAuth;
   private final boolean client;
   private final boolean useAlpn;
-  private final boolean useHybridKeyExchangeProtocol;
+  private final List<String> resolvedKeyExchangeGroups;
+  private final PqcEnforcementPolicy pqcEnforcementPolicy;
   private final String endpointIdentificationAlgorithm;
   private final SSLEngineOptions sslEngineOptions;
   private final List<String> applicationProtocols;
@@ -140,10 +163,17 @@ public class SSLHelper {
   private Future<CachedProvider> cachedProvider;
 
   public SSLHelper(TCPSSLOptions options, List<String> applicationProtocols) {
+
+    List<String> resolvedKeyExchangeGroups = SslEngineUtils.resolveKeyExchangeGroups(
+      options.getSslOptions().getKeyExchangeGroups(),
+      options.getSslOptions().getPqcEnforcementPolicy()
+    );
+
     this.sslEngineOptions = options.getSslEngineOptions();
     this.ssl = options.isSsl();
     this.useAlpn = options.isUseAlpn();
-    this.useHybridKeyExchangeProtocol = options.isUseHybridKeyExchangeProtocol();
+    this.resolvedKeyExchangeGroups = resolvedKeyExchangeGroups;
+    this.pqcEnforcementPolicy = options.getSslOptions().getPqcEnforcementPolicy();
     this.client = options instanceof ClientOptionsBase;
     this.trustAll = options instanceof ClientOptionsBase && ((ClientOptionsBase)options).isTrustAll();
     this.clientAuth = options instanceof NetServerOptions ? ((NetServerOptions)options).getClientAuth() : ClientAuth.NONE;
@@ -265,7 +295,7 @@ public class SSLHelper {
       c.sslContextProvider(), c.sslOptions.getSslHandshakeTimeout(), c.sslOptions.getSslHandshakeTimeoutUnit(), sni,
       trustAll,
       useAlpn,
-      useHybridKeyExchangeProtocol,
+      resolvedKeyExchangeGroups,
       ctx.owner().getInternalWorkerPool().executor(),
       c.useWorkerPool
     ));
@@ -324,7 +354,7 @@ public class SSLHelper {
         boolean useWorkerPool;
         final boolean jdkSSLProvider;
         try {
-          SSLEngineOptions resolvedEngineOptions = resolveEngineOptions(sslEngineOptions, useAlpn);
+          SSLEngineOptions resolvedEngineOptions = resolveEngineOptions(sslEngineOptions, useAlpn, pqcEnforcementPolicy);
           supplier = resolvedEngineOptions::sslContextFactory;
           useWorkerPool = resolvedEngineOptions.getUseWorkerThread();
           jdkSSLProvider = resolvedEngineOptions instanceof JdkSSLEngineOptions;

--- a/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/SslChannelProvider.java
@@ -49,7 +49,7 @@ public class SslChannelProvider {
   private final boolean useWorkerPool;
   private final boolean sni;
   private final boolean useAlpn;
-  private final boolean useHybridKeyExchangeProtocol;
+  private final List<String> keyExchangeGroups;
   private final boolean trustAll;
   private final SslContextProvider sslContextProvider;
   private final SslContext[] sslContexts = new SslContext[2];
@@ -65,13 +65,13 @@ public class SslChannelProvider {
                             boolean sni,
                             boolean trustAll,
                             boolean useAlpn,
-                            boolean useHybridKeyExchangeProtocol,
+                            List<String> keyExchangeGroups,
                             Executor workerPool,
                             boolean useWorkerPool) {
     this.workerPool = workerPool;
     this.useWorkerPool = useWorkerPool;
     this.useAlpn = useAlpn;
-    this.useHybridKeyExchangeProtocol = useHybridKeyExchangeProtocol;
+    this.keyExchangeGroups = keyExchangeGroups;
     this.sni = sni;
     this.trustAll = trustAll;
     this.sslHandshakeTimeout = sslHandshakeTimeout;
@@ -153,7 +153,7 @@ public class SslChannelProvider {
     };
   }
 
-  public SslHandler createClientSslHandler(SocketAddress remoteAddress, String serverName, boolean useAlpn, boolean useHybridKeyExchangeProtocol) {
+  public SslHandler createClientSslHandler(SocketAddress remoteAddress, String serverName, boolean useAlpn, List<String> keyExchangeGroups) {
     SslContext sslContext = sslClientContext(serverName, useAlpn);
     SslHandler sslHandler;
     Executor delegatedTaskExec = useWorkerPool ? workerPool : ImmediateExecutor.INSTANCE;
@@ -162,8 +162,8 @@ public class SslChannelProvider {
     } else {
       sslHandler = sslContext.newHandler(ByteBufAllocator.DEFAULT, remoteAddress.host(), remoteAddress.port(), delegatedTaskExec);
     }
-    if (useHybridKeyExchangeProtocol) {
-      applyHybridCurves(sslHandler);
+    if (keyExchangeGroups != null && !keyExchangeGroups.isEmpty()) {
+      SslEngineUtils.applyKeyExchangeGroups(sslHandler.engine(), keyExchangeGroups);
     }
     sslHandler.setHandshakeTimeout(sslHandshakeTimeout, sslHandshakeTimeoutUnit);
     return sslHandler;
@@ -171,13 +171,13 @@ public class SslChannelProvider {
 
   public ChannelHandler createServerHandler(HostAndPort remoteAddress) {
     if (sni) {
-      return createSniHandler(remoteAddress, useHybridKeyExchangeProtocol);
+      return createSniHandler(remoteAddress, keyExchangeGroups);
     } else {
-      return createServerSslHandler(useAlpn, remoteAddress, useHybridKeyExchangeProtocol);
+      return createServerSslHandler(useAlpn, remoteAddress, keyExchangeGroups);
     }
   }
 
-  private SslHandler createServerSslHandler(boolean useAlpn, HostAndPort remoteAddress, boolean useHybridKeyExchangeProtocol) {
+  private SslHandler createServerSslHandler(boolean useAlpn, HostAndPort remoteAddress, List<String> keyExchangeGroups) {
     SslContext sslContext = sslServerContext(useAlpn);
     Executor delegatedTaskExec = useWorkerPool ? workerPool : ImmediateExecutor.INSTANCE;
     SslHandler sslHandler;
@@ -186,16 +186,16 @@ public class SslChannelProvider {
     } else {
       sslHandler = sslContext.newHandler(ByteBufAllocator.DEFAULT, delegatedTaskExec);
     }
-    if (useHybridKeyExchangeProtocol) {
-      applyHybridCurves(sslHandler);
+    if (keyExchangeGroups != null && !keyExchangeGroups.isEmpty()) {
+      SslEngineUtils.applyKeyExchangeGroups(sslHandler.engine(), keyExchangeGroups);
     }
     sslHandler.setHandshakeTimeout(sslHandshakeTimeout, sslHandshakeTimeoutUnit);
     return sslHandler;
   }
 
-  private SniHandler createSniHandler(HostAndPort remoteAddress, boolean useHybridKeyExchangeProtocol) {
+  private SniHandler createSniHandler(HostAndPort remoteAddress, List<String> keyExchangeGroups) {
     Executor delegatedTaskExec = useWorkerPool ? workerPool : ImmediateExecutor.INSTANCE;
-    return new VertxSniHandler(serverNameMapping(), sslHandshakeTimeoutUnit.toMillis(sslHandshakeTimeout), delegatedTaskExec, useHybridKeyExchangeProtocol, remoteAddress);
+    return new VertxSniHandler(serverNameMapping(), sslHandshakeTimeoutUnit.toMillis(sslHandshakeTimeout), delegatedTaskExec, keyExchangeGroups, remoteAddress);
   }
 
   private static int idx(boolean useAlpn) {

--- a/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
+++ b/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net.impl;
+
+import io.netty.handler.ssl.ReferenceCountedOpenSslEngine;
+import io.netty.internal.tcnative.SSL;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.net.PqcEnforcementPolicy;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *
+ */
+public class SslEngineUtils {
+
+  private static final Logger log = LoggerFactory.getLogger(SslEngineUtils.class);
+
+  private static final List<String> PQ_COMPLIANT_GROUPS = Collections.unmodifiableList(Arrays.asList("X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024"));
+  private static final List<String> DEFAULT_KEY_EXCHANGE_GROUPS = Collections.unmodifiableList(Arrays.asList("X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024", "X25519", "secp256r1", "x448",
+    "secp384r1", "secp521r1"));
+
+  /**
+   * Resolve the effective key exchange groups based on the PQC enforcement policy.
+   * Called once at startup to avoid per-connection computation and logging.
+   */
+  public static List<String> resolveKeyExchangeGroups(List<String> groups, PqcEnforcementPolicy pqcPolicy) {
+    if (pqcPolicy == null) {
+      pqcPolicy = PqcEnforcementPolicy.RELAXED;
+    }
+    switch (pqcPolicy) {
+      case STRICT:
+        if (groups != null && !groups.isEmpty()) {
+          if (!(PQ_COMPLIANT_GROUPS.containsAll(groups))) {
+            log.debug("PQC enforcement policy is STRICT: overriding key exchange groups " + groups + " with " + PQ_COMPLIANT_GROUPS);
+          }
+        }
+        return PQ_COMPLIANT_GROUPS;
+      case CLIENT_NEGOTIATED:
+        if (groups == null || groups.isEmpty()) {
+          log.debug("No key exchange groups list was specified, a default list containing X25519MLKEM768 is selected");
+          return DEFAULT_KEY_EXCHANGE_GROUPS;
+        }
+        if (groups.stream().noneMatch(PQ_COMPLIANT_GROUPS::contains)) {
+          log.debug("PQC enforcement policy is CLIENT_NEGOTIATED: prepending " + PQ_COMPLIANT_GROUPS + " to key exchange groups " + groups);
+          List<String> result = new ArrayList<>(groups.size() + 1);
+          result.addAll(PQ_COMPLIANT_GROUPS);
+          result.addAll(groups);
+          return result;
+        }
+        return groups;
+      case RELAXED:
+      default:
+        return groups;
+    }
+  }
+
+  public static void applyKeyExchangeGroups(SSLEngine engine, List<String> groups) {
+    try {
+      if (engine instanceof ReferenceCountedOpenSslEngine) {
+        long sslPtr = ((ReferenceCountedOpenSslEngine) engine).sslPointer();
+        boolean success = SSL.setCurvesList(sslPtr, String.join(":", groups));
+        if (!success) {
+          log.error("Failed to set key exchange groups " + groups + " on SSL instance, closing engine");
+          engine.closeOutbound();
+        }
+      } else {
+        applyNamedGroups(engine, groups);
+      }
+    } catch (Exception e) {
+      log.error("Unable to apply key exchange groups: " + e.getMessage() + ", closing engine", e);
+      engine.closeOutbound();
+    }
+  }
+
+  public static void applyNamedGroups(SSLEngine engine, List<String> groups) {
+    try {
+      Method setNamedGroups = SSLParameters.class.getDeclaredMethod("setNamedGroups", String[].class);
+      SSLParameters params = engine.getSSLParameters();
+      setNamedGroups.invoke(params, groups.toArray(new String[0]));
+      engine.setSSLParameters(params);
+    } catch (Exception e) {
+      log.warn("Cannot apply key exchange groups " + groups + " on JDK SSL engine: requires JDK 20+", e);
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/net/impl/VertxSniHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxSniHandler.java
@@ -17,6 +17,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AsyncMapping;
 import io.vertx.core.net.HostAndPort;
 
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
@@ -28,15 +29,15 @@ import java.util.concurrent.TimeUnit;
 class VertxSniHandler extends SniHandler {
 
   private final Executor delegatedTaskExec;
-  private final boolean useHybridKeyExchangeProtocol;
+  private final List<String> keyExchangeGroups;
   private final HostAndPort remoteAddress;
 
   public VertxSniHandler(AsyncMapping<? super String, ? extends SslContext> mapping, long handshakeTimeoutMillis, Executor delegatedTaskExec,
-      boolean useHybridKeyExchangeProtocol, HostAndPort remoteAddress) {
+                         List<String> keyExchangeGroups, HostAndPort remoteAddress) {
     super(mapping, handshakeTimeoutMillis);
 
     this.delegatedTaskExec = delegatedTaskExec;
-    this.useHybridKeyExchangeProtocol = useHybridKeyExchangeProtocol;
+    this.keyExchangeGroups = keyExchangeGroups;
     this.remoteAddress = remoteAddress;
   }
 
@@ -48,8 +49,8 @@ class VertxSniHandler extends SniHandler {
     } else {
       sslHandler = context.newHandler(allocator, delegatedTaskExec);
     }
-    if (useHybridKeyExchangeProtocol) {
-      SslChannelProvider.applyHybridCurves(sslHandler);
+    if (keyExchangeGroups != null && !keyExchangeGroups.isEmpty()) {
+      SslEngineUtils.applyKeyExchangeGroups(sslHandler.engine(), keyExchangeGroups);
     }
     sslHandler.setHandshakeTimeout(handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
     return sslHandler;

--- a/src/test/java/io/vertx/it/HybridKeyExchangeTest.java
+++ b/src/test/java/io/vertx/it/HybridKeyExchangeTest.java
@@ -21,20 +21,25 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.*;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.internal.tcnative.SSL;
-import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.http.ClientAuth;
+import io.vertx.core.net.JdkSSLEngineOptions;
 import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.core.net.PqcEnforcementPolicy;
 import io.vertx.test.tls.Cert;
 import io.vertx.test.tls.Trust;
 import org.junit.Assume;
 import org.junit.Test;
 
+import javax.net.ssl.SSLHandshakeException;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Tests hybrid key exchange (X25519MLKEM768) with OpenSSL.
+ * Tests PQC key exchange with OpenSSL.
  */
 public class HybridKeyExchangeTest extends HttpTestBase {
 
@@ -45,7 +50,9 @@ public class HybridKeyExchangeTest extends HttpTestBase {
       Assume.assumeTrue("OpenSSL is not available", false);
       return;
     }
-    System.out.println("OpenSSL available: version=" + OpenSsl.versionString() + " (" + Long.toHexString(OpenSsl.version()) + ")");
+    String version = OpenSsl.versionString();
+    System.out.println("OpenSSL available: version=" + version + " (" + Long.toHexString(OpenSsl.version()) + ")");
+    Assume.assumeFalse("BoringSSL does not support X25519MLKEM768", version.contains("BoringSSL"));
     boolean mlkem;
     try {
       SslContext ctx = SslContextBuilder.forClient()
@@ -70,248 +77,397 @@ public class HybridKeyExchangeTest extends HttpTestBase {
   }
 
   @Test
-  public void testHybridKeyExchangeHandshake() throws Exception {
+  public void testStrictPolicyHandshake() throws Exception {
     assumeMlKemAvailable();
-    server = vertx.createHttpServer(new HttpServerOptions()
+
+    HttpServerOptions serverOptions = new HttpServerOptions()
       .setPort(DEFAULT_HTTPS_PORT)
       .setHost(DEFAULT_HTTPS_HOST)
-      .setSsl(true)
-      .setUseAlpn(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-      .setUseHybridKeyExchangeProtocol(true)
-      .setKeyCertOptions(Cert.SERVER_PEM.get()));
-    server.requestHandler(req -> req.response().end("hybrid-ok"));
+      .setSsl(true);
+    serverOptions.setSslEngineOptions(new OpenSSLEngineOptions());
+    serverOptions.getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setKeyCertOptions(Cert.SERVER_PEM.get());
+
+    server = vertx.createHttpServer(serverOptions);
+    server.requestHandler(req -> req.response().end("strict-ok"));
     startServer(server);
 
-    client = vertx.createHttpClient(new HttpClientOptions()
+    HttpClientOptions clientOptions = new HttpClientOptions();
+    clientOptions
       .setSsl(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-        .setUseAlpn(true)
-      .setUseHybridKeyExchangeProtocol(true)
-      .setTrustAll(true));
-    HttpClient client2 = vertx.createHttpClient(new HttpClientOptions()
-      .setSsl(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-      .setUseHybridKeyExchangeProtocol(false)
-      .setTrustAll(true));
+      .setTrustAll(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    clientOptions.getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT);
 
-    CompletableFuture<Boolean> cf1 = new CompletableFuture<>();
-    CompletableFuture<Boolean> cf2 = new CompletableFuture<>();
+    client = vertx.createHttpClient(clientOptions);
 
-    Future<HttpClientRequest> reqSuccess = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(onSuccess(req -> {
-      req.send().onComplete(onSuccess(resp -> {
-        assertEquals(200, resp.statusCode());
-        assertEquals("TLSv1.3", req.connection().sslSession().getProtocol());
-        resp.body().onComplete(onSuccess(body -> {
-          assertEquals("hybrid-ok", body.toString());
-          cf1.complete(true);
-        }));
-      }));
-    }));
-
-    Future<HttpClientRequest> reqFail = client2.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(
-      onFailure(req -> {
-        assertTrue(req instanceof javax.net.ssl.SSLHandshakeException);
-        cf2.complete(true);
-      })
-    );
-
-    CompletableFuture.allOf(cf1, cf2).thenAccept((v) -> testComplete()).get();
+    Buffer bodyBuffer = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .expecting(req -> req.connection().sslSession().getProtocol().equals("TLSv1.3"))
+      .compose(HttpClientRequest::send)
+      .expecting(HttpResponseExpectation.SC_OK)
+      .compose(HttpClientResponse::body)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(20, TimeUnit.SECONDS);
+    assertEquals("strict-ok", bodyBuffer.toString());
   }
 
   @Test
-  public void testHybridKeyExchangeHandshakeMTLS() throws Exception {
+  public void testStrictPolicyRejectsNonPqcClient() throws Exception {
     assumeMlKemAvailable();
-    server = vertx.createHttpServer(new HttpServerOptions()
+    HttpServerOptions serverOptions = new HttpServerOptions()
       .setPort(DEFAULT_HTTPS_PORT)
       .setHost(DEFAULT_HTTPS_HOST)
       .setSsl(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-      .setUseHybridKeyExchangeProtocol(true)
-      .setClientAuth(ClientAuth.REQUIRED)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    serverOptions
+      .getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setKeyCertOptions(Cert.SERVER_PEM.get());
+    server = vertx.createHttpServer(serverOptions);
+    server.requestHandler(req -> req.response().end("should-not-reach"));
+    startServer(server);
+
+    HttpClientOptions clientOptions = new HttpClientOptions()
+      .setSsl(true)
+      .setTrustAll(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    HttpClient client2 = vertx.createHttpClient(clientOptions);
+
+    client2.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .compose(HttpClientRequest::send)
+      .onComplete(ar -> {
+        assertTrue(ar.failed());
+        assertTrue(ar.cause() instanceof SSLHandshakeException);
+        testComplete();
+      });
+    await();
+  }
+
+  @Test
+  public void testClientNegotiatedPolicyAllowsNonPqcClient() throws Exception {
+    assumeMlKemAvailable();
+    HttpServerOptions serverOptions = new HttpServerOptions()
+      .setPort(DEFAULT_HTTPS_PORT)
+      .setHost(DEFAULT_HTTPS_HOST)
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    serverOptions
+      .getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.CLIENT_NEGOTIATED)
+      .setKeyExchangeGroups(Collections.singletonList("X25519"))
+      .setKeyCertOptions(Cert.SERVER_PEM.get());
+
+    server = vertx.createHttpServer(serverOptions);
+    server.requestHandler(req -> req.response().end("client-negotiated-ok"));
+    startServer(server);
+
+    HttpClientOptions clientOptions = new HttpClientOptions()
+      .setSsl(true)
+      .setTrustAll(true);
+    client = vertx.createHttpClient(clientOptions);
+
+    Buffer bodyBuffer = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .compose(HttpClientRequest::send)
+      .expecting(HttpResponseExpectation.SC_OK)
+      .compose(HttpClientResponse::body)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(20, TimeUnit.SECONDS);
+    assertEquals("client-negotiated-ok", bodyBuffer.toString());
+  }
+
+  @Test
+  public void testClientNegotiatedPolicyWithPqcClient() throws Exception {
+    assumeMlKemAvailable();
+
+    HttpServerOptions serverOptions = new HttpServerOptions()
+      .setPort(DEFAULT_HTTPS_PORT)
+      .setHost(DEFAULT_HTTPS_HOST)
+      .setSsl(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    serverOptions
+      .getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.CLIENT_NEGOTIATED)
+      .setKeyCertOptions(Cert.SERVER_PEM.get());
+    server = vertx.createHttpServer(serverOptions);
+    server.requestHandler(req -> req.response().end("pqc-negotiated-ok"));
+    startServer(server);
+
+    HttpClientOptions clientOptions = new HttpClientOptions()
+      .setSsl(true)
+      .setTrustAll(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    clientOptions
+      .getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT);
+    client = vertx.createHttpClient(clientOptions);
+
+    Buffer bodyBuffer = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .expecting(req -> req.connection().sslSession().getProtocol().equals("TLSv1.3"))
+      .compose(HttpClientRequest::send)
+      .expecting(HttpResponseExpectation.SC_OK)
+      .compose(HttpClientResponse::body)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(20, TimeUnit.SECONDS);
+    assertEquals("pqc-negotiated-ok", bodyBuffer.toString());
+  }
+
+  @Test
+  public void testStrictPolicyMTLS() throws Exception {
+    assumeMlKemAvailable();
+
+    HttpServerOptions serverOptions = new HttpServerOptions()
+      .setPort(DEFAULT_HTTPS_PORT)
+      .setHost(DEFAULT_HTTPS_HOST)
+      .setSsl(true)
+      .setClientAuth(io.vertx.core.http.ClientAuth.REQUIRED)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    serverOptions
+      .getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
       .setKeyCertOptions(Cert.SERVER_PEM_ROOT_CA.get())
-      .setTrustOptions(Trust.SERVER_PEM_ROOT_CA.get()));
+      .setTrustOptions(Trust.SERVER_PEM_ROOT_CA.get());
+    server = vertx.createHttpServer(serverOptions);
     server.requestHandler(req -> {
       assertTrue(req.isSSL());
-      req.response().end("mtls-hybrid-ok");
+      req.response().end("mtls-strict-ok");
     });
     startServer(server);
 
-    client = vertx.createHttpClient(new HttpClientOptions()
+    HttpClientOptions clientOptions = new HttpClientOptions()
       .setSsl(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-      .setUseHybridKeyExchangeProtocol(true)
-      .setKeyCertOptions(Cert.CLIENT_PEM_ROOT_CA.get())
-      .setTrustAll(true));
-    HttpClient client2 = vertx.createHttpClient(new HttpClientOptions()
-      .setSsl(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-      .setUseHybridKeyExchangeProtocol(false)
-      .setKeyCertOptions(Cert.CLIENT_PEM_ROOT_CA.get())
-      .setTrustAll(true));
+      .setTrustAll(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    clientOptions
+      .getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setKeyCertOptions(Cert.CLIENT_PEM_ROOT_CA.get());
+    client = vertx.createHttpClient(clientOptions);
 
-    CompletableFuture<Boolean> cf1 = new CompletableFuture<>();
-    CompletableFuture<Boolean> cf2 = new CompletableFuture<>();
+    Buffer buffer = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .expecting(req -> req.connection().sslSession().getProtocol().equals("TLSv1.3"))
+      .compose(HttpClientRequest::send)
+      .expecting(HttpResponseExpectation.SC_OK)
+      .compose(HttpClientResponse::body)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(20, TimeUnit.SECONDS);
 
-    Future<HttpClientRequest> reqSuccess = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(onSuccess(req -> {
-      req.send().onComplete(onSuccess(resp -> {
-        assertEquals(200, resp.statusCode());
-        assertEquals("TLSv1.3", req.connection().sslSession().getProtocol());
-        resp.body().onComplete(onSuccess(body -> {
-          assertEquals("mtls-hybrid-ok", body.toString());
-          cf1.complete(true);
-        }));
-      }));
-    }));
-
-    Future<HttpClientRequest> reqFail = client2.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(
-      onFailure(req -> {
-        assertTrue(req instanceof javax.net.ssl.SSLHandshakeException);
-        cf2.complete(true);
-      })
-    );
-
-    CompletableFuture.allOf(cf1, cf2).thenAccept((v) -> testComplete()).get();
+    assertEquals("mtls-strict-ok", buffer.toString());
   }
 
   @Test
-  public void testHybridFailsServerSideWhenPqcNotAvailable() throws Exception {
+  public void testStrictPolicyMTLSRejectsNonPqcClient() throws Exception {
     assumeMlKemAvailable();
-    server.close();
-    server = vertx.createHttpServer(new HttpServerOptions()
+
+    HttpServerOptions serverOptions = new HttpServerOptions()
       .setPort(DEFAULT_HTTPS_PORT)
       .setHost(DEFAULT_HTTPS_HOST)
       .setSsl(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-      .setUseHybridKeyExchangeProtocol(true)
-      .setKeyCertOptions(Cert.SERVER_PEM.get()));
+      .setClientAuth(ClientAuth.REQUIRED)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    serverOptions.getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setKeyCertOptions(Cert.SERVER_PEM_ROOT_CA.get())
+      .setTrustOptions(Trust.SERVER_PEM_ROOT_CA.get());
+    server = vertx.createHttpServer(serverOptions);
     server.requestHandler(req -> req.response().end("should-not-reach"));
     startServer(server);
 
-    client = vertx.createHttpClient(new HttpClientOptions()
+    HttpClientOptions clientOptions = new HttpClientOptions()
       .setSsl(true)
-      .setTrustAll(true));
+      .setTrustAll(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    clientOptions.getSslOptions()
+      .setKeyCertOptions(Cert.CLIENT_PEM_ROOT_CA.get());
+    HttpClient client2 = vertx.createHttpClient(clientOptions);
 
-    client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(
-      onFailure(err -> {
-        assertTrue(err instanceof javax.net.ssl.SSLHandshakeException);
+    client2.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .compose(HttpClientRequest::send)
+      .onComplete(ar -> {
+        assertTrue(ar.failed());
+        assertTrue(ar.cause() instanceof SSLHandshakeException);
         testComplete();
-      })
-    );
+      });
     await();
   }
 
   @Test
-  public void testHybridFailsClientSideWhenPqcNotAvailable() throws Exception {
-    assumeMlKemAvailable();
-    server.close();
-    server = vertx.createHttpServer(new HttpServerOptions()
+  public void testStrictPolicyFailsServerStartWhenJdkPqcNotAvailable() throws Exception {
+    Assume.assumeFalse("JDK PQC is available, skipping", JdkSSLEngineOptions.isPqcAvailable());
+
+    HttpServerOptions serverOptions = new HttpServerOptions()
       .setPort(DEFAULT_HTTPS_PORT)
       .setHost(DEFAULT_HTTPS_HOST)
       .setSsl(true)
-      .setKeyCertOptions(Cert.SERVER_PEM.get()));
+      .setSslEngineOptions(new JdkSSLEngineOptions());
+    serverOptions.getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setKeyCertOptions(Cert.SERVER_PEM.get());
+    server = vertx.createHttpServer(serverOptions);
     server.requestHandler(req -> req.response().end("should-not-reach"));
-    startServer(server);
-
-    client = vertx.createHttpClient(new HttpClientOptions()
-      .setSsl(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-      .setUseHybridKeyExchangeProtocol(true)
-      .setTrustAll(true));
-
-    client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(
-      onFailure(err -> {
-        assertTrue(err instanceof javax.net.ssl.SSLHandshakeException);
-        testComplete();
-      })
-    );
+    server.listen().onComplete(ar -> {
+      assertTrue(ar.failed());
+      assertTrue(ar.cause().getMessage().contains("X25519MLKEM768"));
+      assertTrue(ar.cause().getMessage().contains("does not support it"));
+      testComplete();
+    });
     await();
   }
 
   @Test
-  public void testHybridKeyExchangeWithSNI() throws Exception {
+  public void testStrictPolicyFailsClientStartWhenJdkPqcNotAvailable() throws Exception {
+    Assume.assumeFalse("JDK PQC is available, skipping", JdkSSLEngineOptions.isPqcAvailable());
+
+    HttpClientOptions clientOptions = new HttpClientOptions()
+      .setSsl(true)
+      .setTrustAll(true)
+      .setSslEngineOptions(new JdkSSLEngineOptions());
+    clientOptions.getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT);
+
+    RequestOptions request = new RequestOptions()
+      .setPort(8080)
+      .setHost("localhost");
+
+    try {
+      client = vertx.createHttpClient(clientOptions);
+      client.request(request)
+        .toCompletionStage()
+        .toCompletableFuture()
+        .get(20, TimeUnit.SECONDS);
+      fail("Client should have failed to build");
+    } catch (ExecutionException e) {
+      Throwable root = e.getCause();
+      assertTrue(root.getMessage().contains("X25519MLKEM768"));
+      assertTrue(root.getMessage().contains("does not support it"));
+    }
+  }
+
+  @Test
+  public void testStrictPolicyWithSNI() throws Exception {
     assumeMlKemAvailable();
-    server.close();
-    server = vertx.createHttpServer(new HttpServerOptions()
+
+    HttpServerOptions serverOptions = new HttpServerOptions()
       .setPort(DEFAULT_HTTPS_PORT)
       .setHost(DEFAULT_HTTPS_HOST)
       .setSsl(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-      .setUseHybridKeyExchangeProtocol(true)
       .setSni(true)
-      .setKeyCertOptions(Cert.SERVER_PEM.get()));
-    server.requestHandler(req -> req.response().end("sni-hybrid-ok"));
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    serverOptions.getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setKeyCertOptions(Cert.SERVER_PEM.get());
+    server = vertx.createHttpServer(serverOptions);
+    server.requestHandler(req -> req.response().end("sni-strict-ok"));
     startServer(server);
 
-    client = vertx.createHttpClient(new HttpClientOptions()
+    HttpClientOptions clientOptions = new HttpClientOptions()
       .setSsl(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-      .setUseHybridKeyExchangeProtocol(true)
-      .setTrustAll(true));
+      .setTrustAll(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    clientOptions.getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT);
+    client = vertx.createHttpClient(clientOptions);
 
-    client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(onSuccess(req -> {
-      req.send().onComplete(onSuccess(resp -> {
-        assertEquals(200, resp.statusCode());
-        assertEquals("TLSv1.3", req.connection().sslSession().getProtocol());
-        resp.body().onComplete(onSuccess(body -> {
-          assertEquals("sni-hybrid-ok", body.toString());
-          testComplete();
-        }));
-      }));
-    }));
-    await();
+    Buffer body = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .compose(HttpClientRequest::send)
+      .expecting(HttpResponseExpectation.SC_OK)
+      .compose(HttpClientResponse::body)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(20, TimeUnit.SECONDS);
+    assertEquals("sni-strict-ok", body.toString());
   }
 
   @Test
-  public void testHybridFailsWithSNIWhenPqcNotAvailable() throws Exception {
+  public void testRelaxedPolicyWithCustomGroups() throws Exception {
     assumeMlKemAvailable();
-    server.close();
-    server = vertx.createHttpServer(new HttpServerOptions()
+
+    HttpServerOptions serverOptions = new HttpServerOptions()
       .setPort(DEFAULT_HTTPS_PORT)
       .setHost(DEFAULT_HTTPS_HOST)
       .setSsl(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-      .setUseHybridKeyExchangeProtocol(true)
-      .setSni(true)
-      .setKeyCertOptions(Cert.SERVER_PEM.get()));
-    server.requestHandler(req -> req.response().end("should-not-reach"));
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    serverOptions.getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.RELAXED)
+      .setKeyExchangeGroups(Collections.singletonList("X25519MLKEM768"))
+      .setKeyCertOptions(Cert.SERVER_PEM.get());
+    server = vertx.createHttpServer(serverOptions);
+    server.requestHandler(req -> req.response().end("relaxed-custom-ok"));
     startServer(server);
 
-    client = vertx.createHttpClient(new HttpClientOptions()
+    HttpClientOptions clientOptions = new HttpClientOptions()
       .setSsl(true)
-      .setTrustAll(true));
+      .setTrustAll(true)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    clientOptions.getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.RELAXED)
+      .setKeyExchangeGroups(Collections.singletonList("X25519MLKEM768"));
+    client = vertx.createHttpClient(clientOptions);
 
-    client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/").onComplete(
-      onFailure(err -> {
-        assertTrue(err instanceof javax.net.ssl.SSLHandshakeException);
-        testComplete();
-      })
-    );
-    await();
+    Buffer body = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .compose(HttpClientRequest::send)
+      .expecting(HttpResponseExpectation.SC_OK)
+      .compose(HttpClientResponse::body)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(20, TimeUnit.SECONDS);
+    assertEquals("relaxed-custom-ok", body.toString());
   }
 
   @Test
-  public void testHybridWithRawNettySocket() throws Exception {
+  public void testRelaxedPolicyDefaultGroups() throws Exception {
+
+    HttpServerOptions serverOptions = new HttpServerOptions()
+      .setPort(DEFAULT_HTTPS_PORT)
+      .setHost(DEFAULT_HTTPS_HOST)
+      .setSsl(true);
+    serverOptions.getSslOptions()
+      .setKeyCertOptions(Cert.SERVER_PEM.get());
+    server = vertx.createHttpServer(serverOptions);
+    server.requestHandler(req -> req.response().end("relaxed-default-ok"));
+    startServer(server);
+
+    HttpClientOptions clientOptions = new HttpClientOptions()
+      .setSsl(true)
+      .setTrustAll(true);
+    client = vertx.createHttpClient(clientOptions);
+
+    Buffer body = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .compose(HttpClientRequest::send)
+      .expecting(HttpResponseExpectation.SC_OK)
+      .compose(HttpClientResponse::body)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(20, TimeUnit.SECONDS);
+    assertEquals("relaxed-default-ok", body.toString());
+  }
+
+  @Test
+  public void testStrictPolicyWithRawNettySocket() throws Exception {
     assumeMlKemAvailable();
-    // Start Vert.x server with hybrid
-    server.close();
-    server = vertx.createHttpServer(new HttpServerOptions()
+
+    HttpServerOptions serverOptions = new HttpServerOptions()
       .setPort(DEFAULT_HTTPS_PORT)
       .setHost(DEFAULT_HTTPS_HOST)
       .setSsl(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-      .setUseHybridKeyExchangeProtocol(true)
-      .setKeyCertOptions(Cert.SERVER_PEM.get()));
-    server.requestHandler(req -> req.response().end("hybrid-ok"));
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    serverOptions.getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setKeyCertOptions(Cert.SERVER_PEM.get());
+    server = vertx.createHttpServer(serverOptions);
+    server.requestHandler(req -> req.response().end("strict-ok"));
     startServer(server);
 
-    // Raw Netty client
     SslContext sslContext = SslContextBuilder.forClient()
       .sslProvider(SslProvider.OPENSSL)
       .trustManager(InsecureTrustManagerFactory.INSTANCE)
       .build();
 
-    // Will hold the negotiated group from key_share extension
     CompletableFuture<Integer> negotiatedGroup = new CompletableFuture<>();
 
     EventLoopGroup group = new NioEventLoopGroup();
@@ -325,12 +481,10 @@ public class HybridKeyExchangeTest extends HttpTestBase {
             SslHandler sslHandler = sslContext.newHandler(ch.alloc(),
               DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT);
 
-            // Set hybrid curves on the OpenSSL engine
             ReferenceCountedOpenSslEngine engine =
               (ReferenceCountedOpenSslEngine) sslHandler.engine();
             SSL.setCurvesList(engine.sslPointer(), "X25519MLKEM768");
 
-            // Interceptor BEFORE SslHandler sees raw TLS records
             ch.pipeline().addLast("server-hello-interceptor",
               new ServerHelloGroupExtractor(negotiatedGroup));
             ch.pipeline().addLast("ssl", sslHandler);
@@ -357,26 +511,26 @@ public class HybridKeyExchangeTest extends HttpTestBase {
   }
 
   @Test
-  public void testHybridMTLSWithRawNettySocket() throws Exception {
+  public void testStrictPolicyMTLSWithRawNettySocket() throws Exception {
     assumeMlKemAvailable();
-    // Start Vert.x server with hybrid + mTLS
-    server.close();
-    server = vertx.createHttpServer(new HttpServerOptions()
+
+    HttpServerOptions serverOptions = new HttpServerOptions()
       .setPort(DEFAULT_HTTPS_PORT)
       .setHost(DEFAULT_HTTPS_HOST)
       .setSsl(true)
-      .setSslEngineOptions(new OpenSSLEngineOptions())
-      .setUseHybridKeyExchangeProtocol(true)
       .setClientAuth(ClientAuth.REQUIRED)
+      .setSslEngineOptions(new OpenSSLEngineOptions());
+    serverOptions.getSslOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
       .setKeyCertOptions(Cert.SERVER_PEM_ROOT_CA.get())
-      .setTrustOptions(Trust.SERVER_PEM_ROOT_CA.get()));
+      .setTrustOptions(Trust.SERVER_PEM_ROOT_CA.get());
+    server = vertx.createHttpServer(serverOptions);
     server.requestHandler(req -> {
       assertTrue(req.isSSL());
-      req.response().end("mtls-hybrid-ok");
+      req.response().end("mtls-strict-ok");
     });
     startServer(server);
 
-    // Raw Netty client with client cert
     SslContext sslContext = SslContextBuilder.forClient()
       .sslProvider(SslProvider.OPENSSL)
       .trustManager(InsecureTrustManagerFactory.INSTANCE)
@@ -385,7 +539,6 @@ public class HybridKeyExchangeTest extends HttpTestBase {
         getClass().getClassLoader().getResourceAsStream("tls/client-key.pem"))
       .build();
 
-    // Will hold the negotiated group from key_share extension
     CompletableFuture<Integer> negotiatedGroup = new CompletableFuture<>();
 
     EventLoopGroup group = new NioEventLoopGroup();
@@ -399,12 +552,10 @@ public class HybridKeyExchangeTest extends HttpTestBase {
             SslHandler sslHandler = sslContext.newHandler(ch.alloc(),
               DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT);
 
-            // Set hybrid curves on the OpenSSL engine
             ReferenceCountedOpenSslEngine engine =
               (ReferenceCountedOpenSslEngine) sslHandler.engine();
             SSL.setCurvesList(engine.sslPointer(), "X25519MLKEM768");
 
-            // Interceptor BEFORE SslHandler sees raw TLS records
             ch.pipeline().addLast("server-hello-interceptor",
               new ServerHelloGroupExtractor(negotiatedGroup));
             ch.pipeline().addLast("ssl", sslHandler);
@@ -427,6 +578,7 @@ public class HybridKeyExchangeTest extends HttpTestBase {
       ch.close().sync();
     } finally {
       group.shutdownGracefully();
+      testComplete();
     }
   }
 
@@ -456,7 +608,6 @@ public class HybridKeyExchangeTest extends HttpTestBase {
           buf.readerIndex(readerIndex);
         }
       }
-      // Always forward to SslHandler
       super.channelRead(ctx, msg);
     }
 
@@ -486,7 +637,6 @@ public class HybridKeyExchangeTest extends HttpTestBase {
       if (buf.readableBytes() < 2) return;
       int extensionsLength = buf.readUnsignedShort();
 
-      // Walk extensions
       int extensionsEnd = buf.readerIndex() + extensionsLength;
       while (buf.readerIndex() < extensionsEnd && buf.readableBytes() >= 4) {
         int extType = buf.readUnsignedShort();


### PR DESCRIPTION
The single `useHybridKeyExchange` is removed in favor of two properties:

- `key-exchange-groups`: the user can specify which key exchange groups they want to use
- `pqc-enforcement-policy`: the user can specify how PQC will be enforced by Vert.x. The policies are:
	- **STRICT**: only PQC can be used to establish secure connections. If no SSL engine supports it, application won't start. If clients don't support it, SSL handshake fails
	- **CLIENT_NEGOTIATED**: if no SSL engine supports PQC, application won't start. If clients don't support it, falls back to other key exchange group
	- **RELAXED**: no enforcement whatsoever, traditional TLS negotiation

When PQC is required (STRICT or CLIENT_NEGOTIATED), Vert.x auto-selects a PQC-capable engine (JDK or OpenSSL) if none is explicitly configured. If none is available, application fails to start with a VertxException ("PQC enforcement policy requires X25519MLKEM768 but neither JDK nor OpenSSL supports it".

The resolution of key exchange groups and PQC enforcement policy (selecting an available SSL engine, adding X25519MLKEM768 to the list of supported groups for CLIENT_NEGOTIATED or restricting the list of supported groups for STRICT) is performed once in `SslContextManager`.