### PR TITLE
fix: prevent NPE in metricsEnd when HTTP/2 stream ends before response headers are received (#6022) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -208,7 +208,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
   }
 
   private void metricsEnd(Stream stream) {
-    if (metrics != null) {
+    if (metrics != null && stream.response != null) {
       metrics.responseEnd(stream.metric, stream.bytesRead());
     }
   }


### PR DESCRIPTION
Motivation:
When using Vert.x HTTP client with HTTP/2, decompression enabled, and micrometer metrics enabled, a NullPointerException occurs in Http2ClientConnection.metricsEnd() because handler.response is null.

The stream can reach onEnd before response headers are processed (e.g., when a decompressor error closes the stream). In this case, metricsEnd() calls metrics.responseEnd() which tries to access handler.response.statusCode(), causing NPE.

Modification:
Added a null check for stream.response in metricsEnd() before calling metrics.responseEnd(). If the stream ended without receiving response headers, the metrics call is skipped since there is no response to report metrics for.

This mirrors the existing pattern used elsewhere in the codebase where response availability is checked before metrics access.

Result:
No more NPE when an HTTP/2 stream ends before response headers are received. Metrics are only reported when a response is actually available.

Fixes #6022