### PR TITLE
Fix HTTP client close hook leak

### DIFF
--- a/vertx-core/src/main/generated/io/vertx/core/DeploymentOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/DeploymentOptionsConverter.java
@@ -12,21 +12,6 @@ public class DeploymentOptionsConverter {
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, DeploymentOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "config":
-          if (member.getValue() instanceof JsonObject) {
-            obj.setConfig(((JsonObject)member.getValue()).copy());
-          }
-          break;
-        case "threadingModel":
-          if (member.getValue() instanceof String) {
-            obj.setThreadingModel(io.vertx.core.ThreadingModel.valueOf((String)member.getValue()));
-          }
-          break;
-        case "ha":
-          if (member.getValue() instanceof Boolean) {
-            obj.setHa((Boolean)member.getValue());
-          }
-          break;
         case "instances":
           if (member.getValue() instanceof Number) {
             obj.setInstances(((Number)member.getValue()).intValue());
@@ -42,14 +27,29 @@ public class DeploymentOptionsConverter {
             obj.setWorkerPoolSize(((Number)member.getValue()).intValue());
           }
           break;
-        case "maxWorkerExecuteTime":
-          if (member.getValue() instanceof Number) {
-            obj.setMaxWorkerExecuteTime(((Number)member.getValue()).longValue());
+        case "config":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setConfig(((JsonObject)member.getValue()).copy());
+          }
+          break;
+        case "threadingModel":
+          if (member.getValue() instanceof String) {
+            obj.setThreadingModel(io.vertx.core.ThreadingModel.valueOf((String)member.getValue()));
           }
           break;
         case "maxWorkerExecuteTimeUnit":
           if (member.getValue() instanceof String) {
             obj.setMaxWorkerExecuteTimeUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
+          }
+          break;
+        case "maxWorkerExecuteTime":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxWorkerExecuteTime(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "ha":
+          if (member.getValue() instanceof Boolean) {
+            obj.setHa((Boolean)member.getValue());
           }
           break;
       }
@@ -61,21 +61,21 @@ public class DeploymentOptionsConverter {
   }
 
    static void toJson(DeploymentOptions obj, java.util.Map<String, Object> json) {
+    json.put("instances", obj.getInstances());
+    if (obj.getWorkerPoolName() != null) {
+      json.put("workerPoolName", obj.getWorkerPoolName());
+    }
+    json.put("workerPoolSize", obj.getWorkerPoolSize());
     if (obj.getConfig() != null) {
       json.put("config", obj.getConfig());
     }
     if (obj.getThreadingModel() != null) {
       json.put("threadingModel", obj.getThreadingModel().name());
     }
-    json.put("ha", obj.isHa());
-    json.put("instances", obj.getInstances());
-    if (obj.getWorkerPoolName() != null) {
-      json.put("workerPoolName", obj.getWorkerPoolName());
-    }
-    json.put("workerPoolSize", obj.getWorkerPoolSize());
-    json.put("maxWorkerExecuteTime", obj.getMaxWorkerExecuteTime());
     if (obj.getMaxWorkerExecuteTimeUnit() != null) {
       json.put("maxWorkerExecuteTimeUnit", obj.getMaxWorkerExecuteTimeUnit().name());
     }
+    json.put("maxWorkerExecuteTime", obj.getMaxWorkerExecuteTime());
+    json.put("ha", obj.isHa());
   }
 }

--- a/vertx-core/src/main/generated/io/vertx/core/VertxOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/VertxOptionsConverter.java
@@ -12,9 +12,9 @@ public class VertxOptionsConverter {
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, VertxOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "eventLoopPoolSize":
+        case "blockedThreadCheckInterval":
           if (member.getValue() instanceof Number) {
-            obj.setEventLoopPoolSize(((Number)member.getValue()).intValue());
+            obj.setBlockedThreadCheckInterval(((Number)member.getValue()).longValue());
           }
           break;
         case "workerPoolSize":
@@ -22,29 +22,9 @@ public class VertxOptionsConverter {
             obj.setWorkerPoolSize(((Number)member.getValue()).intValue());
           }
           break;
-        case "blockedThreadCheckInterval":
-          if (member.getValue() instanceof Number) {
-            obj.setBlockedThreadCheckInterval(((Number)member.getValue()).longValue());
-          }
-          break;
-        case "maxEventLoopExecuteTime":
-          if (member.getValue() instanceof Number) {
-            obj.setMaxEventLoopExecuteTime(((Number)member.getValue()).longValue());
-          }
-          break;
-        case "maxWorkerExecuteTime":
-          if (member.getValue() instanceof Number) {
-            obj.setMaxWorkerExecuteTime(((Number)member.getValue()).longValue());
-          }
-          break;
-        case "internalBlockingPoolSize":
-          if (member.getValue() instanceof Number) {
-            obj.setInternalBlockingPoolSize(((Number)member.getValue()).intValue());
-          }
-          break;
-        case "haEnabled":
+        case "useDaemonThread":
           if (member.getValue() instanceof Boolean) {
-            obj.setHAEnabled((Boolean)member.getValue());
+            obj.setUseDaemonThread((Boolean)member.getValue());
           }
           break;
         case "quorumSize":
@@ -52,49 +32,9 @@ public class VertxOptionsConverter {
             obj.setQuorumSize(((Number)member.getValue()).intValue());
           }
           break;
-        case "haGroup":
-          if (member.getValue() instanceof String) {
-            obj.setHAGroup((String)member.getValue());
-          }
-          break;
-        case "metricsOptions":
-          if (member.getValue() instanceof JsonObject) {
-            obj.setMetricsOptions(new io.vertx.core.metrics.MetricsOptions((io.vertx.core.json.JsonObject)member.getValue()));
-          }
-          break;
-        case "fileSystemOptions":
-          if (member.getValue() instanceof JsonObject) {
-            obj.setFileSystemOptions(new io.vertx.core.file.FileSystemOptions((io.vertx.core.json.JsonObject)member.getValue()));
-          }
-          break;
-        case "warningExceptionTime":
+        case "eventLoopPoolSize":
           if (member.getValue() instanceof Number) {
-            obj.setWarningExceptionTime(((Number)member.getValue()).longValue());
-          }
-          break;
-        case "eventBusOptions":
-          if (member.getValue() instanceof JsonObject) {
-            obj.setEventBusOptions(new io.vertx.core.eventbus.EventBusOptions((io.vertx.core.json.JsonObject)member.getValue()));
-          }
-          break;
-        case "addressResolverOptions":
-          if (member.getValue() instanceof JsonObject) {
-            obj.setAddressResolverOptions(new io.vertx.core.dns.AddressResolverOptions((io.vertx.core.json.JsonObject)member.getValue()));
-          }
-          break;
-        case "preferNativeTransport":
-          if (member.getValue() instanceof Boolean) {
-            obj.setPreferNativeTransport((Boolean)member.getValue());
-          }
-          break;
-        case "maxEventLoopExecuteTimeUnit":
-          if (member.getValue() instanceof String) {
-            obj.setMaxEventLoopExecuteTimeUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
-          }
-          break;
-        case "maxWorkerExecuteTimeUnit":
-          if (member.getValue() instanceof String) {
-            obj.setMaxWorkerExecuteTimeUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
+            obj.setEventLoopPoolSize(((Number)member.getValue()).intValue());
           }
           break;
         case "warningExceptionTimeUnit":
@@ -102,14 +42,39 @@ public class VertxOptionsConverter {
             obj.setWarningExceptionTimeUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
           }
           break;
-        case "blockedThreadCheckIntervalUnit":
-          if (member.getValue() instanceof String) {
-            obj.setBlockedThreadCheckIntervalUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
+        case "warningExceptionTime":
+          if (member.getValue() instanceof Number) {
+            obj.setWarningExceptionTime(((Number)member.getValue()).longValue());
           }
           break;
-        case "tracingOptions":
+        case "addressResolverOptions":
           if (member.getValue() instanceof JsonObject) {
-            obj.setTracingOptions(new io.vertx.core.tracing.TracingOptions((io.vertx.core.json.JsonObject)member.getValue()));
+            obj.setAddressResolverOptions(new io.vertx.core.dns.AddressResolverOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+        case "internalBlockingPoolSize":
+          if (member.getValue() instanceof Number) {
+            obj.setInternalBlockingPoolSize(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "preferNativeTransport":
+          if (member.getValue() instanceof Boolean) {
+            obj.setPreferNativeTransport((Boolean)member.getValue());
+          }
+          break;
+        case "maxWorkerExecuteTime":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxWorkerExecuteTime(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "haGroup":
+          if (member.getValue() instanceof String) {
+            obj.setHAGroup((String)member.getValue());
+          }
+          break;
+        case "maxEventLoopExecuteTime":
+          if (member.getValue() instanceof Number) {
+            obj.setMaxEventLoopExecuteTime(((Number)member.getValue()).longValue());
           }
           break;
         case "disableTCCL":
@@ -117,9 +82,44 @@ public class VertxOptionsConverter {
             obj.setDisableTCCL((Boolean)member.getValue());
           }
           break;
-        case "useDaemonThread":
+        case "blockedThreadCheckIntervalUnit":
+          if (member.getValue() instanceof String) {
+            obj.setBlockedThreadCheckIntervalUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
+          }
+          break;
+        case "eventBusOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setEventBusOptions(new io.vertx.core.eventbus.EventBusOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+        case "fileSystemOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setFileSystemOptions(new io.vertx.core.file.FileSystemOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+        case "maxEventLoopExecuteTimeUnit":
+          if (member.getValue() instanceof String) {
+            obj.setMaxEventLoopExecuteTimeUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
+          }
+          break;
+        case "metricsOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setMetricsOptions(new io.vertx.core.metrics.MetricsOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+        case "haEnabled":
           if (member.getValue() instanceof Boolean) {
-            obj.setUseDaemonThread((Boolean)member.getValue());
+            obj.setHAEnabled((Boolean)member.getValue());
+          }
+          break;
+        case "tracingOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setTracingOptions(new io.vertx.core.tracing.TracingOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+        case "maxWorkerExecuteTimeUnit":
+          if (member.getValue() instanceof String) {
+            obj.setMaxWorkerExecuteTimeUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
           }
           break;
       }
@@ -131,49 +131,49 @@ public class VertxOptionsConverter {
   }
 
    static void toJson(VertxOptions obj, java.util.Map<String, Object> json) {
-    json.put("eventLoopPoolSize", obj.getEventLoopPoolSize());
-    json.put("workerPoolSize", obj.getWorkerPoolSize());
     json.put("blockedThreadCheckInterval", obj.getBlockedThreadCheckInterval());
-    json.put("maxEventLoopExecuteTime", obj.getMaxEventLoopExecuteTime());
-    json.put("maxWorkerExecuteTime", obj.getMaxWorkerExecuteTime());
-    json.put("internalBlockingPoolSize", obj.getInternalBlockingPoolSize());
-    json.put("haEnabled", obj.isHAEnabled());
+    json.put("workerPoolSize", obj.getWorkerPoolSize());
+    if (obj.getUseDaemonThread() != null) {
+      json.put("useDaemonThread", obj.getUseDaemonThread());
+    }
     json.put("quorumSize", obj.getQuorumSize());
+    json.put("eventLoopPoolSize", obj.getEventLoopPoolSize());
+    if (obj.getWarningExceptionTimeUnit() != null) {
+      json.put("warningExceptionTimeUnit", obj.getWarningExceptionTimeUnit().name());
+    }
+    json.put("warningExceptionTime", obj.getWarningExceptionTime());
+    if (obj.getAddressResolverOptions() != null) {
+      json.put("addressResolverOptions", obj.getAddressResolverOptions().toJson());
+    }
+    json.put("internalBlockingPoolSize", obj.getInternalBlockingPoolSize());
+    json.put("preferNativeTransport", obj.getPreferNativeTransport());
+    json.put("maxWorkerExecuteTime", obj.getMaxWorkerExecuteTime());
     if (obj.getHAGroup() != null) {
       json.put("haGroup", obj.getHAGroup());
     }
-    if (obj.getMetricsOptions() != null) {
-      json.put("metricsOptions", obj.getMetricsOptions().toJson());
+    json.put("maxEventLoopExecuteTime", obj.getMaxEventLoopExecuteTime());
+    json.put("disableTCCL", obj.getDisableTCCL());
+    if (obj.getBlockedThreadCheckIntervalUnit() != null) {
+      json.put("blockedThreadCheckIntervalUnit", obj.getBlockedThreadCheckIntervalUnit().name());
+    }
+    if (obj.getEventBusOptions() != null) {
+      json.put("eventBusOptions", obj.getEventBusOptions().toJson());
     }
     if (obj.getFileSystemOptions() != null) {
       json.put("fileSystemOptions", obj.getFileSystemOptions().toJson());
     }
-    json.put("warningExceptionTime", obj.getWarningExceptionTime());
-    if (obj.getEventBusOptions() != null) {
-      json.put("eventBusOptions", obj.getEventBusOptions().toJson());
-    }
-    if (obj.getAddressResolverOptions() != null) {
-      json.put("addressResolverOptions", obj.getAddressResolverOptions().toJson());
-    }
-    json.put("preferNativeTransport", obj.getPreferNativeTransport());
     if (obj.getMaxEventLoopExecuteTimeUnit() != null) {
       json.put("maxEventLoopExecuteTimeUnit", obj.getMaxEventLoopExecuteTimeUnit().name());
     }
-    if (obj.getMaxWorkerExecuteTimeUnit() != null) {
-      json.put("maxWorkerExecuteTimeUnit", obj.getMaxWorkerExecuteTimeUnit().name());
+    if (obj.getMetricsOptions() != null) {
+      json.put("metricsOptions", obj.getMetricsOptions().toJson());
     }
-    if (obj.getWarningExceptionTimeUnit() != null) {
-      json.put("warningExceptionTimeUnit", obj.getWarningExceptionTimeUnit().name());
-    }
-    if (obj.getBlockedThreadCheckIntervalUnit() != null) {
-      json.put("blockedThreadCheckIntervalUnit", obj.getBlockedThreadCheckIntervalUnit().name());
-    }
+    json.put("haEnabled", obj.isHAEnabled());
     if (obj.getTracingOptions() != null) {
       json.put("tracingOptions", obj.getTracingOptions().toJson());
     }
-    json.put("disableTCCL", obj.getDisableTCCL());
-    if (obj.getUseDaemonThread() != null) {
-      json.put("useDaemonThread", obj.getUseDaemonThread());
+    if (obj.getMaxWorkerExecuteTimeUnit() != null) {
+      json.put("maxWorkerExecuteTimeUnit", obj.getMaxWorkerExecuteTimeUnit().name());
     }
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -368,7 +368,9 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       closeable = impl;
       client = new CleanableHttpClient(vertx.cleaner(), impl);
     }
-    cf.add(closeable);
+    Closeable closeHook = closeable;
+    cf.add(closeHook);
+    client.closeFuture().onComplete(ar -> cf.remove(closeHook));
     return client;
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
@@ -19,6 +19,7 @@ import io.vertx.core.http.impl.CleanableHttpClient;
 import io.vertx.core.http.impl.tcp.TcpHttpClientTransport;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.http.HttpClientInternal;
 import io.vertx.core.internal.net.NetClientInternal;
 import io.vertx.core.net.*;
 import io.vertx.core.net.impl.tcp.CleanableNetClient;
@@ -214,6 +215,15 @@ public class VertxTest extends VertxTestBase {
         .onComplete(TestUtils.onSuccess(v -> testComplete()));
     }
     await();
+  }
+
+  @Test
+  public void testCloseHttpClientRemovesCloseHook() {
+    VertxInternal vertx = (VertxInternal) vertx();
+    HttpClient client = vertx.httpClientBuilder().build();
+    HttpClientInternal delegate = ((CleanableHttpClient) client).unwrap();
+    client.close().await();
+    Assert.assertFalse(vertx.closeFuture().remove(delegate));
   }
 
   @Test


### PR DESCRIPTION
Motivation:

HTTP clients created with `httpClientBuilder()` register their internal closeable with the creating context's `CloseFuture`. Explicitly closing a client did not remove this hook, causing the context to retain the closed client and its resources for the context's lifetime.

This change removes the hook when the underlying HTTP client's close future completes. It also adds a regression test verifying that an explicitly closed client is detached from the context's `CloseFuture`.

Fixes #6268.

Conformance:

I have signed the Eclipse Contributor Agreement and adhered to the Vert.x code style guidelines.

Testing:

```text
mvn -pl vertx-core '-Dtest=io.vertx.tests.vertx.VertxTest#testCloseHttpClientRemovesCloseHook' test

Result: 1 test run, 0 failures, 0 errors.
```