### PR TITLE
Port of 5.1 HTTP client fixes

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/CleanableHttpClient.java
@@ -10,13 +10,12 @@
  */
 package io.vertx.core.http.impl;
 
-import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.http.*;
 import io.vertx.core.http.HttpClientConnection;
 import io.vertx.core.impl.CleanableObject;
-import io.vertx.core.impl.CleanableResource;
+import io.vertx.core.internal.CloseableResource;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.http.HttpClientTransport;
 import io.vertx.core.internal.http.HttpClientInternal;
@@ -35,7 +34,7 @@ import java.util.function.Function;
  */
 public class CleanableHttpClient extends CleanableObject<HttpClientInternal> implements HttpClientInternal {
 
-  public CleanableHttpClient(Cleaner cleaner, CleanableResource<HttpClientInternal> dispose) {
+  public CleanableHttpClient(Cleaner cleaner, CloseableResource<HttpClientInternal> dispose) {
     super(cleaner, dispose);
   }
 
@@ -98,11 +97,6 @@ public class CleanableHttpClient extends CleanableObject<HttpClientInternal> imp
   @Override
   public Future<Void> closeFuture() {
     return getOrDie().closeFuture();
-  }
-
-  @Override
-  public void close(Completable<Void> completion) {
-    getOrDie().close(completion);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBase.java
@@ -27,7 +27,7 @@ import java.util.function.Predicate;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public abstract class HttpClientBase implements MetricsProvider, Closeable {
+public abstract class HttpClientBase implements MetricsProvider {
 
   protected final VertxInternal vertx;
   protected final ProxyOptions defaultProxyOptions;
@@ -55,10 +55,6 @@ public abstract class HttpClientBase implements MetricsProvider, Closeable {
 
   public Future<Void> closeFuture() {
     return closeSequence.future();
-  }
-
-  public void close(Completable<Void> completion) {
-    closeSequence.close(completion);
   }
 
   private ProxyOptions getProxyOptions(ProxyOptions proxyOptions) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -2,6 +2,7 @@ package io.vertx.core.http.impl;
 
 
 import io.vertx.core.Closeable;
+import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.http.*;
@@ -360,11 +361,40 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
     } else {
       resource = createHttpClientImpl(co2, ssl, httpMetrics, resolver, redirectHandler, transport, quicTransport);
     }
-    HttpClientInternal client = new CleanableHttpClient(vertx.cleaner(), resource);
-    Closeable closeable = completion -> resource
-      .shutdown(Duration.ZERO)
-      .onComplete(completion);
-    cf.add(closeable);
-    return client;
+    ClientCloseableResource ccr = new ClientCloseableResource(cf, resource);
+    cf.add(ccr);
+    return new CleanableHttpClient(vertx.cleaner(), ccr);
+  }
+
+  // This should somehow get unified and reused
+  // at the moment this is required to unregister the resource from the owner when the client closes
+  // either explicitly or is collected
+  private static class ClientCloseableResource implements CloseableResource<HttpClientInternal>, Closeable {
+
+    private final CloseFuture owner;
+    private final CloseableResource<HttpClientInternal> resource;
+
+    public ClientCloseableResource(CloseFuture owner, CloseableResource<HttpClientInternal> resource) {
+      this.owner = owner;
+      this.resource = resource;
+    }
+
+    @Override
+    public void close(Completable<Void> completion) {
+      resource
+        .shutdown(Duration.ZERO)
+        .onComplete(completion);
+    }
+
+    @Override
+    public HttpClientInternal get() {
+      return resource.get();
+    }
+
+    @Override
+    public Future<Void> shutdown(Duration duration) {
+      owner.remove(this);
+      return resource.shutdown(duration);
+    }
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -10,6 +10,7 @@ import io.vertx.core.http.Http2ClientConfig;
 import io.vertx.core.http.HttpClientConfig;
 import io.vertx.core.http.impl.quic.QuicHttpClientTransport;
 import io.vertx.core.http.impl.tcp.TcpHttpClientTransport;
+import io.vertx.core.internal.CloseableResource;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
@@ -348,26 +349,21 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       shared = null;
     }
 
-
     HttpClientConfig co2 = co;
     CloseFuture cf = resolveCloseFuture();
-    HttpClientInternal client;
-    Closeable closeable;
+    CloseableResource<HttpClientInternal> resource;
     if (shared != null) {
-      CloseFuture closeFuture = new CloseFuture();
-      client = vertx.createSharedResource("__vertx.shared.httpClients", co.getName(), closeFuture, cf_ -> {
-        HttpClientImpl impl = createHttpClientImpl(co2, ssl, httpMetrics, resolver, redirectHandler, transport, quicTransport);
-        cf_.add(completion -> impl.close().onComplete(completion));
-        return impl;
-      });
-      HttpClientImpl real = (HttpClientImpl)client;
-      client = new CleanableHttpClient(vertx.cleaner(), real);
-      closeable = closeFuture;
+      resource = vertx.createSharedResource(
+        "__vertx.shared.httpClients",
+        co.getName(),
+        () -> createHttpClientImpl(co2, ssl, httpMetrics, resolver, redirectHandler, transport, quicTransport));
     } else {
-      HttpClientImpl impl = createHttpClientImpl(co2, ssl, httpMetrics, resolver, redirectHandler, transport, quicTransport);
-      closeable = impl;
-      client = new CleanableHttpClient(vertx.cleaner(), impl);
+      resource = createHttpClientImpl(co2, ssl, httpMetrics, resolver, redirectHandler, transport, quicTransport);
     }
+    HttpClientInternal client = new CleanableHttpClient(vertx.cleaner(), resource);
+    Closeable closeable = completion -> resource
+      .shutdown(Duration.ZERO)
+      .onComplete(completion);
     cf.add(closeable);
     return client;
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -14,7 +14,7 @@ package io.vertx.core.http.impl;
 import io.vertx.core.*;
 import io.vertx.core.http.*;
 import io.vertx.core.http.impl.tcp.TcpHttpClientTransport;
-import io.vertx.core.impl.CleanableResource;
+import io.vertx.core.internal.CloseableResource;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.VertxInternal;
@@ -47,7 +47,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class HttpClientImpl extends HttpClientBase implements HttpClientInternal, MetricsProvider, CleanableResource<HttpClientInternal> {
+public class HttpClientImpl extends HttpClientBase implements HttpClientInternal, MetricsProvider, CloseableResource<HttpClientInternal> {
 
   // Pattern to check we are not dealing with an absoluate URI
   static final Pattern ABS_URI_START_PATTERN = Pattern.compile("^\\p{Alpha}[\\p{Alpha}\\p{Digit}+.\\-]*:");

--- a/vertx-core/src/main/java/io/vertx/core/impl/CleanableObject.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/CleanableObject.java
@@ -11,6 +11,7 @@
 package io.vertx.core.impl;
 
 import io.vertx.core.Future;
+import io.vertx.core.internal.CloseableResource;
 
 import java.lang.ref.Cleaner;
 import java.lang.ref.WeakReference;
@@ -23,18 +24,18 @@ public class CleanableObject<T> {
 
   public static final Duration DEFAULT_CLEAN_TIMEOUT = Duration.ofSeconds(30);
 
-  private static class Action<T> extends WeakReference<CleanableResource<T>> implements Runnable {
+  private static class Action<T> extends WeakReference<CloseableResource<T>> implements Runnable {
 
     private Duration timeout = DEFAULT_CLEAN_TIMEOUT;
     private Future<Void> closeFuture;
 
-    public Action(CleanableResource<T> resource) {
+    public Action(CloseableResource<T> resource) {
       super(resource);
     }
 
     @Override
     public void run() {
-      CleanableResource<T> d = get();
+      CloseableResource<T> d = get();
       if (d != null) {
         closeFuture = d.shutdown(timeout);
       }
@@ -44,14 +45,14 @@ public class CleanableObject<T> {
   private Cleaner.Cleanable cleanable;
   private Action<T> action;
 
-  public CleanableObject(Cleaner cleaner, CleanableResource<T> dispose) {
+  public CleanableObject(Cleaner cleaner, CloseableResource<T> dispose) {
     this.action = new Action<>(dispose);
     this.cleanable = cleaner.register(this, action);
   }
 
   protected final T get() {
     Action<T> action = this.action;
-    CleanableResource<T> resource;
+    CloseableResource<T> resource;
     return action != null && (resource = action.get()) != null ? resource.get() : null;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/impl/SharedResourceHolder.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/SharedResourceHolder.java
@@ -11,16 +11,17 @@
 
 package io.vertx.core.impl;
 
-import io.vertx.core.Closeable;
-import io.vertx.core.Completable;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.internal.CloseFuture;
+import io.vertx.core.internal.CloseableResource;
 import io.vertx.core.shareddata.LocalMap;
 import io.vertx.core.shareddata.Shareable;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 class SharedResourceHolder<C> implements Shareable {
@@ -29,66 +30,56 @@ class SharedResourceHolder<C> implements Shareable {
     LocalMap<String, SharedResourceHolder<C>> localMap = vertx.sharedData().getLocalMap(resourceKey);
     ArrayList<SharedResourceHolder<C>> values = new ArrayList<>(localMap.values());
     localMap.clear();
-    return values.stream().map(sc -> sc.resource).collect(Collectors.toList());
+    return values.stream().map(sc -> sc.resource.get()).collect(Collectors.toList());
   }
 
-  static <R> R createSharedResource(Vertx vertx, String resourceKey, String resourceName, CloseFuture closeFuture, Function<CloseFuture, R> supplier) {
+  static <R> CloseableResource<R> createSharedResource(Vertx vertx, String resourceKey, String resourceName, Supplier<CloseableResource<R>> supplier) {
     LocalMap<String, SharedResourceHolder<R>> localMap = vertx.sharedData().getLocalMap(resourceKey);
     SharedResourceHolder<R> v = localMap.compute(resourceName, (key, value) -> {
       if (value == null) {
-        Hook<R> hook = new Hook<>(vertx, resourceKey, resourceName);
-        R resource = supplier.apply(hook.closeFuture);
-        return new SharedResourceHolder<>(hook, 1, resource);
+        CloseableResource<R> resource = supplier.get();
+        return new SharedResourceHolder<>(1, resource);
       } else {
-        return new SharedResourceHolder<>(value.hook, value.count + 1, value.resource);
+        return new SharedResourceHolder<>(value.count + 1, value.resource);
       }
     });
-    R resource = v.resource;
-    closeFuture.add(v.hook);
-    return resource;
+    CloseableResource<R> resource = v.resource;
+    return new CloseableResource<>() {
+      final AtomicBoolean shutdown = new AtomicBoolean();
+      @Override
+      public R get() {
+        return resource.get();
+      }
+      @Override
+      public Future<Void> shutdown(Duration duration) {
+        if ( (shutdown.compareAndSet(false, true))) {
+          LocalMap<String, SharedResourceHolder<R>> localMap1 = vertx.sharedData().getLocalMap(resourceKey);
+          SharedResourceHolder<R> res = localMap1.compute(resourceName, (key, value) -> {
+            if (value == null) {
+              return null; // Should never happen unless bug
+            } else if (value.count == 1) {
+              return null;
+            } else {
+              return new SharedResourceHolder<>(value.count - 1, value.resource);
+            }
+          });
+          if (res == null) {
+            return resource.shutdown(duration);
+          } else {
+            return Future.succeededFuture();
+          }
+        } else {
+          return Future.succeededFuture();
+        }
+      }
+    };
   }
 
-  final Hook<C> hook;
   final int count;
-  final C resource;
+  final CloseableResource<C> resource;
 
-  SharedResourceHolder(Hook<C> hook, int count, C resource) {
-    this.hook = hook;
+  SharedResourceHolder(int count, CloseableResource<C> resource) {
     this.count = count;
     this.resource = resource;
-  }
-
-  private static class Hook<C> implements Closeable {
-
-    private final Vertx vertx;
-    private final CloseFuture closeFuture;
-    private final String resourceKey;
-    private final String resourceName;
-
-    private Hook(Vertx vertx, String resourceKey, String resourceName) {
-      this.vertx = vertx;
-      this.closeFuture = new CloseFuture();
-      this.resourceKey = resourceKey;
-      this.resourceName = resourceName;
-    }
-
-    @Override
-    public void close(Completable<Void> completion) {
-      LocalMap<String, SharedResourceHolder<C>> localMap1 = vertx.sharedData().getLocalMap(resourceKey);
-      SharedResourceHolder<C> res = localMap1.compute(resourceName, (key, value) -> {
-        if (value == null) {
-          return null; // Should never happen unless bug
-        } else if (value.count == 1) {
-          return null;
-        } else {
-          return new SharedResourceHolder<>(this, value.count - 1, value.resource);
-        }
-      });
-      if (res == null) {
-        closeFuture.close(completion);
-      } else {
-        completion.succeed();
-      }
-    }
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -37,6 +37,7 @@ import io.vertx.core.http.impl.tcp.TcpHttpClientTransport;
 import io.vertx.core.http.HttpClientConfig;
 import io.vertx.core.impl.deployment.DefaultDeploymentManager;
 import io.vertx.core.impl.deployment.DefaultDeployment;
+import io.vertx.core.internal.CloseableResource;
 import io.vertx.core.internal.deployment.Deployment;
 import io.vertx.core.internal.deployment.DeploymentContext;
 import io.vertx.core.internal.deployment.DeploymentManager;
@@ -428,7 +429,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       closeable = closeFuture;
     } else {
       WebSocketClientImpl impl = createWebSocketClientImpl(options);
-      closeable = impl;
+      closeable = completion -> impl.close().onComplete(completion);
       client = new CleanableWebSocketClient(impl, CleanerProvider.INSTANCE.get(), impl::shutdown);
     }
     cf.add(closeable);
@@ -1337,8 +1338,9 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     }
   }
 
-  public <C> C createSharedResource(String resourceKey, String resourceName, CloseFuture closeFuture, Function<CloseFuture, C> supplier) {
-    return SharedResourceHolder.createSharedResource(this, resourceKey, resourceName, closeFuture, supplier);
+  @Override
+  public <C> CloseableResource<C> createSharedResource(String resourceKey, String resourceName, Supplier<CloseableResource<C>> supplier) {
+    return SharedResourceHolder.createSharedResource(this, resourceKey, resourceName, supplier);
   }
 
   void duplicate(ContextBase src, ContextBase dst) {

--- a/vertx-core/src/main/java/io/vertx/core/internal/CloseableResource.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/CloseableResource.java
@@ -8,18 +8,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.core.impl;
+package io.vertx.core.internal;
 
 import io.vertx.core.Future;
 
 import java.time.Duration;
 
 /**
- * Cleanable resource.
+ * Closeable resource.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public interface CleanableResource<T> {
+public interface CloseableResource<T> {
 
   /**
    * @return the actual resource

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxInternal.java
@@ -30,12 +30,14 @@ import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.spi.tracing.VertxTracer;
 
 import java.lang.ref.Cleaner;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * This interface provides services for vert.x core internal use only
@@ -138,7 +140,30 @@ public interface VertxInternal extends Vertx {
 
   Cleaner cleaner();
 
-  <C> C createSharedResource(String resourceKey, String resourceName, CloseFuture closeFuture, Function<CloseFuture, C> supplier);
+  /**
+   * @deprecated instead use {@link #createSharedResource(String, String, Supplier)}
+   */
+  @Deprecated
+  default <C> C createSharedResource(String resourceKey, String resourceName, CloseFuture closeFuture, Function<CloseFuture, C> supplier) {
+    CloseableResource<C> shared = createSharedResource(resourceKey, resourceName, () -> new CloseableResource<>() {
+      final CloseFuture closeFuture = new CloseFuture();
+      final C resource = supplier.apply(closeFuture);
+      @Override
+      public C get() {
+        return resource;
+      }
+      @Override
+      public Future<Void> shutdown(Duration duration) {
+        return closeFuture.close();
+      }
+    });
+    closeFuture.add(completion -> shared
+      .shutdown(Duration.ZERO)
+      .onComplete(completion));
+    return shared.get();
+  }
+
+  <C> CloseableResource<C> createSharedResource(String resourceKey, String resourceName, Supplier<CloseableResource<C>> supplier);
 
   HttpClientBuilderInternal httpClientBuilder();
 

--- a/vertx-core/src/main/java/io/vertx/core/internal/VertxWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/VertxWrapper.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -72,8 +71,8 @@ public abstract class VertxWrapper implements VertxInternal {
   }
 
   @Override
-  public <C> C createSharedResource(String resourceKey, String resourceName, CloseFuture closeFuture, Function<CloseFuture, C> supplier) {
-    return delegate.createSharedResource(resourceKey, resourceName, closeFuture, supplier);
+  public <C> CloseableResource<C> createSharedResource(String resourceKey, String resourceName, Supplier<CloseableResource<C>> supplier) {
+    return delegate.createSharedResource(resourceKey, resourceName, supplier);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpClientInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpClientInternal.java
@@ -11,7 +11,6 @@
 
 package io.vertx.core.internal.http;
 
-import io.vertx.core.Closeable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.http.*;
@@ -24,7 +23,7 @@ import java.util.function.Function;
 /**
  * Http client internal API.
  */
-public interface HttpClientInternal extends HttpClientAgent, MetricsProvider, Closeable {
+public interface HttpClientInternal extends HttpClientAgent, MetricsProvider {
 
   /**
    * @return the vertx, for use in package related classes only.

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetClient.java
@@ -14,7 +14,7 @@ import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.impl.CleanableObject;
-import io.vertx.core.impl.CleanableResource;
+import io.vertx.core.internal.CloseableResource;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.net.NetClientInternal;
 import io.vertx.core.net.*;
@@ -30,7 +30,7 @@ import java.lang.ref.Cleaner;
  */
 public class CleanableNetClient extends CleanableObject<NetClientInternal> implements NetClientInternal {
 
-  public CleanableNetClient(Cleaner cleaner, CleanableResource<NetClientInternal> resource) {
+  public CleanableNetClient(Cleaner cleaner, CloseableResource<NetClientInternal> resource) {
     super(cleaner, resource);
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/NetClientImpl.java
@@ -22,7 +22,7 @@ import io.netty.util.concurrent.GenericFutureListener;
 import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.impl.CleanableResource;
+import io.vertx.core.internal.CloseableResource;
 import io.vertx.core.impl.Utils;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.PromiseInternal;
@@ -54,7 +54,7 @@ import java.util.function.Supplier;
  * @author <a href="http://tfox.org">Tim Fox</a>
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class NetClientImpl implements NetClientInternal, CleanableResource<NetClientInternal> {
+public class NetClientImpl implements NetClientInternal, CloseableResource<NetClientInternal> {
 
   private static final Logger log = LoggerFactory.getLogger(NetClientImpl.class);
   protected final Duration idleTimeout;

--- a/vertx-core/src/test/java/io/vertx/tests/http/SharedHttpClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/SharedHttpClientTest.java
@@ -15,6 +15,7 @@ import io.vertx.core.*;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.*;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.http.HttpClientInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
@@ -29,6 +30,8 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static io.vertx.core.http.HttpMethod.GET;
+import static io.vertx.test.http.AbstractHttpTest.DEFAULT_HTTP_HOST;
+import static io.vertx.test.http.AbstractHttpTest.DEFAULT_HTTP_PORT;
 
 public class SharedHttpClientTest extends VertxTestBase {
 
@@ -36,6 +39,30 @@ public class SharedHttpClientTest extends VertxTestBase {
   private static final int CLIENT_VERTICLE_INSTANCES = 8;
   private static final int NUM_REQUESTS_PER_VERTICLE = 50 * SHARED_POOL_SIZE;
   private static final int TOTAL_REQUESTS = CLIENT_VERTICLE_INSTANCES * NUM_REQUESTS_PER_VERTICLE;
+
+  @Test
+  public void testShared() {
+    HttpServer server = vertx.createHttpServer().requestHandler(request -> {
+      request.response().end();
+    });
+    server
+      .listen(DEFAULT_HTTP_PORT)
+      .await();
+    HttpClientInternal client1 = (HttpClientInternal)vertx.createHttpClient(new HttpClientOptions().setShared(true));
+    HttpClientInternal client2 = (HttpClientInternal)vertx.createHttpClient(new HttpClientOptions().setShared(true));
+    HttpClientInternal real = client2.unwrap();
+    assertSame(client1.unwrap(), real);
+    client1.close().await();
+    assertFalse(real.closeFuture().isComplete());
+    client2
+      .request(GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/")
+      .compose(request -> request
+        .send()
+        .compose(HttpClientResponse::end))
+      .await();
+    client2.close().await();
+    assertTrue(real.closeFuture().isComplete());
+  }
 
   @Test
   public void testVerticlesUseSamePool() throws Exception {

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/CleanableObjectTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/CleanableObjectTest.java
@@ -13,7 +13,7 @@ package io.vertx.tests.vertx;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.impl.CleanableObject;
-import io.vertx.core.impl.CleanableResource;
+import io.vertx.core.internal.CloseableResource;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Before;
@@ -87,7 +87,7 @@ public class CleanableObjectTest extends VertxTestBase {
     runGC(() -> resourceRef.get() == null);
   }
 
-  private static class TestResource implements CleanableResource<TestResource> {
+  private static class TestResource implements CloseableResource<TestResource> {
 
     private volatile Duration shutdownDuration;
     private Promise<Void> shutdownCompletion = Promise.promise();

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/SharedResourceTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/SharedResourceTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.vertx;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.internal.CloseableResource;
+import io.vertx.core.internal.VertxInternal;
+import io.vertx.test.core.VertxTestBase2;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.*;
+
+public class SharedResourceTest extends VertxTestBase2 {
+
+  @Test
+  public void testSharedResource() {
+    TestResource resource = testResource("val");
+    VertxInternal vertx = (VertxInternal) this.vertx;
+    CloseableResource<String> ref1 = vertx.createSharedResource("key", "name", resource.supplier);
+    CloseableResource<String> ref2 = vertx.createSharedResource("key", "name", resource.supplier);
+    assertEquals(1, resource.count);
+    assertEquals("val", ref1.get());
+    assertEquals("val", ref2.get());
+    assertTrue(ref1.shutdown(Duration.ZERO).succeeded());
+    assertNull(resource.shutdown());
+    assertTrue(ref1.shutdown(Duration.ZERO).succeeded());
+    assertNull(resource.shutdown());
+    Future<Void> shutdown = ref2.shutdown(Duration.ZERO);
+    assertFalse(shutdown.succeeded());
+    assertNotNull(resource.shutdown());
+    resource.succeedShutdown();
+    assertTrue(shutdown.succeeded());
+  }
+
+  private static TestResource testResource(String value) {
+    return new TestResource(value);
+  }
+
+  private static class TestResource implements CloseableResource<String> {
+
+    private int count;
+    private final Supplier<CloseableResource<String>> supplier;
+    private final Promise<Void> completion;
+    private final AtomicReference<Duration> shutdown;
+    private final String value;
+
+    public TestResource(String value) {
+      this.completion = Promise.promise();
+      this.shutdown = new AtomicReference<>();
+      this.value = value;
+      this.supplier = () -> {
+        count++;
+        return TestResource.this;
+      };
+    }
+
+    public void succeedShutdown() {
+      completion.succeed();
+    }
+
+    public Duration shutdown() {
+      return shutdown.get();
+    }
+
+    @Override
+    public String get() {
+      return value;
+    }
+
+    @Override
+    public Future<Void> shutdown(Duration duration) {
+      if (shutdown.compareAndSet(null, duration)) {
+        return completion.future();
+      } else {
+        throw new IllegalStateException();
+      }
+    }
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
@@ -19,6 +19,7 @@ import io.vertx.core.http.impl.CleanableHttpClient;
 import io.vertx.core.http.impl.tcp.TcpHttpClientTransport;
 import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.internal.http.HttpClientInternal;
 import io.vertx.core.internal.net.NetClientInternal;
 import io.vertx.core.net.*;
 import io.vertx.core.net.impl.tcp.CleanableNetClient;
@@ -248,7 +249,36 @@ public class VertxTest extends VertxTestBase {
     } finally {
       vertx.close().await();
     }
+  }
 
+  @Test
+  public void testFinalizeHttpClientRegisteredWithCloseHook() {
+    Vertx vertx = Vertx.vertx();
+
+    try {
+
+      AtomicReference<HttpClientInternal> ref = new AtomicReference<>();
+
+      String id = vertx.deployVerticle(context -> {
+        HttpClientInternal client = (HttpClientInternal) vertx.createHttpClient();
+        ref.set(client);
+        return Future.succeededFuture();
+      }).await();
+
+      HttpClientInternal proxy = ref.getAndSet(null);
+      Assert.assertNotNull(proxy);
+      HttpClientInternal real = proxy.unwrap();
+      WeakReference<HttpClientInternal> realWeakRef = new WeakReference<>(real);
+      real = null;
+      proxy.close().await();
+      runGC();
+      Assert.assertNull(realWeakRef.get());
+      vertx.undeploy(id).await();
+      runGC();
+      Assert.assertNull(realWeakRef.get());
+    } finally {
+      vertx.close().await();
+    }
   }
 
   @Test
@@ -400,7 +430,7 @@ public class VertxTest extends VertxTestBase {
   }
 
   @Test
-  public void testStickContextFinalization() throws Exception {
+  public void testStickyContextFinalization() throws Exception {
     Vertx vertx = vertx();
     try {
       AtomicReference<WeakReference<Context>> ref = new AtomicReference<>();


### PR DESCRIPTION
- **Fix shared HTTP client implementation.**
- **Unregister the cleanable http client resource from the owner when the client closes**
