### PR TITLE
Support HTTP request trailers

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -235,6 +235,46 @@ public interface HttpClientRequest extends WriteStream<Buffer> {
   HttpClientRequest putHeader(CharSequence name, Iterable<CharSequence> values);
 
   /**
+   * @return The HTTP trailers
+   */
+  @CacheReturn
+  MultiMap trailers();
+
+  /**
+   * Put an HTTP trailer
+   * <p>
+   * Trailers are sent after the request body, so the request is always sent chunked when any
+   * trailer is set.
+   *
+   * @param name  the trailer name
+   * @param value  the trailer value
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpClientRequest putTrailer(String name, String value);
+
+  /**
+   * Like {@link #putTrailer(String, String)} but using CharSequence
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  HttpClientRequest putTrailer(CharSequence name, CharSequence value);
+
+  /**
+   * Like {@link #putTrailer(String, String)} but providing multiple values via a String Iterable
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  HttpClientRequest putTrailer(String name, Iterable<String> values);
+
+  /**
+   * Like {@link #putTrailer(String, Iterable)} but with CharSequence Iterable
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  @Fluent
+  HttpClientRequest putTrailer(CharSequence name, Iterable<CharSequence> value);
+
+  /**
    * Set the trace operation of this request.
    *
    * @param op the operation

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -150,6 +150,29 @@ public interface HttpServerRequest extends ReadStream<Buffer>, HttpRequestHead {
   HttpServerResponse response();
 
   /**
+   * Return the first trailer value with the specified name
+   * <p>
+   * Trailers are only available after the request has been fully received, i.e. after the
+   * {@link #endHandler(Handler) end handler} has been called.
+   *
+   * @param trailerName  the trailer name
+   * @return the trailer value
+   */
+  @Nullable String getTrailer(String trailerName);
+
+  /**
+   * Return the trailers.
+   * <p>
+   * Trailers are only available after the request has been fully received, i.e. after the
+   * {@link #endHandler(Handler) end handler} has been called. Before that, and for requests
+   * that carry no trailers, the returned map is empty.
+   *
+   * @return the trailers
+   */
+  @CacheReturn
+  MultiMap trailers();
+
+  /**
    * Override the charset to use for decoding the query parameter map, when none is set, {@code UTF8} is used.
    *
    * @param charset the charset to use for decoding query params

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -37,6 +37,11 @@ public interface HttpClientConnection extends HttpConnection {
   MultiMap newHttpRequestHeaders();
 
   /**
+   * @return an empty trailer map suitable for this connection's protocol
+   */
+  MultiMap newHttpTrailers();
+
+  /**
    * @return the number of active request/response (streams)
    */
   long activeStreams();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -56,6 +56,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   private int maxRedirects;
   private int numberOfRedirections;
   private final MultiMap headers;
+  private MultiMap trailers;
   private boolean trailersSent;
   private boolean headersSent;
   private StreamPriority priority;
@@ -203,6 +204,42 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   @Override
   public MultiMap headers() {
     return headers;
+  }
+
+  @Override
+  public synchronized MultiMap trailers() {
+    if (trailers == null) {
+      trailers = stream.connection().newHttpTrailers();
+    }
+    return trailers;
+  }
+
+  @Override
+  public synchronized HttpClientRequest putTrailer(String name, String value) {
+    checkEnded();
+    trailers().set(name, value);
+    return this;
+  }
+
+  @Override
+  public synchronized HttpClientRequest putTrailer(CharSequence name, CharSequence value) {
+    checkEnded();
+    trailers().set(name, value);
+    return this;
+  }
+
+  @Override
+  public synchronized HttpClientRequest putTrailer(String name, Iterable<String> values) {
+    checkEnded();
+    trailers().set(name, values);
+    return this;
+  }
+
+  @Override
+  public synchronized HttpClientRequest putTrailer(CharSequence name, Iterable<CharSequence> value) {
+    checkEnded();
+    trailers().set(name, value);
+    return this;
   }
 
   @Override
@@ -531,6 +568,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
     boolean writeHead;
     boolean writeEnd;
     boolean chunked;
+    MultiMap trailersToSend;
     synchronized (this) {
       if (reset != null) {
         return context.failedFuture(reset);
@@ -557,16 +595,31 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
           }
         }
       }
+      // Trailers ride on the terminating chunk, so the request must be chunked: Netty
+      // silently drops trailing headers when a Content-Length framing is used.
+      // Captured under the lock, like every other value used after it, so the reference is
+      // safely published to whichever thread performs the write.
+      trailersToSend = end && !connect && !isConnect && trailers != null && !trailers.isEmpty()
+        ? trailers
+        : null;
       if (!headersSent) {
         if (!connect) {
-          boolean requiresContentLength = !this.chunked && !headers.contains(CONTENT_LENGTH);
-          if (end) {
-            if (buff != null && requiresContentLength) {
-              headers().set(CONTENT_LENGTH, HttpUtils.positiveLongToString(buff.length()));
+          if (trailersToSend != null) {
+            if (!this.chunked) {
+              headers.remove(CONTENT_LENGTH);
+              headers.set(TRANSFER_ENCODING, CHUNKED);
+              this.chunked = true;
             }
-          } else if (requiresContentLength) {
-            headers.set(TRANSFER_ENCODING, CHUNKED);
-            this.chunked = true;
+          } else {
+            boolean requiresContentLength = !this.chunked && !headers.contains(CONTENT_LENGTH);
+            if (end) {
+              if (buff != null && requiresContentLength) {
+                headers().set(CONTENT_LENGTH, HttpUtils.positiveLongToString(buff.length()));
+              }
+            } else if (requiresContentLength) {
+              headers.set(TRANSFER_ENCODING, CHUNKED);
+              this.chunked = true;
+            }
           }
         }
         headersSent = true;
@@ -576,7 +629,8 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
         writeHead = false;
       }
       chunked = this.chunked;
-      writeEnd = !isConnect && end;
+      // Suppress the body's end marker so the trailers can carry it instead.
+      writeEnd = !isConnect && end && trailersToSend == null;
       trailersSent = end;
     }
 
@@ -594,6 +648,12 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
         throw new IllegalArgumentException();
       }
       future = stream.writeChunk(buff, writeEnd);
