### PR TITLE
Let the DNS client use an unresolved server address.

### DIFF
--- a/vertx-core/src/main/asciidoc/dns.adoc
+++ b/vertx-core/src/main/asciidoc/dns.adoc
@@ -21,6 +21,8 @@ You can also create the client with options and configure the query timeout.
 Creating the client with no arguments or omitting the server address will use the address of the server used internally
 for non blocking address resolution.
 
+You can specify an unresolved server address, in which case the client will resolve the address prior querying the server.
+
 [source,$lang]
 ----
 {@link examples.DNSExamples#example1__}

--- a/vertx-core/src/main/generated/io/vertx/core/dns/DnsClientOptionsConverter.java
+++ b/vertx-core/src/main/generated/io/vertx/core/dns/DnsClientOptionsConverter.java
@@ -42,6 +42,11 @@ public class DnsClientOptionsConverter {
             obj.setRecursionDesired((Boolean)member.getValue());
           }
           break;
+        case "hostResolutionRetryDelay":
+          if (member.getValue() instanceof Number) {
+            obj.setHostResolutionRetryDelay(java.time.Duration.of(((Number)member.getValue()).longValue(), java.time.temporal.ChronoUnit.MILLIS));
+          }
+          break;
       }
     }
   }
@@ -61,5 +66,8 @@ public class DnsClientOptionsConverter {
       json.put("activityLogFormat", obj.getActivityLogFormat().name());
     }
     json.put("recursionDesired", obj.isRecursionDesired());
+    if (obj.getHostResolutionRetryDelay() != null) {
+      json.put("hostResolutionRetryDelay", obj.getHostResolutionRetryDelay().toMillis());
+    }
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/dns/DnsClientOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/DnsClientOptions.java
@@ -17,6 +17,9 @@ import io.vertx.core.VertxOptions;
 import io.vertx.core.json.JsonObject;
 import io.netty.handler.logging.ByteBufFormat;
 
+import java.time.Duration;
+import java.util.Objects;
+
 /**
  * Configuration options for Vert.x DNS client.
  *
@@ -56,12 +59,18 @@ public class DnsClientOptions {
   */
   public static final boolean DEFAULT_RECURSION_DESIRED = true;
 
+  /**
+   * The default value for the host resolution retry delay = {@code 10} seconds
+   */
+  public static final Duration DEFAULT_HOST_RESOLUTION_RETRY_DELAY = Duration.ofSeconds(10);
+
   private int port = DEFAULT_PORT;
   private String host = DEFAULT_HOST;
   private long queryTimeout = DEFAULT_QUERY_TIMEOUT;
   private boolean logActivity = DEFAULT_LOG_ENABLED;
   private ByteBufFormat activityLogFormat = DEFAULT_LOG_ACTIVITY_FORMAT;
   private boolean recursionDesired = DEFAULT_RECURSION_DESIRED;
+  private Duration hostResolutionRetryDelay = DEFAULT_HOST_RESOLUTION_RETRY_DELAY;
 
   public DnsClientOptions() {
   }
