### PR TITLE
Fix smallrye openssl CI build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <vertx.testNativeTransport>false</vertx.testNativeTransport>
     <vertx.testDomainSockets>false</vertx.testDomainSockets>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
-    <smallrye.openssl.version>0.1.4</smallrye.openssl.version>
+    <smallrye.openssl.version>0.2.3</smallrye.openssl.version>
   </properties>
 
   <dependencyManagement>
@@ -482,7 +482,6 @@
                 <vertx-test-alpn-openssl>false</vertx-test-alpn-openssl>
               </systemProperties>
               <classpathDependencyExcludes>
-                  <classpathDependencyExclude>io.smallrye:smallrye-openssl</classpathDependencyExclude>
                   <classpathDependencyExclude>io.netty:netty-tcnative-boringssl-static</classpathDependencyExclude>
               </classpathDependencyExcludes>
             </configuration>
@@ -512,6 +511,18 @@
               <includes>
                 <include>io/vertx/it/HybridKeyExchangeTest.java</include>
               </includes>
+              <skip>${vertx.surefire.skipHybridKeyExchange}</skip>
+              <additionalClasspathDependencies>
+                <additionalClasspathDependency>
+                  <groupId>io.smallrye</groupId>
+                  <artifactId>smallrye-openssl</artifactId>
+                  <classifier>${vertx.surefire.nativeClassifier}</classifier>
+                  <version>${smallrye.openssl.version}</version>
+                </additionalClasspathDependency>
+              </additionalClasspathDependencies>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>io.netty:netty-tcnative-boringssl-static</classpathDependencyExclude>
+              </classpathDependencyExcludes>
             </configuration>
           </execution>
           <execution>
@@ -985,12 +996,16 @@
     </profile>
 
     <profile>
-      <id>linux</id>
+      <id>linux-x86_64</id>
       <activation>
         <os>
           <family>linux</family>
         </os>
       </activation>
+      <properties>
+        <vertx.surefire.nativeClassifier>linux-x86_64</vertx.surefire.nativeClassifier>
+        <vertx.surefire.skipHybridKeyExchange>false</vertx.surefire.skipHybridKeyExchange>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>
@@ -999,10 +1014,36 @@
           <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>io.smallrye</groupId>
-          <artifactId>smallrye-openssl</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
           <classifier>linux-x86_64</classifier>
-          <version>${smallrye.openssl.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>linux-aarch64</id>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+      </activation>
+      <properties>
+        <vertx.surefire.nativeClassifier>linux-aarch_64</vertx.surefire.nativeClassifier>
+        <vertx.surefire.skipHybridKeyExchange>false</vertx.surefire.skipHybridKeyExchange>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <classifier>linux-aarch_64</classifier>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+          <classifier>linux-aarch_64</classifier>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -1016,6 +1057,10 @@
           <arch>x86_64</arch>
         </os>
       </activation>
+      <properties>
+        <vertx.surefire.skipHybridKeyExchange>true</vertx.surefire.skipHybridKeyExchange>
+        <vertx.surefire.nativeClassifier>osx-x86_64</vertx.surefire.nativeClassifier>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>
@@ -1046,6 +1091,10 @@
           <arch>aarch64</arch>
         </os>
       </activation>
+      <properties>
+        <vertx.surefire.skipHybridKeyExchange>true</vertx.surefire.skipHybridKeyExchange>
+        <vertx.surefire.nativeClassifier>osx-aarch_64</vertx.surefire.nativeClassifier>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>
@@ -1075,6 +1124,10 @@
           <family>windows</family>
         </os>
       </activation>
+      <properties>
+        <vertx.surefire.skipHybridKeyExchange>true</vertx.surefire.skipHybridKeyExchange>
+        <vertx.surefire.nativeClassifier>windows-x86_64</vertx.surefire.nativeClassifier>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>io.netty</groupId>


### PR DESCRIPTION
- upgrade io.smallrye:smallrye-openssl 0.2.3
- only use smallrye-openssl during hybrid-key-exchange execution of failsafe
- stop using smallrye-openssl during unit tests