### PR TITLE
Support event-bus interceptor chain failure.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/eventbus/DeliveryContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/DeliveryContext.java
@@ -35,6 +35,21 @@ public interface DeliveryContext<T> {
   void next();
 
   /**
+   * {@link #fail(ReplyFailure, int, String)} with {@link ReplyFailure#RECIPIENT_FAILURE}
+   */
+  boolean fail(int failureCode, String message);
+
+  /**
+   * Terminate the interception chain immediately and fail the message.
+   *
+   * @param failure the failure
+   * @param failureCode the failure code
+   * @param message the message
+   * @return true if the operation succeeded
+   */
+  boolean fail(ReplyFailure failure,  int failureCode, String message);
+
+  /**
    * @return true if the message is being sent (point to point) or False if the message is being published
    */
   boolean send();

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/DeliveryContextImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/DeliveryContextImpl.java
@@ -13,6 +13,8 @@ package io.vertx.core.eventbus.impl;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.DeliveryContext;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
 import io.vertx.core.internal.ContextInternal;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -24,12 +26,12 @@ class DeliveryContextImpl<T> implements DeliveryContext<T> {
   private final MessageImpl<?, T> message;
   private final ContextInternal context;
   private final Object body;
-  private final Runnable dispatch;
+  private final Handler<ReplyException> dispatch;
   private final Handler<DeliveryContext<?>>[] interceptors;
   private volatile int interceptorIdx;
 
   protected DeliveryContextImpl(MessageImpl<?, T> message, Handler<DeliveryContext<?>>[] interceptors,
-                                ContextInternal context, Object body, Runnable dispatch) {
+                                ContextInternal context, Object body, Handler<ReplyException> dispatch) {
     this.message = message;
     this.interceptors = interceptors;
     this.context = context;
@@ -54,6 +56,26 @@ class DeliveryContextImpl<T> implements DeliveryContext<T> {
   }
 
   @Override
+  public boolean fail(int failureCode, String message) {
+    return fail(ReplyFailure.RECIPIENT_FAILURE, failureCode, message);
+  }
+
+  @Override
+  public boolean fail(ReplyFailure failure, int failureCode, String message) {
+    while (true) {
+      int idx = UPDATER.get(this);
+      if (idx > interceptors.length) {
+        return false;
+      }
+      if (UPDATER.compareAndSet(this, idx, interceptors.length + 1)) {
+        break;
+      }
+    }
+    dispatch.handle(new ReplyException(failure, failureCode, message));
+    return true;
+  }
+
+  @Override
   public void next() {
     int idx = UPDATER.getAndIncrement(this);
     if (idx < interceptors.length) {
@@ -68,7 +90,7 @@ class DeliveryContextImpl<T> implements DeliveryContext<T> {
         }
       }
     } else if (idx == interceptors.length) {
-      dispatch.run();
+      dispatch.handle(null);
     } else {
       throw new IllegalStateException();
     }

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -95,7 +95,13 @@ public abstract class HandlerRegistration<T> implements Closeable {
   void dispatchMessage(Function<Message<T>, Future<?>> processor, MessageImpl<?, T> message, ContextInternal context) {
     Handler<DeliveryContext<?>>[] interceptors = message.bus.inboundInterceptors();
     if (interceptors.length > 0) {
-      Runnable dispatch = () -> dispatch(context, message, processor);
+      Handler<ReplyException> dispatch = failure -> {
+        if (failure == null) {
+          dispatch(context, message, processor);
+        } else {
+          message.reply(failure);
+        }
+      };
       DeliveryContextImpl<T> deliveryCtx = new DeliveryContextImpl<>(message, interceptors, context, message.receivedBody, dispatch);
       deliveryCtx.next();
     } else {

--- a/vertx-core/src/main/java/io/vertx/core/eventbus/impl/SendContext.java
+++ b/vertx-core/src/main/java/io/vertx/core/eventbus/impl/SendContext.java
@@ -49,10 +49,10 @@ public class SendContext<T> implements Promise<Void> {
   void send() {
     Handler<DeliveryContext<?>>[] interceptors = message.bus.outboundInterceptors();
     if (interceptors.length > 0) {
-      DeliveryContextImpl<T> deliveryContext = new DeliveryContextImpl<>(message, interceptors, ctx,  message.sentBody, this::sendOrPub);
+      DeliveryContextImpl<T> deliveryContext = new DeliveryContextImpl<>(message, interceptors, ctx,  message.sentBody, this::sendOrPubOrFail);
       deliveryContext.next();
     } else {
-      sendOrPub();
+      sendOrPubOrFail(null);
     }
   }
 
@@ -113,23 +113,32 @@ public class SendContext<T> implements Promise<Void> {
     }
   }
 
-  private void sendOrPub() {
-    VertxTracer tracer = ctx.tracer();
-    if (tracer != null) {
-      if (message.trace == null) {
-        src = true;
-        BiConsumer<String, String> biConsumer = (String key, String val) -> message.headers().set(key, val);
-        TracingPolicy tracingPolicy = options.getTracingPolicy();
-        if (tracingPolicy == null) {
-          tracingPolicy = TracingPolicy.PROPAGATE;
+  private void sendOrPubOrFail(ReplyException failure) {
+    if (failure == null) {
+      VertxTracer tracer = ctx.tracer();
+      if (tracer != null) {
+        if (message.trace == null) {
+          src = true;
+          BiConsumer<String, String> biConsumer = (String key, String val) -> message.headers().set(key, val);
+          TracingPolicy tracingPolicy = options.getTracingPolicy();
+          if (tracingPolicy == null) {
+            tracingPolicy = TracingPolicy.PROPAGATE;
+          }
+          message.trace = tracer.sendRequest(ctx, SpanKind.RPC, tracingPolicy, message, message.send ? "send" : "publish", biConsumer, MessageTagExtractor.INSTANCE);
+        } else {
+          // Handle failure here
+          tracer.sendResponse(ctx, null, message.trace, null, TagExtractor.empty());
         }
-        message.trace = tracer.sendRequest(ctx, SpanKind.RPC, tracingPolicy, message, message.send ? "send" : "publish", biConsumer, MessageTagExtractor.INSTANCE);
-      } else {
-        // Handle failure here
-        tracer.sendResponse(ctx, null, message.trace, null, TagExtractor.empty());
+      }
+      bus.sendOrPub(this);
+    } else {
+      // Fail write promise
+      writePromise.fail(failure);
+
+      // Fail reply handler when it exists
+      if (replyHandler != null) {
+        replyHandler.fail(failure);
       }
     }
-    bus.sendOrPub(this);
   }
-
 }

--- a/vertx-core/src/test/java/io/vertx/tests/eventbus/EventBusInterceptorTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/eventbus/EventBusInterceptorTest.java
@@ -12,10 +12,10 @@
 package io.vertx.tests.eventbus;
 
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.DeliveryContext;
-import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.*;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
@@ -423,6 +423,105 @@ public class EventBusInterceptorTest extends VertxTestBase {
     eb.send("some-address", "armadillo");
     waitUntil(() -> caught.get() != null);
     assertSame(expected, caught.get());
+  }
+
+  @Test
+  public void testOutboundReplySendFailure() {
+    eb.addOutboundInterceptor(sc -> {
+      assertTrue(sc.fail(3, "test"));
+      try {
+        sc.next();
+        fail();
+      } catch (IllegalStateException expected) {
+      }
+    });
+    eb.consumer("some-address", msg -> {
+      fail();
+    });
+    MessageProducer<String> sender = eb.sender("some-address");
+    Future<Void> fut = sender.write("armadillo");
+    fut.onComplete(onFailure(expected -> {
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
+  public void testOutboundReplyRequestFailure() {
+    eb.addOutboundInterceptor(sc -> {
+      assertTrue(sc.fail(ReplyFailure.NO_HANDLERS, 3, "test"));
+      try {
+        sc.next();
+        fail();
+      } catch (IllegalStateException expected) {
+      }
+    });
+    eb.consumer("some-address", msg -> {
+      fail();
+    });
+    Future<Message<Object>> fut = eb.request("some-address", "armadillo");
+    fut.onComplete(onFailure(expected -> {
+      ReplyException replyException = (ReplyException) expected;
+      assertEquals(3, replyException.failureCode());
+      assertEquals(ReplyFailure.NO_HANDLERS, replyException.failureType());
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
+  public void testInboundReplySendFailure() {
+    eb.addInboundInterceptor(sc -> {
+      assertTrue(sc.fail(3, "test"));
+      try {
+        sc.next();
+        fail();
+      } catch (IllegalStateException expected) {
+      }
+    });
+    eb.consumer("some-address", msg -> {
+      fail();
+    });
+    MessageProducer<String> sender = eb.sender("some-address");
+    Future<Void> fut = sender.write("armadillo");
+    fut.onComplete(onSuccess(expected -> {
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
+  public void testInboundReplyRequestFailure() {
+    eb.addInboundInterceptor(dc -> {
+      if (dc.message().address().equals("some-address")) {
+        assertTrue(dc.fail(3, "test"));
+        try {
+          dc.next();
+          fail();
+        } catch (IllegalStateException expected) {
+        }
+      } else {
+        dc.next();
+      }
+    });
+    eb.addInboundInterceptor(dc -> {
+      if (dc.message().address().equals("some-address")) {
+        fail();
+      } else {
+        dc.next();
+      }
+    });
+    eb.consumer("some-address", msg -> {
+      fail();
+    });
+    Future<Message<Object>> fut = eb.request("some-address", "armadillo");
+    fut.onComplete(onFailure(expected -> {
+      ReplyException replyException = (ReplyException) expected;
+      assertEquals(3, replyException.failureCode());
+      assertEquals(ReplyFailure.RECIPIENT_FAILURE, replyException.failureType());
+      testComplete();
+    }));
+    await();
   }
 
   @Override


### PR DESCRIPTION
Motivation:

The event-bus interceptor chain does not provide a clean way to fail a message interception, some case can be achieved by failing the message itself but that works for limited cases and it does not handle the interception in progress.

Cleanly failing a message delivery can be useful in some scenario, specially for testing purposes.

Changes:

Add a `DeliveryContext#fail` method that performs a clean fail of the message by interrupting the interception chain and properly failing the message:

The message will not make progress anymore and the sender will receive a failure notification whether it is the write future for outbound message writes or the reply handler.
