### PR TITLE
HTTP client pool should not consider two keys with the same host and distinct IP addresses to be equals.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/EndpointKey.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/EndpointKey.java
@@ -23,21 +23,27 @@ public final class EndpointKey {
   // Todo : that should become a scheme ???
   final boolean ssl;
   final HttpVersion protocol;
-  final SocketAddress server;
+  private final SocketAddress server;
+  private final ProxyOptions proxyOptions;
   final HostAndPort authority;
-  final ProxyOptions proxyOptions;
   final ClientSSLOptions sslOptions;
 
-  public EndpointKey(boolean ssl, HttpVersion protocol, ClientSSLOptions sslOptions, ProxyOptions proxyOptions, SocketAddress server, HostAndPort authority) {
-    if (server == null) {
-      throw new NullPointerException("No null server address");
-    }
+  public EndpointKey(boolean ssl, HttpVersion protocol, ClientSSLOptions sslOptions, SocketAddress server, HostAndPort authority) {
+    this.ssl = ssl;
+    this.protocol = protocol;
+    this.sslOptions = sslOptions;
+    this.proxyOptions = null;
+    this.authority = authority;
+    this.server = server;
+  }
+
+  public EndpointKey(boolean ssl, HttpVersion protocol, ClientSSLOptions sslOptions, ProxyOptions proxyOptions, HostAndPort authority) {
     this.ssl = ssl;
     this.protocol = protocol;
     this.sslOptions = sslOptions;
     this.proxyOptions = proxyOptions;
     this.authority = authority;
-    this.server = server;
+    this.server = null;
   }
 
   @Override
@@ -47,7 +53,7 @@ public final class EndpointKey {
     }
     if (o instanceof EndpointKey) {
       EndpointKey that = (EndpointKey) o;
-      return ssl == that.ssl && Objects.equals(protocol, that.protocol) && server.equals(that.server) && Objects.equals(authority, that.authority) && Objects.equals(sslOptions, that.sslOptions) && equals(proxyOptions, that.proxyOptions);
+      return ssl == that.ssl && Objects.equals(protocol, that.protocol) && Objects.equals(server, that.server) && Objects.equals(authority, that.authority) && Objects.equals(sslOptions, that.sslOptions) && equals(proxyOptions, that.proxyOptions);
     }
     return false;
   }
@@ -56,12 +62,14 @@ public final class EndpointKey {
   public int hashCode() {
     int result = ssl ? 1 : 0;
     result = 31 * result + (protocol == null ? 0 : protocol.hashCode());
-    result = 31 * result + server.hashCode();
     if (authority != null) {
       result = 31 * result + authority.hashCode();
     }
     if (sslOptions != null) {
       result = 31 * result + sslOptions.hashCode();
+    }
+    if (server != null) {
+      result = 31 * result + server.hashCode();
     }
     if (proxyOptions != null) {
       result = 31 * result + hashCode(proxyOptions);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -184,17 +184,20 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     }
   }
 
-  private Function<EndpointKey, SharedHttpClientConnectionGroup> httpEndpointProvider(boolean resolveOrigin, HttpClientTransport transport) {
+  private Function<EndpointKey, SharedHttpClientConnectionGroup> httpEndpointProvider(boolean resolveOrigin, SocketAddress server, ProxyOptions _proxyOptions, HttpClientTransport transport) {
     return (key) -> {
       int maxPoolSize = Math.max(poolOptions.getHttp1MaxSize(), poolOptions.getHttp2MaxSize());
-      ClientMetrics clientMetrics = HttpClientImpl.this.httpMetrics != null ? HttpClientImpl.this.httpMetrics.createEndpointMetrics(key.server, maxPoolSize) : null;
+      ClientMetrics clientMetrics = HttpClientImpl.this.httpMetrics != null ? HttpClientImpl.this.httpMetrics.createEndpointMetrics(server, maxPoolSize) : null;
       PoolMetrics poolMetrics = HttpClientImpl.this.httpMetrics != null ? vertx.metrics().createPoolMetrics("http", key.authority.toString(), maxPoolSize) : null;
-      ProxyOptions proxyOptions = key.proxyOptions;
+      ProxyOptions proxyOptions = _proxyOptions;
       ClientSSLOptions sslOptions = key.sslOptions;
+      SocketAddress connect;
       if (proxyOptions != null && !key.ssl && proxyOptions.getType() == ProxyType.HTTP) {
-        SocketAddress server = SocketAddress.inetSocketAddress(proxyOptions.getPort(), proxyOptions.getHost());
-        key = new EndpointKey(key.ssl, key.protocol, sslOptions, proxyOptions, server, key.authority);
+        connect = SocketAddress.inetSocketAddress(proxyOptions.getPort(), proxyOptions.getHost());
+        key = new EndpointKey(key.ssl, key.protocol, sslOptions, proxyOptions, key.authority);
         proxyOptions = null;
+      } else {
+        connect = server;
       }
       HttpVersion protocol = key.protocol;
       List<HttpVersion> protocols;
@@ -243,7 +246,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
         p,
         poolMetrics,
         key.authority,
-        key.server);
+        connect);
     };
   }
 
@@ -519,11 +522,20 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     String traceOperation,
     long idleTimeout,
     boolean followRedirects,
-    ProxyOptions proxyOptions, SocketAddress server, boolean useSSL, ClientSSLOptions sslOptions,
-                                 HostAndPort authority, long connectTimeout) {
+    ProxyOptions proxyOptions,
+    SocketAddress server,
+    boolean useSSL,
+    ClientSSLOptions sslOptions,
+    HostAndPort authority,
+    long connectTimeout) {
     ContextInternal streamCtx = vertx.getOrCreateContext();
-    EndpointKey key = new EndpointKey(useSSL, protocol, sslOptions, proxyOptions, server, authority);
-    Future<ConnectionObtainedResult> fut2 = resourceManager.withResourceAsync(key, httpEndpointProvider(false, transport), (endpoint, created) -> {
+    EndpointKey key;
+    if (proxyOptions != null) {
+      key = new EndpointKey(useSSL, protocol, sslOptions, proxyOptions, authority);
+    } else {
+      key = new EndpointKey(useSSL, protocol, sslOptions, server, authority);
+    }
+    Future<ConnectionObtainedResult> fut2 = resourceManager.withResourceAsync(key, httpEndpointProvider(false, server, proxyOptions, transport), (endpoint, created) -> {
       Future<Lease<HttpClientConnection>> fut = endpoint.requestConnection(streamCtx, connectTimeout);
       return fut.compose(lease -> {
         HttpClientConnection conn = lease.get();
@@ -735,14 +747,20 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
                         SocketAddress server,
                         HostAndPort authority,
                         Function<SharedHttpClientConnectionGroup, Future<T>> function) {
-    EndpointKey key = new EndpointKey(useSSL, protocol != null ? protocol.version() : null, sslOptions, null, server, authority);
+    SocketAddress serverKey = server;
+    if (serverKey.hostAddress() != null && Objects.equals(server.host(), authority.host())) {
+      // Ensure that two keys with same authority and distinct IP addresses are distinct
+      // such as DNS client side load balancing
+      serverKey = SocketAddress.inetSocketAddress(server.port(), server.hostAddress());
+    }
+    EndpointKey key = new EndpointKey(useSSL, protocol != null ? protocol.version() : null, sslOptions, serverKey, authority);
     HttpClientTransport transport;
     if (protocol != null && protocol.version() == HttpVersion.HTTP_3) {
       transport = quicTransport;
     } else {
       transport = tcpTransport;
     }
-    Function<EndpointKey, SharedHttpClientConnectionGroup> provider = httpEndpointProvider(resolveOrigin, transport);
+    Function<EndpointKey, SharedHttpClientConnectionGroup> provider = httpEndpointProvider(resolveOrigin, server, null, transport);
     return resourceManager.withResourceAsync(key, provider, (group, created) -> function.apply(group));
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/WebSocketClientImpl.java
@@ -94,14 +94,14 @@ public class WebSocketClientImpl extends HttpClientBase implements WebSocketClie
     HostAndPort peer = HostAndPort.create(host, port);
     ProxyOptions proxyOptions = computeProxyOptions(connectOptions.getProxyOptions(), addr);
     ClientSSLOptions sslOptions = sslOptions(options.isVerifyHost(), connectOptions, defaultSslOptions);
-    EndpointKey key = new EndpointKey(connectOptions.isSsl() != null ? connectOptions.isSsl() : options.isSsl(), HttpVersion.HTTP_1_1, sslOptions, proxyOptions, addr, peer);
+    EndpointKey key = new EndpointKey(connectOptions.isSsl() != null ? connectOptions.isSsl() : options.isSsl(), HttpVersion.HTTP_1_1, sslOptions, proxyOptions, peer);
     // todo: cache
     Function<EndpointKey, WebSocketGroup> provider = (key_) -> {
       int maxPoolSize = options.getMaxConnections();
-      ClientMetrics clientMetrics = WebSocketClientImpl.this.httpMetrics != null ? WebSocketClientImpl.this.httpMetrics.createEndpointMetrics(key_.server, maxPoolSize) : null;
-      PoolMetrics queueMetrics = WebSocketClientImpl.this.httpMetrics != null ? vertx.metrics().createPoolMetrics("ws", key_.server.toString(), maxPoolSize) : null;
-      HttpConnectParams params = new HttpConnectParams(List.of(HttpVersion.HTTP_1_1), sslOptions, key_.proxyOptions, key_.ssl);
-      return new WebSocketGroup(key_.server, httpMetrics, clientMetrics, queueMetrics, options, maxPoolSize, connector, params, key_.authority, 0L);
+      ClientMetrics clientMetrics = WebSocketClientImpl.this.httpMetrics != null ? WebSocketClientImpl.this.httpMetrics.createEndpointMetrics(addr, maxPoolSize) : null;
+      PoolMetrics queueMetrics = WebSocketClientImpl.this.httpMetrics != null ? vertx.metrics().createPoolMetrics("ws", addr.toString(), maxPoolSize) : null;
+      HttpConnectParams params = new HttpConnectParams(List.of(HttpVersion.HTTP_1_1), sslOptions, proxyOptions, key_.ssl);
+      return new WebSocketGroup(addr, httpMetrics, clientMetrics, queueMetrics, options, maxPoolSize, connector, params, key_.authority, 0L);
     };
     webSocketCM
       .withResourceAsync(key, provider, (endpoint, created) -> endpoint.requestConnection(ctx, connectOptions, 0L))

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -45,6 +45,7 @@ import io.vertx.test.http.SimpleHttpTest2;
 import io.vertx.test.tls.Cert;
 import io.vertx.tests.http.http3.Http3Test;
 import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -64,6 +65,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.*;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static io.vertx.core.http.HttpMethod.*;
@@ -6172,31 +6174,64 @@ public abstract class HttpTest extends SimpleHttpTest2 {
 
   @WithDnsServer(records = {@DnsRecord(name = "vertx.io", address = "127.0.0.1"), @DnsRecord(name = "vertx.io", address = "127.0.0.2")})
   @Test
-  public void testDnsClientSideLoadBalancingDisabled(Checkpoint checkpoint) throws Exception {
-    testDnsClientSideLoadBalancing(checkpoint, false);
+  public void testDnsClientSideLoadBalancingDisabled() throws Exception {
+    testDnsClientSideLoadBalancing(false);
   }
 
   @WithDnsServer(records = {@DnsRecord(name = "vertx.io", address = "127.0.0.1"), @DnsRecord(name = "vertx.io", address = "127.0.0.2")})
   @Test
-  public void testDnsClientSideLoadBalancingEnabled(Checkpoint checkpoint) throws Exception {
-    testDnsClientSideLoadBalancing(checkpoint, true);
+  public void testDnsClientSideLoadBalancingEnabled() throws Exception {
+    testDnsClientSideLoadBalancing(true);
   }
 
-  private void testDnsClientSideLoadBalancing(Checkpoint checkpoint, boolean enabled) throws Exception {
-    AtomicInteger val = new AtomicInteger();
+  private void testDnsClientSideLoadBalancing(boolean enabled) {
+    List<String> hosts = List.of("127.0.0.1", "127.0.0.2");
+    List<String> actualHosts = new ArrayList<>();
+    for (String host : hosts) {
+      try {
+        HttpServer server = config
+          .forServer()
+          .create(vertx)
+          .requestHandler(request -> request.response().end())
+          .listen(DEFAULT_HTTP_PORT, host)
+          .await();
+        actualHosts.add(host);
+      } catch (Exception e) {
+        // Could be a bind error on MacOS or Windows
+        // on MacOS : 'sudo ifconfig lo0 alias 127.0.0.2 up'
+      }
+    }
+    AtomicReference<Set<String>> balancedHosts = new AtomicReference<>();
+    AtomicInteger idx = new AtomicInteger();
     HttpClient client = config
       .forClient()
+      .setVerifyHost(false)
       .setConnectTimeout(Duration.ofMillis(500))
       .builder(vertx)
       .withLoadBalancer(enabled ? endpoints -> () -> {
-        val.set(endpoints.size());
-        return 0;
+        balancedHosts.set(endpoints
+          .stream()
+          .map(se -> se.address().hostAddress())
+          .collect(Collectors.toSet()));
+        return idx.getAndIncrement() % endpoints.size();
       } : null)
       .build();
-    client.request(HttpMethod.GET,"vertx.io", "/").onComplete(TestUtils.onFailure(err -> {
-      assertEquals(enabled ? 2 : 0, val.get());
-      checkpoint.succeed();
-    }));
+    Set<String> ipAdresses = new HashSet<>();
+    for (int i = 0;i < hosts.size();i++) {
+      SocketAddress addr = client
+        .request(GET, DEFAULT_HTTP_PORT, "vertx.io", "/")
+        .compose(r -> {
+          return r.send().compose(resp -> resp.end().map(r.connection().remoteAddress()));
+        })
+        .await();
+      ipAdresses.add(addr.hostAddress());
+    }
+    if (enabled) {
+      Assertions.assertThat(ipAdresses).containsAll(actualHosts);
+      Assertions.assertThat(balancedHosts.get()).containsAll(hosts);
+    } else {
+      assertEquals(Set.of("127.0.0.1"), ipAdresses);
+    }
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/impl/EndPointKeyTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/impl/EndPointKeyTest.java
@@ -29,25 +29,25 @@ public class EndPointKeyTest {
   public void testEndPointKey() {
     final SocketAddress addr = SocketAddress.inetSocketAddress(8080, "localhost");
     final HostAndPort peer = HostAndPort.create("localhost", 8080);
-    EndpointKey key1 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions(), addr, peer);
-    EndpointKey key2 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions(), addr, peer);
+    EndpointKey key1 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, addr, peer);
+    EndpointKey key2 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, addr, peer);
     assertEquals(key1, key2);
     assertEquals(key1.hashCode(), key2.hashCode());
-    EndpointKey key3 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setUsername("foo").setPassword("bar"), addr, peer);
-    EndpointKey key4 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setUsername("foo").setPassword("bar"), addr, peer);
+    EndpointKey key3 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setUsername("foo").setPassword("bar"), peer);
+    EndpointKey key4 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setUsername("foo").setPassword("bar"), peer);
     assertEquals(key3, key4);
     assertEquals(key3.hashCode(), key4.hashCode());
-    EndpointKey key5 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setHost("localhost"), addr, peer);
-    EndpointKey key6 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setHost("127.0.0.1"), addr, peer);
+    EndpointKey key5 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setHost("localhost"), peer);
+    EndpointKey key6 = new EndpointKey(false, HttpVersion.HTTP_1_1, null, new ProxyOptions().setHost("127.0.0.1"), peer);
     assertNotEquals(key5, key6);
     assertNotEquals(key5.hashCode(), key6.hashCode());
     assertNotEquals(key1.hashCode(), key6.hashCode());
     EndpointKey key7 = new EndpointKey(false, HttpVersion.HTTP_1_1, null,
-      new ProxyOptions().setProxyAuthorization("Negotiate token-1"), addr, peer);
+      new ProxyOptions().setProxyAuthorization("Negotiate token-1"), peer);
     EndpointKey key8 = new EndpointKey(false, HttpVersion.HTTP_1_1, null,
-      new ProxyOptions().setProxyAuthorization("Negotiate token-1"), addr, peer);
+      new ProxyOptions().setProxyAuthorization("Negotiate token-1"), peer);
     EndpointKey key9 = new EndpointKey(false, HttpVersion.HTTP_1_1, null,
-      new ProxyOptions().setProxyAuthorization("Negotiate token-2"), addr, peer);
+      new ProxyOptions().setProxyAuthorization("Negotiate token-2"), peer);
     assertEquals(key7, key8);
     assertEquals(key7.hashCode(), key8.hashCode());
     assertNotEquals(key7, key9);


### PR DESCRIPTION
Motivation:

HTTP client pool key comparison relies on the server address equality, this implies that two keys have the same host but distinct ip addresses are equals.

As consequence the endpoint will use the same pool and connections to the server.

This happens with DNS client side load balancing that provides a list of endpoint with the same host but different IP addresses.

Changes:

Change the HTTP client pool endpoint key to use the IP address as host when the host is equals to the server authority.

Avoid reusing the endpoint key fields as it used to be and instead use objects provided when building the pool instead, since the fields might change.
