### PR TITLE
Fix smallrye openssl CI build

### DIFF
--- a/vertx-core/pom.xml
+++ b/vertx-core/pom.xml
@@ -30,7 +30,7 @@
     <jmh.version>1.37</jmh.version>
     <vertx.surefire.nettyTransport>jdk</vertx.surefire.nettyTransport>
     <vertx.surefire.useDomainSockets>false</vertx.surefire.useDomainSockets>
-    <smallrye.openssl.version>0.1.4</smallrye.openssl.version>
+    <smallrye.openssl.version>0.2.3</smallrye.openssl.version>
   </properties>
 
   <dependencies>
@@ -422,7 +422,6 @@
                 <vertx-test-alpn-openssl>false</vertx-test-alpn-openssl>
               </systemProperties>
               <classpathDependencyExcludes>
-                <classpathDependencyExclude>io.smallrye:smallrye-openssl</classpathDependencyExclude>
                 <classpathDependencyExclude>io.netty:netty-tcnative-boringssl-static</classpathDependencyExclude>
               </classpathDependencyExcludes>
             </configuration>
@@ -452,6 +451,18 @@
               <includes>
                 <include>io/vertx/it/HybridKeyExchangeTest.java</include>
               </includes>
+              <skip>${vertx.surefire.skipHybridKeyExchange}</skip>
+              <additionalClasspathDependencies>
+                <additionalClasspathDependency>
+                  <groupId>io.smallrye</groupId>
+                  <artifactId>smallrye-openssl</artifactId>
+                  <classifier>${vertx.surefire.nativeClassifier}</classifier>
+                  <version>${smallrye.openssl.version}</version>
+                </additionalClasspathDependency>
+              </additionalClasspathDependencies>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>io.netty:netty-tcnative-boringssl-static</classpathDependencyExclude>
+              </classpathDependencyExcludes>
             </configuration>
           </execution>
           <execution>
@@ -1026,6 +1037,10 @@
           <arch>x86_64</arch>
         </os>
       </activation>
+      <properties>
+        <vertx.surefire.nativeClassifier>linux-x86_64</vertx.surefire.nativeClassifier>
+        <vertx.surefire.skipHybridKeyExchange>false</vertx.surefire.skipHybridKeyExchange>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>
@@ -1046,10 +1061,9 @@
           <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>io.smallrye</groupId>
-          <artifactId>smallrye-openssl</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
           <classifier>linux-x86_64</classifier>
