### PR TITLE
Support host names in DNS client setup

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
@@ -56,7 +56,7 @@ public class DnsClientImpl implements DnsClient {
     }
 
     DnsAddressResolverProvider provider = DnsAddressResolverProvider.create(vertx, vertx.nameResolver().options()
-      .setServers(Collections.singletonList(dnsServer.getHostString() + ":" + dnsServer.getPort()))
+      .setServers(Collections.singletonList(dnsServer.getAddress().getHostAddress() + ":" + dnsServer.getPort()))
       .setOptResourceEnabled(false));
 
     this.options = new DnsClientOptions(options);

--- a/vertx-core/src/test/java/io/vertx/tests/dns/DNSTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/dns/DNSTest.java
@@ -614,6 +614,11 @@ public class DNSTest extends VertxTestBase {
     vertx.createDnsClient(new DnsClientOptions().setPort(53).setHost("::1"));
   }
 
+  @Test
+  public void testLocalhostNameServer() {
+    vertx.createDnsClient(new DnsClientOptions().setPort(53).setHost("localhost"));
+  }
+
   private DnsClient prepareDns() {
     return prepareDns(new DnsClientOptions().setQueryTimeout(15000));
   }


### PR DESCRIPTION
Motivation:

Vert.x 4 was supporting using a host name in the DNS setup (typically localhost, which is what Testcontainers returns in the Stork quickstart).

I'm not sure exactly if there's a good reason to break this behavior so I prepared a patch that restores the existing behavior, and is arguably more correct as only IP addresses are supported after this call and getHost() can return a host name.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
