### PR TITLE
Fix HTTP client load balancing for multi-homed hosts

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/EndpointKey.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/EndpointKey.java
@@ -23,21 +23,27 @@ public final class EndpointKey {
   // Todo : that should become a scheme ???
   final boolean ssl;
   final HttpVersion protocol;
-  final SocketAddress server;
+  private final SocketAddress server; // For now don't expose
+  private final ProxyOptions proxyOptions; // For now don't expose
   final HostAndPort authority;
-  final ProxyOptions proxyOptions;
   final ClientSSLOptions sslOptions;
 
-  public EndpointKey(boolean ssl, HttpVersion protocol, ClientSSLOptions sslOptions, ProxyOptions proxyOptions, SocketAddress server, HostAndPort authority) {
-    if (server == null) {
-      throw new NullPointerException("No null server address");
-    }
+  public EndpointKey(boolean ssl, HttpVersion protocol, ClientSSLOptions sslOptions, SocketAddress server, HostAndPort authority) {
+    this.ssl = ssl;
+    this.protocol = protocol;
+    this.sslOptions = sslOptions;
+    this.proxyOptions = null;
+    this.authority = authority;
+    this.server = server.hostAddress() != null ? SocketAddress.inetSocketAddress(server.port(), server.hostAddress()) : server;
+  }
+
+  public EndpointKey(boolean ssl, HttpVersion protocol, ClientSSLOptions sslOptions, ProxyOptions proxyOptions, HostAndPort authority) {
     this.ssl = ssl;
     this.protocol = protocol;
     this.sslOptions = sslOptions;
     this.proxyOptions = proxyOptions;
     this.authority = authority;
-    this.server = server;
+    this.server = null;
   }
 
   @Override
@@ -47,7 +53,7 @@ public final class EndpointKey {
     }
     if (o instanceof EndpointKey) {
       EndpointKey that = (EndpointKey) o;
-      return ssl == that.ssl && Objects.equals(protocol, that.protocol) && server.equals(that.server) && Objects.equals(authority, that.authority) && Objects.equals(sslOptions, that.sslOptions) && equals(proxyOptions, that.proxyOptions);
+      return ssl == that.ssl && Objects.equals(protocol, that.protocol) && Objects.equals(server, that.server) && Objects.equals(authority, that.authority) && Objects.equals(sslOptions, that.sslOptions) && equals(proxyOptions, that.proxyOptions);
     }
     return false;
   }
@@ -56,12 +62,14 @@ public final class EndpointKey {
   public int hashCode() {
     int result = ssl ? 1 : 0;
     result = 31 * result + (protocol == null ? 0 : protocol.hashCode());
-    result = 31 * result + server.hashCode();
     if (authority != null) {
       result = 31 * result + authority.hashCode();
     }
     if (sslOptions != null) {
       result = 31 * result + sslOptions.hashCode();
+    }
+    if (server != null) {
+      result = 31 * result + server.hashCode();
     }
     if (proxyOptions != null) {
       result = 31 * result + hashCode(proxyOptions);
@@ -92,6 +100,6 @@ public final class EndpointKey {
 
   @Override
   public String toString() {
-    return server.toString();
+    return server != null ? server.toString() : proxyOptions.toString();
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -187,20 +187,24 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     }
   }
 
-  private Function<EndpointKey, SharedHttpClientConnectionGroup> httpEndpointProvider(boolean resolveOrigin, HttpClientTransport transport) {
+  private Function<EndpointKey, SharedHttpClientConnectionGroup> httpEndpointProvider(boolean resolveOrigin, SocketAddress server, ProxyOptions _proxyOptions, HttpClientTransport transport) {
     return (key) -> {
       int maxPoolSize = Math.max(poolOptions.getHttp1MaxSize(), poolOptions.getHttp2MaxSize());
-      ClientMetrics clientMetrics = HttpClientImpl.this.httpMetrics != null ? HttpClientImpl.this.httpMetrics.createEndpointMetrics(key.server, maxPoolSize) : null;
+      ClientMetrics clientMetrics = HttpClientImpl.this.httpMetrics != null ? HttpClientImpl.this.httpMetrics.createEndpointMetrics(server, maxPoolSize) : null;
       PoolMetrics poolMetrics = HttpClientImpl.this.httpMetrics != null ? vertx.metrics().createPoolMetrics("http", key.authority.toString(), maxPoolSize) : null;
-      ProxyOptions proxyOptions = key.proxyOptions;
+      ProxyOptions proxyOptions = _proxyOptions;
       ClientSSLOptions sslOptions = key.sslOptions;
-      boolean forwardProxy = false;
+      SocketAddress connect;
+      boolean forwardProxy;
       if (proxyOptions != null && !key.ssl && (proxyOptions.getType() == ProxyType.HTTP || proxyOptions.getType() == ProxyType.HTTPS)) {
-        SocketAddress server = SocketAddress.inetSocketAddress(proxyOptions.getPort(), proxyOptions.getHost());
-        key = new EndpointKey(key.ssl, key.protocol, sslOptions, proxyOptions, server, key.authority);
+        connect = SocketAddress.inetSocketAddress(proxyOptions.getPort(), proxyOptions.getHost());
+        key = new EndpointKey(key.ssl, key.protocol, sslOptions, proxyOptions, key.authority);
         // Forward mode: the single socket connects to the proxy as the server while the logical
         // origin stays plain HTTP (key.ssl == false).
         forwardProxy = true;
+      } else {
+        forwardProxy = false;
+        connect = server;
       }
       HttpVersion protocol = key.protocol;
       List<HttpVersion> protocols;
@@ -249,7 +253,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
         p,
         poolMetrics,
         key.authority,
-        key.server);
+        connect);
     };
   }
 
@@ -525,11 +529,20 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     String traceOperation,
     long idleTimeout,
     boolean followRedirects,
-    ProxyOptions proxyOptions, SocketAddress server, boolean useSSL, ClientSSLOptions sslOptions,
-                                 HostAndPort authority, long connectTimeout) {
+    ProxyOptions proxyOptions,
+    SocketAddress server,
+    boolean useSSL,
+    ClientSSLOptions sslOptions,
+    HostAndPort authority,
+    long connectTimeout) {
     ContextInternal streamCtx = vertx.getOrCreateContext();
-    EndpointKey key = new EndpointKey(useSSL, protocol, sslOptions, proxyOptions, server, authority);
-    Future<ConnectionObtainedResult> fut2 = resourceManager.withResourceAsync(key, httpEndpointProvider(false, transport), (endpoint, created) -> {
+    EndpointKey key;
+    if (proxyOptions != null) {
+      key = new EndpointKey(useSSL, protocol, sslOptions, proxyOptions, authority);
+    } else {
+      key = new EndpointKey(useSSL, protocol, sslOptions, server, authority);
+    }
+    Future<ConnectionObtainedResult> fut2 = resourceManager.withResourceAsync(key, httpEndpointProvider(false, server, proxyOptions, transport), (endpoint, created) -> {
       Future<Lease<HttpClientConnection>> fut = endpoint.requestConnection(streamCtx, connectTimeout);
       return fut.compose(lease -> {
         HttpClientConnection conn = lease.get();
@@ -741,14 +754,14 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
                         SocketAddress server,
                         HostAndPort authority,
                         Function<SharedHttpClientConnectionGroup, Future<T>> function) {
-    EndpointKey key = new EndpointKey(useSSL, protocol != null ? protocol.version() : null, sslOptions, null, server, authority);
+    EndpointKey key = new EndpointKey(useSSL, protocol != null ? protocol.version() : null, sslOptions, server, authority);
     HttpClientTransport transport;
     if (protocol != null && protocol.version() == HttpVersion.HTTP_3) {
       transport = quicTransport;
     } else {
       transport = tcpTransport;
     }
-    Function<EndpointKey, SharedHttpClientConnectionGroup> provider = httpEndpointProvider(resolveOrigin, transport);
+    Function<EndpointKey, SharedHttpClientConnectionGroup> provider = httpEndpointProvider(resolveOrigin, server, null, transport);
     return resourceManager.withResourceAsync(key, provider, (group, created) -> function.apply(group));
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
@@ -94,14 +94,17 @@ public class WebSocketClientImpl extends HttpClientBase implements WebSocketClie
     HostAndPort peer = HostAndPort.create(host, port);
     ProxyOptions proxyOptions = computeProxyOptions(connectOptions.getProxyOptions(), addr);
     ClientSSLOptions sslOptions = sslOptions(options.isVerifyHost(), connectOptions, defaultSslOptions);
-    EndpointKey key = new EndpointKey(connectOptions.isSsl() != null ? connectOptions.isSsl() : options.isSsl(), HttpVersion.HTTP_1_1, sslOptions, proxyOptions, addr, peer);
+    boolean ssl = connectOptions.isSsl() != null ? connectOptions.isSsl() : options.isSsl();
+    EndpointKey key = proxyOptions != null ?
+      new EndpointKey(ssl, HttpVersion.HTTP_1_1, sslOptions, proxyOptions, peer) :
+      new EndpointKey(ssl, HttpVersion.HTTP_1_1, sslOptions, addr, peer);
     // todo: cache
     Function<EndpointKey, WebSocketGroup> provider = (key_) -> {
       int maxPoolSize = options.getMaxConnections();
-      ClientMetrics clientMetrics = WebSocketClientImpl.this.httpMetrics != null ? WebSocketClientImpl.this.httpMetrics.createEndpointMetrics(key_.server, maxPoolSize) : null;
-      PoolMetrics queueMetrics = WebSocketClientImpl.this.httpMetrics != null ? vertx.metrics().createPoolMetrics("ws", key_.server.toString(), maxPoolSize) : null;
-      HttpConnectParams params = new HttpConnectParams(List.of(HttpVersion.HTTP_1_1), sslOptions, key_.proxyOptions, key_.ssl);
-      return new WebSocketGroup(key_.server, httpMetrics, clientMetrics, queueMetrics, options, maxPoolSize, connector, params, key_.authority, 0L);
+      ClientMetrics clientMetrics = WebSocketClientImpl.this.httpMetrics != null ? WebSocketClientImpl.this.httpMetrics.createEndpointMetrics(addr, maxPoolSize) : null;
+      PoolMetrics queueMetrics = WebSocketClientImpl.this.httpMetrics != null ? vertx.metrics().createPoolMetrics("ws", addr.toString(), maxPoolSize) : null;
+      HttpConnectParams params = new HttpConnectParams(List.of(HttpVersion.HTTP_1_1), sslOptions, proxyOptions, key_.ssl);
+      return new WebSocketGroup(addr, httpMetrics, clientMetrics, queueMetrics, options, maxPoolSize, connector, params, key_.authority, 0L);
     };
     webSocketCM
       .withResourceAsync(key, provider, (endpoint, created) -> endpoint.requestConnection(ctx, connectOptions, 0L))

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -38,6 +38,7 @@ import io.vertx.core.internal.net.NetSocketInternal;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
+import io.vertx.core.net.endpoint.LoadBalancer;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.test.core.*;
@@ -72,6 +73,32 @@ public class Http1xTest extends HttpTest {
 
   public Http1xTest() {
     super(HttpConfigurator.Http1x.DEFAULT);
+  }
+
+  @Test
+  @WithDnsServer(records = {@DnsRecord(name = "vertx.io", address = "127.0.0.1"), @DnsRecord(name = "vertx.io", address = "127.0.0.2")})
+  public void testDnsClientSideLoadBalancingUsesDistinctPools() throws Exception {
+    Set<String> expected = Set.of("127.0.0.1", "127.0.0.2");
+    for (String host : expected) {
+      vertx.createHttpServer()
+        .requestHandler(request -> request.response().end(host))
+        .listen(DEFAULT_HTTP_PORT, host)
+        .await();
+    }
+    HttpClient client = vertx.httpClientBuilder()
+      .with(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_1_1))
+      .withLoadBalancer(LoadBalancer.ROUND_ROBIN)
+      .build();
+    Set<String> actual = new HashSet<>();
+    for (int i = 0; i < expected.size(); i++) {
+      String host = client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, "vertx.io", "/")
+        .compose(HttpClientRequest::send)
+        .compose(HttpClientResponse::body)
+        .map(Buffer::toString)
+        .await();
+      actual.add(host);
+    }
+    assertEquals(expected, actual);
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/impl/EndPointKeyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/impl/EndPointKeyTest.java
@@ -17,6 +17,9 @@ import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.SocketAddress;
 import org.junit.Test;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -26,32 +29,40 @@ import static org.junit.Assert.assertNotEquals;
 public class EndPointKeyTest {
 
   @Test
-  public void testEndPointKey() {
+  public void testEndPointKey() throws Exception {
     final SocketAddress addr = SocketAddress.inetSocketAddress(8080, "localhost");
     final HostAndPort peer = HostAndPort.create("localhost", 8080);
-    EndpointKey key1 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions(), addr, peer);
-    EndpointKey key2 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions(), addr, peer);
+    EndpointKey key1 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, addr, peer);
+    EndpointKey key2 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, addr, peer);
     assertEquals(key1, key2);
     assertEquals(key1.hashCode(), key2.hashCode());
-    EndpointKey key3 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setUsername("foo").setPassword("bar"), addr, peer);
-    EndpointKey key4 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setUsername("foo").setPassword("bar"), addr, peer);
+    EndpointKey key3 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setUsername("foo").setPassword("bar"), peer);
+    EndpointKey key4 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setUsername("foo").setPassword("bar"), peer);
     assertEquals(key3, key4);
     assertEquals(key3.hashCode(), key4.hashCode());
-    EndpointKey key5 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setHost("localhost"), addr, peer);
-    EndpointKey key6 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setHost("127.0.0.1"), addr, peer);
+    EndpointKey key5 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setHost("localhost"), peer);
+    EndpointKey key6 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setHost("127.0.0.1"), peer);
     assertNotEquals(key5, key6);
     assertNotEquals(key5.hashCode(), key6.hashCode());
     assertNotEquals(key1.hashCode(), key6.hashCode());
     EndpointKey key7 = new EndpointKey(false, HttpVersion.HTTP_1_1, null,
-      new ProxyOptions().setProxyAuthorization("Negotiate token-1"), addr, peer);
+      new ProxyOptions().setProxyAuthorization("Negotiate token-1"), peer);
     EndpointKey key8 = new EndpointKey(false, HttpVersion.HTTP_1_1, null,
-      new ProxyOptions().setProxyAuthorization("Negotiate token-1"), addr, peer);
+      new ProxyOptions().setProxyAuthorization("Negotiate token-1"), peer);
     EndpointKey key9 = new EndpointKey(false, HttpVersion.HTTP_1_1, null,
-      new ProxyOptions().setProxyAuthorization("Negotiate token-2"), addr, peer);
+      new ProxyOptions().setProxyAuthorization("Negotiate token-2"), peer);
     assertEquals(key7, key8);
     assertEquals(key7.hashCode(), key8.hashCode());
     assertNotEquals(key7, key9);
     assertNotEquals(key7.hashCode(), key9.hashCode());