@@ -77,6 +86,7 @@ public class DnsClientOptions {
     logActivity = other.logActivity;
     activityLogFormat = other.activityLogFormat;
     recursionDesired = other.recursionDesired;
+    hostResolutionRetryDelay = other.hostResolutionRetryDelay;
   }
 
   /**
@@ -194,6 +204,25 @@ public class DnsClientOptions {
    */
   public DnsClientOptions setRecursionDesired(boolean recursionDesired) {
     this.recursionDesired = recursionDesired;
+    return this;
+  }
+
+  /**
+   * @return the delay between DNS server host resolution retry attempts
+   */
+  public Duration getHostResolutionRetryDelay() {
+    return hostResolutionRetryDelay;
+  }
+
+  /**
+   * Set the delay between retry attempts to resolve the DNS server host name, when the host is specified
+   * as a name instead of an IP address.
+   *
+   * @param hostResolutionRetryDelay the retry delay
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DnsClientOptions setHostResolutionRetryDelay(Duration hostResolutionRetryDelay) {
+    this.hostResolutionRetryDelay = Objects.requireNonNull(hostResolutionRetryDelay);
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
@@ -25,10 +25,12 @@ import io.vertx.core.datagram.impl.InternetProtocolFamily;
 import io.vertx.core.dns.*;
 import io.vertx.core.dns.DnsResponseCode;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.internal.VertxInternal;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -40,67 +42,117 @@ public class DnsClientImpl implements DnsClient {
   private static final Function<List<String>, @Nullable String> FIRST_OF = lst -> lst.size() > 0 ? lst.get(0) : null;
 
   private final VertxInternal vertx;
+  private final String dnsServer;
+  private final int dnsPort;
   private boolean closed;
-  private final Map<EventLoop, DnsNameResolver> resolvers = new HashMap<>();
-  private final Map<EventLoop, DnsNameResolver> ipv4Resolvers = new HashMap<>();
-  private final Map<EventLoop, DnsNameResolver> ipv6Resolvers = new HashMap<>();
-  private final DnsAddressResolverProvider provider;
+  private Future<DnsAddressResolverProvider> provider;
+  private final Map<ResolvedAddressTypes, Future<Resolvers>> resolversMap = new ConcurrentHashMap<>();
   private final DnsClientOptions options;
   private final Set<Promise<?>> inflightRequests = ConcurrentHashMap.newKeySet();
 
   public DnsClientImpl(VertxInternal vertx, DnsClientOptions options) {
-
-    InetSocketAddress dnsServer = new InetSocketAddress(options.getHost(), options.getPort());
-    if (dnsServer.isUnresolved()) {
-      throw new IllegalArgumentException("Cannot resolve the host to a valid ip address");
-    }
-
-    DnsAddressResolverProvider provider = DnsAddressResolverProvider.create(vertx, vertx.nameResolver().options()
-      .setServers(Collections.singletonList(dnsServer.getHostString() + ":" + dnsServer.getPort()))
-      .setOptResourceEnabled(false));
-
+    this.dnsServer = options.getHost();
+    this.dnsPort = options.getPort();
     this.options = new DnsClientOptions(options);
-    this.provider = provider;
     this.vertx = vertx;
   }
 
-  private DnsNameResolver resolver(ContextInternal ctx, InternetProtocolFamily ipFamily) {
+  private class Resolvers {
+
+    final DnsAddressResolverProvider provider;
+    final ResolvedAddressTypes resolvedAddressTypes;
+    final Map<EventLoop, DnsNameResolver> resolvers = new ConcurrentHashMap<>();
+
+    public Resolvers(DnsAddressResolverProvider provider,  ResolvedAddressTypes resolvedAddressTypes) {
+      this.provider = provider;
+      this.resolvedAddressTypes = resolvedAddressTypes;
+    }
+
+    DnsNameResolver get(EventLoop eventLoop) {
+      DnsNameResolver resolver = resolvers.get(eventLoop);
+      if (resolver == null) {
+        resolver = resolvers.computeIfAbsent(eventLoop, (el) -> {
+          DnsNameResolverBuilder builder = provider.getDnsNameResolverBuilder();
+          builder.resolvedAddressTypes(resolvedAddressTypes);
+          builder.queryTimeoutMillis(options.getQueryTimeout());
+          builder.recursionDesired(options.isRecursionDesired());
+          return builder.eventLoop(el).build();
+        });
+      }
+      return resolver;
+    }
+
+    public void close() {
+      Collection<DnsNameResolver> values = new ArrayList<>(resolvers.values());
+      resolvers.clear();
+      for (DnsNameResolver resolver : values) {
+        resolver.close();
+      }
+    }
+  }
+
+  private Future<DnsNameResolver> resolver(ContextInternal ctx, InternetProtocolFamily ipFamily) {
+    ResolvedAddressTypes addrTypes;
+    if (ipFamily == null) {
+      addrTypes = ResolvedAddressTypes.IPV4_PREFERRED;
+    } else {
+      switch (ipFamily) {
+        case IPv4:
+          addrTypes = ResolvedAddressTypes.IPV4_ONLY;
+          break;
+        case IPv6:
+          addrTypes = ResolvedAddressTypes.IPV6_ONLY;
+          break;
+        default:
+          throw new UnsupportedOperationException();
+      }
+    }
     EventLoop el = ctx.nettyEventLoop();
-    DnsNameResolver resolver;
+    Future<DnsAddressResolverProvider> f;
     synchronized (this) {
       if (closed) {
         return null;
       }
-      Map<EventLoop, DnsNameResolver> resolversToUse;
-      ResolvedAddressTypes resolvedAddressTypes;
-      if (ipFamily == null) {
-        resolversToUse = resolvers;
-        resolvedAddressTypes = ResolvedAddressTypes.IPV4_PREFERRED;
-      } else {
-        switch (ipFamily) {
-          case IPv4:
-            resolversToUse = ipv4Resolvers;
-            resolvedAddressTypes = ResolvedAddressTypes.IPV4_ONLY;
-            break;
-          case IPv6:
-            resolversToUse = ipv6Resolvers;
-            resolvedAddressTypes = ResolvedAddressTypes.IPV6_ONLY;
-            break;
-          default:
-            throw new UnsupportedOperationException();
-        }
+      Future<DnsAddressResolverProvider> f2;
+      f2 = provider;
+      if (f2 == null) {
+        f2 = vertx.nameResolver()
+          .resolve(dnsServer)
+          .andThen(ar -> {
+            if (ar.failed()) {
+              Duration retry = options.getHostResolutionRetryDelay();
+              if (!retry.isNegative() && !retry.isZero()) {
+                vertx.setTimer(retry.toMillis(), id -> {
+                  synchronized (DnsClientImpl.this) {
+                    if (!closed) {
+                      DnsClientImpl.this.provider = null;
+                      resolversMap.clear();
+                    }
+                  }
+                });
+              }
+            }
+          })
+          .map(inetAddress -> {
+            return DnsAddressResolverProvider.create(vertx, vertx.nameResolver().options()
+              .setServers(Collections.singletonList(inetAddress.getHostAddress() + ":" + dnsPort))
+              .setOptResourceEnabled(false));
+        });
+        provider = f2;
       }
-      resolver = resolversToUse.get(el);
-      if (resolver == null) {
-        DnsNameResolverBuilder builder = provider.getDnsNameResolverBuilder();
-        builder.resolvedAddressTypes(resolvedAddressTypes);
-        builder.queryTimeoutMillis(options.getQueryTimeout());
-        builder.recursionDesired(options.isRecursionDesired());
-        resolver = builder.eventLoop(el).build();
-        resolversToUse.put(el, resolver);
-      }
+      f = f2;
     }
-    return resolver;
+    Future<Resolvers> resolvers = resolversMap.get(addrTypes);
+    if (resolvers == null) {
+      resolvers = resolversMap.computeIfAbsent(addrTypes, key -> {
+        Promise<Resolvers> p = Promise.promise();
+        f
+          .map(provider -> new Resolvers(provider, key))
+          .onComplete(p);
+        return p.future();
+      });
+    }
+    return resolvers.map(r -> r.get(el));
   }
 
   @Override
@@ -169,25 +221,31 @@ public class DnsClientImpl implements DnsClient {
   private Future<List<String>> resolveAll(String name, InternetProtocolFamily ipFamily) {
     Objects.requireNonNull(name);
     ContextInternal ctx = vertx.getOrCreateContext();
-    DnsNameResolver resolver = resolver(ctx, ipFamily);
+    Future<DnsNameResolver> resolver = resolver(ctx, ipFamily);
     if (resolver == null) {
       return ctx.failedFuture("DNS client is closed");
     }
-    Promise<List<InetAddress>> promise = ctx.promise();
-    inflightRequests.add(promise);
-    io.netty.util.concurrent.Future<List<InetAddress>> res;
-    res = resolver.resolveAll(name);
-    res.addListener((GenericFutureListener<io.netty.util.concurrent.Future<List<InetAddress>>>) future -> {
-      if (inflightRequests.remove(promise)) {
-        if (future.isSuccess()) {
-          promise.complete(future.getNow());
-        } else {
-          promise.fail(future.cause());
+
+    Future<List<InetAddress>> f = resolver.compose(res2 -> {
+
+      PromiseInternal<List<InetAddress>> promise = ctx.promise();
+      inflightRequests.add(promise);
+
+      io.netty.util.concurrent.Future<List<InetAddress>> res;
+      res = res2.resolveAll(name);
+      res.addListener((GenericFutureListener<io.netty.util.concurrent.Future<List<InetAddress>>>) future -> {
+        if (inflightRequests.remove(promise)) {
+          if (future.isSuccess()) {
+            promise.complete(future.getNow());
+          } else {
+            promise.fail(future.cause());
+          }
         }
-      }
+      });
+      return promise.future();
     });
-    return promise
-      .future()
+
+    return f
       .map(addresses -> {
         List<String> ret = new ArrayList<>();
         for (InetAddress inetAddress : addresses) {
@@ -205,24 +263,28 @@ public class DnsClientImpl implements DnsClient {
                                        Comparator<T> comparator) {
     Objects.requireNonNull(name);
     ContextInternal ctx = vertx.getOrCreateContext();
-    DnsNameResolver resolver = resolver(ctx, InternetProtocolFamily.IPv4);
+    Future<DnsNameResolver> resolver = resolver(ctx, InternetProtocolFamily.IPv4);
     if (resolver == null) {
       return ctx.failedFuture("DNS client is closed");
     }
-    Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise = ctx.promise();
-    inflightRequests.add(promise);
-    io.netty.util.concurrent.Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> res = resolver.query(new DefaultDnsQuestion(name, recordType));
-    res.addListener((GenericFutureListener<io.netty.util.concurrent.Future<AddressedEnvelope<DnsResponse, InetSocketAddress>>>) future -> {
-      if (inflightRequests.remove(promise)) {
-        if (future.isSuccess()) {
-          promise.complete(future.getNow());
-        } else {
-          promise.fail(future.cause());
+
+    Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> f = resolver.compose(res2 -> {
+      Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise = ctx.promise();
+      inflightRequests.add(promise);
+      io.netty.util.concurrent.Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> res = res2.query(new DefaultDnsQuestion(name, recordType));
+      res.addListener((GenericFutureListener<io.netty.util.concurrent.Future<AddressedEnvelope<DnsResponse, InetSocketAddress>>>) future -> {
+        if (inflightRequests.remove(promise)) {
+          if (future.isSuccess()) {
+            promise.complete(future.getNow());
+          } else {
+            promise.fail(future.cause());
+          }
         }
-      }
+      });
+      return promise.future();
     });
-    return promise
-      .future()
+
+    return f
       .transform(ar -> {
       if (ar.succeeded()) {
         AddressedEnvelope<DnsResponse, InetSocketAddress> lst = ar.result();
@@ -259,21 +321,26 @@ public class DnsClientImpl implements DnsClient {
 
   @Override
   public Future<Void> close() {
+    List<Future<?>> futures;
     synchronized (this) {
       if (!closed) {
         closed = true;
-        for (Map<EventLoop, DnsNameResolver> resolvers : Arrays.asList(resolvers, ipv4Resolvers, ipv6Resolvers)) {
-          Collection<DnsNameResolver> values = new ArrayList<>(resolvers.values());
-          resolvers.clear();
-          for (DnsNameResolver resolver : values) {
-            resolver.close();
-          }
+        futures = new ArrayList<>();
+        for (Future<Resolvers> resolvers : resolversMap.values()) {
+          Future<Resolvers> f = resolvers.andThen((res, err) -> {
+            if (res != null) {
+              res.close();
+            }
+          });
+          futures.add(resolvers);
         }
         for (Promise<?> inflight : inflightRequests) {
           inflight.tryFail(new VertxException("closed"));
         }
+      } else {
+        return vertx.succeededFuture();
       }
     }
-    return Future.succeededFuture();
+    return Future.join(futures).mapEmpty();
   }
 }

--- a/vertx-core/src/test/java/io/vertx/test/fakedns/MockDnsServer.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakedns/MockDnsServer.java
@@ -107,7 +107,6 @@ public class MockDnsServer {
                 synchronized (MockDnsServer.this) {
                   currentMessage.add(msg);
                 }
-
                 DnsResponse response = new DatagramDnsResponse(msg.recipient(), msg.sender(), msg.id(), DnsOpCode.QUERY);
                 response.addRecord(DnsSection.QUESTION, dnsRecord);
                 RecordStore s = store;

--- a/vertx-core/src/test/java/io/vertx/tests/dns/DNSTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/dns/DNSTest.java
@@ -17,27 +17,26 @@ import io.netty.resolver.dns.DnsNameResolverTimeoutException;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
 import io.vertx.core.VertxOptions;
-import io.vertx.core.dns.DnsClient;
-import io.vertx.core.dns.DnsClientOptions;
-import io.vertx.core.dns.MxRecord;
-import io.vertx.core.dns.SrvRecord;
+import io.vertx.core.dns.*;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakedns.MockDnsServer;
 import io.vertx.test.fakedns.MockDnsServer.RecordStore;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.vertx.test.core.TestUtils;
 import static io.vertx.test.core.TestUtils.assertNullPointerException;
+import static io.vertx.test.fakedns.MockDnsServer.A_store;
 
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
@@ -127,17 +126,6 @@ public class DNSTest extends VertxTestBase {
         testComplete();
       }));
     await();
-  }
-
-  @Test
-  public void testUnresolvedDnsServer() throws Exception {
-    try {
-      DnsClient dns = vertx.createDnsClient(new DnsClientOptions().setHost("iamanunresolvablednsserver.com").setPort(53));
-      Assert.fail();
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof IllegalArgumentException);
-      Assert.assertEquals("Cannot resolve the host to a valid ip address", e.getMessage());
-    }
   }
 
   @Test
@@ -612,6 +600,79 @@ public class DNSTest extends VertxTestBase {
   public void testIpv6NameServer() {
     // We just want to verify that we can create a client with an IPv6 address as DNS server
     vertx.createDnsClient(new DnsClientOptions().setPort(53).setHost("::1"));
+  }
+
+  @Test
+  public void testResolveDnsServerNameSuccess() {
+    String ip = "10.0.0.1";
+    Map<String, String> store = new HashMap<>();
+    store.put("mydns.org", "127.0.0.1");
+    store.put("vertx.io", ip);
+    testResolveDnsServerName(store, DnsClientOptions.DEFAULT_HOST_RESOLUTION_RETRY_DELAY,
+      client -> {
+        List<String> result = client.resolveA("vertx.io").await();
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(ip, result.get(0));
+      });
+  }
+
+  @Test
+  public void testResolveDnsServerNameFailureRecovery() throws Exception {
+    Map<String, String> store = new ConcurrentHashMap<>();
+    testResolveDnsServerName(store, Duration.ofMillis(150), client -> {
+      try {
+        client.resolveA("vertx.io").await();
+        Assert.fail();
+      } catch (Exception e) {
+        Assertions.assertThat(e).isInstanceOf(UnknownHostException.class);
+
+      }
+      try {
+        Thread.sleep(200);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      store.put("mydns.org", "127.0.0.1");
+      client.resolveA("vertx.io").await();
+    });
+  }
+
+  public void testResolveDnsServerName(Map<String, String> store, Duration retryDelay, Consumer<DnsClient> test) {
+    Vertx vertx = Vertx.vertx(new VertxOptions()
+      .setAddressResolverOptions(new AddressResolverOptions()
+        .setCacheNegativeTimeToLive(0)
+        .setServers(List.of(MockDnsServer.IP_ADDRESS + ":" + MockDnsServer.PORT)))
+    );
+    try {
+      mockDnsServer.store(A_store(store));
+      DnsClient dns = vertx.createDnsClient(new DnsClientOptions()
+        .setPort(MockDnsServer.PORT)
+        .setHost("mydns.org")
+        .setHostResolutionRetryDelay(retryDelay));
+      test.accept(dns);
+    } finally {
+      vertx.close().await();
+    }
+  }
+
+  @Test
+  public void testResolveNameServerFailure() {
+    String ip = "10.0.0.1";
+    mockDnsServer.testResolveA(ip);
+    DnsClient dns = vertx.createDnsClient(new DnsClientOptions()
+      .setPort(MockDnsServer.PORT)
+      .setHost("localhost"));
+
+    dns
+      .resolveA("vertx.io")
+      .onComplete(TestUtils.onSuccess(result -> {
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(ip, result.get(0));
+        testComplete();
+      }));
+    await();
   }
 
   private DnsClient prepareDns() {


### PR DESCRIPTION
Motivation:

The DNS client assumes that the queried server address is an IP address, it should be capable to use the vertx name resolver to resolve this address.

Changes:

Allow the client to resolve the server IP address prior querying it when the server address is not resolved.
