### PR TITLE
Harden HTTP version configuration support

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Configuration of a {@link HttpClient}
@@ -39,9 +40,9 @@ public class HttpClientConfig {
       case HTTP_1_0:
         return List.of(HttpVersion.HTTP_1_0);
       case HTTP_1_1:
-        return List.of(HttpVersion.HTTP_1_1);
+        return List.of(HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_0);
       case HTTP_2:
-        return List.of(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1);
+        return List.of(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_0);
       default:
         throw new IllegalArgumentException();
     }
@@ -58,7 +59,7 @@ public class HttpClientConfig {
     return config;
   }
 
-  public static final List<HttpVersion> DEFAULT_SUPPORTED_VERSIONS = List.of(HttpVersion.HTTP_1_1, HttpVersion.HTTP_2);
+  public static final List<HttpVersion> DEFAULT_SUPPORTED_VERSIONS = List.of(HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_0, HttpVersion.HTTP_2);
   public static final long DEFAULT_QUIC_INITIAL_MAX_DATA = 10_485_760L;
   public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL = 1_048_576L;
   public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE = 0L;
@@ -141,10 +142,25 @@ public class HttpClientConfig {
       redirectConfig.setSameOriginBlockedHeaders(options.getSameOriginRedirectBlockedHeaders());
     }
 
+    List<HttpVersion> versions;
+    ClientSSLOptions sslOptions = options.getSslOptions();
+    if (sslOptions == null || !sslOptions.isUseAlpn() || sslOptions.getApplicationLayerProtocols().isEmpty()) {
+      versions = new ArrayList<>(toSupportedVersion(options.getProtocolVersion()));
+    } else {
+      versions = sslOptions.getApplicationLayerProtocols()
+        .stream()
+        .map(HttpVersion::fromAlpnName)
+        .collect(Collectors.toList());
+      if (!versions.contains(options.getProtocolVersion())) {
+        throw new IllegalArgumentException("Default HTTP client version " + options.getProtocolVersion() +
+          " does not belong to the ALPN protocol version list " + versions);
+      }
+    }
+
     this.tcpConfig = new TcpClientConfig(options);
     this.quicConfig = defaultQuicConfig();
     this.ssl = options.isSsl();
