### PR TITLE
Report AsyncFile handler failures to context

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -103,6 +103,7 @@ public class AsyncFileImpl implements AsyncFile {
     }
     this.context = context;
     this.queue = new InboundBuffer<>(context, 0);
+    queue.exceptionHandler(context::reportException);
     queue.handler(buff -> {
       if (buff.length() > 0) {
         handleBuffer(buff);

--- a/vertx-core/src/test/java/io/vertx/tests/file/FileSystemTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/file/FileSystemTest.java
@@ -21,6 +21,8 @@ import io.vertx.core.file.FileSystemException;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.file.impl.AsyncFileImpl;
 import io.vertx.core.impl.Utils;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.test.core.TestUtils;
@@ -38,6 +40,7 @@ import java.io.IOException;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.*;
 import java.nio.file.attribute.*;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -2313,5 +2316,37 @@ public class FileSystemTest extends VertxTestBase {
     asyncFile.exceptionHandler(null);
     asyncFile.drainHandler(null);
     asyncFile.endHandler(null);
+  }
+
+  @Test
+  public void testAsyncFileHandlerFailuresAreReportedToContext() throws Exception {
+    String fileName = "file.txt";
+    createFileWithJunk(fileName, 100);
+    RuntimeException dataFailure = new RuntimeException("data");
+    RuntimeException endFailure = new RuntimeException("end");
+    List<Throwable> reported = new ArrayList<>();
+    AtomicInteger fileExceptions = new AtomicInteger();
+    AtomicReference<Throwable> closeFailure = new AtomicReference<>();
+    CountDownLatch closed = new CountDownLatch(1);
+    ContextInternal context = ((VertxInternal) vertx).getOrCreateContext();
+    context.runOnContext(ignored -> {
+      AsyncFile file = vertx.fileSystem().openBlocking(testDir + pathSep + fileName, new OpenOptions());
+      context.exceptionHandler(reported::add);
+      file.exceptionHandler(ignored2 -> fileExceptions.incrementAndGet());
+      file.endHandler(ignored2 -> {
+        file.close().onComplete(ar -> {
+          closeFailure.set(ar.cause());
+          closed.countDown();
+        });
+        throw endFailure;
+      });
+      file.handler(buffer -> {
+        throw dataFailure;
+      });
+    });
+    TestUtils.awaitLatch(closed);
+    Assert.assertNull(closeFailure.get());
+    Assert.assertEquals(List.of(dataFailure, endFailure), reported);
+    Assert.assertEquals(0, fileExceptions.get());
   }
 }


### PR DESCRIPTION
Motivation:

Fixes #5343.

Exceptions thrown by AsyncFile data or end handlers should be reported to the owning Context, matching existing Vert.x handler semantics and the maintainer guidance in the issue.

This change installs a context exception handler on the AsyncFile inbound buffer and adds regression coverage for both handler types.

Testing:

- `mvn -pl vertx-core -Dtest=FileSystemTest#testAsyncFileHandlerFailuresAreReportedToContext test -B` — 1 passed
- `mvn -pl vertx-core -Dtest=FileSystemTest,InboundBufferTest test -B` — 141 passed
- `mvn -pl vertx-core -DskipTests verify -Pcheckstyle -B` — passed; Spotless reported 0 files needing changes
- `git diff --check origin/master...HEAD` — passed

Before this split, an earlier broad local run was not fully green. It encountered two unrelated environment-sensitive failures outside the modified paths:

- `NameResolverTest#testRotationalServerSelection`: expected `127.0.0.4` but observed `127.0.0.3`.
- `Http1xTest#requestAbsNoPort`: connection timeout to `www.google.com:80`.

These are not counted as passing tests. All 142 relevant test executions listed above passed on the current rebased commit.

Conformance:

AI assistance: OpenAI Codex assisted with implementation and testing.