### PR TITLE
Let ContextInternal#isRunningOnContext consider a duplicated context as its original context

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/ContextInternal.java
@@ -213,10 +213,18 @@ public interface ContextInternal extends Context {
   <T> void execute(T argument, Handler<T> task);
 
   /**
+   * Whether the current thread is running on this context.
+   *
+   * <p> A duplicated context shares the concurrency model of the context it duplicates, therefore
+   * a context and its duplicates are considered the same context by this method: it returns {@code true}
+   * when the current context is this context, a duplicate of this context or the context this
+   * context duplicates.
+   *
    * @return whether the current thread is running on this context
    */
   default boolean isRunningOnContext() {
-    return current() == this && inThread();
+    ContextInternal current = current();
+    return current != null && current.unwrap() == unwrap() && inThread();
   }
 
   /**

--- a/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/ContextTest.java
@@ -474,6 +474,62 @@ public class ContextTest extends VertxTestBase {
     checkDuplicate(ctx, duplicated);
   }
 
+  @Test
+  public void testIsRunningOnContext() throws Exception {
+    testIsRunningOnContext((ContextInternal) vertx.getOrCreateContext(), (ContextInternal) ((VertxInternal) vertx).createEventLoopContext());
+  }
+
+  @Test
+  public void testIsRunningOnContextWorker() throws Exception {
+    testIsRunningOnContext(createWorkerContext(), createWorkerContext());
+  }
+
+  private void testIsRunningOnContext(ContextInternal ctx, ContextInternal other) throws Exception {
+    ContextInternal duplicate = ctx.duplicate();
+    assertFalse(ctx.isRunningOnContext());
+    assertFalse(duplicate.isRunningOnContext());
+    CountDownLatch latch1 = new CountDownLatch(1);
+    ctx.runOnContext(v -> {
+      assertTrue(ctx.isRunningOnContext());
+      // A duplicate shares the concurrency of the context it duplicates
+      assertTrue(duplicate.isRunningOnContext());
+      assertFalse(other.isRunningOnContext());
+      assertFalse(other.duplicate().isRunningOnContext());
+      latch1.countDown();
+    });
+    awaitLatch(latch1);
+    CountDownLatch latch2 = new CountDownLatch(1);
+    duplicate.runOnContext(v -> {
+      assertTrue(duplicate.isRunningOnContext());
+      // The original context and its duplicates are the same context from the concurrency perspective
+      assertTrue(ctx.isRunningOnContext());
+      assertTrue(ctx.duplicate().isRunningOnContext());
+      assertTrue(duplicate.duplicate().isRunningOnContext());
+      assertFalse(other.isRunningOnContext());
+      assertFalse(other.duplicate().isRunningOnContext());
+      latch2.countDown();
+    });
+    awaitLatch(latch2);
+  }
+
+  @Test
+  public void testIsRunningOnContextFromEventBusHandler() throws Exception {
+    // Event-bus messages are delivered on a duplicate of the consumer context, this
+    // must be observed as running on the verticle context (issue #4576)
+    vertx.deployVerticle(new AbstractVerticle() {
+      @Override
+      public void start(Promise<Void> startPromise) {
+        ContextInternal ctx = (ContextInternal) context;
+        vertx.eventBus().<String>consumer("the-address", msg -> {
+          assertTrue(((ContextInternal) Vertx.currentContext()).isDuplicate());
+          assertTrue(ctx.isRunningOnContext());
+          testComplete();
+        }).completion().onComplete(startPromise);
+      }
+    }).onComplete(onSuccess(id -> vertx.eventBus().send("the-address", "msg")));
+    await();
+  }
+
   private void checkDuplicate(ContextInternal ctx, ContextInternal duplicated) throws Exception {
     assertSame(ctx.nettyEventLoop(), duplicated.nettyEventLoop());
     assertSame(ctx.deployment(), duplicated.deployment());


### PR DESCRIPTION
## Motivation

`ContextInternal#isRunningOnContext()` compares the current context with `this` by identity. When code runs on a duplicated context — for instance an event-bus consumer handler deployed in a verticle, since messages are delivered on a duplicate of the consumer context — the verticle context reports that it is *not* running on the context, although the duplicate shares the exact same concurrency model (same event loop / same worker task queue).

Fixes #4576, following the direction discussed there (comparison with the delegate context).

## Changes

- `isRunningOnContext()` now compares the unwrapped contexts: a context, its duplicates and duplicates of duplicates are considered the same context. A null current context is guarded (previously `current() == this` was simply `false`). The javadoc states the rule.
- New `ContextTest` cases:
  - `testIsRunningOnContext` / `testIsRunningOnContextWorker`: original ↔ duplicate ↔ duplicate-of-duplicate all report `true` when running on any of them; a distinct context and its duplicate report `false`; off-thread reports `false`.
  - `testIsRunningOnContextFromEventBusHandler`: the scenario from the issue — a consumer registered in a verticle, message delivered on a duplicate, the verticle context reports `true`.

## Impact

The only internal caller is `FutureBase#emitResult`. Both of its branches dispatch the listener with the future's own context (`beginDispatch`/`endDispatch`), so its observable behaviour is unchanged; when the current thread is on a sibling duplicate it now avoids scheduling an `EmitResultTask` for what would have been an inline execution anyway.

Verified locally: `ContextTest`, the future/context/eventbus/deployment suites, `Http1xTest`, `Http2Test` and the `vertx-core-java21-tests` module (virtual threads) all pass.
