### PR TITLE
Preserve current context in Promise.promise

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/Future.java
+++ b/vertx-core/src/main/java/io/vertx/core/Future.java
@@ -666,7 +666,8 @@ public interface Future<T> extends AsyncResult<T> {
   /**
    * Bridges a {@link CompletionStage} object to a Vert.x future instance.
    * <p>
-   * The Vert.x future handling methods will be called from the thread that completes {@code completionStage}.
+   * When called from a Vert.x context, the Vert.x future handling methods will be called on that context.
+   * Otherwise, they will be called from the thread that completes {@code completionStage}.
    *
    * @param completionStage a completion stage
    * @param <T>             the result type

--- a/vertx-core/src/main/java/io/vertx/core/Promise.java
+++ b/vertx-core/src/main/java/io/vertx/core/Promise.java
@@ -15,6 +15,7 @@ import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.impl.future.PromiseImpl;
+import io.vertx.core.internal.ContextInternal;
 
 
 /**
@@ -32,11 +33,19 @@ public interface Promise<T> extends Completable<T> {
 
   /**
    * Create a promise that hasn't completed yet
+   * <p>
+   * When called from a Vert.x context, the promise is associated with that context and future handlers are
+   * dispatched on it.
+   * Otherwise, future handlers are called from the thread that completes the promise.
    *
    * @param <T>  the result type
    * @return  the promise
    */
   static <T> Promise<T> promise() {
+    Context context = Vertx.currentContext();
+    if (context instanceof ContextInternal) {
+      return ((ContextInternal) context).promise();
+    }
     return new PromiseImpl<>();
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -37,6 +37,7 @@ import io.vertx.core.http.impl.tcp.TcpHttpClientTransport;
 import io.vertx.core.http.HttpClientConfig;
 import io.vertx.core.impl.deployment.DefaultDeploymentManager;
 import io.vertx.core.impl.deployment.DefaultDeployment;
+import io.vertx.core.impl.future.PromiseImpl;
 import io.vertx.core.internal.deployment.Deployment;
 import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.internal.deployment.DeploymentManager;
@@ -804,12 +805,12 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       .transform(ar -> Future.future(h -> eventBus.close((Promise) h)))
       .transform(ar -> closeClusterManager())
       .transform(ar -> {
-        Promise<Void> promise = Promise.promise();
+        Promise<Void> promise = new PromiseImpl<>();
         deleteCacheDirAndShutdown(promise);
         return promise.future();
       });
     Future<Void> val = fut;
-    Promise<Void> p = Promise.promise();
+    Promise<Void> p = new PromiseImpl<>();
     val.onComplete(ar -> {
       eventLoopThreadFactory.newThread(() -> {
         if (ar.succeeded()) {

--- a/vertx-core/src/main/java/io/vertx/core/impl/future/FutureBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/future/FutureBase.java
@@ -205,7 +205,7 @@ public abstract class FutureBase<T> implements FutureInternal<T> {
       promise = context.promise();
     } else {
       instance = GlobalEventExecutor.INSTANCE;
-      promise = Promise.promise();
+      promise = new PromiseImpl<>();
     }
     ScheduledFuture<?> task = instance.schedule(() -> {
       String msg = "Timeout " + unit.toMillis(delay) + " (ms) fired";

--- a/vertx-core/src/test/java/io/vertx/tests/future/FutureTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/future/FutureTest.java
@@ -1653,6 +1653,51 @@ public class FutureTest extends FutureTestBase {
   }
 
   @Test
+  public void testPromiseCapturesCurrentContext() throws Exception {
+    ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
+    CompletableFuture<Promise<String>> successPromise = new CompletableFuture<>();
+    CompletableFuture<Context> successContext = new CompletableFuture<>();
+    CompletableFuture<Promise<String>> failurePromise = new CompletableFuture<>();
+    CompletableFuture<Context> failureContext = new CompletableFuture<>();
+
+    context.runOnContext(ignored -> {
+      Promise<String> promise = Promise.promise();
+      promise.future().onSuccess(value -> successContext.complete(Vertx.currentContext()));
+      successPromise.complete(promise);
+
+      promise = Promise.promise();
+      promise.future().onFailure(err -> failureContext.complete(Vertx.currentContext()));
+      failurePromise.complete(promise);
+    });
+
+    ForkJoinPool.commonPool().execute(() -> successPromise.join().complete("ok"));
+    ForkJoinPool.commonPool().execute(() -> failurePromise.join().fail("boom"));
+
+    assertSame(context, successContext.get(10, TimeUnit.SECONDS));
+    assertSame(context, failureContext.get(10, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void testPromiseWithoutContextRunsOnCompletingThread() throws Exception {
+    assertNull(Vertx.currentContext());
+    Promise<String> promise = Promise.promise();
+    CompletableFuture<Thread> handlerThread = new CompletableFuture<>();
+    CompletableFuture<Context> handlerContext = new CompletableFuture<>();
+    promise.future().onSuccess(value -> {
+      handlerThread.complete(Thread.currentThread());
+      handlerContext.complete(Vertx.currentContext());
+    });
+
+    Thread completingThread = new Thread(() -> promise.complete("ok"));
+    completingThread.start();
+    completingThread.join(TimeUnit.SECONDS.toMillis(10));
+
+    assertFalse(completingThread.isAlive());
+    assertSame(completingThread, handlerThread.get(10, TimeUnit.SECONDS));
+    assertNull(handlerContext.get(10, TimeUnit.SECONDS));
+  }
+
+  @Test
   public void testToCompletionStageTrampolining() {
     waitFor(2);
     Thread mainThread = Thread.currentThread();
@@ -1738,6 +1783,29 @@ public class FutureTest extends FutureTestBase {
     });
 
     await();
+  }
+
+  @Test
+  public void testFromCompletionStageCapturesCurrentContext() throws Exception {
+    ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
+    CompletableFuture<String> completionStage = new CompletableFuture<>();
+    CompletableFuture<String> handlerValue = new CompletableFuture<>();
+    CompletableFuture<Context> handlerContext = new CompletableFuture<>();
+    CompletableFuture<Void> subscribed = new CompletableFuture<>();
+
+    context.runOnContext(ignored -> {
+      Future.fromCompletionStage(completionStage).onSuccess(value -> {
+        handlerValue.complete(value);
+        handlerContext.complete(Vertx.currentContext());
+      });
+      subscribed.complete(null);
+    });
+
+    subscribed.get(10, TimeUnit.SECONDS);
+    ForkJoinPool.commonPool().execute(() -> completionStage.complete("Ok"));
+
+    assertEquals("Ok", handlerValue.get(10, TimeUnit.SECONDS));
+    assertSame(context, handlerContext.get(10, TimeUnit.SECONDS));
   }
 
   @Test
@@ -2010,6 +2078,25 @@ public class FutureTest extends FutureTestBase {
     Promise<String> promise = Promise.promise();
     io.vertx.core.Future<String> fut = promise.future();
     futureTimeoutFires(null, fut);
+  }
+
+  @Test
+  public void contextFreeFutureTimeoutCalledFromContext() throws Exception {
+    Promise<String> promise = Promise.promise();
+    CompletableFuture<Throwable> failure = new CompletableFuture<>();
+    CompletableFuture<Context> handlerContext = new CompletableFuture<>();
+    CompletableFuture<Void> subscribed = new CompletableFuture<>();
+    vertx.runOnContext(ignored -> {
+      promise.future().timeout(100, TimeUnit.MILLISECONDS).onFailure(err -> {
+        failure.complete(err);
+        handlerContext.complete(Vertx.currentContext());
+      });
+      subscribed.complete(null);
+    });
+
+    subscribed.get(10, TimeUnit.SECONDS);
+    assertTrue(failure.get(10, TimeUnit.SECONDS) instanceof TimeoutException);
+    assertNull(handlerContext.get(10, TimeUnit.SECONDS));
   }
 
   private void futureTimeoutFires(Context ctx, io.vertx.core.Future<String> fut) {

--- a/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/VertxConnectionTest.java
@@ -494,14 +494,14 @@ public class VertxConnectionTest extends VertxTestBase {
     waitFor(2);
     disableThreadChecks();
     connectHandler = conn -> {
+      Context context = Vertx.currentContext();
       Promise<Void> promise = Promise.promise();
       ChannelPromise channelPromise = ((VertxConnection) conn).unsafeWrite(Unpooled.copiedBuffer("outbound-1", StandardCharsets.UTF_8), true, promise);
       Future<Void> future = promise.future();
       future.onComplete(onSuccess(v -> {
         new Thread(() -> {
-          Thread curr = Thread.currentThread();
           future.onComplete(ar -> {
-            assertSame(curr, Thread.currentThread());
+            assertSame(context, Vertx.currentContext());
             complete();
           });
           channelPromise.addListener((ChannelFutureListener) f -> {

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
@@ -37,6 +37,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -154,6 +155,20 @@ public class VertxTest extends VertxTestBase {
       testComplete();
     }));
     await();
+  }
+
+  @Test
+  public void testCloseFutureFromContext() throws Exception {
+    Vertx vertx = vertx();
+    CompletableFuture<Void> closed = new CompletableFuture<>();
+    vertx.runOnContext(ignored -> vertx.close().onComplete(ar -> {
+      if (ar.succeeded()) {
+        closed.complete(null);
+      } else {
+        closed.completeExceptionally(ar.cause());
+      }
+    }));
+    closed.get(10, TimeUnit.SECONDS);
   }
 
   @Test


### PR DESCRIPTION
Motivation:

Promise.promise()  currently creates a context-free promise even when called from a Vert.x context. As a result, handlers can run on the foreign thread that completes the promise. This also affects Future.fromCompletionStage(CompletionStage).

Changes:

- create a context-bound promise when a Vert.x context is current
- preserve the existing context-free behavior outside Vert.x
- keep timeout and Vert.x shutdown boundaries explicitly context-free
- document the conditional callback affinity
- add context, no-context, CompletionStage, timeout, shutdown, and network regression coverage

Fixes #4978