+    }
+    if (trailersToSend != null) {
+      MultiMap t = trailersToSend;
+      // Composed rather than fired-and-forgotten: the request is only complete once the
+      // trailers are written, and a failed body write must not emit them.
+      future = future.compose(v -> stream.writeHeaders(t, true));
     }
     if (end) {
       tryComplete();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -148,6 +148,31 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
+  public MultiMap trailers() {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public HttpClientRequest putTrailer(String name, String value) {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public HttpClientRequest putTrailer(CharSequence name, CharSequence value) {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public HttpClientRequest putTrailer(String name, Iterable<String> values) {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public HttpClientRequest putTrailer(CharSequence name, Iterable<CharSequence> value) {
+    throw new IllegalStateException();
+  }
+
+  @Override
   public HttpClientRequest traceOperation(String op) {
     throw new IllegalStateException();
   }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -28,12 +28,6 @@ public interface HttpClientStream extends HttpStream {
 
   Future<Void> writeHead(HttpRequestHead request, boolean chunked, Buffer buf, boolean end, StreamPriority priority, boolean connect);
 
-  /**
-   * Writes a trailing header block, mirroring {@link HttpServerStream#writeHeaders(MultiMap, boolean)}.
-   * Only called after the request body has been written with {@code end == false}.
-   */
-  Future<Void> writeHeaders(MultiMap headers, boolean end);
-
   HttpClientStream headHandler(Handler<HttpResponseHead> handler);
   HttpClientStream resetHandler(Handler<Long> handler);
   HttpClientStream exceptionHandler(Handler<Throwable> handler);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -28,6 +28,12 @@ public interface HttpClientStream extends HttpStream {
 
   Future<Void> writeHead(HttpRequestHead request, boolean chunked, Buffer buf, boolean end, StreamPriority priority, boolean connect);
 
+  /**
+   * Writes a trailing header block, mirroring {@link HttpServerStream#writeHeaders(MultiMap, boolean)}.
+   * Only called after the request body has been written with {@code end == false}.
+   */
+  Future<Void> writeHeaders(MultiMap headers, boolean end);
+
   HttpClientStream headHandler(Handler<HttpResponseHead> handler);
   HttpClientStream resetHandler(Handler<Long> handler);
   HttpClientStream exceptionHandler(Handler<Throwable> handler);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -27,6 +27,7 @@ import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.*;
+import io.vertx.core.http.impl.headers.HeadersAdaptor;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.http.QueryParamDecoder;
 import io.vertx.core.net.HostAndPort;
@@ -60,6 +61,7 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
   private HostAndPort realAuthority;
   private String absoluteURI;
   private MultiMap attributes;
+  private MultiMap trailers;
   private HttpEventHandler eventHandler;
   private boolean ended;
   private Handler<HttpServerFileUpload> uploadHandler;
@@ -188,6 +190,13 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
   public void handleTrailers(MultiMap trailers) {
     HttpEventHandler handler;
     synchronized (connection) {
+      // Setting the trailers must not race with trailers(), where the field can escape:
+      // if the user already obtained the empty map, update it in place instead.
+      if (this.trailers == null) {
+        this.trailers = trailers;
+      } else if (this.trailers != trailers) {
+        this.trailers.setAll(trailers);
+      }
       ended = true;
       if (postRequestDecoder != null) {
         try {
@@ -372,6 +381,25 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
   @Override
   public MultiMap headers() {
     return headersMap;
+  }
+
+  @Override
+  public MultiMap trailers() {
+    synchronized (connection) {
+      if (trailers == null) {
+        trailers = new HeadersAdaptor(new DefaultHttpHeaders());
+      }
+      return trailers;
+    }
+  }
+
+  @Override
+  public String getTrailer(String trailerName) {
+    MultiMap trailers;
+    synchronized (connection) {
+      trailers = this.trailers;
+    }
+    return trailers != null ? trailers.get(trailerName) : null;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -191,8 +191,6 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
   public void handleTrailers(MultiMap trailers) {
     HttpEventHandler handler;
     synchronized (connection) {
-      // Setting the trailers must not race with trailers(), where the field can escape:
-      // if the user already obtained the empty map, update it in place instead.
       if (this.trailers == null) {
         this.trailers = trailers;
       } else if (this.trailers != trailers) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -28,6 +28,7 @@ import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.*;
+import io.vertx.core.http.impl.headers.HeadersAdaptor;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.http.QueryParamDecoder;
 import io.vertx.core.net.HostAndPort;
@@ -61,6 +62,7 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
   private HostAndPort realAuthority;
   private String absoluteURI;
   private MultiMap attributes;
+  private MultiMap trailers;
   private HttpEventHandler eventHandler;
   private boolean ended;
   private Handler<HttpServerFileUpload> uploadHandler;
@@ -189,6 +191,13 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
   public void handleTrailers(MultiMap trailers) {
     HttpEventHandler handler;
     synchronized (connection) {
+      // Setting the trailers must not race with trailers(), where the field can escape:
+      // if the user already obtained the empty map, update it in place instead.
+      if (this.trailers == null) {
+        this.trailers = trailers;
+      } else if (this.trailers != trailers) {
+        this.trailers.setAll(trailers);
+      }
       ended = true;
       if (postRequestDecoder != null) {
         try {
@@ -378,6 +387,25 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
   @Override
   public MultiMap headers() {
     return headersMap;
+  }
+
+  @Override
+  public MultiMap trailers() {
+    synchronized (connection) {
+      if (trailers == null) {
+        trailers = new HeadersAdaptor(new DefaultHttpHeaders());
+      }
+      return trailers;
+    }
+  }
+
+  @Override
+  public String getTrailer(String trailerName) {
+    MultiMap trailers;
+    synchronized (connection) {
+      trailers = this.trailers;
+    }
+    return trailers != null ? trailers.get(trailerName) : null;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerStream.java
@@ -34,7 +34,6 @@ public interface HttpServerStream extends HttpStream {
   HttpServerConnection connection();
 
   Future<Void> writeHead(HttpResponseHead head, Buffer chunk, boolean end);
-  Future<Void> writeHeaders(MultiMap headers, boolean end);
 
   Future<HttpServerStream> sendPush(HostAndPort authority, HttpMethod method, MultiMap headers, String path, StreamPriority priority);
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpStream.java
@@ -44,6 +44,7 @@ public interface HttpStream {
   ByteBufAllocator allocator();
 
   Future<Void> writeChunk(Buffer buf, boolean end);
+  Future<Void> writeHeaders(MultiMap headers, boolean end);
   Future<Void> writeFrame(int type, int flags, Buffer payload);
   Future<Void> writeReset(long code);
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
@@ -83,6 +83,14 @@ class StatisticsGatheringHttpClientStream implements HttpClientStream {
   }
 
   @Override
+  public Future<Void> writeHeaders(MultiMap headers, boolean end) {
+    if (end) {
+      endpointRequest.reportRequestEnd();
+    }
+    return delegate.writeHeaders(headers, end);
+  }
+
+  @Override
   public Future<Void> writeChunk(Buffer buf, boolean end) {
     if (end) {
       endpointRequest.reportRequestEnd();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
@@ -77,6 +77,14 @@ class StatisticsGatheringHttpClientStream implements HttpClientStream {
   }
 
   @Override
+  public Future<Void> writeHeaders(MultiMap headers, boolean end) {
+    if (end) {
+      endpointRequest.reportRequestEnd();
+    }
+    return delegate.writeHeaders(headers, end);
+  }
+
+  @Override
   public Future<Void> writeChunk(Buffer buf, boolean end) {
     if (end) {
       endpointRequest.reportRequestEnd();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
@@ -31,6 +31,7 @@ import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.vertx.core.*;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.http.HttpMethod;
@@ -141,6 +142,11 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
 
   @Override
   public MultiMap newHttpRequestHeaders() {
+    return Http1xHeaders.httpHeaders();
+  }
+
+  @Override
+  public MultiMap newHttpTrailers() {
     return Http1xHeaders.httpHeaders();
   }
 
@@ -388,6 +394,26 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
         stream.request = request;
         beginRequest(stream, request, chunked, buf, end, connect, listener);
       }
+      @Override
+      public void cancel(Throwable cause) {
+        listener.fail(cause);
+      }
+    });
+  }
+
+  private void writeTrailers(Stream stream, io.netty.handler.codec.http.HttpHeaders trailers, Promise<Void> listener) {
+    writeToChannel(new MessageWrite() {
+      @Override
+      public void write() {
+        if (stream.reset) {
+          listener.fail("Stream reset");
+          return;
+        }
+        assert current == stream;
+        unsafeWrite(new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, trailers), listener);
+        endRequest(stream);
+      }
+
       @Override
       public void cancel(Throwable cause) {
         listener.fail(cause);
@@ -661,6 +687,14 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
       PromiseInternal<Void> promise = context.promise();
       conn.writeHead(this, request, chunked, buf != null ? ((BufferInternal)buf).getByteBuf() : null, end, connect, promise);
       return promise.future();
+    }
+
+    @Override
+    public Future<Void> writeHeaders(MultiMap headers, boolean end) {
+      // HTTP/1 trailers ride on the terminating zero-length chunk.
+      Promise<Void> listener = context.promise();
+      conn.writeTrailers(this, (io.netty.handler.codec.http.HttpHeaders) headers, listener);
+      return listener.future();
     }
 
     @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
@@ -32,6 +32,7 @@ import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.vertx.core.*;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.http.HttpMethod;
@@ -142,6 +143,11 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
 
   @Override
   public MultiMap newHttpRequestHeaders() {
+    return Http1xHeaders.httpHeaders();
+  }
+
+  @Override
+  public MultiMap newHttpTrailers() {
     return Http1xHeaders.httpHeaders();
   }
 
@@ -389,6 +395,26 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
         stream.request = request;
         beginRequest(stream, request, chunked, buf, end, connect, listener);
       }
+      @Override
+      public void cancel(Throwable cause) {
+        listener.fail(cause);
+      }
+    });
+  }
+
+  private void writeTrailers(Stream stream, io.netty.handler.codec.http.HttpHeaders trailers, Promise<Void> listener) {
+    writeToChannel(new MessageWrite() {
+      @Override
+      public void write() {
+        if (stream.reset) {
+          listener.fail("Stream reset");
+          return;
+        }
+        assert current == stream;
+        unsafeWrite(new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, trailers), listener);
+        endRequest(stream);
+      }
+
       @Override
       public void cancel(Throwable cause) {
         listener.fail(cause);
@@ -667,6 +693,14 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
       PromiseInternal<Void> promise = context.promise();
       conn.writeHead(this, request, chunked, buf != null ? ((BufferInternal)buf).getByteBuf() : null, end, connect, promise);
       return promise.future();
+    }
+
+    @Override
+    public Future<Void> writeHeaders(MultiMap headers, boolean end) {
+      // HTTP/1 trailers ride on the terminating zero-length chunk.
+      Promise<Void> listener = context.promise();
+      conn.writeTrailers(this, (io.netty.handler.codec.http.HttpHeaders) headers, listener);
+      return listener.future();
     }
 
     @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerConnection.java
@@ -246,18 +246,21 @@ public class Http1ServerConnection extends Http1Connection implements HttpServer
     Buffer buffer = BufferInternal.safeBuffer(content.content());
     Http1ServerRequest request = requestInProgress;
     request.handleContent(buffer);
-    //TODO chunk trailers
     if (content instanceof LastHttpContent) {
-      onEnd();
+      onEnd(((LastHttpContent) content).trailingHeaders());
     }
   }
 
   private void onEnd() {
+    onEnd(null);
+  }
+
+  private void onEnd(HttpHeaders trailers) {
     boolean tryClose;
     Http1ServerRequest request = requestInProgress;
     requestInProgress = null;
     tryClose = (wantClose || shutdownInitiated != null) && responseInProgress == null;
-    request.handleEnd();
+    request.handleEnd(trailers);
     if (tryClose) {
       closeInternal();
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
@@ -71,6 +71,7 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
 
   // Cache this for performance
   private MultiMap headers;
+  private MultiMap trailers;
   private String absoluteURI;
 
   private HttpEventHandler eventHandler;
@@ -103,6 +104,11 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
             @Override
             protected void handleMessage(Object elt) {
               if (elt == InboundBuffer.END_SENTINEL) {
+                onEnd();
+              } else if (elt instanceof MultiMap) {
+                // Trailers travel through the queue so they cannot be observed before the
+                // preceding data has been delivered.
+                setTrailers((MultiMap) elt);
                 onEnd();
               } else {
                 onData((Buffer) elt);
@@ -155,19 +161,37 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
     }
   }
 
-  void handleEnd() {
+  void handleEnd(HttpHeaders nettyTrailers) {
+    Object end = nettyTrailers != null && !nettyTrailers.isEmpty()
+      ? new HeadersAdaptor(nettyTrailers)
+      : InboundBuffer.END_SENTINEL;
     InboundMessageQueue<Object> queue = queue(false);
     if (queue != null) {
-      handleEnd(queue);
+      handleEnd(queue, end);
     } else {
+      if (end != InboundBuffer.END_SENTINEL) {
+        setTrailers((MultiMap) end);
+      }
       context.execute(this, Http1ServerRequest::onEnd);
     }
   }
 
-  private void handleEnd(InboundMessageQueue<Object> queue) {
-    boolean drain = queue.add(InboundBuffer.END_SENTINEL);
+  private void handleEnd(InboundMessageQueue<Object> queue, Object end) {
+    boolean drain = queue.add(end);
     if (drain) {
       queue.drain();
+    }
+  }
+
+  private void setTrailers(MultiMap trailers) {
+    synchronized (conn) {
+      // Must not race with trailers(), where the field can escape: if the user already
+      // obtained the empty map, update it in place instead of replacing it.
+      if (this.trailers == null) {
+        this.trailers = trailers;
+      } else if (this.trailers != trailers) {
+        this.trailers.setAll(trailers);
+      }
     }
   }
 
@@ -280,6 +304,25 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
   @Override
   public HostAndPort authority(boolean real) {
     return real ? null : authority();
+  }
+
+  @Override
+  public MultiMap trailers() {
+    synchronized (conn) {
+      if (trailers == null) {
+        trailers = new HeadersAdaptor(new DefaultHttpHeaders());
+      }
+      return trailers;
+    }
+  }
+
+  @Override
+  public String getTrailer(String trailerName) {
+    MultiMap trailers;
+    synchronized (conn) {
+      trailers = this.trailers;
+    }
+    return trailers != null ? trailers.get(trailerName) : null;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
@@ -72,6 +72,7 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
 
   // Cache this for performance
   private MultiMap headers;
+  private MultiMap trailers;
   private String absoluteURI;
 
   private HttpEventHandler eventHandler;
@@ -104,6 +105,11 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
             @Override
             protected void handleMessage(Object elt) {
               if (elt == InboundBuffer.END_SENTINEL) {
+                onEnd();
+              } else if (elt instanceof MultiMap) {
+                // Trailers travel through the queue so they cannot be observed before the
+                // preceding data has been delivered.
+                setTrailers((MultiMap) elt);
                 onEnd();
               } else {
                 onData((Buffer) elt);
@@ -156,19 +162,37 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
     }
   }
 
-  void handleEnd() {
+  void handleEnd(HttpHeaders nettyTrailers) {
+    Object end = nettyTrailers != null && !nettyTrailers.isEmpty()
+      ? new HeadersAdaptor(nettyTrailers)
+      : InboundBuffer.END_SENTINEL;
     InboundMessageQueue<Object> queue = queue(false);
     if (queue != null) {
-      handleEnd(queue);
+      handleEnd(queue, end);
     } else {
+      if (end != InboundBuffer.END_SENTINEL) {
+        setTrailers((MultiMap) end);
+      }
       context.execute(this, Http1ServerRequest::onEnd);
     }
   }
 
-  private void handleEnd(InboundMessageQueue<Object> queue) {
-    boolean drain = queue.add(InboundBuffer.END_SENTINEL);
+  private void handleEnd(InboundMessageQueue<Object> queue, Object end) {
+    boolean drain = queue.add(end);
     if (drain) {
       queue.drain();
+    }
+  }
+
+  private void setTrailers(MultiMap trailers) {
+    synchronized (conn) {
+      // Must not race with trailers(), where the field can escape: if the user already
+      // obtained the empty map, update it in place instead of replacing it.
+      if (this.trailers == null) {
+        this.trailers = trailers;
+      } else if (this.trailers != trailers) {
+        this.trailers.setAll(trailers);
+      }
     }
   }
 
@@ -286,6 +310,25 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
   @Override
   public HostAndPort authority(boolean real) {
     return real ? null : authority();
+  }
+
+  @Override
+  public MultiMap trailers() {
+    synchronized (conn) {
+      if (trailers == null) {
+        trailers = new HeadersAdaptor(new DefaultHttpHeaders());
+      }
+      return trailers;
+    }
+  }
+
+  @Override
+  public String getTrailer(String trailerName) {
+    MultiMap trailers;
+    synchronized (conn) {
+      trailers = this.trailers;
+    }
+    return trailers != null ? trailers.get(trailerName) : null;
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
@@ -107,8 +107,6 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
               if (elt == InboundBuffer.END_SENTINEL) {
                 onEnd();
               } else if (elt instanceof MultiMap) {
-                // Trailers travel through the queue so they cannot be observed before the
-                // preceding data has been delivered.
                 setTrailers((MultiMap) elt);
                 onEnd();
               } else {
@@ -186,8 +184,6 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
 
   private void setTrailers(MultiMap trailers) {
     synchronized (conn) {
-      // Must not race with trailers(), where the field can escape: if the user already
-      // obtained the empty map, update it in place instead of replacing it.
       if (this.trailers == null) {
         this.trailers = trailers;
       } else if (this.trailers != trailers) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ClientConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ClientConnectionImpl.java
@@ -29,6 +29,7 @@ import io.vertx.core.net.HostAndPort;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.TransportMetrics;
 import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.core.http.impl.headers.HttpHeaders;
 
 import java.time.Duration;
 
@@ -76,6 +77,11 @@ public class Http2ClientConnectionImpl extends Http2ConnectionImpl implements Ht
   @Override
   public MultiMap newHttpRequestHeaders() {
     return new HttpResponseHeaders(new DefaultHttp2Headers());
+  }
+
+  @Override
+  public MultiMap newHttpTrailers() {
+    return new HttpHeaders(new DefaultHttp2Headers());
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ServerConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ServerConnectionImpl.java
@@ -148,8 +148,10 @@ public class Http2ServerConnectionImpl extends Http2ConnectionImpl implements Ht
       stream.context().execute(stream.unwrap(), streamHandler);
       stream.onHeaders(headersMap);
     } else {
-      // Http server request trailer - not implemented yet (in api)
+      // Trailing HEADERS frame: carry the trailers to the request instead of discarding them.
       stream = nettyStream.getProperty(streamKey);
+      stream.onTrailers(new HttpHeaders(headers));
+      return;
     }
     if (endOfStream) {
       stream.onTrailers();

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexClientConnection.java
@@ -32,6 +32,7 @@ import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.spi.metrics.ClientMetrics;
 import io.vertx.core.spi.metrics.TransportMetrics;
+import io.vertx.core.http.impl.headers.HttpHeaders;
 
 public class Http2MultiplexClientConnection extends Http2MultiplexConnection<Http2ClientStream> implements HttpClientConnection, Http2ClientConnection {
 
@@ -75,6 +76,11 @@ public class Http2MultiplexClientConnection extends Http2MultiplexConnection<Htt
   @Override
   public MultiMap newHttpRequestHeaders() {
     return new HttpResponseHeaders(new DefaultHttp2Headers());
+  }
+
+  @Override
+  public MultiMap newHttpTrailers() {
+    return new HttpHeaders(new DefaultHttp2Headers());
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ClientConnection.java
@@ -35,6 +35,7 @@ import io.vertx.core.spi.observability.HttpRequest;
 import io.vertx.core.spi.observability.HttpResponse;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.core.http.impl.headers.HttpHeaders;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -94,6 +95,11 @@ public class Http3ClientConnection extends Http3Connection implements HttpClient
   @Override
   public MultiMap newHttpRequestHeaders() {
     return new HttpRequestHeaders(new DefaultHttp3Headers());
+  }
+
+  @Override
+  public MultiMap newHttpTrailers() {
+    return new HttpHeaders(new DefaultHttp3Headers());
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ClientStream.java
@@ -123,6 +123,11 @@ public class Http3ClientStream extends Http3Stream<Http3ClientStream, Http3Clien
   }
 
   @Override
+  public Future<Void> writeHeaders(MultiMap headers, boolean end) {
+    return writeHeaders((HttpHeaders) headers, null, end);
+  }
+
+  @Override
   public Future<Void> writeHead(HttpRequestHead request, boolean chunked, Buffer chunk, boolean end, StreamPriority priority, boolean connect) {
     HttpRequestHeaders headers = ((HttpRequestHeaders)request.headers());
     headers.authority(request.authority);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
@@ -86,6 +86,11 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
   }
 
   @Override
+  public MultiMap newHttpTrailers() {
+    return Http1xHeaders.httpHeaders();
+  }
+
+  @Override
   public HostAndPort authority() {
     return current.authority();
   }
@@ -168,6 +173,11 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
     @Override
     public Future<Void> writeHead(io.vertx.core.http.impl.HttpRequestHead request, boolean chunked, Buffer buf, boolean end, StreamPriority priority, boolean connect) {
       return delegate.writeHead(request, chunked, buf, end, priority, connect);
+    }
+
+    @Override
+    public Future<Void> writeHeaders(MultiMap headers, boolean end) {
+      return delegate.writeHeaders(headers, end);
     }
 
     @Override
@@ -632,6 +642,28 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
         return upgradedStream.isWritable();
       } else {
         return upgradingStream.isWritable();
+      }
+    }
+
+    @Override
+    public Future<Void> writeHeaders(MultiMap headers, boolean end) {
+      EventExecutor exec = upgradingConnection.channelHandlerContext().executor();
+      if (exec.inEventLoop()) {
+        Future<Void> future = upgradingStream.writeHeaders(headers, end);
+        if (end) {
+          // Trailers terminate the request, so the buffered messages must be flushed here too.
+          ChannelPipeline pipeline = upgradingConnection.channelHandlerContext().pipeline();
+          future = future.andThen(ar -> {
+            if (ar.succeeded()) {
+              pipeline.fireUserEventTriggered(SEND_BUFFERED_MESSAGES_EVENT);
+            }
+          });
+        }
+        return future;
+      } else {
+        Promise<Void> promise = upgradingStream.context().promise();
+        exec.execute(() -> writeHeaders(headers, end).onComplete(promise));
+        return promise.future();
       }
     }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
@@ -85,6 +85,11 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
   }
 
   @Override
+  public MultiMap newHttpTrailers() {
+    return Http1xHeaders.httpHeaders();
+  }
+
+  @Override
   public HostAndPort authority() {
     return current.authority();
   }
@@ -162,6 +167,11 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
     @Override
     public Future<Void> writeHead(io.vertx.core.http.impl.HttpRequestHead request, boolean chunked, Buffer buf, boolean end, StreamPriority priority, boolean connect) {
       return delegate.writeHead(request, chunked, buf, end, priority, connect);
+    }
+
+    @Override
+    public Future<Void> writeHeaders(MultiMap headers, boolean end) {
+      return delegate.writeHeaders(headers, end);
     }
 
     @Override
@@ -621,6 +631,28 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
         return upgradedStream.isWritable();
       } else {
         return upgradingStream.isWritable();
+      }
+    }
+
+    @Override
+    public Future<Void> writeHeaders(MultiMap headers, boolean end) {
+      EventExecutor exec = upgradingConnection.channelHandlerContext().executor();
+      if (exec.inEventLoop()) {
+        Future<Void> future = upgradingStream.writeHeaders(headers, end);
+        if (end) {
+          // Trailers terminate the request, so the buffered messages must be flushed here too.
+          ChannelPipeline pipeline = upgradingConnection.channelHandlerContext().pipeline();
+          future = future.andThen(ar -> {
+            if (ar.succeeded()) {
+              pipeline.fireUserEventTriggered(SEND_BUFFERED_MESSAGES_EVENT);
+            }
+          });
+        }
+        return future;
+      } else {
+        Promise<Void> promise = upgradingStream.context().promise();
+        exec.execute(() -> writeHeaders(headers, end).onComplete(promise));
+        return promise.future();
       }
     }
 

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
@@ -132,6 +132,16 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
+  public String getTrailer(String trailerName) {
+    return delegate.getTrailer(trailerName);
+  }
+
+  @Override
+  public MultiMap trailers() {
+    return delegate.trailers();
+  }
+
+  @Override
   public HttpServerRequest setParamsCharset(String charset) {
     return delegate.setParamsCharset(charset);
   }

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
@@ -131,6 +131,16 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   }
 
   @Override
+  public String getTrailer(String trailerName) {
+    return delegate.getTrailer(trailerName);
+  }
+
+  @Override
+  public MultiMap trailers() {
+    return delegate.trailers();
+  }
+
+  @Override
   public HttpServerRequest setParamsCharset(String charset) {
     return delegate.setParamsCharset(charset);
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -3417,6 +3417,50 @@ public class Http1xTest extends HttpTest {
       .await();
   }
   @Test
+  public void testRequestTrailers(Checkpoint checkpoint) throws Exception {
+    server.requestHandler(req -> {
+      req.endHandler(v -> {
+        assertEquals("chunky", req.getTrailer("X-Trailer"));
+        assertEquals("other", req.getTrailer("X-Other"));
+        assertEquals(2, req.trailers().size());
+        checkpoint.succeed();
+      });
+      req.response().end();
+    });
+    startServer(testAddress);
+    NetClient client = vertx.createNetClient();
+    NetSocket so = client.connect(testAddress).await();
+    so.write("POST / HTTP/1.1\r\n" +
+      "Host: localhost\r\n" +
+      "Transfer-Encoding: chunked\r\n" +
+      "Trailer: X-Trailer\r\n" +
+      "\r\n" +
+      "5\r\nhello\r\n" +
+      "0\r\n" +
+      "X-Trailer: chunky\r\n" +
+      "X-Other: other\r\n" +
+      "\r\n");
+    checkpoint.awaitSuccess();
+  }
+
+  @Test
+  public void testRequestNoTrailers(Checkpoint checkpoint) throws Exception {
+    server.requestHandler(req -> {
+      req.endHandler(v -> {
+        assertTrue(req.trailers().isEmpty());
+        assertNull(req.getTrailer("X-Trailer"));
+        checkpoint.succeed();
+      });
+      req.response().end();
+    });
+    startServer(testAddress);
+    client.request(requestOptions)
+      .compose(req -> req.send(Buffer.buffer("hello")))
+      .await();
+    checkpoint.awaitSuccess();
+  }
+
+  @Test
   public void testInvalidTrailerInHttpServerRequest(Checkpoint checkpoint) throws Exception {
     testHttpServerRequestDecodeError(checkpoint, so -> {
       so.write("0\r\n"); // Empty chunk

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -3396,6 +3396,50 @@ public class Http1xTest extends HttpTest {
       .await();
   }
   @Test
+  public void testRequestTrailers(Checkpoint checkpoint) throws Exception {
+    server.requestHandler(req -> {
+      req.endHandler(v -> {
+        assertEquals("chunky", req.getTrailer("X-Trailer"));
+        assertEquals("other", req.getTrailer("X-Other"));
+        assertEquals(2, req.trailers().size());
+        checkpoint.succeed();
+      });
+      req.response().end();
+    });
+    startServer(testAddress);
+    NetClient client = vertx.createNetClient();
+    NetSocket so = client.connect(testAddress).await();
+    so.write("POST / HTTP/1.1\r\n" +
+      "Host: localhost\r\n" +
+      "Transfer-Encoding: chunked\r\n" +
+      "Trailer: X-Trailer\r\n" +
+      "\r\n" +
+      "5\r\nhello\r\n" +
+      "0\r\n" +
+      "X-Trailer: chunky\r\n" +
+      "X-Other: other\r\n" +
+      "\r\n");
+    checkpoint.awaitSuccess();
+  }
+
+  @Test
+  public void testRequestNoTrailers(Checkpoint checkpoint) throws Exception {
+    server.requestHandler(req -> {
+      req.endHandler(v -> {
+        assertTrue(req.trailers().isEmpty());
+        assertNull(req.getTrailer("X-Trailer"));
+        checkpoint.succeed();
+      });
+      req.response().end();
+    });
+    startServer(testAddress);
+    client.request(requestOptions)
+      .compose(req -> req.send(Buffer.buffer("hello")))
+      .await();
+    checkpoint.awaitSuccess();
+  }
+
+  @Test
   public void testInvalidTrailerInHttpServerRequest(Checkpoint checkpoint) throws Exception {
     testHttpServerRequestDecodeError(checkpoint, so -> {
       so.write("0\r\n"); // Empty chunk

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2ServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2ServerTest.java
@@ -884,6 +884,55 @@ public class Http2ServerTest extends Http2TestBase {
   }
 
   @Test
+  public void testRequestTrailers() throws Exception {
+    server.requestHandler(req -> {
+      req.handler(buff -> {});
+      req.endHandler(v -> {
+        Assert.assertEquals("chunky", req.getTrailer("x-trailer"));
+        Assert.assertEquals("other", req.getTrailer("x-other"));
+        Assert.assertEquals(2, req.trailers().size());
+        req.response().end();
+        testComplete();
+      });
+    });
+    startServer();
+    TestClient client = new TestClient();
+    client.connect(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, request -> {
+      int id = request.nextStreamId();
+      request.encoder.writeHeaders(request.context, id, POST("/").set("content-type", "text/plain"), 0, false, request.context.newPromise());
+      request.encoder.writeData(request.context, id, ((BufferInternal) Buffer.buffer("hello")).getByteBuf(), 0, false, request.context.newPromise());
+      Http2Headers trailers = new DefaultHttp2Headers();
+      trailers.set("x-trailer", "chunky");
+      trailers.set("x-other", "other");
+      request.encoder.writeHeaders(request.context, id, trailers, 0, true, request.context.newPromise());
+      request.context.flush();
+    });
+    await();
+  }
+
+  @Test
+  public void testRequestNoTrailers() throws Exception {
+    server.requestHandler(req -> {
+      req.handler(buff -> {});
+      req.endHandler(v -> {
+        Assert.assertTrue(req.trailers().isEmpty());
+        Assert.assertNull(req.getTrailer("x-trailer"));
+        req.response().end();
+        testComplete();
+      });
+    });
+    startServer();
+    TestClient client = new TestClient();
+    client.connect(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, request -> {
+      int id = request.nextStreamId();
+      request.encoder.writeHeaders(request.context, id, POST("/").set("content-type", "text/plain"), 0, false, request.context.newPromise());
+      request.encoder.writeData(request.context, id, ((BufferInternal) Buffer.buffer("hello")).getByteBuf(), 0, true, request.context.newPromise());
+      request.context.flush();
+    });
+    await();
+  }
+
+  @Test
   public void testTrailers() throws Exception {
     server.requestHandler(req -> {
       HttpServerResponse resp = req.response();

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -1682,6 +1682,70 @@ public abstract class HttpTest extends SimpleHttpTest2 {
   }
 
   @Test
+  public void testRequestTrailers() throws Exception {
+    AtomicReference<String> trailer = new AtomicReference<>();
+    AtomicReference<String> other = new AtomicReference<>();
+    AtomicInteger size = new AtomicInteger(-1);
+    server.requestHandler(req -> {
+      req.endHandler(v -> {
+        trailer.set(req.getTrailer("X-Trailer"));
+        other.set(req.getTrailer("X-Other"));
+        size.set(req.trailers().size());
+        req.response().end();
+      });
+    });
+    startServer(testAddress);
+    client.request(requestOptions)
+      .compose(req -> {
+        req.putTrailer("X-Trailer", "chunky");
+        req.putTrailer("X-Other", "other");
+        return req.send(Buffer.buffer("some-content")).compose(HttpClientResponse::end);
+      })
+      .await();
+    assertEquals("chunky", trailer.get());
+    assertEquals("other", other.get());
+    assertEquals(2, size.get());
+  }
+
+  @Test
+  public void testRequestTrailersWithoutBody() throws Exception {
+    AtomicReference<String> trailer = new AtomicReference<>();
+    server.requestHandler(req -> {
+      req.endHandler(v -> {
+        trailer.set(req.getTrailer("X-Trailer"));
+        req.response().end();
+      });
+    });
+    startServer(testAddress);
+    client.request(requestOptions)
+      .compose(req -> {
+        req.putTrailer("X-Trailer", "chunky");
+        return req.send().compose(HttpClientResponse::end);
+      })
+      .await();
+    assertEquals("chunky", trailer.get());
+  }
+
+  @Test
+  public void testRequestNoTrailers() throws Exception {
+    AtomicInteger size = new AtomicInteger(-1);
+    AtomicReference<String> trailer = new AtomicReference<>();
+    server.requestHandler(req -> {
+      req.endHandler(v -> {
+        size.set(req.trailers().size());
+        trailer.set(req.getTrailer("X-Trailer"));
+        req.response().end();
+      });
+    });
+    startServer(testAddress);
+    client.request(requestOptions)
+      .compose(req -> req.send(Buffer.buffer("some-content")).compose(HttpClientResponse::end))
+      .await();
+    assertEquals(0, size.get());
+    assertNull(trailer.get());
+  }
+
+  @Test
   public void testResponseNoTrailers() throws Exception {
     server.requestHandler(req -> {
       req.response().setChunked(true);
@@ -4012,6 +4076,11 @@ public abstract class HttpTest extends SimpleHttpTest2 {
       public HttpClientRequest putHeader(CharSequence name, CharSequence value) { throw new UnsupportedOperationException(); }
       public HttpClientRequest putHeader(String name, Iterable<String> values) { throw new UnsupportedOperationException(); }
       public HttpClientRequest putHeader(CharSequence name, Iterable<CharSequence> values) { throw new UnsupportedOperationException(); }
+      public MultiMap trailers() { throw new UnsupportedOperationException(); }
+      public HttpClientRequest putTrailer(String name, String value) { throw new UnsupportedOperationException(); }
+      public HttpClientRequest putTrailer(CharSequence name, CharSequence value) { throw new UnsupportedOperationException(); }
+      public HttpClientRequest putTrailer(String name, Iterable<String> values) { throw new UnsupportedOperationException(); }
+      public HttpClientRequest putTrailer(CharSequence name, Iterable<CharSequence> value) { throw new UnsupportedOperationException(); }
       public Future<Void> write(String chunk) { throw new UnsupportedOperationException(); }
       public Future<Void> write(String chunk, String enc) { throw new UnsupportedOperationException(); }
       public HttpClientRequest traceOperation(String op) { throw new UnsupportedOperationException(); }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -1684,6 +1684,70 @@ public abstract class HttpTest extends SimpleHttpTest2 {
   }
 
   @Test
+  public void testRequestTrailers() throws Exception {
+    AtomicReference<String> trailer = new AtomicReference<>();
+    AtomicReference<String> other = new AtomicReference<>();
+    AtomicInteger size = new AtomicInteger(-1);
+    server.requestHandler(req -> {
+      req.endHandler(v -> {
+        trailer.set(req.getTrailer("X-Trailer"));
+        other.set(req.getTrailer("X-Other"));
+        size.set(req.trailers().size());
+        req.response().end();
+      });
+    });
+    startServer(testAddress);
+    client.request(requestOptions)
+      .compose(req -> {
+        req.putTrailer("X-Trailer", "chunky");
+        req.putTrailer("X-Other", "other");
+        return req.send(Buffer.buffer("some-content")).compose(HttpClientResponse::end);
+      })
+      .await();
+    assertEquals("chunky", trailer.get());
+    assertEquals("other", other.get());
+    assertEquals(2, size.get());
+  }
+
+  @Test
+  public void testRequestTrailersWithoutBody() throws Exception {
+    AtomicReference<String> trailer = new AtomicReference<>();
+    server.requestHandler(req -> {
+      req.endHandler(v -> {
+        trailer.set(req.getTrailer("X-Trailer"));
+        req.response().end();
+      });
+    });
+    startServer(testAddress);
+    client.request(requestOptions)
+      .compose(req -> {
+        req.putTrailer("X-Trailer", "chunky");
+        return req.send().compose(HttpClientResponse::end);
+      })
+      .await();
+    assertEquals("chunky", trailer.get());
+  }
+
+  @Test
+  public void testRequestNoTrailers() throws Exception {
+    AtomicInteger size = new AtomicInteger(-1);
+    AtomicReference<String> trailer = new AtomicReference<>();
+    server.requestHandler(req -> {
+      req.endHandler(v -> {
+        size.set(req.trailers().size());
+        trailer.set(req.getTrailer("X-Trailer"));
+        req.response().end();
+      });
+    });
+    startServer(testAddress);
+    client.request(requestOptions)
+      .compose(req -> req.send(Buffer.buffer("some-content")).compose(HttpClientResponse::end))
+      .await();
+    assertEquals(0, size.get());
+    assertNull(trailer.get());
+  }
+
+  @Test
   public void testResponseNoTrailers() throws Exception {
     server.requestHandler(req -> {
       req.response().setChunked(true);
@@ -4014,6 +4078,11 @@ public abstract class HttpTest extends SimpleHttpTest2 {
       public HttpClientRequest putHeader(CharSequence name, CharSequence value) { throw new UnsupportedOperationException(); }
       public HttpClientRequest putHeader(String name, Iterable<String> values) { throw new UnsupportedOperationException(); }
       public HttpClientRequest putHeader(CharSequence name, Iterable<CharSequence> values) { throw new UnsupportedOperationException(); }
+      public MultiMap trailers() { throw new UnsupportedOperationException(); }
+      public HttpClientRequest putTrailer(String name, String value) { throw new UnsupportedOperationException(); }
+      public HttpClientRequest putTrailer(CharSequence name, CharSequence value) { throw new UnsupportedOperationException(); }
+      public HttpClientRequest putTrailer(String name, Iterable<String> values) { throw new UnsupportedOperationException(); }
+      public HttpClientRequest putTrailer(CharSequence name, Iterable<CharSequence> value) { throw new UnsupportedOperationException(); }
       public Future<Void> write(String chunk) { throw new UnsupportedOperationException(); }
       public Future<Void> write(String chunk, String enc) { throw new UnsupportedOperationException(); }
       public HttpClientRequest traceOperation(String op) { throw new UnsupportedOperationException(); }

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ServerTest.java
@@ -123,7 +123,8 @@ public class Http3ServerTest extends VertxTestBase {
 
     server.requestHandler(req -> {
       req.bodyHandler(body -> {
-        // No API to get client trailers
+        Assert.assertEquals("value", req.getTrailer("key"));
+        Assert.assertEquals(1, req.trailers().size());
         req.response().end(body);
       });
     });

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ServerTest.java
@@ -143,6 +143,54 @@ public class Http3ServerTest extends VertxTestBase {
   }
 
   @Test
+  public void testRequestTrailers() throws Exception{
+
+    server.requestHandler(req -> {
+      req.handler(buff -> {});
+      req.endHandler(v -> {
+        Assert.assertEquals("chunky", req.getTrailer("x-trailer"));
+        Assert.assertEquals("other", req.getTrailer("x-other"));
+        Assert.assertEquals(2, req.trailers().size());
+        req.response().end("done");
+      });
+    });
+
+    server.listen(8443, "localhost").await();
+
+    Http3TestClient.Client.Connection connection = client.connect(new InetSocketAddress(NetUtil.LOCALHOST4, 8443));
+    Http3TestClient.Client.Stream stream = connection.stream();
+
+    stream.write(new DefaultHttp3Headers().method("POST").path("/"));
+    stream.write("hello".getBytes(StandardCharsets.UTF_8));
+    stream.end(new DefaultHttp3Headers().set("x-trailer", "chunky").set("x-other", "other"));
+
+    Assert.assertEquals("done", new String(stream.responseBody()));
+  }
+
+  @Test
+  public void testRequestNoTrailers() throws Exception{
+
+    server.requestHandler(req -> {
+      req.handler(buff -> {});
+      req.endHandler(v -> {
+        Assert.assertTrue(req.trailers().isEmpty());
+        Assert.assertNull(req.getTrailer("x-trailer"));
+        req.response().end("done");
+      });
+    });
+
+    server.listen(8443, "localhost").await();
+
+    Http3TestClient.Client.Connection connection = client.connect(new InetSocketAddress(NetUtil.LOCALHOST4, 8443));
+    Http3TestClient.Client.Stream stream = connection.stream();
+
+    stream.write(new DefaultHttp3Headers().method("POST").path("/"));
+    stream.end("hello".getBytes(StandardCharsets.UTF_8));
+
+    Assert.assertEquals("done", new String(stream.responseBody()));
+  }
+
+  @Test
   public void testUnknownFrame() throws Exception{
 
     server.requestHandler(req -> {


### PR DESCRIPTION
Fixes #5253. Two commits: the server reading request trailers, and the client sending them.

`HttpServerRequest` has no way to read trailers, while `HttpClientResponse` exposes `trailers()` and `getTrailer()`. The trailers do arrive — Netty parses them — but the server drops them, and the code already marked both spots:

- `Http1ServerConnection.onContent`: `//TODO chunk trailers`
- `Http2ServerConnectionImpl.onHeadersRead`: `// Http server request trailer - not implemented yet (in api)`

`HttpServerRequestImpl.handleTrailers(MultiMap)` was already receiving the trailers and discarding them.

### Change

`HttpServerRequest` gains `getTrailer(String)` and `trailers()`, declared exactly as on `HttpClientResponse` (`@Nullable` on the former, `@CacheReturn` on the latter). Before the request has ended, and for requests without trailers, `trailers()` returns an empty map rather than null — matching the client side.

- **HTTP/1.1** — `Http1ServerConnection` passes `LastHttpContent.trailingHeaders()` down, and `Http1ServerRequest` writes them into the inbound message queue rather than setting a field directly, so they cannot be observed before the preceding data has been delivered. This mirrors `Http1ClientConnection.onEnd(LastHttpContent)`.
- **HTTP/2 (codec)** — the trailing HEADERS frame is forwarded via `stream.onTrailers(headers)` instead of signalling empty trailers, mirroring `Http2ClientConnectionImpl`.
- **HTTP/2 (multiplex), HTTP/3, QUIC** — already forwarded trailers correctly; unchanged.
- `HttpServerRequestWrapper` gains the two delegating overrides.

Setting the trailers uses the same escape-safe merge as `HttpClientResponseImpl.handleTrailers`: if the caller already obtained the lazily-allocated empty map, it is updated in place instead of replaced.

### Tests

Covering all three protocols:

- **HTTP/1.1** — `Http1xTest.testRequestTrailers` / `testRequestNoTrailers`, driven over a raw socket since the client cannot send trailers.
- **HTTP/2** — `Http2ServerTest.testRequestTrailers` / `testRequestNoTrailers`, sending a trailing HEADERS frame via the Netty test client. Because `Http2MultiplexServerTest extends Http2ServerTest`, these run against both the codec and multiplex connection implementations.
- **HTTP/3** — `Http3ServerTest.testTrailers` already sent request trailers but could only note `// No API to get client trailers`; it now asserts them.

`Http1xTest` (504) and `Http2Test` (359) pass. Each new assertion was checked by reverting the corresponding production change: dropping the HTTP/1 plumbing fails `Http1xTest.testRequestTrailers`, and dropping `stream.onTrailers(...)` in the HTTP/2 codec fails `Http2ServerTest.testRequestTrailers`.

Note: five `testUpgradeToClearText*` / `testPriorKnowledge` cases in `Http2ServerTest` fail on my machine with `BindException: Address already in use` on port 8080, identically on unmodified `master` — a local port conflict, unrelated to this change.

### Second commit — client sending

`HttpClientRequest` gains `trailers()` and the four `putTrailer` overloads, declared exactly as on `HttpServerResponse`.

Trailers ride on the terminating chunk, so a request carrying them is always sent chunked — Netty silently discards trailing headers under `Content-Length` framing, which would yield a request that looks correct and arrives without its trailers. `HttpClientRequestImpl` drops `Content-Length`, forces `Transfer-Encoding`, writes the body with `end=false` and emits the trailers as the terminating write, mirroring `HttpServerResponseImpl`.

`HttpClientStream` gains `writeHeaders(MultiMap, boolean)` — the counterpart of the method `HttpServerStream` already had. HTTP/2 needs no new wire code (`DefaultHttp2Stream` already implements it, covering codec and multiplex); HTTP/3 reuses the server adapter; HTTP/1 is the only new wire path. `HttpClientConnection` gains `newHttpTrailers()` so the protocol-agnostic request can obtain a suitably backed map.

Because the client can now send trailers, the new tests live in `HttpTest` and therefore run under `Http1xTest`, `Http2Test` **and** `Http3Test`: trailers with a body, trailers without a body, and a request with none. Removing the chunked coercion fails `testRequestTrailers` rather than passing silently.

The raw-socket and raw-Netty tests from the first commit are kept on purpose — they show the server accepts trailers from a **non-Vert.x** client, which a test driving our own client cannot demonstrate.

Full run across the affected classes: **1200 tests, 0 failures**. (Two `BindException` errors on my machine come from an unrelated process holding port 8080; they reproduce on unmodified `master`.)

### Concurrency and async

Nothing here blocks — no `await`, `executeBlocking`, latch or synchronous result access is introduced on either side.

- In `HttpClientRequestImpl.doWrite`, the trailers reference is captured **inside** the existing `synchronized` block, alongside the other values used after it (`chunked`, `writeEnd`, `writeHead`), so it is safely published to whichever thread performs the write.
- The trailers write is **composed** onto the body write rather than issued independently: the future returned by `end()` completes only once the trailers are on the wire, and a failed body write short-circuits so trailers are never emitted onto a broken stream.
- The new HTTP/1 `writeTrailers` goes through the connection's outbound `MessageWrite` queue like an ordinary body write, so back-pressure behaviour is unchanged, and every path — stream reset, cancel, successful write — completes the promise. (A missed path there would hang a request rather than fail it.)
- `Http2UpgradeClientConnection.UpgradingStream.writeHeaders` re-dispatches to the event loop when invoked from another thread and still fires `SEND_BUFFERED_MESSAGES_EVENT` on end, mirroring `writeChunk`.
- On the server side, trailers travel through the request's inbound message queue rather than being assigned to a field directly, so they cannot be observed ahead of the data that preceded them under pause/resume.

The `synchronized (conn)` usage follows the existing idiom in these classes: short critical sections with no I/O performed under the lock.

I also have this backported to `4.x` if a maintenance backport is wanted.
