### PR TITLE
A HTTP/1.1 client connection should not be closed upon a stream reset that is already received.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
@@ -371,7 +371,7 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
     }
     stream.reset = true;
     boolean removed = pending.remove(stream);
-    if (!removed) {
+    if (!removed && inflight.contains(stream)) {
       close();
     }
     return removed;

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -2918,21 +2918,21 @@ public class Http1xTest extends HttpTest {
   }
 
   @Test
-  public void testResetClientRequestNotYetSent(Checkpoint checkpoint) throws Exception {
-    testResetClientRequestNotYetSent(checkpoint, false, false);
+  public void testResetClientStreamNotYetSent(Checkpoint checkpoint) throws Exception {
+    testResetClientStreamNotYetSent(checkpoint, false, false);
   }
 
   @Test
-  public void testResetKeepAliveClientRequestNotYetSent(Checkpoint checkpoint) throws Exception {
-    testResetClientRequestNotYetSent(checkpoint, true, false);
+  public void testResetKeepAliveClientStreamNotYetSent(Checkpoint checkpoint) throws Exception {
+    testResetClientStreamNotYetSent(checkpoint, true, false);
   }
 
   @Test
-  public void testResetPipelinedClientRequestNotYetSent(Checkpoint checkpoint) throws Exception {
-    testResetClientRequestNotYetSent(checkpoint, true, true);
+  public void testResetPipelinedStreamRequestNotYetSent(Checkpoint checkpoint) throws Exception {
+    testResetClientStreamNotYetSent(checkpoint, true, true);
   }
 
-  private void testResetClientRequestNotYetSent(Checkpoint checkpoint, boolean keepAlive, boolean pipelined) throws Exception {
+  private void testResetClientStreamNotYetSent(Checkpoint checkpoint, boolean keepAlive, boolean pipelined) throws Exception {
     NetServer server = vertx.createNetServer();
     AtomicInteger numReq = new AtomicInteger();
     server.connectHandler(conn -> {
@@ -2967,6 +2967,27 @@ public class Http1xTest extends HttpTest {
         .compose(HttpClientResponse::end))
       .await();
     assertEquals(1, numReq.get());
+  }
+
+  @Test
+  public void testResetClientStreamClosed() throws Exception {
+    server.requestHandler(request -> {
+      request.response().end();
+    });
+    startServer();
+    io.vertx.core.http.HttpClientConnection connection = client
+      .connect(requestOptions)
+      .await();
+    for (int i = 0;i < 2;i++) {
+      HttpClientRequest request = connection
+        .request(requestOptions)
+        .compose(req -> req
+          .send()
+          .expecting(HttpResponseExpectation.SC_OK)
+          .compose(HttpClientResponse::end).map(req))
+        .await();
+      request.reset();
+    }
   }
 
   @Test


### PR DESCRIPTION
Motivation:

HTTP/1.1 client connection upon stream reset only checks whether the stream is pending and does not check its presence as a connection close guard.

As consequence resetting a received stream closes the connection.

Changes:

Check stream presence among connection streams before closing the connection.
