### PR TITLE
Assign a distinct event loop to each virtual-thread verticle instance

### DIFF
--- a/vertx-core-java21-tests/src/test/java/io/vertx/tests/virtualthread/DeploymentTest.java
+++ b/vertx-core-java21-tests/src/test/java/io/vertx/tests/virtualthread/DeploymentTest.java
@@ -10,9 +10,11 @@
  */
 package io.vertx.tests.virtualthread;
 
+import io.netty.channel.EventLoop;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
+import io.vertx.core.internal.ContextInternal;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.http.HttpTestBase;
 import org.junit.Assert;
@@ -21,6 +23,7 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -41,6 +44,27 @@ public class DeploymentTest extends VertxTestBase {
       }
     }, new DeploymentOptions().setThreadingModel(ThreadingModel.VIRTUAL_THREAD));
     await();
+  }
+
+  @Test
+  public void testDeployInstancesUseDistinctEventLoops() throws Exception {
+    int instances = 4;
+    Vertx vertx = Vertx.vertx(new VertxOptions().setEventLoopPoolSize(2 * instances));
+    try {
+      Set<EventLoop> eventLoops = Collections.newSetFromMap(new ConcurrentHashMap<>());
+      vertx.deployVerticle(() -> new AbstractVerticle() {
+        @Override
+        public void start() {
+          eventLoops.add(((ContextInternal) context).nettyEventLoop());
+        }
+      }, new DeploymentOptions()
+        .setInstances(instances)
+        .setThreadingModel(ThreadingModel.VIRTUAL_THREAD))
+        .await(20, TimeUnit.SECONDS);
+      assertEquals(instances, eventLoops.size());
+    } finally {
+      vertx.close().await();
+    }
   }
 
   @Test

--- a/vertx-core-java21-tests/src/test/java/module-info.java
+++ b/vertx-core-java21-tests/src/test/java/module-info.java
@@ -4,6 +4,8 @@ open module io.vertx.core.java21.tests {
   requires io.vertx.core;
   requires io.vertx.core.tests;
 
+  requires io.netty.transport;
+
   requires static com.fasterxml.jackson.core;
   requires static com.fasterxml.jackson.annotation;
 

--- a/vertx-core/src/main/java/io/vertx/core/impl/deployment/DefaultDeployment.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/deployment/DefaultDeployment.java
@@ -148,17 +148,9 @@ public class DefaultDeployment implements Deployment {
           }
           break;
         case VIRTUAL_THREAD:
-          if (workerLoop == null) {
-            context = contextBuilder
-              .withThreadingModel(ThreadingModel.VIRTUAL_THREAD)
-              .build();
-            workerLoop = context.nettyEventLoop();
-          } else {
-            context = contextBuilder
-              .withThreadingModel(ThreadingModel.VIRTUAL_THREAD)
-              .withEventLoop(workerLoop)
-              .build();
-          }
+          context = contextBuilder
+            .withThreadingModel(ThreadingModel.VIRTUAL_THREAD)
+            .build();
           break;
         default:
           context = contextBuilder


### PR DESCRIPTION
## Motivation

Deploying a verticle with `setInstances(N)` and `ThreadingModel.VIRTUAL_THREAD` pins every instance to the **same** event loop (`vert.x-eventloop-thread-0`) instead of distributing them across the event loop group. Raising the instance count therefore stops scaling I/O — the single event loop saturates while the virtual threads starve. This is a regression from Vert.x 4.5.x, where each virtual-thread instance was assigned an event loop via `eventLoopGroup.next()`.

The reporter's k6 load test (`setInstances(300)`, `VIRTUAL_THREAD`) hit a hard ceiling of ~40k RPS because all 300 instances shared one event loop.

Fixes #5924

## Root cause

In `DefaultDeployment.deploy()`, the `VIRTUAL_THREAD` branch copied the `WORKER` pattern: the first instance's event loop was captured in `workerLoop` and forced on every subsequent instance via `.withEventLoop(workerLoop)`. The `EVENT_LOOP` branch omits `.withEventLoop(...)`, so `ContextBuilderImpl.build()` selects the next loop via `nettyEventLoopGroup().next()` (round-robin).

## Change

Build a fresh context for each virtual-thread instance (no shared-loop reuse), so each one round-robins over the event loop group like the event-loop model already does. `workerLoop` is now used only by the `WORKER` branch.

## Test

`DeploymentTest#testDeployInstancesUseDistinctEventLoops` deploys 4 `VIRTUAL_THREAD` instances (8-loop pool) and asserts 4 distinct netty event loops. It fails on the current code (`expected:<4> but was:<1>`) and passes with the fix; the full `DeploymentTest` and `ContextTest` suites remain green.

@vietj — you mentioned possibly making this configurable. This restores the scaling default; happy to layer a toggle on top in a follow-up if you'd prefer.

---

Implemented with AI assistance (Claude); I reviewed, tested and own all changes.