### PR TITLE
Stop using deprecated NoStackTraceThrowable in vertx-core internals

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/Completable.java
+++ b/vertx-core/src/main/java/io/vertx/core/Completable.java
@@ -10,8 +10,6 @@
  */
 package io.vertx.core;
 
-import io.vertx.core.impl.NoStackTraceThrowable;
-
 /**
  * A view of something that can be completed with a success or failure.
  *
@@ -57,7 +55,7 @@ public interface Completable<T> {
    * @throws IllegalStateException when this instance is already completed or failed
    */
   default void fail(String message) {
-    complete(null, new NoStackTraceThrowable(message));
+    complete(null, VertxException.noStackTrace(message));
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/Promise.java
+++ b/vertx-core/src/main/java/io/vertx/core/Promise.java
@@ -13,7 +13,6 @@ package io.vertx.core;
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
-import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.impl.future.PromiseImpl;
 
 
@@ -144,7 +143,7 @@ public interface Promise<T> extends Completable<T> {
    * @return false when the future is already completed
    */
   default boolean tryFail(String message) {
-    return tryFail(new NoStackTraceThrowable(message));
+    return tryFail(VertxException.noStackTrace(message));
   }
 
   /**

--- a/vertx-core/src/main/java/io/vertx/core/impl/future/FailedFuture.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/future/FailedFuture.java
@@ -14,7 +14,7 @@ package io.vertx.core.impl.future;
 import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.impl.NoStackTraceThrowable;
+import io.vertx.core.VertxException;
 import io.vertx.core.impl.Utils;
 import io.vertx.core.internal.ContextInternal;
 
@@ -46,7 +46,7 @@ public final class FailedFuture<T> extends FutureBase<T> {
    */
   public FailedFuture(ContextInternal context, Throwable t) {
     super(context);
-    this.cause = t != null ? t : new NoStackTraceThrowable(null);
+    this.cause = t != null ? t : VertxException.noStackTrace((String) null);
   }
 
   /**
@@ -62,7 +62,7 @@ public final class FailedFuture<T> extends FutureBase<T> {
    * @param failureMessage the failure message
    */
   public FailedFuture(ContextInternal context, String failureMessage) {
-    this(context, new NoStackTraceThrowable(failureMessage));
+    this(context, VertxException.noStackTrace(failureMessage));
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/impl/future/FutureImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/future/FutureImpl.java
@@ -12,7 +12,6 @@
 package io.vertx.core.impl.future;
 
 import io.vertx.core.*;
-import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.internal.ContextInternal;
 
 import java.util.ArrayList;
@@ -145,7 +144,7 @@ public class FutureImpl<T> extends FutureBase<T> {
 
   public final boolean tryFail(Throwable cause) {
     if (cause == null) {
-      cause = new NoStackTraceThrowable(null);
+      cause = VertxException.noStackTrace((String) null);
     }
     return completeInternal(null, cause);
   }

--- a/vertx-core/src/test/java/io/vertx/tests/future/FutureTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/future/FutureTest.java
@@ -14,7 +14,6 @@ package io.vertx.tests.future;
 import io.vertx.core.*;
 import io.vertx.core.Future;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.core.internal.FutureInternal;
 import io.vertx.core.internal.PromiseInternal;
 import io.vertx.test.core.Repeat;
@@ -330,8 +329,10 @@ public class FutureTest extends FutureTestBase {
   public void testCreateFailedWithNullFailure() {
     io.vertx.core.Future<String> future = io.vertx.core.Future.failedFuture((Throwable)null);
     Checker<String> checker = new Checker<>(future);
-    NoStackTraceThrowable failure = (NoStackTraceThrowable) checker.assertFailed();
+    Throwable failure = checker.assertFailed();
+    assertEquals(VertxException.class, failure.getClass());
     assertNull(failure.getMessage());
+    assertEquals(0, failure.getStackTrace().length);
   }
 
   @Test
@@ -339,8 +340,42 @@ public class FutureTest extends FutureTestBase {
     Promise<String> promise = Promise.promise();
     promise.fail((Throwable)null);
     Checker<String> checker = new Checker<>(promise.future());
-    NoStackTraceThrowable failure = (NoStackTraceThrowable) checker.assertFailed();
+    Throwable failure = checker.assertFailed();
+    assertEquals(VertxException.class, failure.getClass());
     assertNull(failure.getMessage());
+    assertEquals(0, failure.getStackTrace().length);
+  }
+
+  @Test
+  public void testFailWithMessage() {
+    Promise<String> promise = Promise.promise();
+    promise.fail("the-message");
+    Checker<String> checker = new Checker<>(promise.future());
+    Throwable failure = checker.assertFailed();
+    assertEquals(VertxException.class, failure.getClass());
+    assertEquals("the-message", failure.getMessage());
+    assertEquals(0, failure.getStackTrace().length);
+  }
+
+  @Test
+  public void testTryFailWithMessage() {
+    Promise<String> promise = Promise.promise();
+    assertTrue(promise.tryFail("the-message"));
+    Checker<String> checker = new Checker<>(promise.future());
+    Throwable failure = checker.assertFailed();
+    assertEquals(VertxException.class, failure.getClass());
+    assertEquals("the-message", failure.getMessage());
+    assertEquals(0, failure.getStackTrace().length);
+  }
+
+  @Test
+  public void testFailedFutureWithMessage() {
+    io.vertx.core.Future<String> future = io.vertx.core.Future.failedFuture("the-message");
+    Checker<String> checker = new Checker<>(future);
+    Throwable failure = checker.assertFailed();
+    assertEquals(VertxException.class, failure.getClass());
+    assertEquals("the-message", failure.getMessage());
+    assertEquals(0, failure.getStackTrace().length);
   }
 
   @Test
@@ -1913,7 +1948,7 @@ public class FutureTest extends FutureTestBase {
   @Test
   public void testAndThenComplete() {
     waitFor(4);
-    Throwable throwable = new NoStackTraceThrowable("test");
+    Throwable throwable = VertxException.noStackTrace("test");
 
     testAndThen(io.vertx.core.Future.succeededFuture(), null, null);
 
@@ -1934,7 +1969,7 @@ public class FutureTest extends FutureTestBase {
   @Repeat(times = 50)
   public void testAndThenCompleteContextual() {
     waitFor(4);
-    Throwable throwable = new NoStackTraceThrowable("test");
+    Throwable throwable = VertxException.noStackTrace("test");
 
     ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
 

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpClientTimeoutTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpClientTimeoutTest.java
@@ -299,6 +299,8 @@ public abstract class HttpClientTimeoutTest extends HttpTestBase2 {
         // Catch the first, the second is going to be a connection closed exception when the
         // server is shutdown on testComplete
         if (failed.compareAndSet(false, true)) {
+          assertTrue(t instanceof TimeoutException);
+          assertEquals(0, t.getStackTrace().length);
           checkpoint.succeed();
         }
       }));

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ClientTimeoutTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ClientTimeoutTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.http.http3;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientAgent;
+import io.vertx.core.http.HttpClientBuilder;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.test.core.Checkpoint;
+import io.vertx.test.http.HttpConfigurator;
+import io.vertx.tests.http.HttpClientTimeoutTest;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class Http3ClientTimeoutTest extends HttpClientTimeoutTest {
+
+  private final HttpConfigurator config = Http3Configurator.INSTANCE;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    testAddress = SocketAddress.inetSocketAddress(config.port(), config.host());
+    requestOptions = new RequestOptions()
+      .setHost(config.host())
+      .setPort(config.port())
+      .setURI(DEFAULT_TEST_URI);
+  }
+
+  @Override
+  protected HttpServer createHttpServer() {
+    return config.forServer().create(vertx);
+  }
+
+  @Override
+  protected HttpClientAgent createHttpClient() {
+    return config.forClient().create(vertx);
+  }
+
+  @Override
+  protected HttpClientBuilder httpClientBuilder(Vertx vertx) {
+    return config.forClient().builder(vertx);
+  }
+
+  @Ignore("Requires a saturated connection pool, needs stream concurrency limit support in the HTTP/3 test configurator")
+  @Test
+  @Override
+  public void testConnectTimeoutDoesFire() throws Exception {
+  }
+
+  @Ignore("Requires a saturated connection pool, needs stream concurrency limit support in the HTTP/3 test configurator")
+  @Test
+  @Override
+  public void testConnectTimeoutDoesNotFire() throws Exception {
+  }
+
+  @Ignore("Recreates the client from HttpClientOptions which cannot connect to an HTTP/3 server")
+  @Test
+  @Override
+  public void testRequestsTimeoutInQueue(Checkpoint checkpoint) throws Exception {
+  }
+
+  @Ignore("Recreates the client from HttpClientOptions which cannot connect to an HTTP/3 server")
+  @Test
+  @Override
+  public void testRequestTimeoutIsNotDelayedAfterResponseIsReceived(Checkpoint checkpoint) throws Exception {
+  }
+
+  @Ignore("Request idle timeout does not fire on HTTP/3 streams yet")
+  @Test
+  @Override
+  public void testRequestTimesOutWhenIndicatedPeriodExpiresWithoutAResponseFromRemoteServer(Checkpoint checkpoint) throws Exception {
+  }
+
+  @Ignore("Bypasses the HTTP/3 client under test with an HttpClientOptions based client and a NetServer")
+  @Test
+  @Override
+  public void testTimedOutWaiterDoesNotConnect(Checkpoint checkpoint) throws Exception {
+  }
+}


### PR DESCRIPTION
## Motivation

Fixes #5012.

`NoStackTraceThrowable` and `NoStackTraceException` are `@Deprecated(forRemoval = true)`, and 17bad9d7e introduced the transition path: users should catch/observe `VertxException` instead, with the class removal itself planned for Vert.x 6.

However vertx-core internals still instantiate `NoStackTraceThrowable`, so failures created from a message (`Promise#fail(String)`, `Promise#tryFail(String)`, `Future#failedFuture(String)`, `Completable#fail(String)`) or from a `null` cause still surface the deprecated type at runtime.

## Changes

- Replace the internal instantiations in `Completable`, `Promise`, `FailedFuture` and `FutureImpl` with the equivalent `VertxException.noStackTrace(...)` factory. Message and no-stack-trace behaviour are unchanged; the runtime type broadens to `VertxException` (the direct superclass and the documented replacement). `NoStackTraceException` has no remaining usage.
- The deprecated classes themselves are left untouched for removal in Vert.x 6, per 17bad9d7e. Happy to remove them in this PR instead if that is preferred for 5.2.
- `NoStackTraceTimeoutException` is intentionally out of scope: it is not deprecated and must remain a `java.util.concurrent.TimeoutException` for the HTTP client timeout contract.
- Tests: `FutureTest` now pins the failure contract (`VertxException` exact class, message preserved, empty stack trace) for the message/null-cause paths.
- Additional test coverage: the shared `HttpClientTimeoutTest` suite now also runs over HTTP/3 (`Http3ClientTimeoutTest` wired through `Http3Configurator`) and asserts that client request timeout failures are `TimeoutException` instances carrying no stack trace across HTTP/1, HTTP/2 and HTTP/3. HTTP/3 tests relying on behaviours not yet available (pool saturation semantics, client re-creation from `HttpClientOptions`, request idle timeout on streams) are `@Ignore`d with documented reasons.

## Compatibility

Code catching `VertxException` (the documented replacement) is unaffected since `NoStackTraceThrowable extends VertxException`. Only `instanceof NoStackTraceThrowable` checks observe the change, which is the pattern the deprecation instructs migrating away from.
