### PR TITLE
PQC improvements

### DIFF
--- a/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
+++ b/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
@@ -72,7 +72,7 @@ public class JdkSSLEngineOptions extends SSLEngineOptions {
         SSLParameters params = ctx.getDefaultSSLParameters();
         Method getNamedGroups = SSLParameters.class.getDeclaredMethod("getNamedGroups");
         String[] groups = (String[]) getNamedGroups.invoke(params);
-        available = groups != null && Arrays.stream(groups).anyMatch(SslEngineUtils.getPqCompliantGroups()::contains);
+        available = groups != null && Arrays.stream(groups).anyMatch(g -> SslEngineUtils.getPqCompliantGroups().stream().anyMatch(g::equalsIgnoreCase));
       } catch (Exception ignore) {
       }
       jdkPqcAvailable = available;

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -22,6 +22,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.buffer.impl.PartialPooledByteBufAllocator;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.*;
 import io.vertx.core.spi.tls.DefaultSslContextFactory;
 import io.vertx.core.spi.tls.SslContextFactory;
@@ -42,6 +44,7 @@ import java.util.stream.Collectors;
  */
 public class SSLHelper {
 
+  private static final Logger log = LoggerFactory.getLogger(SSLHelper.class);
   private static final AtomicLong seq = new AtomicLong();
   static final EnumMap<ClientAuth, io.netty.handler.ssl.ClientAuth> CLIENT_AUTH_MAPPING = new EnumMap<>(ClientAuth.class);
 
@@ -99,8 +102,10 @@ public class SSLHelper {
         }
       } else {
         if (JdkSSLEngineOptions.isPqcAvailable()) {
+          log.warn("JdkSslEngine supports PQ compliant groups, it will be used for the application");
           engineOptions = new JdkSSLEngineOptions();
         } else if (OpenSSLEngineOptions.isPqcAvailable()) {
+          log.warn("OpenSslEngine supports PQ compliant groups, it will be used for the application");
           engineOptions = new OpenSSLEngineOptions();
         } else {
           throw new VertxException("PQC enforcement policy " + pqcPolicy + " requires X25519MLKEM768 but neither JDK nor OpenSSL support it");

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -102,10 +102,10 @@ public class SSLHelper {
         }
       } else {
         if (JdkSSLEngineOptions.isPqcAvailable()) {
-          log.warn("JdkSslEngine supports PQ compliant groups, it will be used for the application");
+          log.debug("JdkSslEngine supports PQ compliant groups, it will be used for the application");
           engineOptions = new JdkSSLEngineOptions();
         } else if (OpenSSLEngineOptions.isPqcAvailable()) {
-          log.warn("OpenSslEngine supports PQ compliant groups, it will be used for the application");
+          log.debug("OpenSslEngine supports PQ compliant groups, it will be used for the application");
           engineOptions = new OpenSSLEngineOptions();
         } else {
           throw new VertxException("PQC enforcement policy " + pqcPolicy + " requires X25519MLKEM768 but neither JDK nor OpenSSL support it");

--- a/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
+++ b/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
@@ -22,7 +22,9 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  *
@@ -34,6 +36,14 @@ public class SslEngineUtils {
   private static final List<String> PQ_COMPLIANT_GROUPS = Collections.unmodifiableList(Arrays.asList("X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024"));
   private static final List<String> DEFAULT_KEY_EXCHANGE_GROUPS = Collections.unmodifiableList(Arrays.asList("X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024", "X25519", "secp256r1", "x448",
     "secp384r1", "secp521r1"));
+  private static final Set<String> PQ_COMPLIANT_GROUPS_UPPER;
+  static {
+    Set<String> upper = new HashSet<>();
+    for (String g : PQ_COMPLIANT_GROUPS) {
+      upper.add(g.toUpperCase());
+    }
+    PQ_COMPLIANT_GROUPS_UPPER = Collections.unmodifiableSet(upper);
+  }
 
   public static List<String> getPqCompliantGroups() {
     return PQ_COMPLIANT_GROUPS;
@@ -48,19 +58,22 @@ public class SslEngineUtils {
     }
     switch (pqcPolicy) {
       case STRICT:
-        if (groups != null && !groups.isEmpty()) {
-          if (!(PQ_COMPLIANT_GROUPS.containsAll(groups))) {
-            log.debug("PQC enforcement policy is STRICT: overriding key exchange groups " + groups + " with " + PQ_COMPLIANT_GROUPS);
-          }
+        if (groups == null || groups.isEmpty()) {
+          log.warn("No key exchange groups list was specified, the default list " + PQ_COMPLIANT_GROUPS + " is used");
+          return PQ_COMPLIANT_GROUPS;
         }
-        return PQ_COMPLIANT_GROUPS;
+        if (!groups.stream().allMatch(g -> PQ_COMPLIANT_GROUPS_UPPER.contains(g.toUpperCase()))) {
+          log.warn("PQC enforcement policy is STRICT: overriding key exchange groups " + groups + " with " + PQ_COMPLIANT_GROUPS);
+          return PQ_COMPLIANT_GROUPS;
+        }
+        return groups;
       case CLIENT_NEGOTIATED:
         if (groups == null || groups.isEmpty()) {
-          log.debug("No key exchange groups list was specified, a default list containing X25519MLKEM768 is selected");
+          log.warn("No key exchange groups list was specified, the default list " + DEFAULT_KEY_EXCHANGE_GROUPS + " is used");
           return DEFAULT_KEY_EXCHANGE_GROUPS;
         }
-        if (groups.stream().noneMatch(PQ_COMPLIANT_GROUPS::contains)) {
-          log.debug("PQC enforcement policy is CLIENT_NEGOTIATED: prepending " + PQ_COMPLIANT_GROUPS + " to key exchange groups " + groups);
+        if (groups.stream().noneMatch(g -> PQ_COMPLIANT_GROUPS_UPPER.contains(g.toUpperCase()))) {
+          log.warn("PQC enforcement policy is CLIENT_NEGOTIATED: prepending " + PQ_COMPLIANT_GROUPS + " to key exchange groups " + groups);
           List<String> result = new ArrayList<>(groups.size() + 1);
           result.addAll(PQ_COMPLIANT_GROUPS);
           result.addAll(groups);

--- a/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
+++ b/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
@@ -59,7 +59,7 @@ public class SslEngineUtils {
     switch (pqcPolicy) {
       case STRICT:
         if (groups == null || groups.isEmpty()) {
-          log.warn("No key exchange groups list was specified, the default list " + PQ_COMPLIANT_GROUPS + " is used");
+          log.debug("No key exchange groups list was specified, the default list " + PQ_COMPLIANT_GROUPS + " is used");
           return PQ_COMPLIANT_GROUPS;
         }
         if (!groups.stream().allMatch(g -> PQ_COMPLIANT_GROUPS_UPPER.contains(g.toUpperCase()))) {
@@ -69,11 +69,11 @@ public class SslEngineUtils {
         return groups;
       case CLIENT_NEGOTIATED:
         if (groups == null || groups.isEmpty()) {
-          log.warn("No key exchange groups list was specified, the default list " + DEFAULT_KEY_EXCHANGE_GROUPS + " is used");
+          log.debug("No key exchange groups list was specified, the default list " + DEFAULT_KEY_EXCHANGE_GROUPS + " is used");
           return DEFAULT_KEY_EXCHANGE_GROUPS;
         }
         if (groups.stream().noneMatch(g -> PQ_COMPLIANT_GROUPS_UPPER.contains(g.toUpperCase()))) {
-          log.warn("PQC enforcement policy is CLIENT_NEGOTIATED: prepending " + PQ_COMPLIANT_GROUPS + " to key exchange groups " + groups);
+          log.debug("PQC enforcement policy is CLIENT_NEGOTIATED: prepending " + PQ_COMPLIANT_GROUPS + " to key exchange groups " + groups);
           List<String> result = new ArrayList<>(groups.size() + 1);
           result.addAll(PQ_COMPLIANT_GROUPS);
           result.addAll(groups);

--- a/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
+++ b/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
@@ -63,7 +63,7 @@ public class SslEngineUtils {
           return PQ_COMPLIANT_GROUPS;
         }
         if (!groups.stream().allMatch(g -> PQ_COMPLIANT_GROUPS_UPPER.contains(g.toUpperCase()))) {
-          log.warn("PQC enforcement policy is STRICT: overriding key exchange groups " + groups + " with " + PQ_COMPLIANT_GROUPS);
+          log.debug("PQC enforcement policy is STRICT: overriding key exchange groups " + groups + " with " + PQ_COMPLIANT_GROUPS);
           return PQ_COMPLIANT_GROUPS;
         }
         return groups;
@@ -111,7 +111,7 @@ public class SslEngineUtils {
       setNamedGroups.invoke(params, (Object) groups.toArray(new String[0]));
       engine.setSSLParameters(params);
     } catch (Exception e) {
-      log.warn("Cannot apply key exchange groups " + groups + " on JDK SSL engine: requires JDK 20+", e);
+      log.debug("Cannot apply key exchange groups " + groups + " on JDK SSL engine: requires JDK 20+", e);
     }
   }
 }

--- a/src/test/java/io/vertx/core/net/SslEngineUtilsTest.java
+++ b/src/test/java/io/vertx/core/net/SslEngineUtilsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.net;
+
+import io.vertx.core.net.impl.SslEngineUtils;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SslEngineUtilsTest {
+
+  // The canonical PQ compliant groups defined in SslEngineUtils
+  private static final List<String> PQ_COMPLIANT = SslEngineUtils.getPqCompliantGroups();
+
+  // --- STRICT policy ---
+
+  @Test
+  public void testStrictPolicyAcceptsAllLowercasePqGroups() {
+    List<String> groups = Arrays.asList("x25519mlkem768", "secp256r1mlkem768", "secp384r1mlkem1024");
+    assertEquals(groups, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.STRICT));
+  }
+
+  @Test
+  public void testStrictPolicyAcceptsAllUppercasePqGroups() {
+    List<String> groups = Arrays.asList("X25519MLKEM768", "SECP256R1MLKEM768", "SECP384R1MLKEM1024");
+    assertEquals(groups, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.STRICT));
+  }
+
+  @Test
+  public void testStrictPolicyAcceptsMixedCasePqGroups() {
+    List<String> groups = Arrays.asList("X25519Mlkem768", "secP256r1MLKEM768");
+    assertEquals(groups, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.STRICT));
+  }
+
+  @Test
+  public void testStrictPolicyOverridesNonPqGroups() {
+    List<String> groups = Arrays.asList("X25519", "secp256r1");
+    assertEquals(PQ_COMPLIANT, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.STRICT));
+  }
+
+  @Test
+  public void testStrictPolicyOverridesGroupsContainingNonPqEntry() {
+    // One PQ (wrong case) + one non-PQ — the non-PQ entry triggers override
+    List<String> groups = Arrays.asList("x25519mlkem768", "X25519");
+    assertEquals(PQ_COMPLIANT, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.STRICT));
+  }
+
+  // --- CLIENT_NEGOTIATED policy ---
+
+  @Test
+  public void testClientNegotiatedDoesNotPrependWhenLowercasePqGroupPresent() {
+    List<String> groups = Arrays.asList("x25519mlkem768", "X25519");
+    assertEquals(groups, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.CLIENT_NEGOTIATED));
+  }
+
+  @Test
+  public void testClientNegotiatedDoesNotPrependWhenUppercasePqGroupPresent() {
+    List<String> groups = Arrays.asList("X25519MLKEM768", "secp256r1");
+    assertEquals(groups, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.CLIENT_NEGOTIATED));
+  }
+
+  @Test
+  public void testClientNegotiatedDoesNotPrependWhenMixedCasePqGroupPresent() {
+    List<String> groups = Arrays.asList("secP384r1MLKEM1024", "X25519");
+    assertEquals(groups, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.CLIENT_NEGOTIATED));
+  }
+
+  @Test
+  public void testClientNegotiatedPrependsWhenNoPqGroupPresent() {
+    List<String> nonPq = Arrays.asList("X25519", "secp256r1");
+    List<String> result = SslEngineUtils.resolveKeyExchangeGroups(nonPq, PqcEnforcementPolicy.CLIENT_NEGOTIATED);
+    assertEquals(PQ_COMPLIANT.size() + nonPq.size(), result.size());
+    assertEquals(PQ_COMPLIANT, result.subList(0, PQ_COMPLIANT.size()));
+    assertEquals(nonPq, result.subList(PQ_COMPLIANT.size(), result.size()));
+  }
+}


### PR DESCRIPTION
- `STRICT` PQC policy now doesn't override user provided named groups if they're all PQ compliant
- groups comparisons, detection was case sensitive in SslEngineUtils, it is no longer 
- logs describing the choices made by Vert.x regarding Ssl Engine and named groups selection are now 'warn' instead of  debug': they will thus appear in Quarkus

added unit tests for `SslEngineUtils` checking the insensitiveness of the comparisons and the behaviour