### PR TITLE
Fix incorrect SimpleConnectionPool callback in SharedHttpClientConnectionGroup

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/SharedHttpClientConnectionGroup.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/SharedHttpClientConnectionGroup.java
@@ -121,7 +121,7 @@ class SharedHttpClientConnectionGroup extends ManagedResource {
       if (timeout > 0L && timerID == -1L) {
         timerID = context.setTimer(timeout, id -> {
           pool.pool.cancel(waiter, (res, err) -> {
-            if (err == null & res)
+            if (err == null && res)
               promise.fail(new NoStackTraceTimeoutException("The timeout of " + timeout + " ms has been exceeded when getting a connection to " + server));
             });
         });


### PR DESCRIPTION
Motivation:

`SharedHttpClientConnectionGroup` has a semantically incorrect callback on pool waiter cancellation that triggers an NPE when the pool is closed: the err is not null and therefore the right clause of the expression should not be executed.

Changes:

Fix the expression to be correct.
