### PR TITLE
fix: resolve double-slash path in FileResolverImpl when fileName is root

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/file/impl/FileResolverImpl.java
@@ -264,7 +264,7 @@ public class FileResolverImpl implements FileResolver {
       String[] listing = resource.list();
       if (listing != null) {
         for (String file : listing) {
-          String subResource = fileName + "/" + file;
+          String subResource = fileName + (fileName.endsWith("/") ? "" : "/") + file;
           URL url2 = getValidClassLoaderResource(cl, subResource);
           unpackFromFileURL(url2, subResource, cl);
         }
@@ -410,12 +410,12 @@ public class FileResolverImpl implements FileResolver {
   /**
    * bundle:// urls are used by OSGi implementations to refer to a file contained in a bundle, or in a fragment. There
    * is not much we can do to get the file from it, except reading it from the url. This method copies the files by
-   * reading it from the url.
-   *
-   * @param url the url
-   * @param  fileName the file name used to cache the content
-   * @return the extracted file
-   */
+  * reading it from the url.
+  *
+  * @param url the url
+  * @param  fileName the file name used to cache the content
+  * @return the extracted file
+  */
   private File unpackFromBundleURL(URL url, String fileName, boolean isDir) {
     try {
       if ((getClassLoader() != null && isBundleUrlDirectory(url)) || isDir) {


### PR DESCRIPTION
## Description

Fixes #6280

When `FileResolverImpl.resolve()` is called with an absolute path (e.g., `/application.yml`), the `parentFile` loop in `resolveFile2()` reaches the root path `/` and calls `unpackUrlResource(url, "/", cl, true)`. In `unpackFromFileURL`, when iterating over the directory listing, the `subResource` construction concatenates `fileName + "/" + file`, producing `//application.yml` (double-slash prefix) instead of `/application.yml`.

This causes the subsequent `getValidClassLoaderResource(cl, subResource)` call to fail because `//application.yml` is not a valid classpath resource path.

### Root cause
`unpackFromFileURL` unconditionally adds `/` between `fileName` and `file`, but when `fileName` is already `/` (the root path), this produces a double-slash prefix.

### Fix
Use a conditional separator: append `/` only when `fileName` does not already end with `/`.

```java
String subResource = fileName + (fileName.endsWith("/") ? "" : "/") + file;
```

### Steps to reproduce
1. Call `fileResolver.resolveFile("/application.yml")` when the classloader has a resource root at a temp directory
2. Observe the exception caused by `//application.yml` not being found
