### PR TITLE
fix: avoid blocking WebSocket accept handshake on worker context

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/ServerWebSocketHandshaker.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/websocket/ServerWebSocketHandshaker.java
@@ -37,9 +37,7 @@ import java.security.cert.Certificate;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
@@ -101,21 +99,12 @@ public class ServerWebSocketHandshaker extends FutureImpl<ServerWebSocket> imple
       }
       done = true;
     }
-    ServerWebSocket ws;
-    try {
-      ws = acceptHandshake();
-    } catch (Exception e) {
-      return rejectHandshake(BAD_REQUEST.code())
-        .transform(ar -> {
-          if (ar.succeeded()) {
-            return request.context().failedFuture(e);
-          } else {
-            // result is null
-            return (Future) ar;
-          }
-        });
-    }
-    tryComplete(ws);
+    acceptHandshake()
+      .onSuccess(ws -> tryComplete(ws))
+      .onFailure(e -> {
+        tryFail(e);
+        rejectHandshake(BAD_REQUEST.code());
+      });
     return this;
   }
 
@@ -168,7 +157,7 @@ public class ServerWebSocketHandshaker extends FutureImpl<ServerWebSocket> imple
     return response.setStatusCode(sc).end(status.reasonPhrase());
   }
 
-  private ServerWebSocket acceptHandshake() {
+  private Future<ServerWebSocket> acceptHandshake() {
     Http1ServerConnection httpConn = (Http1ServerConnection) request.connection();
     ChannelHandlerContext chctx = httpConn.channelHandlerContext();
     Channel channel = chctx.channel();
@@ -198,25 +187,23 @@ public class ServerWebSocketHandshaker extends FutureImpl<ServerWebSocket> imple
       webSocketConn.metric(httpConn.metric());
       return webSocketConn;
     });
-    CompletableFuture<Void> latch = new CompletableFuture<>();
+    Promise<ServerWebSocket> promise = request.context().promise();
     httpConn.context().execute(() -> {
-      // Must be done on event-loop
-      pipeline.replace(VertxHandler.class, "handler", handler);
-      latch.complete(null);
+      try {
+        // pipeline swap must happen on the event-loop context
+        pipeline.replace(VertxHandler.class, "handler", handler);
+        ServerWebSocketImpl webSocket = (ServerWebSocketImpl) handler.getConnection().webSocket();
+        if (METRICS_ENABLED && httpConn.httpMetrics != null) {
+          httpConn.httpMetrics.requestUpgraded(request.metric());
+          webSocket.setMetric(httpConn.httpMetrics.connected(request));
+        }
+        webSocket.registerHandler(httpConn.context().owner().eventBus());
+        promise.complete(webSocket);
+      } catch (Exception e) {
+        promise.fail(e);
+      }
     });
-    // This should actually only block the thread on a worker thread
-    try {
-      latch.get(10, TimeUnit.SECONDS);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-    ServerWebSocketImpl webSocket = (ServerWebSocketImpl) handler.getConnection().webSocket();
-    if (METRICS_ENABLED && httpConn.httpMetrics != null) {
-      httpConn.httpMetrics.requestUpgraded(request.metric());
-      webSocket.setMetric(httpConn.httpMetrics.connected(request));
-    }
-    webSocket.registerHandler(httpConn.context().owner().eventBus());
-    return webSocket;
+    return promise.future();
   }
 
   @Override


### PR DESCRIPTION
Fixes #6284

## Problem
On a `ThreadingModel.WORKER` verticle, `HttpServerRequest.toWebSocket()` can block its carrier thread for exactly 10s and then fail. `ServerWebSocketHandshaker.acceptHandshake()` queues the Netty pipeline-swap task onto the context executor and then blocks on `CompletableFuture.get(10, SECONDS)` waiting for it. On a serialized worker executor the queued task cannot run until the wait returns, causing a self-deadlock. The subsequent `IllegalStateException: Response head already sent` hides the real cause.

## Fix
Make `acceptHandshake()` asynchronous: it now returns a `Future<ServerWebSocket>` and the pipeline swap + websocket setup runs on the event-loop context via a `Promise`, eliminating the blocking wait entirely. `accept()` chains on the result with `onSuccess`/\/`onFailure` instead of blocking.

Affects WebSocket/SockJS upgrades on worker verticles — the worker thread is never blocked, so the 10s stall and the unreportable failure are both removed.