### PR TITLE
Skip NetTest.testEndHandlerCalledAfterAllEmissions on io_uring (#6253)

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/NetTest.java
@@ -163,6 +163,7 @@ public class NetTest {
 
   @Test
   public void testEndHandlerCalledAfterAllEmissions() {
+    Assume.assumeFalse("Intermittent failure with io_uring, see https://github.com/netty/netty/issues/17049", TRANSPORT == Transport.IO_URING);
     Buffer  buffer = TestUtils.randomBuffer(1024 * 1024);
     server = vertx.createNetServer().connectHandler(so -> {
       so.end(buffer);


### PR DESCRIPTION
Likely caused by a Netty io_uring readPending race that can cause intermittent read stalls under autoRead toggling.

Re-enable after upgrading past Netty 4.2.16.Final.

See https://github.com/netty/netty/issues/17049
Fix https://github.com/netty/netty/pull/17087