### PR TITLE
fix: increase HTTP/2 connection window default from 64KB to 1MB (#6238)

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -44,7 +44,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   /**
    * The default connection window size for HTTP/2 = -1
    */
-  public static final int DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE = -1;
+  public static final int DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE = 1024 * 1024;
 
   /**
    * The default keep alive timeout for HTTP/2 connection can send = 60 seconds

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -124,7 +124,7 @@ public class HttpServerOptions extends NetServerOptions {
   /**
    * The default HTTP/2 connection window size = -1
    */
-  public static final int DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE = -1;
+  public static final int DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE = 1024 * 1024;
 
   /**
    * Default value of whether decompression is supported = {@code false}


### PR DESCRIPTION
Fixes #6238

## Description

The default HTTP/2 connection window size is `-1`, which means Netty's default stream initial window size (64KB) is used for the connection window. For large payloads (e.g., 10MB+ gRPC messages), this requires hundreds of WINDOW_UPDATE round-trips before the application receives the full body, causing 25s+ latency vs ~1s with a properly sized window.

## Changes

- **`HttpServerOptions.java`**: Changed `DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE` from `-1` to `1024 * 1024` (1MB)
- **`HttpClientOptions.java`**: Same change for consistency

## Why 1MB?

- Matches Netty's default HTTP/2 connection window size used by the legacy gRPC-Java/Netty stack
- Large enough to avoid excessive WINDOW_UPDATE round-trips for typical large messages (10MB+)
- Small enough to not significantly increase memory pressure (the window is a budget, not an allocation)
- Users who need a different value can still configure it via `setConnectionWindowSize()`

## Verification

- The condition `connectionWindowSize > 0` in `HttpServerConnectionHandler.java` already handles positive values correctly
- With the new default of 1MB, `setWindowSize()` will be called with a reasonable value
- No behavioral change for users who explicitly configure `setConnectionWindowSize()`
