### PR TITLE
#6238 Improve HTTP/2 flow control defaults

### DIFF
--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -92,7 +92,17 @@ WARNING: browsers do not support `h2c`, for serving websites you should use `h2`
 When a server accepts an HTTP/2 connection, it sends to the client its {@link io.vertx.core.http.Http2ServerConfig#getInitialSettings initial settings}. These settings define how the client can use the connection, the default initial settings for a server are:
 
 - {@link io.vertx.core.http.Http2Settings#getMaxConcurrentStreams}: `100` as recommended by the HTTP/2 RFC
+- {@link io.vertx.core.http.Http2Settings#getInitialWindowSize}: `1 MiB`
 - the default HTTP/2 settings values for the remaining settings
+
+HTTP/2 flow control uses two independent receive windows. The initial window size in
+{@link io.vertx.core.http.Http2ServerConfig#getInitialSettings} applies to each stream, while
+{@link io.vertx.core.http.Http2ServerConfig#getConnectionWindowSize} applies to the combined data received by all
+streams on a connection. The connection window defaults to `16 MiB`.
+
+Applications receiving large request bodies, such as large gRPC messages, can tune both values. Larger windows improve
+throughput on connections with significant bandwidth or latency, at the cost of allowing more data to be buffered before
+back-pressure is applied.
 
 === Configuring an HTTP/3 server
 

--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -989,6 +989,13 @@ To perform `h2` requests, TLS must be enabled:
 
 `{@link io.vertx.core.http.Http2ClientConfig}` captures the configuration of HTTP/2 specific aspects.
 
+The HTTP/2 client receive window defaults to `1 MiB` per stream and `16 MiB` for the connection. Applications receiving
+large response bodies can tune the stream window with
+{@link io.vertx.core.http.Http2ClientConfig#getInitialSettings} and the connection window with
+{@link io.vertx.core.http.Http2ClientConfig#setConnectionWindowSize(int)}. Larger windows improve throughput on
+connections with significant bandwidth or latency, at the cost of allowing more data to be buffered before back-pressure
+is applied.
+
 === Configuring an HTTP/3 client
 
 Vert.x supports HTTP/3 over QUIC, we recommend reading the <<quic_client,QUIC client section>>.

--- a/vertx-core/src/main/java/io/vertx/core/http/Http2ClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/Http2ClientConfig.java
@@ -39,7 +39,8 @@ public class Http2ClientConfig {
     keepAliveTimeout = Duration.ofSeconds(HttpClientOptions.DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT);
     upgradeMaxContentLength = HttpClientOptions.DEFAULT_HTTP2_UPGRADE_MAX_CONTENT_LENGTH;
     multiplexImplementation = HttpClientOptions.DEFAULT_HTTP_2_MULTIPLEX_IMPLEMENTATION;
-    initialSettings = new Http2Settings();
+    initialSettings = new Http2Settings()
+      .setInitialWindowSize(HttpClientOptions.DEFAULT_INITIAL_SETTINGS_INITIAL_WINDOW_SIZE);
     clearTextUpgrade = HttpClientOptions.DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE;
     clearTextUpgradeWithPreflightRequest = HttpClientOptions.DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE_WITH_PREFLIGHT_REQUEST;
   }
@@ -90,11 +91,11 @@ public class Http2ClientConfig {
   }
 
   /**
-   * Set the default HTTP/2 connection window size. It overrides the initial window
-   * size set by {@link Http2Settings#getInitialWindowSize}, so the connection window size
-   * is greater than for its streams, in order the data throughput.
+   * Set the default HTTP/2 connection window size. This window is shared by all streams
+   * on the connection and is independent from the per-stream window configured by
+   * {@link Http2Settings#setInitialWindowSize(int)}.
    * <p/>
-   * A value of {@code -1} reuses the initial window size setting.
+   * A value of {@code -1} uses the HTTP/2 protocol default connection window size.
    *
    * @param connectionWindowSize the window size applied to the connection
    * @return a reference to this, so the API can be used fluently

--- a/vertx-core/src/main/java/io/vertx/core/http/Http2ServerConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/Http2ServerConfig.java
@@ -34,7 +34,9 @@ public class Http2ServerConfig {
   private Duration rstFloodWindowDuration;
 
   public Http2ServerConfig() {
-    initialSettings = new Http2Settings().setMaxConcurrentStreams(DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS);
+    initialSettings = new Http2Settings()
+      .setMaxConcurrentStreams(DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS)
+      .setInitialWindowSize(DEFAULT_INITIAL_SETTINGS_INITIAL_WINDOW_SIZE);
     connectionWindowSize = DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE;
     rstFloodMaxRstFramePerWindow = DEFAULT_HTTP2_RST_FLOOD_MAX_RST_FRAME_PER_WINDOW;
     rstFloodWindowDuration = Duration.of(DEFAULT_HTTP2_RST_FLOOD_WINDOW_DURATION, DEFAULT_HTTP2_RST_FLOOD_WINDOW_DURATION_TIME_UNIT.toChronoUnit());
@@ -120,11 +122,11 @@ public class Http2ServerConfig {
   }
 
   /**
-   * Set the default HTTP/2 connection window size. It overrides the initial window
-   * size set by {@link Http2Settings#getInitialWindowSize}, so the connection window size
-   * is greater than for its streams, in order the data throughput.
+   * Set the default HTTP/2 connection window size. This window is shared by all streams
+   * on the connection and is independent from the per-stream window configured by
+   * {@link Http2Settings#setInitialWindowSize(int)}.
    * <p/>
-   * A value of {@code -1} reuses the initial window size setting.
+   * A value of {@code -1} uses the HTTP/2 protocol default connection window size.
    *
    * @param connectionWindowSize the window size applied to the connection
    * @return a reference to this, so the API can be used fluently

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -42,9 +42,14 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final int DEFAULT_HTTP2_MULTIPLEXING_LIMIT = -1;
 
   /**
-   * The default connection window size for HTTP/2 = -1
+   * The default initial HTTP/2 stream window size = 1 MiB
    */
-  public static final int DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE = -1;
+  public static final int DEFAULT_INITIAL_SETTINGS_INITIAL_WINDOW_SIZE = 1024 * 1024;
+
+  /**
+   * The default connection window size for HTTP/2 = 16 MiB
+   */
+  public static final int DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE = 16 * 1024 * 1024;
 
   /**
    * The default keep alive timeout for HTTP/2 connection can send = 60 seconds
@@ -508,11 +513,11 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   /**
-   * Set the default HTTP/2 connection window size. It overrides the initial window
-   * size set by {@link Http2Settings#getInitialWindowSize}, so the connection window size
-   * is greater than for its streams, in order the data throughput.
+   * Set the default HTTP/2 connection window size. This window is shared by all streams
+   * on the connection and is independent from the per-stream window configured by
+   * {@link Http2Settings#setInitialWindowSize(int)}.
    * <p/>
-   * A value of {@code -1} reuses the initial window size setting.
+   * A value of {@code -1} uses the HTTP/2 protocol default connection window size.
    *
    * @param http2ConnectionWindowSize the window size applied to the connection
    * @return a reference to this, so the API can be used fluently

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -122,9 +122,14 @@ public class HttpServerOptions extends NetServerOptions {
   public static final long DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS = 100;
 
   /**
-   * The default HTTP/2 connection window size = -1
+   * The default initial HTTP/2 stream window size = 1 MiB
    */
-  public static final int DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE = -1;
+  public static final int DEFAULT_INITIAL_SETTINGS_INITIAL_WINDOW_SIZE = 1024 * 1024;
+
+  /**
+   * The default HTTP/2 connection window size = 16 MiB
+   */
+  public static final int DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE = 16 * 1024 * 1024;
 
   /**
    * Default value of whether decompression is supported = {@code false}
@@ -956,11 +961,11 @@ public class HttpServerOptions extends NetServerOptions {
   }
 
   /**
-   * Set the default HTTP/2 connection window size. It overrides the initial window
-   * size set by {@link Http2Settings#getInitialWindowSize}, so the connection window size
-   * is greater than for its streams, in order the data throughput.
+   * Set the default HTTP/2 connection window size. This window is shared by all streams
+   * on the connection and is independent from the per-stream window configured by
+   * {@link Http2Settings#setInitialWindowSize(int)}.
    * <p/>
-   * A value of {@code -1} reuses the initial window size setting.
+   * A value of {@code -1} uses the HTTP/2 protocol default connection window size.
    *
    * @param http2ConnectionWindowSize the window size applied to the connection
    * @return a reference to this, so the API can be used fluently

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -417,7 +417,9 @@ public class Http1xTest extends HttpTest {
     assertTrue(options.getSslEngineOptions() instanceof JdkSSLEngineOptions);
 
     Http2Settings initialSettings = randomHttp2Settings();
-    assertEquals(new Http2Settings().setMaxConcurrentStreams(HttpServerOptions.DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS), options.getInitialSettings());
+    assertEquals(new Http2Settings()
+      .setMaxConcurrentStreams(HttpServerOptions.DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS)
+      .setInitialWindowSize(HttpServerOptions.DEFAULT_INITIAL_SETTINGS_INITIAL_WINDOW_SIZE), options.getInitialSettings());
     assertEquals(options, options.setInitialSettings(initialSettings));
     assertEquals(initialSettings, options.getInitialSettings());
 
@@ -426,7 +428,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(options, options.setAlpnVersions(alpnVersions));
     assertEquals(alpnVersions, options.getAlpnVersions());
 
-    assertEquals(HttpClientOptions.DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE, options.getHttp2ConnectionWindowSize());
+    assertEquals(HttpServerOptions.DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE, options.getHttp2ConnectionWindowSize());
     rand = TestUtils.randomPositiveInt();
     assertEquals(options, options.setHttp2ConnectionWindowSize(rand));
     assertEquals(rand, options.getHttp2ConnectionWindowSize());

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -256,7 +256,8 @@ public class Http1xTest extends HttpTest {
     assertEquals(100, options.getMaxHeaderSize());
 
     Http2Settings initialSettings = randomHttp2Settings();
-    assertEquals(new Http2Settings(), options.getInitialSettings());
+    assertEquals(new Http2Settings()
+      .setInitialWindowSize(HttpClientOptions.DEFAULT_INITIAL_SETTINGS_INITIAL_WINDOW_SIZE), options.getInitialSettings());
     assertEquals(options, options.setInitialSettings(initialSettings));
     assertEquals(initialSettings, options.getInitialSettings());
 

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2ClientTest.java
@@ -2070,6 +2070,41 @@ public class Http2ClientTest extends Http2TestBase {
   }
 
   @Test
+  public void testDefaultFlowControlWindows() throws Exception {
+    waitFor(2);
+    AtomicInteger connectionWindowSizeIncrement = new AtomicInteger();
+    ServerBootstrap bootstrap = createH2Server((decoder, encoder) -> new Http2EventAdapter() {
+      @Override
+      public void onSettingsRead(ChannelHandlerContext ctx, io.netty.handler.codec.http2.Http2Settings settings) throws Http2Exception {
+        vertx.runOnContext(v -> {
+          Assert.assertEquals(
+            Integer.valueOf(HttpClientOptions.DEFAULT_INITIAL_SETTINGS_INITIAL_WINDOW_SIZE),
+            settings.initialWindowSize());
+          complete();
+        });
+      }
+
+      @Override
+      public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement) throws Http2Exception {
+        if (streamId == 0) {
+          int total = connectionWindowSizeIncrement.addAndGet(windowSizeIncrement);
+          vertx.runOnContext(v -> {
+            int expected = HttpClientOptions.DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE -
+              io.vertx.core.http.Http2Settings.DEFAULT_INITIAL_WINDOW_SIZE;
+            Assert.assertTrue(total <= expected);
+            if (total == expected) {
+              complete();
+            }
+          });
+        }
+      }
+    });
+    ChannelFuture s = bootstrap.bind(DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT).sync();
+    client.request(requestOptions).onComplete(TestUtils.onSuccess(HttpClientRequest::send));
+    await();
+  }
+
+  @Test
   public void testConnectionWindowSize() throws Exception {
     ServerBootstrap bootstrap = createH2Server((decoder, encoder) -> new Http2EventAdapter() {
       @Override
@@ -2082,7 +2117,9 @@ public class Http2ClientTest extends Http2TestBase {
     });
     ChannelFuture s = bootstrap.bind(DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT).sync();
     client.close();
-    client = vertx.createHttpClient(new HttpClientOptions(clientOptions).setHttp2ConnectionWindowSize(65535 * 2));
+    client = vertx.createHttpClient(new HttpClientOptions(clientOptions)
+      .setInitialSettings(new io.vertx.core.http.Http2Settings())
+      .setHttp2ConnectionWindowSize(65535 * 2));
     HttpClientRequest request = client.request(requestOptions).await();
     request.send();
     await();
@@ -2102,7 +2139,9 @@ public class Http2ClientTest extends Http2TestBase {
     ChannelFuture s = bootstrap.bind(DEFAULT_HTTPS_HOST, DEFAULT_HTTPS_PORT).sync();
     client.close();
     client = vertx.httpClientBuilder()
-      .with(clientOptions)
+      .with(new HttpClientOptions(clientOptions)
+        .setInitialSettings(new io.vertx.core.http.Http2Settings())
+        .setHttp2ConnectionWindowSize(-1))
       .withConnectHandler(conn -> {
         Assert.assertEquals(65535, conn.getWindowSize());
         conn.setWindowSize(65535 + 10000);

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2ServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2ServerTest.java
@@ -3188,6 +3188,40 @@ public class Http2ServerTest extends Http2TestBase {
   }
 
   @Test
+  public void testDefaultFlowControlWindows() throws Exception {
+    waitFor(2);
+    server.requestHandler(req -> req.response().end());
+    startServer();
+    TestClient client = new TestClient();
+    client.connect(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, request -> {
+      request.decoder.frameListener(new Http2EventAdapter() {
+        @Override
+        public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
+          vertx.runOnContext(v -> {
+            Assert.assertEquals(
+              Integer.valueOf(HttpServerOptions.DEFAULT_INITIAL_SETTINGS_INITIAL_WINDOW_SIZE),
+              settings.initialWindowSize());
+            complete();
+          });
+        }
+
+        @Override
+        public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement) throws Http2Exception {
+          if (streamId == 0) {
+            vertx.runOnContext(v -> {
+              Assert.assertEquals(
+                HttpServerOptions.DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE - io.vertx.core.http.Http2Settings.DEFAULT_INITIAL_WINDOW_SIZE,
+                windowSizeIncrement);
+              complete();
+            });
+          }
+        }
+      });
+    });
+    await();
+  }
+
+  @Test
   public void testConnectionWindowSize() throws Exception {
     server.close();
     server = vertx.createHttpServer(new HttpServerOptions(serverOptions).setHttp2ConnectionWindowSize(65535 + 65535));
@@ -3212,6 +3246,8 @@ public class Http2ServerTest extends Http2TestBase {
 
   @Test
   public void testUpdateConnectionWindowSize() throws Exception {
+    server.close();
+    server = vertx.createHttpServer(new HttpServerOptions(serverOptions).setHttp2ConnectionWindowSize(-1));
     server.connectionHandler(conn -> {
       Assert.assertEquals(65535, conn.getWindowSize());
       conn.setWindowSize(65535 + 10000);

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2ServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2ServerTest.java
@@ -3190,6 +3190,7 @@ public class Http2ServerTest extends Http2TestBase {
   @Test
   public void testDefaultFlowControlWindows() throws Exception {
     waitFor(2);
+    AtomicInteger connectionWindowSizeIncrement = new AtomicInteger();
     server.requestHandler(req -> req.response().end());
     startServer();
     TestClient client = new TestClient();
@@ -3208,11 +3209,14 @@ public class Http2ServerTest extends Http2TestBase {
         @Override
         public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement) throws Http2Exception {
           if (streamId == 0) {
+            int total = connectionWindowSizeIncrement.addAndGet(windowSizeIncrement);
             vertx.runOnContext(v -> {
-              Assert.assertEquals(
-                HttpServerOptions.DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE - io.vertx.core.http.Http2Settings.DEFAULT_INITIAL_WINDOW_SIZE,
-                windowSizeIncrement);
-              complete();
+              int expected = HttpServerOptions.DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE -
+                io.vertx.core.http.Http2Settings.DEFAULT_INITIAL_WINDOW_SIZE;
+              Assert.assertTrue(total <= expected);
+              if (total == expected) {
+                complete();
+              }
             });
           }
         }
@@ -3224,7 +3228,9 @@ public class Http2ServerTest extends Http2TestBase {
   @Test
   public void testConnectionWindowSize() throws Exception {
     server.close();
-    server = vertx.createHttpServer(new HttpServerOptions(serverOptions).setHttp2ConnectionWindowSize(65535 + 65535));
+    server = vertx.createHttpServer(new HttpServerOptions(serverOptions)
+      .setInitialSettings(new io.vertx.core.http.Http2Settings())
+      .setHttp2ConnectionWindowSize(65535 + 65535));
     server.requestHandler(req  -> {
       req.response().end();
     });
@@ -3247,7 +3253,9 @@ public class Http2ServerTest extends Http2TestBase {
   @Test
   public void testUpdateConnectionWindowSize() throws Exception {
     server.close();
-    server = vertx.createHttpServer(new HttpServerOptions(serverOptions).setHttp2ConnectionWindowSize(-1));
+    server = vertx.createHttpServer(new HttpServerOptions(serverOptions)
+      .setInitialSettings(new io.vertx.core.http.Http2Settings())
+      .setHttp2ConnectionWindowSize(-1));
     server.connectionHandler(conn -> {
       Assert.assertEquals(65535, conn.getWindowSize());
       conn.setWindowSize(65535 + 10000);


### PR DESCRIPTION
Motivation:

Large HTTP/2 request and response bodies, such as 10 MiB+ gRPC unary messages, can be extremely slow because Vert.x uses the HTTP/2 protocol-default 65,535-byte stream and connection flow-control windows. Without dynamic window auto-tuning, small static windows repeatedly stall large transfers while waiting for WINDOW_UPDATE frames.

Modifications:

- Increase the default initial HTTP/2 stream window from 64 KiB to 1 MiB for HTTP servers and clients.
- Increase the default HTTP/2 connection window to 16 MiB for HTTP servers and clients.
- Document stream-level and connection-level flow control defaults and their memory/throughput trade-off.
- Add tests for the server and client default window sizes.

Result:

Large HTTP/2 transfers and concurrent streams can make progress with fewer flow-control update cycles.

Fixes #6238

Conformance:

I have signed the Eclipse Contributor Agreement and confirm that this contribution adheres to the Vert.x code style guidelines.