### PR TITLE
Add regression tests for the net client close hook registration

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
@@ -282,6 +282,53 @@ public class VertxTest extends VertxTestBase {
   }
 
   @Test
+  public void testFinalizeNetClientRegisteredWithCloseHook() {
+    Vertx vertx = Vertx.vertx();
+
+    try {
+
+      AtomicReference<NetClient> ref = new AtomicReference<>();
+
+      String id = vertx.deployVerticle(context -> {
+        ref.set(vertx.createNetClient());
+        return Future.succeededFuture();
+      }).await();
+
+      NetClient proxy = ref.getAndSet(null);
+      Assert.assertNotNull(proxy);
+      NetClientInternal real = ((CleanableNetClient) proxy).unwrap();
+      WeakReference<NetClientInternal> realWeakRef = new WeakReference<>(real);
+      real = null;
+      proxy.close().await();
+      runGC();
+      Assert.assertNull(realWeakRef.get());
+      vertx.undeploy(id).await();
+      runGC();
+      Assert.assertNull(realWeakRef.get());
+    } finally {
+      vertx.close().await();
+    }
+  }
+
+  @Test
+  public void testFinalizeNetClientRegisteredWithVertxCloseHook() {
+    Vertx vertx = Vertx.vertx();
+
+    try {
+      NetClient proxy = vertx.createNetClient();
+      NetClientInternal real = ((CleanableNetClient) proxy).unwrap();
+      WeakReference<NetClientInternal> realWeakRef = new WeakReference<>(real);
+      real = null;
+      proxy.close().await();
+      proxy = null;
+      runGC();
+      Assert.assertNull(realWeakRef.get());
+    } finally {
+      vertx.close().await();
+    }
+  }
+
+  @Test
   public void testCascadeCloseHttpClient() throws Exception {
     Vertx vertx1 = vertx();
     try {


### PR DESCRIPTION
## Motivation

#6311 reports that a client created with `createNetClient()` is never released, even after `close()` completes, so each call leaves one `NetClientImpl` reachable for the life of the Vert.x instance.

The leak is real but is already fixed on master. Bisecting with the tests in this PR:

- d9e1080b4 — fails: `expected null, but was:<io.vertx.core.net.impl.tcp.NetClientImpl@...>`
- 6a0a037e2 (*Introduce context resource cleanup*, #6286) — passes

`ResourceHook.shutdown` now calls `owner.remove(this)` before delegating to the resource, so shutting the client down — explicitly or through the cleaner — unregisters the close hook and the client becomes collectable. That generalised the HTTP client fix from abab114c7, whose `ClientCloseableResource` carried the note that it "should somehow get unified and reused".

Nothing covers the net client case, so this adds the missing tests rather than a fix.

## Change

Two tests mirroring `testFinalizeHttpClientRegisteredWithCloseHook`:

- `testFinalizeNetClientRegisteredWithCloseHook` — client created inside a verticle, so the owner is the context close future; it also asserts the client does not resurface after undeploy.
- `testFinalizeNetClientRegisteredWithVertxCloseHook` — client created with the Vert.x instance as owner, matching the reproducer in the issue.

Both were verified to fail at d9e1080b4 and pass from 6a0a037e2 onwards, so they lock in the behaviour rather than merely passing today.

## Test

Full `VertxTest`: 21 tests, 0 failures.

## Note

The 5.1 branch does not contain 6a0a037e2 and still leaks — `testFinalizeNetClientRegisteredWithVertxCloseHook` fails there at 6b710f6f2, which matches the 5.1.6 report. I left that out of this PR since the backport is your call; happy to open one against 5.1 if you want it.
