### PR TITLE
Shutting down a cleanable object should produce a valid result when the underlying resource is shutdown.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/CleanableObject.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/CleanableObject.java
@@ -38,6 +38,8 @@ public class CleanableObject<T> {
       CloseableResource<? extends T> d = get();
       if (d != null) {
         closeFuture = d.shutdown(timeout);
+      } else {
+        closeFuture = Future.succeededFuture();
       }
     }
   }

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/CleanableObjectTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/CleanableObjectTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import java.lang.ref.Cleaner;
 import java.lang.ref.WeakReference;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.vertx.tests.vertx.VertxTest.runGC;
@@ -85,6 +86,30 @@ public class CleanableObjectTest extends VertxTestBase {
     WeakReference<TestResource> resourceRef = new WeakReference<>(resource);
     resource = null;
     runGC(() -> resourceRef.get() == null);
+  }
+
+  @Test
+  public void testCloseCollectedResource() {
+    AtomicBoolean actuallyShutdown = new AtomicBoolean();
+    CloseableResource<Object> resource = new CloseableResource<>() {
+      @Override
+      public Object get() {
+        return null;
+      }
+      @Override
+      public Future<Void> shutdown(Duration timeout) {
+        actuallyShutdown.set(true);
+        return Future.succeededFuture();
+      }
+    };
+    CleanableObject<Object> object = new CleanableObject<>(cleaner, resource);
+    WeakReference<CloseableResource<Object>> reference = new WeakReference<>(resource);
+    resource = null;
+    runGC(() -> reference.get() == null);
+    Future<Void> shutdown = object.shutdown(Duration.ZERO);
+    assertNotNull(shutdown);
+    assertTrue(shutdown.succeeded());
+    assertFalse(actuallyShutdown.get());
   }
 
   private static class TestResource implements CloseableResource<TestResource> {


### PR DESCRIPTION
Motivation:

CleanableObject action maintains a weak reference on the resource, when the underlying resource is actually reclaimed, shutting down the cleanable object produces a null result.

Changes:

When the resource is collected, set the cleanable action close future to a succeeded future.