+
+    SocketAddress addr1 = SocketAddress.inetSocketAddress(new InetSocketAddress(InetAddress.getByAddress("vertx.io", new byte[]{127, 0, 0, 1}), 8080));
+    SocketAddress addr2 = SocketAddress.inetSocketAddress(new InetSocketAddress(InetAddress.getByAddress("vertx.io", new byte[]{127, 0, 0, 2}), 8080));
+    EndpointKey key10 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, addr1, peer);
+    EndpointKey key11 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, addr2, peer);
+    EndpointKey key12 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, SocketAddress.inetSocketAddress(8080, "127.0.0.1"), peer);
+    assertNotEquals(key10, key11);
+    assertEquals(key10, key12);
   }
 
 }


### PR DESCRIPTION
Motivation:

An `HttpClient` configured with a `LoadBalancer` resolved every address for a multi-homed host, but requests still connected to only one IP.

The resolved `InetAddress` instances retained the original hostname. As a result, the generated `SocketAddress` instances compared equally and shared the same connection-pool key, despite representing different IP addresses.

This change creates socket addresses using the resolved numeric IP while retaining the original `InetAddress`. Each resolved IP therefore receives a distinct connection pool and can be selected by the configured load balancer.

The existing DNS client-side load-balancing test now also verifies that DNS results produce distinct server addresses.

Fixes #6200

Conformance:

I have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md

I have followed the Vert.x code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines

Verification:

```
mvn -pl vertx-core -Dtest=Http1xTest#testDnsClientSideLoadBalancingEnabled test

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```