### PR TITLE
Revert "fix: do not close pooled connection when resetting a completed HTTP/1.1 request (#6294)"

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
@@ -371,7 +371,7 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
     }
     stream.reset = true;
     boolean removed = pending.remove(stream);
-    if (!removed && !stream.closed) {
+    if (!removed) {
       close();
     }
     return removed;

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http1xTest.java
@@ -5770,33 +5770,4 @@ public class Http1xTest extends HttpTest {
     Assert.assertEquals("absoluteURI() should not synthesize ':-1'", "http://example.com/path", body.toString());
   }
 
-
-  @Test
-  // Regression test for https://github.com/eclipse-vertx/vert.x/issues/6294
-  public void testResetCompletedRequestDoesNotCloseReusedConnection() throws Exception {
-    CountDownLatch serverLatch = new CountDownLatch(2);
-    server.requestHandler(req -> {
-      req.response().end();
-      serverLatch.countDown();
-    });
-    startServer(testAddress);
-    client = vertx.httpClientBuilder()
-      .with(new HttpClientOptions().setKeepAlive(true))
-      .with(new PoolOptions().setHttp1MaxSize(1))
-      .build();
-    // Request A - completes and returns connection to pool
-    client.request(new RequestOptions(requestOptions).setURI("/first"))
-      .compose(req -> req.send().compose(HttpClientResponse::end))
-      .await();
-    // Request B - reuses the pooled connection from A
-    client.request(new RequestOptions(requestOptions).setURI("/second"))
-      .compose(req -> {
-        // Late reset() on the already-completed request A must not close the pooled connection
-        req.reset(0);
-        return req.send().expecting(HttpResponseExpectation.SC_OK).compose(HttpClientResponse::end);
-      })
-      .await();
-    serverLatch.await(10, TimeUnit.SECONDS);
-  }
-
 }


### PR DESCRIPTION
Reverts eclipse-vertx/vert.x#6296