-    this.versions = new ArrayList<>(toSupportedVersion(options.getProtocolVersion()));
+    this.versions = versions;
     this.http1Config = options.getHttp1Config();
     this.http2Config = options.getHttp2Config();
     this.http3Config = new Http3ClientConfig();

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerConfig.java
@@ -33,7 +33,7 @@ public class HttpServerConfig {
    */
   public static final int DEFAULT_HTTP3_PORT = 443;
 
-  public static final Set<HttpVersion> DEFAULT_VERSIONS = Collections.unmodifiableSet(EnumSet.of(HttpVersion.HTTP_1_1, HttpVersion.HTTP_2));
+  public static final Set<HttpVersion> DEFAULT_VERSIONS = Collections.unmodifiableSet(EnumSet.of(HttpVersion.HTTP_1_0, HttpVersion.HTTP_1_1, HttpVersion.HTTP_2));
 
   public static final long DEFAULT_QUIC_INITIAL_MAX_DATA = 10_485_760L;
   public static final long DEFAULT_QUIC_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL = 0L;
@@ -103,12 +103,12 @@ public class HttpServerConfig {
       if (options.isUseAlpn()) {
         versions = EnumSet.copyOf(options.getAlpnVersions());
       } else {
-        versions = EnumSet.of(HttpVersion.HTTP_1_1);
+        versions = EnumSet.of(HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_0);
       }
     } else if (options.isHttp2ClearTextEnabled()) {
       versions = EnumSet.copyOf(DEFAULT_VERSIONS);
     } else {
-      versions = EnumSet.of(HttpVersion.HTTP_1_1);
+      versions = EnumSet.of(HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_0);
     }
 
     ObservabilityConfig observabilityConfig = null;
@@ -146,10 +146,10 @@ public class HttpServerConfig {
   }
 
   /**
-   * Create a default configuration of a server accepting HTTP/1.1 and HTTP/2 protocols.
+   * Create a default configuration of a server accepting HTTP/1.0, HTTP/1.1 and HTTP/2 protocols.
    */
   public HttpServerConfig() {
-    this.versions = EnumSet.of(HttpVersion.HTTP_1_1, HttpVersion.HTTP_2);
+    this.versions = EnumSet.copyOf(DEFAULT_VERSIONS);
     this.formDecoderConfig = null;
     this.queryParamDecoderConfig = null;
     this.handle100ContinueAutomatically = HttpServerOptions.DEFAULT_HANDLE_100_CONTINE_AUTOMATICALLY;

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -212,7 +212,12 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
         if (transport instanceof TcpHttpClientTransport) {
           int http1MaxSize = poolOptions.getHttp1MaxSize();
           int http2MaxSize = poolOptions.getHttp2MaxSize();
-          int initialPoolKind = protocol == HttpVersion.HTTP_1_1 || protocol == HttpVersion.HTTP_1_0 ? 0 : 1;
+          int initialPoolKind;
+          if (protocol == null) {
+            initialPoolKind = versions.contains(HttpVersion.HTTP_2) ? 1 : 0;
+          } else {
+            initialPoolKind = protocol == HttpVersion.HTTP_1_1 || protocol == HttpVersion.HTTP_1_0 ? 0 : 1;
+          }
           return new SharedHttpClientConnectionGroup.Pool(group, transport, queueMaxSize, http1MaxSize, http2MaxSize, maxLifetime, initialPoolKind, params, contextProvider);
         } else {
           int http3MaxSize = poolOptions.getHttp3MaxSize();
@@ -382,6 +387,9 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
         transport = quicTransport;
       }
     } else {
+      if (!versions.contains(version)) {
+        return vertx.failedFuture("Requested HTTP version " + version + " unsupported by this client " + versions);
+      }
       switch (version) {
         case HTTP_1_0:
         case HTTP_1_1:

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequestHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequestHandler.java
@@ -12,10 +12,13 @@ package io.vertx.core.http.impl.http1;
 
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.ServerWebSocketHandshake;
 import io.vertx.core.http.impl.tcp.HttpServerConnectionHandler;
 import io.vertx.core.http.impl.websocket.ServerWebSocketHandshaker;
+
+import java.util.Set;
 
 import static io.vertx.core.http.HttpHeaders.UPGRADE;
 import static io.vertx.core.http.HttpHeaders.WEBSOCKET;
@@ -32,9 +35,11 @@ import static io.vertx.core.http.HttpHeaders.WEBSOCKET;
  */
 public class Http1ServerRequestHandler implements Handler<HttpServerRequest> {
 
+  private final Set<HttpVersion> versions;
   private final HttpServerConnectionHandler handlers;
 
-  public Http1ServerRequestHandler(HttpServerConnectionHandler handlers) {
+  public Http1ServerRequestHandler(Set<HttpVersion> versions, HttpServerConnectionHandler handlers) {
+    this.versions = versions;
     this.handlers = handlers;
   }
 
@@ -66,7 +71,7 @@ public class Http1ServerRequestHandler implements Handler<HttpServerRequest> {
           req.response().setStatusCode(400).end();
         }
       }
-    } else if (req.version() == null) {
+    } else if (req.version() == null || !versions.contains(req.version())) {
       // Invalid HTTP version, i.e not HTTP/1.1 or HTTP/1.0
       req.response().setStatusCode(501).end();
       req.connection().close();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/HttpServerConnectionHandler.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/HttpServerConnectionHandler.java
@@ -28,6 +28,7 @@ import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.http.QueryParamDecoder;
 
 import java.util.ArrayList;
+import java.util.Set;
 
 /**
  * HTTP server connection handler.
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 public class HttpServerConnectionHandler implements Handler<HttpServerConnection> {
 
   public final TcpHttpServer server;
+  public final Set<HttpVersion> versions;
   public final String serverOrigin;
   public final Handler<HttpServerRequest> requestHandler;
   public final Handler<HttpServerRequest> invalidRequestHandler;
@@ -49,6 +51,7 @@ public class HttpServerConnectionHandler implements Handler<HttpServerConnection
 
   public HttpServerConnectionHandler(
     TcpHttpServer server,
+    Set<HttpVersion> versions,
     String serverOrigin,
     Handler<HttpServerRequest> requestHandler,
     Handler<HttpServerRequest> invalidRequestHandler,
@@ -58,6 +61,7 @@ public class HttpServerConnectionHandler implements Handler<HttpServerConnection
     Handler<Throwable> exceptionHandler,
     int connectionWindowSize) {
     this.server = server;
+    this.versions = versions;
     this.serverOrigin = serverOrigin;
     this.requestHandler = requestHandler;
     this.invalidRequestHandler = invalidRequestHandler == null ? HttpServerRequest.DEFAULT_INVALID_REQUEST_HANDLER : invalidRequestHandler;
@@ -77,7 +81,7 @@ public class HttpServerConnectionHandler implements Handler<HttpServerConnection
       // some casting and a header check
     } else {
       if (conn instanceof Http1ServerConnection) {
-        requestHandler =  new Http1ServerRequestHandler(this);
+        requestHandler =  new Http1ServerRequestHandler(versions, this);
         Http1ServerConnection c = (Http1ServerConnection) conn;
         initializeWebSocketExtensions(c.channelHandlerContext().pipeline());
       }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpClientTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpClientTransport.java
@@ -215,10 +215,33 @@ public class TcpHttpClientTransport implements HttpClientTransport {
         case "http/1.1":
         case "http/1.0":
         case "":
+          HttpVersion version;
           if (http1Config != null) {
+            switch (protocol) {
+              case "http/1.1":
+                version = HttpVersion.HTTP_1_1;
+                break;
+              case "http/1.0":
+                version = HttpVersion.HTTP_1_0;
+                break;
+              default:
+                // Empty string - no ALPN
+                // pick the first compatible protocol
+                version = null;
+                for (HttpVersion p : params.protocols) {
+                  if (p == HttpVersion.HTTP_1_1 || p == HttpVersion.HTTP_1_0) {
+                    version = p;
+                    break;
+                  }
+                }
+                break;
+            }
+          } else {
+            version = null;
+          }
+          if (version != null) {
             applyHttp1xConnectionOptions(ch.pipeline());
-            HttpVersion version = "http/1.0".equals(protocol) ? HttpVersion.HTTP_1_0 : HttpVersion.HTTP_1_1;
-            http1xConnected(version, server, authority, true, context, transportMetrics, metric, ch, clientMetrics, promise);
+            http1xConnected(version, false, server, authority, true, context, transportMetrics, metric, ch, clientMetrics, promise);
           } else {
             so.close();
             promise.tryFail(new IllegalStateException("HTTP/1.1 not supported"));
@@ -233,14 +256,14 @@ public class TcpHttpClientTransport implements HttpClientTransport {
       if (params.protocols.get(0) == HttpVersion.HTTP_2) {
         if (http2Config.isClearTextUpgrade()) {
           applyHttp1xConnectionOptions(pipeline);
-          http1xConnected(HttpVersion.HTTP_2, server, authority, false, context, transportMetrics, metric, ch, clientMetrics, promise);
+          http1xConnected(HttpVersion.HTTP_2, true, server, authority, false, context, transportMetrics, metric, ch, clientMetrics, promise);
         } else {
           applyHttp2ConnectionOptions(pipeline);
           http2Connected(context, authority, transportMetrics, metric, ch, clientMetrics, promise);
         }
       } else {
         applyHttp1xConnectionOptions(pipeline);
-        http1xConnected(params.protocols.get(0), server, authority, false, context, transportMetrics, metric, ch, clientMetrics, promise);
+        http1xConnected(params.protocols.get(0), false, server, authority, false, context, transportMetrics, metric, ch, clientMetrics, promise);
       }
     }
     return promise.future();
@@ -318,6 +341,7 @@ public class TcpHttpClientTransport implements HttpClientTransport {
   }
 
   private void http1xConnected(HttpVersion version,
+                               boolean upgrade,
                                SocketAddress server,
                                HostAndPort authority,
                                boolean ssl,
@@ -327,7 +351,6 @@ public class TcpHttpClientTransport implements HttpClientTransport {
                                Channel ch,
                                ClientMetrics clientMetrics,
                                Promise<HttpClientConnection> future) {
-    boolean upgrade = version == HttpVersion.HTTP_2 && http2Config.isClearTextUpgrade();
     VertxHandler<Http1ClientConnection> clientHandler = VertxHandler.create(chctx -> {
       Http1ClientConnection conn = new Http1ClientConnection(upgrade ? HttpVersion.HTTP_1_1 : version, webSocketMetrics, transportMetrics,
         http1Config, tracingPolicy, useDecompression, chctx, ssl, server, authority, context, clientMetrics);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpServer.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/TcpHttpServer.java
@@ -29,7 +29,9 @@ import io.vertx.core.spi.metrics.HttpServerMetrics;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -223,6 +225,7 @@ public class TcpHttpServer implements HttpServerInternal {
     QueryParamDecoderConfig queryParamDecoderConfig = config.getQueryParamConfig() != null ? config.getQueryParamConfig() : new QueryParamDecoderConfig();
     Http1ServerConfig http1Config = config.getVersions().contains(HttpVersion.HTTP_1_0) || config.getVersions().contains(HttpVersion.HTTP_1_1) ? config.getHttp1Config() != null ? config.getHttp1Config() : new Http1ServerConfig() : null;
     Http2ServerConfig http2Config = config.getVersions().contains(HttpVersion.HTTP_2) ? config.getHttp2Config() != null ? config.getHttp2Config() : new Http2ServerConfig() : null;
+    Set<HttpVersion> versions = EnumSet.copyOf(config.getVersions());
     server.connectHandler(so -> {
       NetSocketImpl soi = (NetSocketImpl) so;
       Supplier<ContextInternal> streamContextSupplier = context::duplicate;
@@ -231,6 +234,7 @@ public class TcpHttpServer implements HttpServerInternal {
       String serverOrigin = (ssl ? "https" : "http") + "://" + host + ":" + port;
       HttpServerConnectionHandler handler = new HttpServerConnectionHandler(
         this,
+        versions,
         serverOrigin,
         requestHandler,
         invalidRequestHandler,

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpClientConfigTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpClientConfigTest.java
@@ -28,7 +28,7 @@ public class HttpClientConfigTest {
     assertNull(config.getHttp2Config());
     assertNull(config.getHttp3Config());
     assertFalse(config.isSsl());
-    assertEquals(List.of(HTTP_1_1, HTTP_2), config.getVersions());
+    assertEquals(List.of(HTTP_1_1, HTTP_1_0, HTTP_2), config.getVersions());
   }
 
   @Test
@@ -38,7 +38,7 @@ public class HttpClientConfigTest {
     assertNotNull(config.getHttp2Config());
     assertNotNull(config.getHttp3Config());
     assertFalse(config.isSsl());
-    assertEquals(List.of(HTTP_1_1), config.getVersions());
+    assertEquals(List.of(HTTP_1_1, HTTP_1_0), config.getVersions());
   }
 
   @Test
@@ -48,7 +48,7 @@ public class HttpClientConfigTest {
     assertNotNull(config.getHttp2Config());
     assertNotNull(config.getHttp3Config());
     assertFalse(config.isSsl());
-    assertEquals(List.of(HTTP_2, HTTP_1_1), config.getVersions());
+    assertEquals(List.of(HTTP_2, HTTP_1_1, HTTP_1_0), config.getVersions());
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpPoolCapacityTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpPoolCapacityTest.java
@@ -1,13 +1,6 @@
 package io.vertx.tests.http;
 
-import io.vertx.core.http.Http2Settings;
-import io.vertx.core.http.HttpClientAgent;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServer;
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.http.HttpVersion;
-import io.vertx.core.http.PoolOptions;
+import io.vertx.core.http.*;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.http.HttpConfigurator;
 import org.junit.Test;

--- a/vertx-core/src/test/java/io/vertx/tests/http/SupportedVersionsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/SupportedVersionsTest.java
@@ -40,11 +40,11 @@ public class SupportedVersionsTest extends VertxTestBase {
     .setVersions(HttpVersion.HTTP_3)
     .setQuicPort(DEFAULT_HTTPS_PORT);
   private static final ServerSSLOptions DEFAULT_SERVER_TLS = new ServerSSLOptions().setKeyCertOptions(Cert.SNI_JKS.get()).removeEnabledSecureTransportProtocol("TLSv1.3");
-  private static final ServerSSLOptions DEFAULT_SERVER_TLS_NO_ALPN = new ServerSSLOptions().setKeyCertOptions(Cert.SNI_JKS.get()).setUseAlpn(false);
+  private static final ServerSSLOptions DEFAULT_SERVER_TLS_WITH_ALPN = new ServerSSLOptions(DEFAULT_SERVER_TLS).setUseAlpn(true);
   private static final ClientSSLOptions DEFAULT_CLIENT_TLS = new ClientSSLOptions().setTrustAll(true).removeEnabledSecureTransportProtocol("TLSv1.3");
 
   private static final HttpClientOptions LEGACY_CLIENT_DEFAULT_TLS = new HttpClientOptions().setSsl(true).setTrustAll(true);
-  private static final HttpClientOptions LEGACY_CLIENT_DEFAULT_TLS_WITH_ALPN = new HttpClientOptions(LEGACY_CLIENT_DEFAULT_TLS);
+  private static final HttpClientOptions LEGACY_CLIENT_DEFAULT_TLS_WITH_ALPN = new HttpClientOptions(LEGACY_CLIENT_DEFAULT_TLS).setUseAlpn(true);
   private static final HttpClientConfig CLIENT_DEFAULT = new HttpClientConfig();
   private static final HttpClientConfig CLIENT_DEFAULT_TLS = new HttpClientConfig().setSsl(true);
 
@@ -75,7 +75,7 @@ public class SupportedVersionsTest extends VertxTestBase {
     HttpVersion version = testDefaultVersion(server, client);
     assertEquals(HttpVersion.HTTP_1_1, version);
     List<HttpVersion> accepted = testAcceptedVersions(server, client);
-    assertEquals(Arrays.asList(HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1, null), accepted);
+    assertEquals(Arrays.asList(HttpVersion.HTTP_1_0, HttpVersion.HTTP_1_1, null), accepted);
   }
 
   @Test
@@ -85,7 +85,17 @@ public class SupportedVersionsTest extends VertxTestBase {
     HttpVersion version = testDefaultVersion(server, client);
     assertEquals(HttpVersion.HTTP_1_1, version); // Depends on server : check that
     List<HttpVersion> accepted = testAcceptedVersions(server, client);
-    assertEquals(Arrays.asList(HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1, null), accepted);
+    assertEquals(Arrays.asList(HttpVersion.HTTP_1_0, HttpVersion.HTTP_1_1, null), accepted);
+  }
+
+  @Test
+  public void testLegacyHttp11TlsAlpnOverrideTest() {
+    HttpServerOptions server = new HttpServerOptions(TCP_SERVER_DEFAULT_TLS_WITH_ALPN).setAlpnVersions(List.of(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1));
+    HttpClientOptions client = new HttpClientOptions(LEGACY_CLIENT_DEFAULT_TLS_WITH_ALPN).setProtocolVersion(HttpVersion.HTTP_1_1).setAlpnVersions(List.of(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1));
+    HttpVersion version = testDefaultVersion(server, client);
+    assertEquals(HttpVersion.HTTP_2, version);
+    List<HttpVersion> accepted = testAcceptedVersions(server, client);
+    assertEquals(Arrays.asList(null, HttpVersion.HTTP_1_1, HttpVersion.HTTP_2), accepted);
   }
 
   @Test
@@ -115,7 +125,7 @@ public class SupportedVersionsTest extends VertxTestBase {
     HttpVersion version = testDefaultVersion(server, client);
     assertEquals(HttpVersion.HTTP_2, version);
     List<HttpVersion> accepted = testAcceptedVersions(server, client);
-    assertEquals(Arrays.asList(HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1, HttpVersion.HTTP_2), accepted);
+    assertEquals(Arrays.asList(null, HttpVersion.HTTP_1_1, HttpVersion.HTTP_2), accepted);
   }
 
   private HttpVersion testDefaultVersion(HttpServerOptions serverOptions, HttpClientOptions clientOptions) {
@@ -137,12 +147,12 @@ public class SupportedVersionsTest extends VertxTestBase {
       new HttpServerConfig(),
       new HttpClientConfig().setVersions(HttpVersion.HTTP_1_1, HttpVersion.HTTP_2),
       HttpVersion.HTTP_1_1,
-      HttpVersion.HTTP_1_0, HttpVersion.HTTP_1_1, HttpVersion.HTTP_2);
+      null, HttpVersion.HTTP_1_1, HttpVersion.HTTP_2);
     test(
       new HttpServerConfig(),
       new HttpClientConfig().setVersions(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1),
       HttpVersion.HTTP_2,
-      HttpVersion.HTTP_1_0, HttpVersion.HTTP_1_1, HttpVersion.HTTP_2);
+      null, HttpVersion.HTTP_1_1, HttpVersion.HTTP_2);
     test(
       new HttpServerConfig(),
       new HttpClientConfig().setVersions(HttpVersion.HTTP_2)
@@ -159,17 +169,17 @@ public class SupportedVersionsTest extends VertxTestBase {
       new HttpServerConfig().setVersions(HttpVersion.HTTP_1_1),
       new HttpClientConfig(),
       HttpVersion.HTTP_1_1,
-      HttpVersion.HTTP_1_0, HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1);
+      null, HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1);
     test(
       new HttpServerConfig().setVersions(HttpVersion.HTTP_1_1),
       new HttpClientConfig().setVersions(HttpVersion.HTTP_1_1, HttpVersion.HTTP_2),
       HttpVersion.HTTP_1_1,
-      HttpVersion.HTTP_1_0, HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1);
+      null, HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1);
     test(
       new HttpServerConfig().setVersions(HttpVersion.HTTP_1_1),
       new HttpClientConfig().setVersions(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1),
       HttpVersion.HTTP_1_1,
-      HttpVersion.HTTP_1_0, HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1);
+      null, HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1);
     test(
       new HttpServerConfig().setVersions(HttpVersion.HTTP_1_1),
       new HttpClientConfig().setVersions(HttpVersion.HTTP_2)
@@ -213,7 +223,7 @@ public class SupportedVersionsTest extends VertxTestBase {
       new HttpServerConfig(),
       new HttpClientConfig().setSsl(true),
       HttpVersion.HTTP_2,
-      null, HttpVersion.HTTP_1_1, HttpVersion.HTTP_2);
+      HttpVersion.HTTP_1_0, HttpVersion.HTTP_1_1, HttpVersion.HTTP_2);
     test(
       new HttpServerConfig(),
       new HttpClientConfig().setSsl(true).setVersions(HttpVersion.HTTP_1_1, HttpVersion.HTTP_2),
@@ -242,17 +252,17 @@ public class SupportedVersionsTest extends VertxTestBase {
       new HttpServerConfig().setVersions(HttpVersion.HTTP_1_1),
       new HttpClientConfig().setSsl(true),
       HttpVersion.HTTP_1_1,
-      HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1);
+      null, HttpVersion.HTTP_1_1, null);
     test(
       new HttpServerConfig().setVersions(HttpVersion.HTTP_1_1),
       new HttpClientConfig().setSsl(true).setVersions(HttpVersion.HTTP_1_1, HttpVersion.HTTP_2),
       HttpVersion.HTTP_1_1,
-      HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1);
+      null, HttpVersion.HTTP_1_1, null);
     test(
       new HttpServerConfig().setVersions(HttpVersion.HTTP_1_1),
       new HttpClientConfig().setSsl(true).setVersions(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1),
       HttpVersion.HTTP_1_1,
-      HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1);
+      null, HttpVersion.HTTP_1_1, null);
     test(
       new HttpServerConfig().setVersions(HttpVersion.HTTP_1_1),
       new HttpClientConfig().setSsl(true).setVersions(HttpVersion.HTTP_2),
@@ -262,7 +272,7 @@ public class SupportedVersionsTest extends VertxTestBase {
       new HttpServerConfig().setVersions(HttpVersion.HTTP_1_1),
       new HttpClientConfig().setSsl(true).setVersions(HttpVersion.HTTP_1_1),
       HttpVersion.HTTP_1_1,
-      HttpVersion.HTTP_1_1, HttpVersion.HTTP_1_1, null);
+      null, HttpVersion.HTTP_1_1, null);
   }
 
   @Test
@@ -326,21 +336,17 @@ public class SupportedVersionsTest extends VertxTestBase {
 //  }
 
   private void test(HttpServerConfig server, HttpClientConfig client, HttpVersion defaultVersion, HttpVersion... acceptedVersions) {
-    test(server, client, true, defaultVersion, acceptedVersions);
-  }
-
-  private void test(HttpServerConfig server, HttpClientConfig client, boolean useAlpn, HttpVersion defaultVersion, HttpVersion... acceptedVersions) {
-    HttpVersion version = testDefaultVersion(server, client, useAlpn);
+    HttpVersion version = testDefaultVersion(server, client);
     assertEquals(defaultVersion, version);
-//    List<HttpVersion> accepted = testAcceptedVersions(server, client, useAlpn);
-//    assertEquals(Arrays.asList(acceptedVersions), accepted);
+    List<HttpVersion> accepted = testAcceptedVersions(server, client);
+    assertEquals(Arrays.asList(acceptedVersions), accepted);
   }
 
-  private HttpVersion testDefaultVersion(HttpServerConfig serverConfig, HttpClientConfig clientConfig, boolean useAlpn) {
+  private HttpVersion testDefaultVersion(HttpServerConfig serverConfig, HttpClientConfig clientConfig) {
     return testDefaultVersion(
       () -> {
         if (clientConfig.isSsl()) {
-          return vertx.createHttpServer(serverConfig, useAlpn ? DEFAULT_SERVER_TLS : DEFAULT_SERVER_TLS_NO_ALPN);
+          return vertx.createHttpServer(serverConfig, DEFAULT_SERVER_TLS);
         } else {
           return vertx.createHttpServer(serverConfig);
         }
@@ -349,9 +355,15 @@ public class SupportedVersionsTest extends VertxTestBase {
     );
   }
 
-  private List<HttpVersion> testAcceptedVersions(HttpServerConfig serverConfig, HttpClientConfig clientConfig, boolean useAlpn) {
+  private List<HttpVersion> testAcceptedVersions(HttpServerConfig serverConfig, HttpClientConfig clientConfig) {
     return testAcceptedVersions(
-      () -> vertx.createHttpServer(serverConfig, useAlpn ? DEFAULT_SERVER_TLS : DEFAULT_SERVER_TLS_NO_ALPN),
+      () -> {
+        if (clientConfig.isSsl()) {
+          return vertx.createHttpServer(serverConfig, DEFAULT_SERVER_TLS);
+        } else {
+          return vertx.createHttpServer(serverConfig);
+        }
+      },
       () -> vertx.createHttpClient(clientConfig, DEFAULT_CLIENT_TLS)
     );
   }


### PR DESCRIPTION
# Motivation

The new HTTP version configuration defines the list of HTTP versions supported by the client or the server.

The implementation does not always enforce this requirement.

# Changes

- A version specific client request should not be sent when the client does not support it.
- A server request should ensure that the protocol is supported by the server before processing it.
- During a client SSL handshake, when ALPN is not supported by the server, the client should fallback to a supported protocol.
- A client configured with options should respect the supported ALPN versions when set.
- Update the default configuration to support HTTP/1.0 by default as well, since previous support was implied by HTTP/1.1 presence.
