### PR TITLE
fix: do not close pooled connection when resetting a completed HTTP/1.1 request (#6294)

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
@@ -371,7 +371,7 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
     }
     stream.reset = true;
     boolean removed = pending.remove(stream);
-    if (!removed) {
+    if (!removed && !stream.closed) {
       close();
     }
     return removed;

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -5770,4 +5770,33 @@ public class Http1xTest extends HttpTest {
     Assert.assertEquals("absoluteURI() should not synthesize ':-1'", "http://example.com/path", body.toString());
   }
 
+
+  @Test
+  // Regression test for https://github.com/eclipse-vertx/vert.x/issues/6294
+  public void testResetCompletedRequestDoesNotCloseReusedConnection() throws Exception {
+    CountDownLatch serverLatch = new CountDownLatch(2);
+    server.requestHandler(req -> {
+      req.response().end();
+      serverLatch.countDown();
+    });
+    startServer(testAddress);
+    client = vertx.httpClientBuilder()
+      .with(new HttpClientOptions().setKeepAlive(true))
+      .with(new PoolOptions().setHttp1MaxSize(1))
+      .build();
+    // Request A - completes and returns connection to pool
+    client.request(new RequestOptions(requestOptions).setURI("/first"))
+      .compose(req -> req.send().compose(HttpClientResponse::end))
+      .await();
+    // Request B - reuses the pooled connection from A
+    client.request(new RequestOptions(requestOptions).setURI("/second"))
+      .compose(req -> {
+        // Late reset() on the already-completed request A must not close the pooled connection
+        req.reset(0);
+        return req.send().expecting(HttpResponseExpectation.SC_OK).compose(HttpClientResponse::end);
+      })
+      .await();
+    serverLatch.await(10, TimeUnit.SECONDS);
+  }
+
 }


### PR DESCRIPTION
## Fixes

Closes #6294

## Problem

`Http1ClientConnection.reset(Stream)` calls `close()` on the physical connection when the stream is not found in the `pending` queue. However, a fully completed stream (both request and response ended) is no longer tracked in `pending` — it has already been removed after the response was fully received. If the connection has been returned to the pool and reused by a subsequent request, the late `reset()` call on the completed stream incorrectly closes the physical connection, killing the in-flight request that is now using it.

## Root cause

```java
private Boolean reset(Stream stream) {
    if (stream.reset) {
      return null;
    }
    stream.reset = true;
    boolean removed = pending.remove(stream);
    if (!removed) {
      close();  // closes connection even for fully-completed streams
    }
    return removed;
  }
```

When `pending.remove(stream)` returns `false`, the code unconditionally calls `close()`. But a stream that has already completed (response received, request ended, `onClose()` called) is not in `pending` — this is the normal case, not an error.

## Fix

Added `!stream.closed` guard: only close the connection when the stream is still in-flight (not in `pending` and not already completed). A completed stream that receives a late `reset()` call is treated as a no-op.

```java
if (!removed && !stream.closed) {
    close();
}
```

The `closed` flag is set by `Stream.onClose()`, which is called when the stream has fully completed. This is the definitive signal that a stream is done and should not trigger connection closure.

## Test

Added `testResetCompletedRequestDoesNotCloseReusedConnection` in `Http1xTest.java`:
- Request A completes and returns the connection to the pool
- Request B reuses the pooled connection
- `reset()` is called on the completed request A
- Verifies that request B still completes successfully (the late reset did not close the pooled connection)
