### PR TITLE
fix: CleanableObject.shutdown() returns null when resource was GC'd

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/CleanableObject.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/CleanableObject.java
@@ -81,7 +81,8 @@ public class CleanableObject<T> {
       assert cleanable != null;
       action.timeout = timeout;
       cleanable.clean();
-      return action.closeFuture;
+      Future<Void> closeFuture = action.closeFuture;
+      return closeFuture != null ? closeFuture : Future.succeededFuture();
     } else {
       return Future.succeededFuture();
     }


### PR DESCRIPTION
## Description

When `CleanableObject.shutdown(Duration)` is called after the underlying resource has been garbage collected (e.g., after Vert.x instance shutdown while the caller still holds a wrapper), the method returns `null` instead of a `Future<Void>`, causing `NullPointerException` in callers that chain `close().onSuccess(...)`.

### Root Cause

`CleanableObject.Action` extends `WeakReference<CloseableResource>`. When the `Cleanable.clean()` triggers `Action.run()`, the reference may already be cleared by GC — in that case `closeFuture` is never set and stays `null`. The `shutdown()` method then returns this `null` instead of a completed future.

### Fix

Return `Future.succeededFuture()` when `action.closeFuture` is `null` after `clean()`, matching the semantics of the already-shut-down branch (the `else` block).

This was hit in the wild by Quarkus: the OpenTelemetry OTLP exporter races its `shutdown()` against Vert.x termination, and on a GC-timing-sensitive JVM (JDK 25 Semeru in CI), `client.close()` returned `null`, producing an NPE and a flaky test (see quarkusio/quarkus#55946).

Closes #6302