### PR TITLE
Implement JDK PQC availability detection

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/JdkDependent.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/JdkDependent.java
@@ -43,6 +43,10 @@ public class JdkDependent {
     return false;
   }
 
+  public static boolean isPqcAvailable() {
+    return false;
+  }
+
   public static void applyNamedGroups(SSLEngine engine, List<String> groups) {
     if (log.isDebugEnabled()) {
       log.warn("Cannot apply key exchange groups " + groups + " on JDK SSL engine: requires JDK 20+");

--- a/vertx-core/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
@@ -14,6 +14,7 @@ package io.vertx.core.net;
 import io.netty.handler.ssl.SslProvider;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
+import io.vertx.core.impl.JdkDependent;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tls.DefaultSslContextFactory;
 import io.vertx.core.spi.tls.SslContextFactory;
@@ -58,12 +59,11 @@ public class JdkSSLEngineOptions extends SSLEngineOptions {
   }
 
   /**
-   * @return if PQC key exchange (X25519MLKEM768) is available via the JDK SSL engine
-   * @implNote currently this returns {@code false} but implementation will change in the future when JDK support evolves
+   * @return if PQC key exchange is available via the JDK SSL engine, i.e. the JDK supports
+   * at least one of the PQ-compliant named groups (X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024)
    */
   public static synchronized boolean isPqcAvailable() {
-    // Todo: implement it when JDK add supports
-    return false;
+    return JdkDependent.isPqcAvailable();
   }
 
   public JdkSSLEngineOptions() {

--- a/vertx-core/src/main/java21/io/vertx/core/impl/JdkDependent.java
+++ b/vertx-core/src/main/java21/io/vertx/core/impl/JdkDependent.java
@@ -11,9 +11,12 @@
 package io.vertx.core.impl;
 
 import java.util.concurrent.ThreadFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Utils dependent on the JDK implementation.
@@ -37,6 +40,19 @@ public class JdkDependent {
    */
   public static boolean isVirtual(Thread thread) {
     return thread.isVirtual();
+  }
+
+  private static final Set<String> PQ_COMPLIANT_GROUPS = Set.of("X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024");
+
+  public static boolean isPqcAvailable() {
+    try {
+      SSLContext ctx = SSLContext.getDefault();
+      SSLParameters params = ctx.getDefaultSSLParameters();
+      String[] groups = params.getNamedGroups();
+      return groups != null && Arrays.stream(groups).anyMatch(PQ_COMPLIANT_GROUPS::contains);
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   public static void applyNamedGroups(SSLEngine engine, List<String> groups) {

--- a/vertx-core/src/test/java/io/vertx/it/HybridKeyExchangeTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/HybridKeyExchangeTest.java
@@ -34,6 +34,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 import io.vertx.core.VertxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLHandshakeException;
 import java.util.List;
@@ -44,6 +46,8 @@ import java.util.concurrent.TimeUnit;
  * Tests PQC key exchange with OpenSSL.
  */
 public class HybridKeyExchangeTest extends HttpTestBase {
+
+  private static final Logger log = LoggerFactory.getLogger(HybridKeyExchangeTest.class);
 
   private static void assumeMlKemAvailable() {
     boolean available = OpenSsl.isAvailable();
@@ -577,6 +581,86 @@ public class HybridKeyExchangeTest extends HttpTestBase {
     }
   }
 
+
+  private static void assumeJdkPqcAvailable() {
+    Assume.assumeTrue("JDK PQC is not available", JdkSSLEngineOptions.isPqcAvailable());
+  }
+
+  @Test
+  public void testStrictPolicyHandshakeJdk() throws Exception {
+    assumeJdkPqcAvailable();
+    ServerSSLOptions serverSslOptions = new ServerSSLOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setKeyCertOptions(Cert.SERVER_PEM.get());
+
+    server = vertx.httpServerBuilder()
+      .with(new HttpServerConfig(new HttpServerOptions()
+        .setPort(DEFAULT_HTTPS_PORT)
+        .setHost(DEFAULT_HTTPS_HOST)))
+      .with(new JdkSSLEngineOptions())
+      .with(serverSslOptions)
+      .build();
+    server.requestHandler(req -> req.response().end("jdk-strict-ok"));
+    startServer(server);
+
+    ClientSSLOptions pqcClientSsl = new ClientSSLOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setTrustAll(true);
+    client = vertx.httpClientBuilder()
+      .with(new HttpClientOptions().setSsl(true))
+      .with(new JdkSSLEngineOptions())
+      .with(pqcClientSsl)
+      .build();
+
+    var bodyBuffer = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .expecting(req -> req.connection().sslSession().getProtocol().equals("TLSv1.3"))
+      .compose(HttpClientRequest::send)
+      .expecting(HttpResponseExpectation.SC_OK)
+      .compose(HttpClientResponse::body)
+      .await();
+    assertEquals("jdk-strict-ok", bodyBuffer.toString());
+  }
+
+  @Test
+  public void testStrictPolicyMTLSJdk() throws Exception {
+    assumeJdkPqcAvailable();
+    ServerSSLOptions serverSslOptions = new ServerSSLOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setClientAuth(io.vertx.core.http.ClientAuth.REQUIRED)
+      .setKeyCertOptions(Cert.SERVER_PEM_ROOT_CA.get())
+      .setTrustOptions(Trust.SERVER_PEM_ROOT_CA.get());
+
+    server = vertx.httpServerBuilder()
+      .with(new HttpServerConfig(new HttpServerOptions()
+        .setPort(DEFAULT_HTTPS_PORT)
+        .setHost(DEFAULT_HTTPS_HOST)))
+      .with(new JdkSSLEngineOptions())
+      .with(serverSslOptions)
+      .build();
+    server.requestHandler(req -> {
+      assertTrue(req.isSSL());
+      req.response().end("jdk-mtls-strict-ok");
+    });
+    startServer(server);
+
+    ClientSSLOptions pqcClientSsl = new ClientSSLOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setKeyCertOptions(Cert.CLIENT_PEM_ROOT_CA.get())
+      .setTrustAll(true);
+    client = vertx.httpClientBuilder()
+      .with(new HttpClientOptions().setSsl(true))
+      .with(new JdkSSLEngineOptions())
+      .with(pqcClientSsl)
+      .build();
+
+    var buffer = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .expecting(req -> req.connection().sslSession().getProtocol().equals("TLSv1.3"))
+      .compose(HttpClientRequest::send)
+      .expecting(HttpResponseExpectation.SC_OK)
+      .compose(HttpClientResponse::body)
+      .await();
+    assertEquals("jdk-mtls-strict-ok", buffer.toString());
+  }
 
   static class ServerHelloGroupExtractor extends ChannelInboundHandlerAdapter {
 


### PR DESCRIPTION
Follow-up to #6236.

`JdkSSLEngineOptions.isPqcAvailable()` was hardcoded to false. This PR implements the actual detection using the multi-release JAR pattern already in place:
- Base implementation (< JDK 21): returns false
- JDK 21+ implementation: checks `SSLParameters.getNamedGroups()` for the presence of at least one PQ-compliant group (`X25519MLKEM768`, `SecP256r1MLKEM768`, `SecP384r1MLKEM1024`)

`JdkSSLEngineOptions.isPqcAvailable()` now delegates to `JdkDependent.isPqcAvailable()`, meaning STRICT and CLIENT_NEGOTIATED enforcement policies will automatically auto-select the JDK engine for PQC once a supporting JDK is available (expected JDK 25 backport, October 2026).