### PR TITLE
Clarify raw vs normalized path usage in Vert.x Core documentation

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/HttpRequestHead.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpRequestHead.java
@@ -27,7 +27,16 @@ public interface HttpRequestHead {
   String uri();
 
   /**
-   * @return The path part of the uri. For example {@code /somepath/somemorepath/someresource.foo}
+   * Returns the path component of the HTTP request URI.
+   * <p>
+   * This is the raw, non-normalized path as received from the client.
+   * It may contain duplicated separators or traversal segments such as {@code ".."}.
+   * <p>
+   * For security-sensitive logic (for example access control, routing or
+   * filesystem checks), applications should prefer using a normalized path
+   * provided by the framework instead of relying on this raw value.
+   *
+   * @return the raw path component of the request URI
    */
   @Nullable
   String path();


### PR DESCRIPTION
## Motivation

Developers may assume that `HttpServerRequest#path()` / `HttpRequestHead#path()` returns a normalized version of the request path. In practice, the value reflects the path from the request URI and may contain repeated separators or path traversal markers such as `//` or `..`.

Making this behavior explicit helps avoid incorrect assumptions when implementing path-based logic, particularly when using Vert.x Web routing.

## What changed

- Clarify the `HttpRequestHead#path()` Javadoc to explicitly document that the returned path is not normalized.
- Reapply the clarification cleanly on top of the current `master`.

## Previous PR

This supersedes #5824, which became outdated and developed conflicts after changes in `master`.

The original feedback from #5824 has been taken into account while rebasing the change onto the current codebase.
