### PR TITLE
Add a MessageProducer#write variant with delivery options.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/MessageProducer.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/MessageProducer.java
@@ -55,6 +55,15 @@ public interface MessageProducer<T> {
   Future<Void> write(T body);
 
   /**
+   * Like {@link #write(Object)} but with specific delivery {@code options}.
+   *
+   * @param body the message body
+   * @param options the message delivery options
+   * @return a future signaling the proper message write
+   */
+  Future<Void> write(T body, DeliveryOptions options);
+
+  /**
    * Closes the producer, this method should be called when the message producer is not used anymore.
    *
    * @return a future completed with the result

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
@@ -45,6 +45,11 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
 
   @Override
   public Future<Void> write(T body) {
+    return write(body, options);
+  }
+
+  @Override
+  public Future<Void> write(T body, DeliveryOptions options) {
     MessageImpl msg = bus.createMessage(send, localOnly, address, options.getHeaders(), body, options.getCodecName());
     return bus.sendOrPubInternal(msg, options, null);
   }

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/LocalEventBusTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/LocalEventBusTest.java
@@ -1231,29 +1231,50 @@ public class LocalEventBusTest extends EventBusTestBase {
 
   @Test
   public void testUpdateDeliveryOptionsOnProducer() {
+    int times = 5;
+    waitFor(times);
     MessageProducer<String> producer = eb.sender(ADDRESS1);
     MessageConsumer<String> consumer = eb.<String>consumer(ADDRESS1);
-    consumer.completion().onComplete(v -> {
-      Assert.assertTrue(v.succeeded());
-      producer.write("no-header");
-    });
     consumer.handler(msg -> {
       String body = msg.body();
       Assert.assertNotNull(body);
-      switch (body) {
-        case "no-header":
-          Assert.assertNull(msg.headers().get("header-name"));
-          producer.deliveryOptions(new DeliveryOptions().addHeader("header-name", "header-value"));
-          producer.write("with-header");
-          break;
-        case "with-header":
-          Assert.assertEquals("header-value", msg.headers().get("header-name"));
+      Assert.assertEquals("header-value", msg.headers().get("header-name"));
+      complete();
+    }).completion()
+      .await();
+    producer.deliveryOptions(new DeliveryOptions().addHeader("header-name", "header-value"));
+    for (int i = 0;i < times;i++) {
+      producer.write("with-header");
+    }
+    await();
+  }
+
+  @Test
+  public void testUpdateDeliveryOptionsOnProducerWrite() {
+    int times = 5;
+    MessageProducer<String> producer = eb.sender(ADDRESS1);
+    MessageConsumer<String> consumer = eb.<String>consumer(ADDRESS1);
+    List<String> expectedHeaders = new ArrayList<>();
+    for (int i = 0;i < times;i++) {
+      expectedHeaders.add("header-value-" + i);
+    }
+    List<String> headers = new ArrayList<>();
+    consumer.handler(msg -> {
+        String body = msg.body();
+        Assert.assertNotNull(body);
+        String header = msg.headers().get("header-name");
+        Assert.assertNotNull(header);
+        headers.add(header);
+        if (headers.size() == times) {
+          Assert.assertEquals(expectedHeaders, headers);
           testComplete();
-          break;
-        default:
-          Assert.fail();
-      }
-    });
+        }
+      }).completion()
+      .await();
+    producer.deliveryOptions(new DeliveryOptions().addHeader("header-name", "header-value"));
+    for (String expectedHeader : expectedHeaders) {
+      producer.write("with-header", new DeliveryOptions().addHeader("header-name", expectedHeader));
+    }
     await();
   }
 


### PR DESCRIPTION
Motivation:

The `MessageProducer` should have a `write(T, DeliveryOptions)` variant for sending messages.

As work-around we need to overload the producer delivery options on every write.

This is useful for the event-bus gRPC streaming support.

Changes:

Add `MessageProducer#write(T, DeliveryOptions)` and implement/test it.
