### PR TITLE
Add streaming I/O methods to JsonCodec SPI

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/json/Json.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/Json.java
@@ -17,6 +17,8 @@ import io.vertx.core.spi.json.JsonCodec;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -159,5 +161,46 @@ public class Json {
    */
   public static void encodeTo(Object obj, OutputStream out) throws EncodeException {
     CODEC.toOutputStream(obj, out);
+  }
+
+  /**
+   * Decode a given JSON reader to a POJO of the given class type.
+   * <p>
+   * The codec does not close or flush the reader.
+   *
+   * @param reader the JSON reader.
+   * @param clazz the class to map to.
+   * @param <T> the generic type.
+   * @return an instance of T
+   * @throws DecodeException when there is a parsing or invalid mapping.
+   */
+  public static <T> T decodeValue(Reader reader, Class<T> clazz) throws DecodeException {
+    return CODEC.fromReader(reader, clazz);
+  }
+
+  /**
+   * Decode a given JSON reader.
+   * <p>
+   * The codec does not close or flush the reader.
+   *
+   * @param reader the JSON reader.
+   * @return a JSON element which can be a {@link JsonArray}, {@link JsonObject}, {@link String}, etc.
+   * @throws DecodeException when there is a parsing or invalid mapping.
+   */
+  public static Object decodeValue(Reader reader) throws DecodeException {
+    return CODEC.fromReader(reader);
+  }
+
+  /**
+   * Encode a POJO to JSON and write it to the given {@link Writer}.
+   * <p>
+   * The codec does not close or flush the writer.
+   *
+   * @param obj a POJO
+   * @param writer the writer to write to
+   * @throws EncodeException if a property cannot be encoded.
+   */
+  public static void encodeTo(Object obj, Writer writer) throws EncodeException {
+    CODEC.toWriter(obj, writer);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/json/Json.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/Json.java
@@ -15,6 +15,9 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.spi.JsonFactory;
 import io.vertx.core.spi.json.JsonCodec;
 
+import java.io.InputStream;
+import java.io.OutputStream;
+
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -115,5 +118,46 @@ public class Json {
    */
   public static <T> T decodeValue(Buffer buf, Class<T> clazz) throws DecodeException {
     return CODEC.fromBuffer(buf, clazz);
+  }
+
+  /**
+   * Decode a given JSON input stream to a POJO of the given class type.
+   * <p>
+   * The input is expected to be UTF-8 encoded. The codec does not close or flush the stream.
+   *
+   * @param in the JSON input stream.
+   * @param clazz the class to map to.
+   * @param <T> the generic type.
+   * @return an instance of T
+   * @throws DecodeException when there is a parsing or invalid mapping.
+   */
+  public static <T> T decodeValue(InputStream in, Class<T> clazz) throws DecodeException {
+    return CODEC.fromInputStream(in, clazz);
+  }
+
+  /**
+   * Decode a given JSON input stream.
+   * <p>
+   * The input is expected to be UTF-8 encoded. The codec does not close or flush the stream.
+   *
+   * @param in the JSON input stream.
+   * @return a JSON element which can be a {@link JsonArray}, {@link JsonObject}, {@link String}, etc.
+   * @throws DecodeException when there is a parsing or invalid mapping.
+   */
+  public static Object decodeValue(InputStream in) throws DecodeException {
+    return CODEC.fromInputStream(in);
+  }
+
+  /**
+   * Encode a POJO to JSON and write it to the given {@link OutputStream}.
+   * <p>
+   * The output is UTF-8 encoded. The codec does not close or flush the stream.
+   *
+   * @param obj a POJO
+   * @param out the output stream to write to
+   * @throws EncodeException if a property cannot be encoded.
+   */
+  public static void encodeTo(Object obj, OutputStream out) throws EncodeException {
+    CODEC.toOutputStream(obj, out);
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/json/Json.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/Json.java
@@ -134,7 +134,7 @@ public class Json {
    * @throws DecodeException when there is a parsing or invalid mapping.
    */
   public static <T> T decodeValue(InputStream in, Class<T> clazz) throws DecodeException {
-    return CODEC.fromInputStream(in, clazz);
+    return CODEC.fromStream(in, clazz);
   }
 
   /**
@@ -147,7 +147,7 @@ public class Json {
    * @throws DecodeException when there is a parsing or invalid mapping.
    */
   public static Object decodeValue(InputStream in) throws DecodeException {
-    return CODEC.fromInputStream(in);
+    return CODEC.fromStream(in);
   }
 
   /**
@@ -160,7 +160,7 @@ public class Json {
    * @throws EncodeException if a property cannot be encoded.
    */
   public static void encodeTo(Object obj, OutputStream out) throws EncodeException {
-    CODEC.toOutputStream(obj, out);
+    CODEC.toStream(obj, out);
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
@@ -27,6 +27,8 @@ import io.vertx.core.json.JsonObject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
 import java.util.List;
 import java.util.Map;
 
@@ -190,6 +192,29 @@ public class DatabindCodec extends JacksonCodec {
         .without(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
         .without(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM)
         .writeValue(out, object);
+    } catch (Exception e) {
+      throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
+    }
+  }
+
+  @Override
+  public <T> T fromReader(Reader reader, Class<T> clazz) throws DecodeException {
+    try {
+      JsonParser parser = mapper.getFactory().createParser(reader);
+      parser.disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
+      return fromParser(parser, clazz);
+    } catch (IOException e) {
+      throw new DecodeException("Failed to decode:" + e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public void toWriter(Object object, Writer writer) throws EncodeException {
+    try {
+      mapper.writer()
+        .without(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
+        .without(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM)
+        .writeValue(writer, object);
     } catch (Exception e) {
       throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
     }

--- a/vertx-core/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.json.jackson;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -25,6 +26,7 @@ import io.vertx.core.json.JsonObject;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -87,6 +89,17 @@ public class DatabindCodec extends JacksonCodec {
 
   public <T> T fromBuffer(Buffer buf, TypeReference<T> typeRef) throws DecodeException {
     return fromParser(createParser(buf), typeRef);
+  }
+
+  @Override
+  public <T> T fromInputStream(InputStream in, Class<T> clazz) throws DecodeException {
+    try {
+      JsonParser parser = mapper.getFactory().createParser(in);
+      parser.disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
+      return fromParser(parser, clazz);
+    } catch (IOException e) {
+      throw new DecodeException("Failed to decode:" + e.getMessage(), e);
+    }
   }
 
   public static JsonParser createParser(BufferInternal buf) {
@@ -165,6 +178,18 @@ public class DatabindCodec extends JacksonCodec {
         result = mapper.writeValueAsBytes(object);
       }
       return Buffer.buffer(result);
+    } catch (Exception e) {
+      throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
+    }
+  }
+
+  @Override
+  public void toOutputStream(Object object, OutputStream out) throws EncodeException {
+    try {
+      mapper.writer()
+        .without(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
+        .without(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM)
+        .writeValue(out, object);
     } catch (Exception e) {
       throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
     }

--- a/vertx-core/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/jackson/DatabindCodec.java
@@ -94,7 +94,7 @@ public class DatabindCodec extends JacksonCodec {
   }
 
   @Override
-  public <T> T fromInputStream(InputStream in, Class<T> clazz) throws DecodeException {
+  public <T> T fromStream(InputStream in, Class<T> clazz) throws DecodeException {
     try {
       JsonParser parser = mapper.getFactory().createParser(in);
       parser.disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
@@ -186,7 +186,7 @@ public class DatabindCodec extends JacksonCodec {
   }
 
   @Override
-  public void toOutputStream(Object object, OutputStream out) throws EncodeException {
+  public void toStream(Object object, OutputStream out) throws EncodeException {
     try {
       mapper.writer()
         .without(JsonGenerator.Feature.AUTO_CLOSE_TARGET)

--- a/vertx-core/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -32,6 +32,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
 import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -182,6 +183,30 @@ public class JacksonCodec implements JsonCodec {
   public void toOutputStream(Object object, OutputStream out) throws EncodeException {
     try {
       JsonGenerator generator = createGenerator(out, false);
+      generator.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+      generator.disable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM);
+      encodeJson(object, generator);
+      generator.close();
+    } catch (IOException e) {
+      throw new EncodeException(e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public <T> T fromReader(Reader reader, Class<T> clazz) throws DecodeException {
+    try {
+      JsonParser parser = factory.createParser(reader);
+      parser.disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
+      return fromParser(parser, clazz);
+    } catch (IOException e) {
+      throw new DecodeException("Failed to decode:" + e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public void toWriter(Object object, Writer writer) throws EncodeException {
+    try {
+      JsonGenerator generator = createGenerator(writer, false);
       generator.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
       generator.disable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM);
       encodeJson(object, generator);

--- a/vertx-core/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -131,6 +131,17 @@ public class JacksonCodec implements JsonCodec {
   }
 
   @Override
+  public <T> T fromInputStream(InputStream in, Class<T> clazz) throws DecodeException {
+    try {
+      JsonParser parser = factory.createParser(in);
+      parser.disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
+      return fromParser(parser, clazz);
+    } catch (IOException e) {
+      throw new DecodeException("Failed to decode:" + e.getMessage(), e);
+    }
+  }
+
+  @Override
   public <T> T fromValue(Object json, Class<T> toValueType) {
     throw new DecodeException("Mapping " + toValueType.getName() + "  is not available without Jackson Databind on the classpath");
   }
@@ -164,6 +175,19 @@ public class JacksonCodec implements JsonCodec {
       throw new EncodeException(e.getMessage(), e);
     } finally {
       br.releaseToPool();
+    }
+  }
+
+  @Override
+  public void toOutputStream(Object object, OutputStream out) throws EncodeException {
+    try {
+      JsonGenerator generator = createGenerator(out, false);
+      generator.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+      generator.disable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM);
+      encodeJson(object, generator);
+      generator.close();
+    } catch (IOException e) {
+      throw new EncodeException(e.getMessage(), e);
     }
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
+++ b/vertx-core/src/main/java/io/vertx/core/json/jackson/JacksonCodec.java
@@ -132,7 +132,7 @@ public class JacksonCodec implements JsonCodec {
   }
 
   @Override
-  public <T> T fromInputStream(InputStream in, Class<T> clazz) throws DecodeException {
+  public <T> T fromStream(InputStream in, Class<T> clazz) throws DecodeException {
     try {
       JsonParser parser = factory.createParser(in);
       parser.disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
@@ -180,7 +180,7 @@ public class JacksonCodec implements JsonCodec {
   }
 
   @Override
-  public void toOutputStream(Object object, OutputStream out) throws EncodeException {
+  public void toStream(Object object, OutputStream out) throws EncodeException {
     try {
       JsonGenerator generator = createGenerator(out, false);
       generator.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);

--- a/vertx-core/src/main/java/io/vertx/core/spi/json/JsonCodec.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/json/JsonCodec.java
@@ -14,6 +14,12 @@ package io.vertx.core.spi.json;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.EncodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -67,5 +73,59 @@ public interface JsonCodec {
    */
   default Buffer toBuffer(Object object) throws EncodeException {
     return toBuffer(object, false);
+  }
+
+  /**
+   * Decode JSON from the given {@link InputStream} to an object of the specified type.
+   * <p>
+   * The input is expected to be UTF-8 encoded.
+   * <p>
+   * The codec does not close or flush the stream; the caller retains ownership.
+   *
+   * @param in    the input stream containing UTF-8 encoded JSON
+   * @param clazz the required object's class
+   * @return the decoded instance
+   * @throws DecodeException anything preventing the decoding
+   */
+  default <T> T fromInputStream(InputStream in, Class<T> clazz) throws DecodeException {
+    try {
+      return fromBuffer(Buffer.buffer(in.readAllBytes()), clazz);
+    } catch (IOException e) {
+      throw new DecodeException(e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Decode JSON from the given {@link InputStream}.
+   * <p>
+   * The input is expected to be UTF-8 encoded.
+   * <p>
+   * The codec does not close or flush the stream; the caller retains ownership.
+   *
+   * @param in the input stream containing UTF-8 encoded JSON
+   * @return a JSON element which can be a {@link JsonArray}, {@link JsonObject}, {@link String}, etc.
+   * @throws DecodeException anything preventing the decoding
+   */
+  default Object fromInputStream(InputStream in) throws DecodeException {
+    return fromInputStream(in, Object.class);
+  }
+
+  /**
+   * Encode the specified object as JSON to the given {@link OutputStream}.
+   * <p>
+   * The output is UTF-8 encoded.
+   * <p>
+   * The codec does not close or flush the stream; the caller retains ownership.
+   *
+   * @param object the object to encode
+   * @param out    the output stream to write to
+   * @throws EncodeException anything preventing the encoding
+   */
+  default void toOutputStream(Object object, OutputStream out) throws EncodeException {
+    try {
+      out.write(toBuffer(object).getBytes());
+    } catch (IOException e) {
+      throw new EncodeException(e.getMessage(), e);
+    }
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/spi/json/JsonCodec.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/json/JsonCodec.java
@@ -20,6 +20,8 @@ import io.vertx.core.json.JsonObject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -124,6 +126,60 @@ public interface JsonCodec {
   default void toOutputStream(Object object, OutputStream out) throws EncodeException {
     try {
       out.write(toBuffer(object).getBytes());
+    } catch (IOException e) {
+      throw new EncodeException(e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Decode JSON from the given {@link Reader} to an object of the specified type.
+   * <p>
+   * The codec does not close or flush the reader; the caller retains ownership.
+   *
+   * @param reader the reader containing JSON text
+   * @param clazz  the required object's class
+   * @return the decoded instance
+   * @throws DecodeException anything preventing the decoding
+   */
+  default <T> T fromReader(Reader reader, Class<T> clazz) throws DecodeException {
+    try {
+      StringBuilder sb = new StringBuilder();
+      char[] buf = new char[4096];
+      int n;
+      while ((n = reader.read(buf)) != -1) {
+        sb.append(buf, 0, n);
+      }
+      return fromString(sb.toString(), clazz);
+    } catch (IOException e) {
+      throw new DecodeException(e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Decode JSON from the given {@link Reader}.
+   * <p>
+   * The codec does not close or flush the reader; the caller retains ownership.
+   *
+   * @param reader the reader containing JSON text
+   * @return a JSON element which can be a {@link JsonArray}, {@link JsonObject}, {@link String}, etc.
+   * @throws DecodeException anything preventing the decoding
+   */
+  default Object fromReader(Reader reader) throws DecodeException {
+    return fromReader(reader, Object.class);
+  }
+
+  /**
+   * Encode the specified object as JSON to the given {@link Writer}.
+   * <p>
+   * The codec does not close or flush the writer; the caller retains ownership.
+   *
+   * @param object the object to encode
+   * @param writer the writer to write to
+   * @throws EncodeException anything preventing the encoding
+   */
+  default void toWriter(Object object, Writer writer) throws EncodeException {
+    try {
+      writer.write(toString(object));
     } catch (IOException e) {
       throw new EncodeException(e.getMessage(), e);
     }

--- a/vertx-core/src/main/java/io/vertx/core/spi/json/JsonCodec.java
+++ b/vertx-core/src/main/java/io/vertx/core/spi/json/JsonCodec.java
@@ -89,7 +89,7 @@ public interface JsonCodec {
    * @return the decoded instance
    * @throws DecodeException anything preventing the decoding
    */
-  default <T> T fromInputStream(InputStream in, Class<T> clazz) throws DecodeException {
+  default <T> T fromStream(InputStream in, Class<T> clazz) throws DecodeException {
     try {
       return fromBuffer(Buffer.buffer(in.readAllBytes()), clazz);
     } catch (IOException e) {
@@ -108,8 +108,8 @@ public interface JsonCodec {
    * @return a JSON element which can be a {@link JsonArray}, {@link JsonObject}, {@link String}, etc.
    * @throws DecodeException anything preventing the decoding
    */
-  default Object fromInputStream(InputStream in) throws DecodeException {
-    return fromInputStream(in, Object.class);
+  default Object fromStream(InputStream in) throws DecodeException {
+    return fromStream(in, Object.class);
   }
 
   /**
@@ -123,7 +123,7 @@ public interface JsonCodec {
    * @param out    the output stream to write to
    * @throws EncodeException anything preventing the encoding
    */
-  default void toOutputStream(Object object, OutputStream out) throws EncodeException {
+  default void toStream(Object object, OutputStream out) throws EncodeException {
     try {
       out.write(toBuffer(object).getBytes());
     } catch (IOException e) {

--- a/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/DatabindCodec.java
+++ b/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/DatabindCodec.java
@@ -13,6 +13,8 @@ package io.vertx.core.json.jackson.v3;
 
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.core.StreamWriteFeature;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
@@ -26,6 +28,7 @@ import io.vertx.core.json.JsonObject;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -79,6 +82,11 @@ public class DatabindCodec extends JacksonCodec {
 
   public <T> T fromBuffer(Buffer buf, TypeReference<T> typeRef) throws DecodeException {
     return fromParser(createParser(buf), typeRef);
+  }
+
+  @Override
+  public <T> T fromInputStream(InputStream in, Class<T> clazz) throws DecodeException {
+    return fromParser(mapper.reader().without(StreamReadFeature.AUTO_CLOSE_SOURCE).createParser(in), clazz);
   }
 
   public static JsonParser createParser(BufferInternal buf) {
@@ -149,6 +157,18 @@ public class DatabindCodec extends JacksonCodec {
         result = mapper.writeValueAsBytes(object);
       }
       return Buffer.buffer(result);
+    } catch (Exception e) {
+      throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
+    }
+  }
+
+  @Override
+  public void toOutputStream(Object object, OutputStream out) throws EncodeException {
+    try {
+      mapper.writer()
+        .without(StreamWriteFeature.AUTO_CLOSE_TARGET)
+        .without(StreamWriteFeature.FLUSH_PASSED_TO_STREAM)
+        .writeValue(out, object);
     } catch (Exception e) {
       throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
     }

--- a/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/DatabindCodec.java
+++ b/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/DatabindCodec.java
@@ -29,6 +29,8 @@ import io.vertx.core.json.JsonObject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
 import java.util.List;
 import java.util.Map;
 
@@ -169,6 +171,23 @@ public class DatabindCodec extends JacksonCodec {
         .without(StreamWriteFeature.AUTO_CLOSE_TARGET)
         .without(StreamWriteFeature.FLUSH_PASSED_TO_STREAM)
         .writeValue(out, object);
+    } catch (Exception e) {
+      throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
+    }
+  }
+
+  @Override
+  public <T> T fromReader(Reader reader, Class<T> clazz) throws DecodeException {
+    return fromParser(mapper.reader().without(StreamReadFeature.AUTO_CLOSE_SOURCE).createParser(reader), clazz);
+  }
+
+  @Override
+  public void toWriter(Object object, Writer writer) throws EncodeException {
+    try {
+      mapper.writer()
+        .without(StreamWriteFeature.AUTO_CLOSE_TARGET)
+        .without(StreamWriteFeature.FLUSH_PASSED_TO_STREAM)
+        .writeValue(writer, object);
     } catch (Exception e) {
       throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
     }

--- a/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/DatabindCodec.java
+++ b/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/DatabindCodec.java
@@ -87,7 +87,7 @@ public class DatabindCodec extends JacksonCodec {
   }
 
   @Override
-  public <T> T fromInputStream(InputStream in, Class<T> clazz) throws DecodeException {
+  public <T> T fromStream(InputStream in, Class<T> clazz) throws DecodeException {
     return fromParser(mapper.reader().without(StreamReadFeature.AUTO_CLOSE_SOURCE).createParser(in), clazz);
   }
 
@@ -165,7 +165,7 @@ public class DatabindCodec extends JacksonCodec {
   }
 
   @Override
-  public void toOutputStream(Object object, OutputStream out) throws EncodeException {
+  public void toStream(Object object, OutputStream out) throws EncodeException {
     try {
       mapper.writer()
         .without(StreamWriteFeature.AUTO_CLOSE_TARGET)

--- a/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/JacksonCodec.java
+++ b/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/JacksonCodec.java
@@ -190,6 +190,24 @@ public class JacksonCodec implements JsonCodec {
     }
   }
 
+  @Override
+  public <T> T fromReader(java.io.Reader reader, Class<T> clazz) throws DecodeException {
+    return fromParser(factory.createParser(ORC_NO_CLOSE, reader), clazz);
+  }
+
+  @Override
+  public void toWriter(Object object, java.io.Writer writer) throws EncodeException {
+    try {
+      JsonGenerator generator = createGenerator(writer, false);
+      generator.configure(StreamWriteFeature.AUTO_CLOSE_TARGET, false);
+      generator.configure(StreamWriteFeature.FLUSH_PASSED_TO_STREAM, false);
+      encodeJson(object, generator);
+      generator.close();
+    } catch (Exception e) {
+      throw new EncodeException(e.getMessage(), e);
+    }
+  }
+
   public static JsonParser createParser(String str) {
     return factory.createParser(ObjectReadContext.empty(), str);
   }

--- a/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/JacksonCodec.java
+++ b/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/JacksonCodec.java
@@ -118,6 +118,13 @@ public class JacksonCodec implements JsonCodec {
 
   static final JsonFactory factory = buildFactory();
 
+  private static final ObjectReadContext ORC_NO_CLOSE = new ObjectReadContext.Base() {
+    @Override
+    public int getStreamReadFeatures(int defaults) {
+      return defaults & ~StreamReadFeature.AUTO_CLOSE_SOURCE.getMask();
+    }
+  };
+
   @Override
   public <T> T fromString(String json, Class<T> clazz) throws DecodeException {
     return fromParser(createParser(json), clazz);
@@ -126,6 +133,11 @@ public class JacksonCodec implements JsonCodec {
   @Override
   public <T> T fromBuffer(Buffer json, Class<T> clazz) throws DecodeException {
     return fromParser(createParser(json), clazz);
+  }
+
+  @Override
+  public <T> T fromInputStream(InputStream in, Class<T> clazz) throws DecodeException {
+    return fromParser(factory.createParser(ORC_NO_CLOSE, in), clazz);
   }
 
   @Override
@@ -162,6 +174,19 @@ public class JacksonCodec implements JsonCodec {
       throw new EncodeException(e.getMessage(), e);
     } finally {
       br.releaseToPool();
+    }
+  }
+
+  @Override
+  public void toOutputStream(Object object, OutputStream out) throws EncodeException {
+    try {
+      JsonGenerator generator = createGenerator(out, false);
+      generator.configure(StreamWriteFeature.AUTO_CLOSE_TARGET, false);
+      generator.configure(StreamWriteFeature.FLUSH_PASSED_TO_STREAM, false);
+      encodeJson(object, generator);
+      generator.close();
+    } catch (Exception e) {
+      throw new EncodeException(e.getMessage(), e);
     }
   }
 

--- a/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/JacksonCodec.java
+++ b/vertx-core/src/main/java21/io/vertx/core/json/jackson/v3/JacksonCodec.java
@@ -136,7 +136,7 @@ public class JacksonCodec implements JsonCodec {
   }
 
   @Override
-  public <T> T fromInputStream(InputStream in, Class<T> clazz) throws DecodeException {
+  public <T> T fromStream(InputStream in, Class<T> clazz) throws DecodeException {
     return fromParser(factory.createParser(ORC_NO_CLOSE, in), clazz);
   }
 
@@ -178,7 +178,7 @@ public class JacksonCodec implements JsonCodec {
   }
 
   @Override
-  public void toOutputStream(Object object, OutputStream out) throws EncodeException {
+  public void toStream(Object object, OutputStream out) throws EncodeException {
     try {
       JsonGenerator generator = createGenerator(out, false);
       generator.configure(StreamWriteFeature.AUTO_CLOSE_TARGET, false);

--- a/vertx-core/src/test/java/io/vertx/tests/json/JsonCodecTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/json/JsonCodecTest.java
@@ -28,9 +28,15 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FilterInputStream;
 import java.io.FilterOutputStream;
+import java.io.FilterReader;
+import java.io.FilterWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -740,6 +746,189 @@ public abstract class JsonCodecTest {
     codec.toOutputStream(obj, out);
     assertFalse("Codec should not close the OutputStream", closed[0]);
     assertFalse("Codec should not flush the OutputStream", flushed[0]);
+  }
+
+  @Test
+  public void testDecodeJsonObjectFromReader() {
+    String json = "{\"foo\":\"bar\",\"num\":123}";
+    Map<?, ?> map = codec.fromReader(new StringReader(json), Map.class);
+    assertEquals("bar", map.get("foo"));
+    assertEquals(123, map.get("num"));
+  }
+
+  @Test
+  public void testDecodeJsonArrayFromReader() {
+    String json = "[\"foo\",123,true]";
+    List<?> list = codec.fromReader(new StringReader(json), List.class);
+    assertEquals("foo", list.get(0));
+    assertEquals(123, list.get(1));
+    assertEquals(true, list.get(2));
+  }
+
+  @Test
+  public void testDecodeFromReaderUnknownContent() {
+    assertEquals(1, decodeFromReader("1"));
+    assertEquals(true, decodeFromReader("true"));
+    assertEquals("whatever", decodeFromReader("\"whatever\""));
+    assertNull(decodeFromReader("null"));
+
+    JsonObject obj = new JsonObject().put("foo", "bar");
+    assertEquals(obj, decodeFromReader(obj.toString()));
+
+    JsonArray arr = new JsonArray().add(1).add(false).add("whatever").add(obj);
+    assertEquals(arr, decodeFromReader(arr.toString()));
+  }
+
+  private Object decodeFromReader(String json) {
+    return codec.fromReader(new StringReader(json), Object.class);
+  }
+
+  @Test
+  public void testDecodeFromReaderEquivalence() {
+    byte[] bytes = TestUtils.randomByteArray(10);
+    String strBytes = TestUtils.toBase64String(bytes);
+    Instant now = Instant.now();
+    String strInstant = ISO_INSTANT.format(now);
+    String json = "{\"mystr\":\"foo\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
+      "myboolean\":true,\"mybinary\":\"" + strBytes + "\",\"myinstant\":\"" + strInstant + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}";
+
+    Object fromString = codec.fromString(json, Object.class);
+    Object fromReader = codec.fromReader(new StringReader(json), Object.class);
+    assertEquals(fromString, fromReader);
+  }
+
+  @Test
+  public void testDecodeFromReaderInvalidJson() {
+    for (String test : new String[]{"\"3", "qiwjdoiqwjdiqwjd", "{\"foo\":1},{\"bar\":2}"}) {
+      try {
+        codec.fromReader(new StringReader(test), Map.class);
+        fail("Should have thrown DecodeException for: " + test);
+      } catch (DecodeException ignore) {
+      }
+    }
+  }
+
+  @Test
+  public void testDecodeFromReaderEmpty() {
+    try {
+      codec.fromReader(new StringReader(""), Object.class);
+      fail();
+    } catch (DecodeException ignore) {
+    }
+  }
+
+  @Test
+  public void testDecodeFromReaderWithComments() {
+    String jsonWithComments =
+      "// comment\n" +
+        "{\"foo\": \"bar\" /* inline */}";
+    Map<?, ?> map = codec.fromReader(new StringReader(jsonWithComments), Map.class);
+    assertEquals("bar", map.get("foo"));
+  }
+
+  @Test
+  public void testDecodeFromReaderDoesNotCloseReader() throws IOException {
+    String json = "{\"key\":\"value\"}";
+    boolean[] closed = {false};
+    Reader reader = new FilterReader(new StringReader(json)) {
+      @Override
+      public void close() throws IOException {
+        closed[0] = true;
+        super.close();
+      }
+    };
+    codec.fromReader(reader, Map.class);
+    assertFalse("Codec should not close the Reader", closed[0]);
+  }
+
+  @Test
+  public void testEncodeJsonObjectToWriter() {
+    JsonObject jsonObject = new JsonObject().put("foo", "bar").put("num", 123);
+    StringWriter sw = new StringWriter();
+    codec.toWriter(jsonObject, sw);
+    assertEquals(codec.toString(jsonObject), sw.toString());
+  }
+
+  @Test
+  public void testEncodeJsonArrayToWriter() {
+    JsonArray jsonArray = new JsonArray().add("foo").add(123).add(true);
+    StringWriter sw = new StringWriter();
+    codec.toWriter(jsonArray, sw);
+    assertEquals(codec.toString(jsonArray), sw.toString());
+  }
+
+  @Test
+  public void testEncodeToWriterEquivalence() {
+    JsonObject obj = new JsonObject()
+      .put("str", "hello")
+      .put("num", 42)
+      .put("bool", true)
+      .putNull("nil")
+      .put("nested", new JsonObject().put("a", 1))
+      .put("arr", new JsonArray().add("x").add(2));
+
+    StringWriter sw = new StringWriter();
+    codec.toWriter(obj, sw);
+    assertEquals(codec.toString(obj), sw.toString());
+  }
+
+  @Test
+  public void testEncodeNullToWriter() {
+    StringWriter sw = new StringWriter();
+    codec.toWriter(null, sw);
+    assertEquals("null", sw.toString());
+  }
+
+  @Test
+  public void testEncodeScalarToWriter() {
+    StringWriter sw = new StringWriter();
+    codec.toWriter("hello", sw);
+    assertEquals("\"hello\"", sw.toString());
+
+    sw = new StringWriter();
+    codec.toWriter(42, sw);
+    assertEquals("42", sw.toString());
+
+    sw = new StringWriter();
+    codec.toWriter(true, sw);
+    assertEquals("true", sw.toString());
+  }
+
+  @Test
+  public void testEncodeToWriterDoesNotCloseOrFlushWriter() {
+    JsonObject obj = new JsonObject().put("key", "value");
+    boolean[] closed = {false};
+    boolean[] flushed = {false};
+    Writer writer = new FilterWriter(new StringWriter()) {
+      @Override
+      public void close() throws IOException {
+        closed[0] = true;
+        super.close();
+      }
+      @Override
+      public void flush() throws IOException {
+        flushed[0] = true;
+        super.flush();
+      }
+    };
+    codec.toWriter(obj, writer);
+    assertFalse("Codec should not close the Writer", closed[0]);
+    assertFalse("Codec should not flush the Writer", flushed[0]);
+  }
+
+  @Test
+  public void testReaderWriterRoundTrip() {
+    JsonObject original = new JsonObject()
+      .put("name", "test")
+      .put("value", 42)
+      .put("nested", new JsonObject().put("a", true))
+      .put("arr", new JsonArray().add(1).add("two").add(new JsonObject().put("three", 3)));
+
+    StringWriter sw = new StringWriter();
+    codec.toWriter(original, sw);
+
+    Object decoded = codec.fromReader(new StringReader(sw.toString()), Object.class);
+    assertEquals(original, decoded);
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/json/JsonCodecTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/json/JsonCodecTest.java
@@ -579,87 +579,41 @@ public abstract class JsonCodecTest {
 
   @Test
   public void testDecodeJsonObjectFromInputStream() {
-    String json = "{\"foo\":\"bar\",\"num\":123}";
-    InputStream in = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
-    Map<?, ?> map = codec.fromInputStream(in, Map.class);
-    assertEquals("bar", map.get("foo"));
-    assertEquals(123, map.get("num"));
+    testDecodeJsonObjectStreaming(false);
   }
 
   @Test
   public void testDecodeJsonArrayFromInputStream() {
-    String json = "[\"foo\",123,true]";
-    InputStream in = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
-    List<?> list = codec.fromInputStream(in, List.class);
-    assertEquals("foo", list.get(0));
-    assertEquals(123, list.get(1));
-    assertEquals(true, list.get(2));
+    testDecodeJsonArrayStreaming(false);
   }
 
   @Test
   public void testDecodeFromInputStreamUnknownContent() {
-    assertEquals(1, decodeFromInputStream("1"));
-    assertEquals(true, decodeFromInputStream("true"));
-    assertEquals("whatever", decodeFromInputStream("\"whatever\""));
-    assertNull(decodeFromInputStream("null"));
-
-    JsonObject obj = new JsonObject().put("foo", "bar");
-    assertEquals(obj, decodeFromInputStream(obj.toString()));
-
-    JsonArray arr = new JsonArray().add(1).add(false).add("whatever").add(obj);
-    assertEquals(arr, decodeFromInputStream(arr.toString()));
-  }
-
-  private Object decodeFromInputStream(String json) {
-    return codec.fromInputStream(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), Object.class);
+    testDecodeStreamingUnknownContent(false);
   }
 
   @Test
   public void testDecodeFromInputStreamEquivalence() {
-    byte[] bytes = TestUtils.randomByteArray(10);
-    String strBytes = TestUtils.toBase64String(bytes);
-    Instant now = Instant.now();
-    String strInstant = ISO_INSTANT.format(now);
-    String json = "{\"mystr\":\"foo\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
-      "myboolean\":true,\"mybinary\":\"" + strBytes + "\",\"myinstant\":\"" + strInstant + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}";
-
-    Object fromString = codec.fromString(json, Object.class);
-    Object fromStream = codec.fromInputStream(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), Object.class);
-    assertEquals(fromString, fromStream);
+    testDecodeStreamingEquivalence(false);
   }
 
   @Test
   public void testDecodeFromInputStreamInvalidJson() {
-    for (String test : new String[]{"\"3", "qiwjdoiqwjdiqwjd", "{\"foo\":1},{\"bar\":2}"}) {
-      try {
-        codec.fromInputStream(new ByteArrayInputStream(test.getBytes(StandardCharsets.UTF_8)), Map.class);
-        fail("Should have thrown DecodeException for: " + test);
-      } catch (DecodeException ignore) {
-      }
-    }
+    testDecodeStreamingInvalidJson(false);
   }
 
   @Test
   public void testDecodeFromInputStreamEmpty() {
-    try {
-      codec.fromInputStream(new ByteArrayInputStream(new byte[0]), Object.class);
-      fail();
-    } catch (DecodeException ignore) {
-    }
+    testDecodeStreamingEmpty(false);
   }
 
   @Test
   public void testDecodeFromInputStreamWithComments() {
-    String jsonWithComments =
-      "// comment\n" +
-        "{\"foo\": \"bar\" /* inline */}";
-    InputStream in = new ByteArrayInputStream(jsonWithComments.getBytes(StandardCharsets.UTF_8));
-    Map<?, ?> map = codec.fromInputStream(in, Map.class);
-    assertEquals("bar", map.get("foo"));
+    testDecodeStreamingWithComments(false);
   }
 
   @Test
-  public void testDecodeFromInputStreamDoesNotCloseStream() throws IOException {
+  public void testDecodeFromInputStreamDoesNotCloseStream() {
     String json = "{\"key\":\"value\"}";
     boolean[] closed = {false};
     InputStream in = new FilterInputStream(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
@@ -674,160 +628,42 @@ public abstract class JsonCodecTest {
   }
 
   @Test
-  public void testEncodeJsonObjectToOutputStream() {
-    JsonObject jsonObject = new JsonObject().put("foo", "bar").put("num", 123);
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    codec.toOutputStream(jsonObject, baos);
-    assertEquals(codec.toString(jsonObject), baos.toString(StandardCharsets.UTF_8));
-  }
-
-  @Test
-  public void testEncodeJsonArrayToOutputStream() {
-    JsonArray jsonArray = new JsonArray().add("foo").add(123).add(true);
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    codec.toOutputStream(jsonArray, baos);
-    assertEquals(codec.toString(jsonArray), baos.toString(StandardCharsets.UTF_8));
-  }
-
-  @Test
-  public void testEncodeToOutputStreamEquivalence() {
-    JsonObject obj = new JsonObject()
-      .put("str", "hello")
-      .put("num", 42)
-      .put("bool", true)
-      .putNull("nil")
-      .put("nested", new JsonObject().put("a", 1))
-      .put("arr", new JsonArray().add("x").add(2));
-
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    codec.toOutputStream(obj, baos);
-    assertArrayEquals(codec.toBuffer(obj).getBytes(), baos.toByteArray());
-  }
-
-  @Test
-  public void testEncodeNullToOutputStream() {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    codec.toOutputStream(null, baos);
-    assertEquals("null", baos.toString(StandardCharsets.UTF_8));
-  }
-
-  @Test
-  public void testEncodeScalarToOutputStream() {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    codec.toOutputStream("hello", baos);
-    assertEquals("\"hello\"", baos.toString(StandardCharsets.UTF_8));
-
-    baos.reset();
-    codec.toOutputStream(42, baos);
-    assertEquals("42", baos.toString(StandardCharsets.UTF_8));
-
-    baos.reset();
-    codec.toOutputStream(true, baos);
-    assertEquals("true", baos.toString(StandardCharsets.UTF_8));
-  }
-
-  @Test
-  public void testEncodeToOutputStreamDoesNotCloseOrFlushStream() {
-    JsonObject obj = new JsonObject().put("key", "value");
-    boolean[] closed = {false};
-    boolean[] flushed = {false};
-    OutputStream out = new FilterOutputStream(new ByteArrayOutputStream()) {
-      @Override
-      public void close() throws IOException {
-        closed[0] = true;
-        super.close();
-      }
-      @Override
-      public void flush() throws IOException {
-        flushed[0] = true;
-        super.flush();
-      }
-    };
-    codec.toOutputStream(obj, out);
-    assertFalse("Codec should not close the OutputStream", closed[0]);
-    assertFalse("Codec should not flush the OutputStream", flushed[0]);
-  }
-
-  @Test
   public void testDecodeJsonObjectFromReader() {
-    String json = "{\"foo\":\"bar\",\"num\":123}";
-    Map<?, ?> map = codec.fromReader(new StringReader(json), Map.class);
-    assertEquals("bar", map.get("foo"));
-    assertEquals(123, map.get("num"));
+    testDecodeJsonObjectStreaming(true);
   }
 
   @Test
   public void testDecodeJsonArrayFromReader() {
-    String json = "[\"foo\",123,true]";
-    List<?> list = codec.fromReader(new StringReader(json), List.class);
-    assertEquals("foo", list.get(0));
-    assertEquals(123, list.get(1));
-    assertEquals(true, list.get(2));
+    testDecodeJsonArrayStreaming(true);
   }
 
   @Test
   public void testDecodeFromReaderUnknownContent() {
-    assertEquals(1, decodeFromReader("1"));
-    assertEquals(true, decodeFromReader("true"));
-    assertEquals("whatever", decodeFromReader("\"whatever\""));
-    assertNull(decodeFromReader("null"));
-
-    JsonObject obj = new JsonObject().put("foo", "bar");
-    assertEquals(obj, decodeFromReader(obj.toString()));
-
-    JsonArray arr = new JsonArray().add(1).add(false).add("whatever").add(obj);
-    assertEquals(arr, decodeFromReader(arr.toString()));
-  }
-
-  private Object decodeFromReader(String json) {
-    return codec.fromReader(new StringReader(json), Object.class);
+    testDecodeStreamingUnknownContent(true);
   }
 
   @Test
   public void testDecodeFromReaderEquivalence() {
-    byte[] bytes = TestUtils.randomByteArray(10);
-    String strBytes = TestUtils.toBase64String(bytes);
-    Instant now = Instant.now();
-    String strInstant = ISO_INSTANT.format(now);
-    String json = "{\"mystr\":\"foo\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
-      "myboolean\":true,\"mybinary\":\"" + strBytes + "\",\"myinstant\":\"" + strInstant + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}";
-
-    Object fromString = codec.fromString(json, Object.class);
-    Object fromReader = codec.fromReader(new StringReader(json), Object.class);
-    assertEquals(fromString, fromReader);
+    testDecodeStreamingEquivalence(true);
   }
 
   @Test
   public void testDecodeFromReaderInvalidJson() {
-    for (String test : new String[]{"\"3", "qiwjdoiqwjdiqwjd", "{\"foo\":1},{\"bar\":2}"}) {
-      try {
-        codec.fromReader(new StringReader(test), Map.class);
-        fail("Should have thrown DecodeException for: " + test);
-      } catch (DecodeException ignore) {
-      }
-    }
+    testDecodeStreamingInvalidJson(true);
   }
 
   @Test
   public void testDecodeFromReaderEmpty() {
-    try {
-      codec.fromReader(new StringReader(""), Object.class);
-      fail();
-    } catch (DecodeException ignore) {
-    }
+    testDecodeStreamingEmpty(true);
   }
 
   @Test
   public void testDecodeFromReaderWithComments() {
-    String jsonWithComments =
-      "// comment\n" +
-        "{\"foo\": \"bar\" /* inline */}";
-    Map<?, ?> map = codec.fromReader(new StringReader(jsonWithComments), Map.class);
-    assertEquals("bar", map.get("foo"));
+    testDecodeStreamingWithComments(true);
   }
 
   @Test
-  public void testDecodeFromReaderDoesNotCloseReader() throws IOException {
+  public void testDecodeFromReaderDoesNotCloseReader() {
     String json = "{\"key\":\"value\"}";
     boolean[] closed = {false};
     Reader reader = new FilterReader(new StringReader(json)) {
@@ -841,57 +677,153 @@ public abstract class JsonCodecTest {
     assertFalse("Codec should not close the Reader", closed[0]);
   }
 
+
+  private <T> T decodeStreaming(String json, Class<T> clazz, boolean useReader) {
+    if (useReader) {
+      return codec.fromReader(new StringReader(json), clazz);
+    } else {
+      return codec.fromInputStream(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), clazz);
+    }
+  }
+
+  private void testDecodeJsonObjectStreaming(boolean useReader) {
+    String json = "{\"foo\":\"bar\",\"num\":123}";
+    Map<?, ?> map = decodeStreaming(json, Map.class, useReader);
+    assertEquals("bar", map.get("foo"));
+    assertEquals(123, map.get("num"));
+  }
+
+  private void testDecodeJsonArrayStreaming(boolean useReader) {
+    String json = "[\"foo\",123,true]";
+    List<?> list = decodeStreaming(json, List.class, useReader);
+    assertEquals("foo", list.get(0));
+    assertEquals(123, list.get(1));
+    assertEquals(true, list.get(2));
+  }
+
+  private void testDecodeStreamingUnknownContent(boolean useReader) {
+    assertEquals(1, decodeStreaming("1", Object.class, useReader));
+    assertEquals(true, decodeStreaming("true", Object.class, useReader));
+    assertEquals("whatever", decodeStreaming("\"whatever\"", Object.class, useReader));
+    assertNull(decodeStreaming("null", Object.class, useReader));
+
+    JsonObject obj = new JsonObject().put("foo", "bar");
+    assertEquals(obj, decodeStreaming(obj.toString(), Object.class, useReader));
+
+    JsonArray arr = new JsonArray().add(1).add(false).add("whatever").add(obj);
+    assertEquals(arr, decodeStreaming(arr.toString(), Object.class, useReader));
+  }
+
+  private void testDecodeStreamingEquivalence(boolean useReader) {
+    byte[] bytes = TestUtils.randomByteArray(10);
+    String strBytes = TestUtils.toBase64String(bytes);
+    Instant now = Instant.now();
+    String strInstant = ISO_INSTANT.format(now);
+    String json = "{\"mystr\":\"foo\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
+      "myboolean\":true,\"mybinary\":\"" + strBytes + "\",\"myinstant\":\"" + strInstant + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}";
+
+    Object fromString = codec.fromString(json, Object.class);
+    Object fromStreaming = decodeStreaming(json, Object.class, useReader);
+    assertEquals(fromString, fromStreaming);
+  }
+
+  private void testDecodeStreamingInvalidJson(boolean useReader) {
+    for (String test : new String[]{"\"3", "qiwjdoiqwjdiqwjd", "{\"foo\":1},{\"bar\":2}"}) {
+      try {
+        decodeStreaming(test, Map.class, useReader);
+        fail("Should have thrown DecodeException for: " + test);
+      } catch (DecodeException ignore) {
+      }
+    }
+  }
+
+  private void testDecodeStreamingEmpty(boolean useReader) {
+    try {
+      decodeStreaming("", Object.class, useReader);
+      fail();
+    } catch (DecodeException ignore) {
+    }
+  }
+
+  private void testDecodeStreamingWithComments(boolean useReader) {
+    String jsonWithComments =
+      "// comment\n" +
+        "{\"foo\": \"bar\" /* inline */}";
+    Map<?, ?> map = decodeStreaming(jsonWithComments, Map.class, useReader);
+    assertEquals("bar", map.get("foo"));
+  }
+
+  @Test
+  public void testEncodeJsonObjectToOutputStream() {
+    testEncodeJsonObjectStreaming(false);
+  }
+
+  @Test
+  public void testEncodeJsonArrayToOutputStream() {
+    testEncodeJsonArrayStreaming(false);
+  }
+
+  @Test
+  public void testEncodeToOutputStreamEquivalence() {
+    testEncodeStreamingEquivalence(false);
+  }
+
+  @Test
+  public void testEncodeNullToOutputStream() {
+    testEncodeNullStreaming(false);
+  }
+
+  @Test
+  public void testEncodeScalarToOutputStream() {
+    testEncodeScalarStreaming(false);
+  }
+
+  @Test
+  public void testEncodeToOutputStreamDoesNotCloseOrFlushStream() {
+    JsonObject obj = new JsonObject().put("key", "value");
+    boolean[] closed = {false};
+    boolean[] flushed = {false};
+    OutputStream out = new FilterOutputStream(new ByteArrayOutputStream()) {
+      @Override
+      public void close() throws IOException {
+        closed[0] = true;
+        super.close();
+      }
+
+      @Override
+      public void flush() throws IOException {
+        flushed[0] = true;
+        super.flush();
+      }
+    };
+    codec.toOutputStream(obj, out);
+    assertFalse("Codec should not close the OutputStream", closed[0]);
+    assertFalse("Codec should not flush the OutputStream", flushed[0]);
+  }
+
   @Test
   public void testEncodeJsonObjectToWriter() {
-    JsonObject jsonObject = new JsonObject().put("foo", "bar").put("num", 123);
-    StringWriter sw = new StringWriter();
-    codec.toWriter(jsonObject, sw);
-    assertEquals(codec.toString(jsonObject), sw.toString());
+    testEncodeJsonObjectStreaming(true);
   }
 
   @Test
   public void testEncodeJsonArrayToWriter() {
-    JsonArray jsonArray = new JsonArray().add("foo").add(123).add(true);
-    StringWriter sw = new StringWriter();
-    codec.toWriter(jsonArray, sw);
-    assertEquals(codec.toString(jsonArray), sw.toString());
+    testEncodeJsonArrayStreaming(true);
   }
 
   @Test
   public void testEncodeToWriterEquivalence() {
-    JsonObject obj = new JsonObject()
-      .put("str", "hello")
-      .put("num", 42)
-      .put("bool", true)
-      .putNull("nil")
-      .put("nested", new JsonObject().put("a", 1))
-      .put("arr", new JsonArray().add("x").add(2));
-
-    StringWriter sw = new StringWriter();
-    codec.toWriter(obj, sw);
-    assertEquals(codec.toString(obj), sw.toString());
+    testEncodeStreamingEquivalence(true);
   }
 
   @Test
   public void testEncodeNullToWriter() {
-    StringWriter sw = new StringWriter();
-    codec.toWriter(null, sw);
-    assertEquals("null", sw.toString());
+    testEncodeNullStreaming(true);
   }
 
   @Test
   public void testEncodeScalarToWriter() {
-    StringWriter sw = new StringWriter();
-    codec.toWriter("hello", sw);
-    assertEquals("\"hello\"", sw.toString());
-
-    sw = new StringWriter();
-    codec.toWriter(42, sw);
-    assertEquals("42", sw.toString());
-
-    sw = new StringWriter();
-    codec.toWriter(true, sw);
-    assertEquals("true", sw.toString());
+    testEncodeScalarStreaming(true);
   }
 
   @Test
@@ -916,34 +848,69 @@ public abstract class JsonCodecTest {
     assertFalse("Codec should not flush the Writer", flushed[0]);
   }
 
-  @Test
-  public void testReaderWriterRoundTrip() {
-    JsonObject original = new JsonObject()
-      .put("name", "test")
-      .put("value", 42)
-      .put("nested", new JsonObject().put("a", true))
-      .put("arr", new JsonArray().add(1).add("two").add(new JsonObject().put("three", 3)));
+  private String encodeStreaming(Object object, boolean useWriter) {
+    if (useWriter) {
+      StringWriter sw = new StringWriter();
+      codec.toWriter(object, sw);
+      return sw.toString();
+    } else {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      codec.toOutputStream(object, baos);
+      return baos.toString(StandardCharsets.UTF_8);
+    }
+  }
 
-    StringWriter sw = new StringWriter();
-    codec.toWriter(original, sw);
+  private void testEncodeJsonObjectStreaming(boolean useWriter) {
+    JsonObject jsonObject = new JsonObject().put("foo", "bar").put("num", 123);
+    assertEquals(codec.toString(jsonObject), encodeStreaming(jsonObject, useWriter));
+  }
 
-    Object decoded = codec.fromReader(new StringReader(sw.toString()), Object.class);
-    assertEquals(original, decoded);
+  private void testEncodeJsonArrayStreaming(boolean useWriter) {
+    JsonArray jsonArray = new JsonArray().add("foo").add(123).add(true);
+    assertEquals(codec.toString(jsonArray), encodeStreaming(jsonArray, useWriter));
+  }
+
+  private void testEncodeStreamingEquivalence(boolean useWriter) {
+    JsonObject obj = new JsonObject()
+      .put("str", "hello")
+      .put("num", 42)
+      .put("bool", true)
+      .putNull("nil")
+      .put("nested", new JsonObject().put("a", 1))
+      .put("arr", new JsonArray().add("x").add(2));
+
+    assertEquals(codec.toString(obj), encodeStreaming(obj, useWriter));
+  }
+
+  private void testEncodeNullStreaming(boolean useWriter) {
+    assertEquals("null", encodeStreaming(null, useWriter));
+  }
+
+  private void testEncodeScalarStreaming(boolean useWriter) {
+    assertEquals("\"hello\"", encodeStreaming("hello", useWriter));
+    assertEquals("42", encodeStreaming(42, useWriter));
+    assertEquals("true", encodeStreaming(true, useWriter));
   }
 
   @Test
   public void testInputStreamOutputStreamRoundTrip() {
+    testStreamingRoundTrip(false);
+  }
+
+  @Test
+  public void testReaderWriterRoundTrip() {
+    testStreamingRoundTrip(true);
+  }
+
+  private void testStreamingRoundTrip(boolean useReaderWriter) {
     JsonObject original = new JsonObject()
       .put("name", "test")
       .put("value", 42)
       .put("nested", new JsonObject().put("a", true))
       .put("arr", new JsonArray().add(1).add("two").add(new JsonObject().put("three", 3)));
 
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    codec.toOutputStream(original, baos);
-
-    InputStream in = new ByteArrayInputStream(baos.toByteArray());
-    Object decoded = codec.fromInputStream(in, Object.class);
+    String encoded = encodeStreaming(original, useReaderWriter);
+    Object decoded = decodeStreaming(encoded, Object.class, useReaderWriter);
     assertEquals(original, decoded);
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/json/JsonCodecTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/json/JsonCodecTest.java
@@ -24,8 +24,16 @@ import io.vertx.test.core.TestUtils;
 import org.junit.Assume;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -561,5 +569,192 @@ public abstract class JsonCodecTest {
     // if other than EncodeException happens here, then
     // there is probably a leak closing the netty buffer output stream
     codec.toBuffer(new RuntimeException("Unsupported"));
+  }
+
+  @Test
+  public void testDecodeJsonObjectFromInputStream() {
+    String json = "{\"foo\":\"bar\",\"num\":123}";
+    InputStream in = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+    Map<?, ?> map = codec.fromInputStream(in, Map.class);
+    assertEquals("bar", map.get("foo"));
+    assertEquals(123, map.get("num"));
+  }
+
+  @Test
+  public void testDecodeJsonArrayFromInputStream() {
+    String json = "[\"foo\",123,true]";
+    InputStream in = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+    List<?> list = codec.fromInputStream(in, List.class);
+    assertEquals("foo", list.get(0));
+    assertEquals(123, list.get(1));
+    assertEquals(true, list.get(2));
+  }
+
+  @Test
+  public void testDecodeFromInputStreamUnknownContent() {
+    assertEquals(1, decodeFromInputStream("1"));
+    assertEquals(true, decodeFromInputStream("true"));
+    assertEquals("whatever", decodeFromInputStream("\"whatever\""));
+    assertNull(decodeFromInputStream("null"));
+
+    JsonObject obj = new JsonObject().put("foo", "bar");
+    assertEquals(obj, decodeFromInputStream(obj.toString()));
+
+    JsonArray arr = new JsonArray().add(1).add(false).add("whatever").add(obj);
+    assertEquals(arr, decodeFromInputStream(arr.toString()));
+  }
+
+  private Object decodeFromInputStream(String json) {
+    return codec.fromInputStream(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), Object.class);
+  }
+
+  @Test
+  public void testDecodeFromInputStreamEquivalence() {
+    byte[] bytes = TestUtils.randomByteArray(10);
+    String strBytes = TestUtils.toBase64String(bytes);
+    Instant now = Instant.now();
+    String strInstant = ISO_INSTANT.format(now);
+    String json = "{\"mystr\":\"foo\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
+      "myboolean\":true,\"mybinary\":\"" + strBytes + "\",\"myinstant\":\"" + strInstant + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}";
+
+    Object fromString = codec.fromString(json, Object.class);
+    Object fromStream = codec.fromInputStream(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), Object.class);
+    assertEquals(fromString, fromStream);
+  }
+
+  @Test
+  public void testDecodeFromInputStreamInvalidJson() {
+    for (String test : new String[]{"\"3", "qiwjdoiqwjdiqwjd", "{\"foo\":1},{\"bar\":2}"}) {
+      try {
+        codec.fromInputStream(new ByteArrayInputStream(test.getBytes(StandardCharsets.UTF_8)), Map.class);
+        fail("Should have thrown DecodeException for: " + test);
+      } catch (DecodeException ignore) {
+      }
+    }
+  }
+
+  @Test
+  public void testDecodeFromInputStreamEmpty() {
+    try {
+      codec.fromInputStream(new ByteArrayInputStream(new byte[0]), Object.class);
+      fail();
+    } catch (DecodeException ignore) {
+    }
+  }
+
+  @Test
+  public void testDecodeFromInputStreamWithComments() {
+    String jsonWithComments =
+      "// comment\n" +
+        "{\"foo\": \"bar\" /* inline */}";
+    InputStream in = new ByteArrayInputStream(jsonWithComments.getBytes(StandardCharsets.UTF_8));
+    Map<?, ?> map = codec.fromInputStream(in, Map.class);
+    assertEquals("bar", map.get("foo"));
+  }
+
+  @Test
+  public void testDecodeFromInputStreamDoesNotCloseStream() throws IOException {
+    String json = "{\"key\":\"value\"}";
+    boolean[] closed = {false};
+    InputStream in = new FilterInputStream(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
+      @Override
+      public void close() throws IOException {
+        closed[0] = true;
+        super.close();
+      }
+    };
+    codec.fromInputStream(in, Map.class);
+    assertFalse("Codec should not close the InputStream", closed[0]);
+  }
+
+  @Test
+  public void testEncodeJsonObjectToOutputStream() {
+    JsonObject jsonObject = new JsonObject().put("foo", "bar").put("num", 123);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    codec.toOutputStream(jsonObject, baos);
+    assertEquals(codec.toString(jsonObject), baos.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testEncodeJsonArrayToOutputStream() {
+    JsonArray jsonArray = new JsonArray().add("foo").add(123).add(true);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    codec.toOutputStream(jsonArray, baos);
+    assertEquals(codec.toString(jsonArray), baos.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testEncodeToOutputStreamEquivalence() {
+    JsonObject obj = new JsonObject()
+      .put("str", "hello")
+      .put("num", 42)
+      .put("bool", true)
+      .putNull("nil")
+      .put("nested", new JsonObject().put("a", 1))
+      .put("arr", new JsonArray().add("x").add(2));
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    codec.toOutputStream(obj, baos);
+    assertArrayEquals(codec.toBuffer(obj).getBytes(), baos.toByteArray());
+  }
+
+  @Test
+  public void testEncodeNullToOutputStream() {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    codec.toOutputStream(null, baos);
+    assertEquals("null", baos.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testEncodeScalarToOutputStream() {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    codec.toOutputStream("hello", baos);
+    assertEquals("\"hello\"", baos.toString(StandardCharsets.UTF_8));
+
+    baos.reset();
+    codec.toOutputStream(42, baos);
+    assertEquals("42", baos.toString(StandardCharsets.UTF_8));
+
+    baos.reset();
+    codec.toOutputStream(true, baos);
+    assertEquals("true", baos.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testEncodeToOutputStreamDoesNotCloseOrFlushStream() {
+    JsonObject obj = new JsonObject().put("key", "value");
+    boolean[] closed = {false};
+    boolean[] flushed = {false};
+    OutputStream out = new FilterOutputStream(new ByteArrayOutputStream()) {
+      @Override
+      public void close() throws IOException {
+        closed[0] = true;
+        super.close();
+      }
+      @Override
+      public void flush() throws IOException {
+        flushed[0] = true;
+        super.flush();
+      }
+    };
+    codec.toOutputStream(obj, out);
+    assertFalse("Codec should not close the OutputStream", closed[0]);
+    assertFalse("Codec should not flush the OutputStream", flushed[0]);
+  }
+
+  @Test
+  public void testInputStreamOutputStreamRoundTrip() {
+    JsonObject original = new JsonObject()
+      .put("name", "test")
+      .put("value", 42)
+      .put("nested", new JsonObject().put("a", true))
+      .put("arr", new JsonArray().add(1).add("two").add(new JsonObject().put("three", 3)));
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    codec.toOutputStream(original, baos);
+
+    InputStream in = new ByteArrayInputStream(baos.toByteArray());
+    Object decoded = codec.fromInputStream(in, Object.class);
+    assertEquals(original, decoded);
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/json/JsonCodecTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/json/JsonCodecTest.java
@@ -623,7 +623,7 @@ public abstract class JsonCodecTest {
         super.close();
       }
     };
-    codec.fromInputStream(in, Map.class);
+    codec.fromStream(in, Map.class);
     assertFalse("Codec should not close the InputStream", closed[0]);
   }
 
@@ -682,7 +682,7 @@ public abstract class JsonCodecTest {
     if (useReader) {
       return codec.fromReader(new StringReader(json), clazz);
     } else {
-      return codec.fromInputStream(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), clazz);
+      return codec.fromStream(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), clazz);
     }
   }
 
@@ -796,7 +796,7 @@ public abstract class JsonCodecTest {
         super.flush();
       }
     };
-    codec.toOutputStream(obj, out);
+    codec.toStream(obj, out);
     assertFalse("Codec should not close the OutputStream", closed[0]);
     assertFalse("Codec should not flush the OutputStream", flushed[0]);
   }
@@ -855,7 +855,7 @@ public abstract class JsonCodecTest {
       return sw.toString();
     } else {
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      codec.toOutputStream(object, baos);
+      codec.toStream(object, baos);
       return baos.toString(StandardCharsets.UTF_8);
     }
   }


### PR DESCRIPTION
Allow JSON decoding/encoding directly from/to streams and character sources, so that SQL clients can avoid intermediate `String` or `byte[]` allocations.

- `fromInputStream` / `toOutputStream` for UTF-8 wire encodings (PG, MySQL)
- `fromReader` / `toWriter` for non-UTF-8 wire encodings (e.g. MSSQL with UTF-16LE)

Some portions of this content were created with the assistance of Claude Opus 4.6