-          <version>${smallrye.openssl.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -1063,6 +1077,10 @@
           <arch>amd64</arch>
         </os>
       </activation>
+      <properties>
+        <vertx.surefire.skipHybridKeyExchange>false</vertx.surefire.skipHybridKeyExchange>
+        <vertx.surefire.nativeClassifier>linux-x86_64</vertx.surefire.nativeClassifier>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>
@@ -1083,10 +1101,9 @@
           <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>io.smallrye</groupId>
-          <artifactId>smallrye-openssl</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
           <classifier>linux-x86_64</classifier>
-          <version>${smallrye.openssl.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -1100,6 +1117,10 @@
           <arch>aarch64</arch>
         </os>
       </activation>
+      <properties>
+        <vertx.surefire.skipHybridKeyExchange>false</vertx.surefire.skipHybridKeyExchange>
+        <vertx.surefire.nativeClassifier>linux-aarch_64</vertx.surefire.nativeClassifier>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>
@@ -1120,10 +1141,9 @@
           <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>io.smallrye</groupId>
-          <artifactId>smallrye-openssl</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
           <classifier>linux-aarch_64</classifier>
-          <version>${smallrye.openssl.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -1137,6 +1157,10 @@
           <arch>x86_64</arch>
         </os>
       </activation>
+      <properties>
+        <vertx.surefire.skipHybridKeyExchange>true</vertx.surefire.skipHybridKeyExchange>
+        <vertx.surefire.nativeClassifier>osx-x86_64</vertx.surefire.nativeClassifier>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>
@@ -1173,6 +1197,10 @@
           <arch>aarch64</arch>
         </os>
       </activation>
+      <properties>
+        <vertx.surefire.skipHybridKeyExchange>true</vertx.surefire.skipHybridKeyExchange>
+        <vertx.surefire.nativeClassifier>osx-aarch_64</vertx.surefire.nativeClassifier>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>
@@ -1208,6 +1236,10 @@
           <family>windows</family>
         </os>
       </activation>
+      <properties>
+        <vertx.surefire.skipHybridKeyExchange>true</vertx.surefire.skipHybridKeyExchange>
+        <vertx.surefire.nativeClassifier>windows-x86_64</vertx.surefire.nativeClassifier>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>

--- a/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextManager.java
@@ -186,7 +186,7 @@ public abstract class SslContextManager<P extends SslContextProvider> {
     if (sslOptions instanceof ClientSSLOptions) {
       ClientSSLOptions clientSSLOptions = (ClientSSLOptions) sslOptions;
       if (clientSSLOptions.isTrustAll()) {
-        return TrustAllOptions.INSTANCE;
+        return TrustAllOptions.instance(!clientSSLOptions.getHostnameVerificationAlgorithm().isEmpty());
       }
     }
     return sslOptions.getTrustOptions();

--- a/vertx-core/src/main/java/io/vertx/core/internal/tls/TrustAllOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/tls/TrustAllOptions.java
@@ -14,6 +14,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.net.TrustOptions;
 
 import javax.net.ssl.*;
+import java.net.Socket;
 import java.security.KeyStore;
 import java.security.Provider;
 import java.security.cert.X509Certificate;
@@ -24,27 +25,46 @@ import java.util.function.Function;
  */
 class TrustAllOptions implements TrustOptions {
 
-  public static TrustAllOptions INSTANCE = new TrustAllOptions();
-
-  private static final TrustManager TRUST_ALL_MANAGER = new X509TrustManager() {
+  private static final TrustManager TRUST_ALL_MANAGER_NO_VERIFY = new X509ExtendedTrustManager() {
     @Override
-    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {
-    }
-
+    public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) { }
     @Override
-    public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {
-    }
-
+    public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) { }
     @Override
-    public X509Certificate[] getAcceptedIssuers() {
-      return new X509Certificate[0];
-    }
+    public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) { }
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) { }
+    @Override
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) { }
+    @Override
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s) { }
+    @Override
+    public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+  };
+
+  private static final TrustManager TRUST_ALL_MANAGER_VERIFY = new X509TrustManager() {
+    @Override
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) { }
+    @Override
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s) { }
+    @Override
+    public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
   };
 
   private static final Provider PROVIDER = new Provider("", 0.0, "") {
   };
 
-  private TrustAllOptions() {
+  private static TrustAllOptions INSTANCE_NO_VERIFY = new TrustAllOptions(TRUST_ALL_MANAGER_NO_VERIFY);
+  private static TrustAllOptions INSTANCE_VERIFY = new TrustAllOptions(TRUST_ALL_MANAGER_VERIFY);
+
+  static TrustOptions instance(boolean verifyHost) {
+    return verifyHost ? INSTANCE_VERIFY : INSTANCE_NO_VERIFY;
+  }
+
+  private final TrustManager tm;
+
+  private TrustAllOptions(TrustManager tm) {
+    this.tm = tm;
   }
 
   @Override
@@ -65,7 +85,7 @@ class TrustAllOptions implements TrustOptions {
 
       @Override
       protected TrustManager[] engineGetTrustManagers() {
-        return new TrustManager[] { TRUST_ALL_MANAGER };
+        return new TrustManager[] { tm };
       }
     }, PROVIDER, "") {
 
@@ -74,6 +94,6 @@ class TrustAllOptions implements TrustOptions {
 
   @Override
   public Function<String, TrustManager[]> trustManagerMapper(Vertx vertx) {
-    return name -> new TrustManager[] { TRUST_ALL_MANAGER };
+    return name -> new TrustManager[] { tm };
   }
 }

--- a/vertx-core/src/test/java/io/vertx/it/HybridKeyExchangeTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/HybridKeyExchangeTest.java
@@ -103,7 +103,9 @@ public class HybridKeyExchangeTest extends HttpTestBase {
       .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
       .setTrustAll(true);
     client = vertx.httpClientBuilder()
-      .with(new HttpClientOptions().setSsl(true))
+      .with(new HttpClientOptions()
+        .setSsl(true)
+        .setVerifyHost(false))
       .with(new OpenSSLEngineOptions())
       .with(pqcClientSsl)
       .build();
@@ -137,7 +139,9 @@ public class HybridKeyExchangeTest extends HttpTestBase {
     ClientSSLOptions nonPqcClientSsl = new ClientSSLOptions()
       .setTrustAll(true);
     HttpClientAgent client2 = vertx.httpClientBuilder()
-      .with(new HttpClientOptions().setSsl(true))
+      .with(new HttpClientOptions()
+        .setSsl(true)
+        .setVerifyHost(false))
       .with(new OpenSSLEngineOptions())
       .with(nonPqcClientSsl)
       .build();
@@ -173,7 +177,9 @@ public class HybridKeyExchangeTest extends HttpTestBase {
     ClientSSLOptions nonPqcClientSsl = new ClientSSLOptions()
       .setTrustAll(true);
     client = vertx.httpClientBuilder()
-      .with(new HttpClientOptions().setSsl(true))
+      .with(new HttpClientOptions()
+        .setSsl(true)
+        .setVerifyHost(false))
       .with(nonPqcClientSsl)
       .build();
 
@@ -206,7 +212,9 @@ public class HybridKeyExchangeTest extends HttpTestBase {
       .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
       .setTrustAll(true);
     client = vertx.httpClientBuilder()
-      .with(new HttpClientOptions().setSsl(true))
+      .with(new HttpClientOptions()
+        .setSsl(true)
+        .setVerifyHost(false))
       .with(new OpenSSLEngineOptions())
       .with(pqcClientSsl)
       .build();
@@ -247,7 +255,9 @@ public class HybridKeyExchangeTest extends HttpTestBase {
       .setKeyCertOptions(Cert.CLIENT_PEM_ROOT_CA.get())
       .setTrustAll(true);
     client = vertx.httpClientBuilder()
-      .with(new HttpClientOptions().setSsl(true))
+      .with(new HttpClientOptions()
+        .setSsl(true)
+        .setVerifyHost(false))
       .with(new OpenSSLEngineOptions())
       .with(pqcClientSsl)
       .build();
@@ -285,7 +295,9 @@ public class HybridKeyExchangeTest extends HttpTestBase {
       .setKeyCertOptions(Cert.CLIENT_PEM_ROOT_CA.get())
       .setTrustAll(true);
     HttpClientAgent client2 = vertx.httpClientBuilder()
-      .with(new HttpClientOptions().setSsl(true))
+      .with(new HttpClientOptions()
+        .setSsl(true)
+        .setVerifyHost(false))
       .with(new OpenSSLEngineOptions())
       .with(nonPqcClientSsl)
       .build();
@@ -333,7 +345,9 @@ public class HybridKeyExchangeTest extends HttpTestBase {
 
     try {
       client = vertx.httpClientBuilder()
-        .with(new HttpClientOptions().setSsl(true))
+        .with(new HttpClientOptions()
+          .setSsl(true)
+          .setVerifyHost(false))
         .with(new JdkSSLEngineOptions())
         .with(clientSsl)
         .build();
@@ -366,7 +380,9 @@ public class HybridKeyExchangeTest extends HttpTestBase {
       .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
       .setTrustAll(true);
     client = vertx.httpClientBuilder()
-      .with(new HttpClientOptions().setSsl(true))
+      .with(new HttpClientOptions()
+        .setSsl(true)
+        .setVerifyHost(false))
       .with(new OpenSSLEngineOptions())
       .with(pqcClientSsl)
       .build();
@@ -402,7 +418,9 @@ public class HybridKeyExchangeTest extends HttpTestBase {
       .setKeyExchangeGroups(List.of("X25519MLKEM768"))
       .setTrustAll(true);
     client = vertx.httpClientBuilder()
-      .with(new HttpClientOptions().setSsl(true))
+      .with(new HttpClientOptions()
+        .setSsl(true)
+        .setVerifyHost(false))
       .with(new OpenSSLEngineOptions())
       .with(clientSsl)
       .build();
@@ -432,7 +450,9 @@ public class HybridKeyExchangeTest extends HttpTestBase {
     ClientSSLOptions clientSsl = new ClientSSLOptions()
       .setTrustAll(true);
     client = vertx.httpClientBuilder()
-      .with(new HttpClientOptions().setSsl(true))
+      .with(new HttpClientOptions()
+        .setSsl(true)
+        .setVerifyHost(false))
       .with(clientSsl)
       .build();
 

--- a/vertx-core/src/test/java/io/vertx/it/tls/SSLEngineTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/tls/SSLEngineTest.java
@@ -101,6 +101,7 @@ public class SSLEngineTest extends HttpTestBase2 {
       .setSsl(true)
       .setUseAlpn(useAlpn)
       .setTrustAll(true)
+      .setVerifyHost(false)
       .setProtocolVersion(version));
     client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath")
       .compose(req -> req
@@ -144,7 +145,8 @@ public class SSLEngineTest extends HttpTestBase2 {
     WebSocketClient wsClient = vertx.createWebSocketClient(new WebSocketClientOptions()
       .setSslEngineOptions(sslEngineOptions)
       .setSsl(true)
-      .setTrustAll(true));
+      .setTrustAll(true)
+      .setVerifyHost(false));
     WebSocket ws = wsClient.connect(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/").await();
     test.assertSslSessionContextType(ws.sslSession().getSessionContext());
     ws.writeTextMessage("test");

--- a/vertx-core/src/test/java/io/vertx/tests/tls/HttpTLSTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/tls/HttpTLSTest.java
@@ -333,20 +333,20 @@ public abstract class HttpTLSTest extends SimpleHttpTest {
   @Test
   // Specify some matching cipher suites
   public void testTLSMatchingCipherSuites() throws Exception {
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll().serverEnabledCipherSuites(ENABLED_CIPHER_SUITES).pass();
+    testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE).serverEnabledCipherSuites(ENABLED_CIPHER_SUITES).pass();
   }
 
   @Test
   // Specify some non matching cipher suites
   public void testTLSNonMatchingCipherSuites() throws Exception {
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll().serverEnabledCipherSuites(new String[]{"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"}).clientEnabledCipherSuites(new String[]{"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"}).fail();
+    testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE).serverEnabledCipherSuites(new String[]{"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"}).clientEnabledCipherSuites(new String[]{"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"}).fail();
   }
 
   @Test
   // Specify some matching TLS protocols
   public void testTLSMatchingProtocolVersions() throws Exception {
     assumeTcp();
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll()
+    testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE)
       .serverEnabledSecureTransportProtocol(new String[]{"TLSv1", "TLSv1.1", "TLSv1.2"}).pass();
   }
 
@@ -383,14 +383,14 @@ public abstract class HttpTLSTest extends SimpleHttpTest {
   // Specify some matching TLS protocols
   public void testTLSInvalidProtocolVersion() throws Exception {
     assumeTcp();
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll().serverEnabledSecureTransportProtocol(new String[]{"HelloWorld"}).fail();
+    testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE).serverEnabledSecureTransportProtocol(new String[]{"HelloWorld"}).fail();
   }
 
   @Test
   // Specify some non matching TLS protocols
   public void testTLSNonMatchingProtocolVersions() throws Exception {
     assumeTcp();
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll().serverEnabledSecureTransportProtocol(new String[]{"TLSv1.2"}).clientEnabledSecureTransportProtocol(new String[]{"SSLv2Hello", "TLSv1.1"}).fail();
+    testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE).serverEnabledSecureTransportProtocol(new String[]{"TLSv1.2"}).clientEnabledSecureTransportProtocol(new String[]{"SSLv2Hello", "TLSv1.1"}).fail();
   }
 
   @Test
@@ -488,7 +488,7 @@ public abstract class HttpTLSTest extends SimpleHttpTest {
   // TLSv1.3
   public void testTLSv1_3() throws Exception {
     Assume.assumeFalse(System.getProperty("java.version").startsWith("1.8"));
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll()
+    testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE)
       .clientEnabledSecureTransportProtocol(new String[]{"TLSv1.3"})
       .serverEnabledSecureTransportProtocol(new String[]{"TLSv1.3"}).pass();
   }
@@ -497,7 +497,7 @@ public abstract class HttpTLSTest extends SimpleHttpTest {
   // TLSv1.3 with OpenSSL
   public void testTLSv1_3OpenSSL() throws Exception {
     assumeOpenSSL();
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll()
+    testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE)
       .clientOpenSSL()
       .clientEnabledSecureTransportProtocol(new String[]{"TLSv1.3"})
       .serverOpenSSL()
@@ -509,7 +509,7 @@ public abstract class HttpTLSTest extends SimpleHttpTest {
   public void testDisableTLSv1_3() throws Exception {
     assumeTcp();
     Assume.assumeFalse(System.getProperty("java.version").startsWith("1.8"));
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll()
+    testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE)
       .clientEnabledSecureTransportProtocol(new String[]{"TLSv1.3"})
       .serverEnabledSecureTransportProtocol(new String[]{"TLSv1.2"})
       .fail();
@@ -519,7 +519,7 @@ public abstract class HttpTLSTest extends SimpleHttpTest {
   // Disable TLSv1.3 with OpenSSL
   public void testDisableTLSv1_3OpenSSL() throws Exception {
     assumeOpenSSL();
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll()
+    testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE)
       .clientEnabledSecureTransportProtocol(new String[]{"TLSv1.3"})
       .serverEnabledSecureTransportProtocol(new String[]{"TLSv1.2"})
       .serverOpenSSL()
@@ -531,7 +531,7 @@ public abstract class HttpTLSTest extends SimpleHttpTest {
   public void testDisableTLSv1_2() throws Exception {
     assumeTcp();
     Assume.assumeFalse(System.getProperty("java.version").startsWith("1.8"));
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll()
+    testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE)
       .clientEnabledSecureTransportProtocol(new String[]{"TLSv1.2"})
       .serverEnabledSecureTransportProtocol(new String[]{"TLSv1.3"})
       .fail();
@@ -541,7 +541,7 @@ public abstract class HttpTLSTest extends SimpleHttpTest {
   // Disable TLSv1.2 with OpenSSL
   public void testDisableTLSv1_2OpenSSL() throws Exception {
     assumeOpenSSL();
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll()
+    testTLS(Cert.NONE, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.NONE)
       .clientEnabledSecureTransportProtocol(new String[]{"TLSv1.2"})
       .serverEnabledSecureTransportProtocol(new String[]{"TLSv1.3"})
       .serverOpenSSL()


### PR DESCRIPTION
- upgrade io.smallrye:smallrye-openssl 0.2.3
- only use smallrye-openssl during hybrid-key-exchange execution of failsafe
- stop using smallrye-openssl during unit tests
