### PR TITLE
HTTP client form upload should not send a chunked transfer encoding header on HTTP/3

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -327,6 +327,13 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
           // Bug ?
           continue;
         }
+      } else if (header.getKey().equalsIgnoreCase(TRANSFER_ENCODING.toString())) {
+        // The encoder produces an HTTP/1.1 request: a chunked transfer encoding must be translated
+        // to a chunked request instead of copying the header, since HTTP/2 and HTTP/3 forbid it
+        if (CHUNKED.toString().equalsIgnoreCase(header.getValue())) {
+          setChunked(true);
+        }
+        continue;
       }
       putHeader(header.getKey(), header.getValue());
     }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3ClientStream.java
@@ -125,6 +125,8 @@ public class Http3ClientStream extends Http3Stream<Http3ClientStream, Http3Clien
   @Override
   public Future<Void> writeHead(HttpRequestHead request, boolean chunked, Buffer chunk, boolean end, StreamPriority priority, boolean connect) {
     HttpRequestHeaders headers = ((HttpRequestHeaders)request.headers());
+    // Connection specific header forbidden by HTTP/3
+    headers.remove(io.vertx.core.http.HttpHeaders.TRANSFER_ENCODING);
     headers.authority(request.authority);
     headers.method(request.method);
     headers.trace(request.traceOperation);

--- a/vertx-core/src/test/java/io/vertx/tests/http/fileupload/HttpClientFileUploadTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/fileupload/HttpClientFileUploadTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 public abstract class HttpClientFileUploadTest extends SimpleHttpTest {
@@ -291,6 +292,8 @@ public abstract class HttpClientFileUploadTest extends SimpleHttpTest {
     List<Upload> toUpload,
     Consumer<HttpServerRequest> checker) throws Exception {
     List<Upload> uploads = Collections.synchronizedList(new ArrayList<>());
+    AtomicReference<HttpVersion> requestVersion = new AtomicReference<>();
+    AtomicReference<String> requestTransferEncoding = new AtomicReference<>();
     File[] testFiles = new File[toUpload.size()];
     for (int i = 0;i < testFiles.length;i++) {
       Upload upload = toUpload.get(i);
@@ -315,6 +318,8 @@ public abstract class HttpClientFileUploadTest extends SimpleHttpTest {
         });
       });
       req.endHandler(v -> {
+        requestVersion.set(req.version());
+        requestTransferEncoding.set(req.getHeader(HttpHeaders.TRANSFER_ENCODING));
         req.response().end();
         checker.accept(req);
       });
@@ -327,6 +332,20 @@ public abstract class HttpClientFileUploadTest extends SimpleHttpTest {
         .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::body))
       .await();
+
+    switch (requestVersion.get()) {
+      case HTTP_1_1:
+        // Chunked file uploads are streamed with the chunked transfer encoding
+        Assert.assertEquals("chunked", requestTransferEncoding.get());
+        break;
+      case HTTP_2:
+      case HTTP_3:
+        // Transfer encoding is a connection specific header forbidden by HTTP/2 and HTTP/3
+        Assert.assertNull(requestTransferEncoding.get());
+        break;
+      default:
+        break;
+    }
 
     return uploads;
   }

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ClientTest.java
@@ -102,6 +102,35 @@ public class Http3ClientTest extends VertxTestBase {
   }
 
   @Test
+  public void testChunkedTransferEncodingHeaderIsSanitized() {
+    // The transfer encoding header is a connection specific header forbidden by HTTP/3, a client
+    // setting it manually (like it would for HTTP/1.1) should not have it sent on the wire
+    AtomicReference<String> transferEncoding = new AtomicReference<>();
+    server.requestHandler(req -> {
+      req.bodyHandler(buff -> {
+        transferEncoding.set(req.getHeader(HttpHeaders.TRANSFER_ENCODING));
+        req.response().end(buff);
+      });
+    });
+    server.listen(8443, "localhost").await();
+
+    HttpClientConnection connection = client.connect(new HttpConnectOptions()
+      .setHost("localhost")
+      .setPort(8443)).await();
+
+    Buffer response = connection.request(HttpMethod.POST, 8443, "localhost", "/")
+      .compose(request -> request
+        .putHeader(HttpHeaders.TRANSFER_ENCODING, HttpHeaders.CHUNKED)
+        .send("Hello World"))
+      .expecting(HttpResponseExpectation.SC_OK)
+      .compose(HttpClientResponse::body)
+      .await();
+
+    Assert.assertEquals("Hello World", response.toString());
+    Assert.assertNull(transferEncoding.get());
+  }
+
+  @Test
   public void testResponseTrailers() throws Exception {
     server.requestHandler(req -> {
       req.response()


### PR DESCRIPTION
## Motivation

`HttpClientRequest#send(ClientForm)` builds the body with Netty's `HttpPostRequestEncoder`, which produces an HTTP/1.1 request; the encoder headers are then copied on the request, including `transfer-encoding: chunked` when the form is streamed (file uploads). That header is a connection specific header forbidden by HTTP/2 (RFC 9113 §8.2.2) and HTTP/3 (RFC 9114 §4.2).

HTTP/2 client streams have sanitized it since a5afe84f1 (5.0.2), but HTTP/3 client streams do not: a chunked multipart form upload over HTTP/3 currently sends `transfer-encoding: chunked` on the wire (the Vert.x server tolerates it, which is why the existing HTTP/3 upload tests did not catch it).

Fixes #5690.

## Changes

- `HttpClientRequestImpl#send(ClientForm)`: instead of copying the encoder's `transfer-encoding: chunked` header, the request is switched to chunked mode with `setChunked(true)`. The HTTP/1.1 client connection still writes the header from the chunked flag, HTTP/2 and HTTP/3 never see it — this fixes the problem at the source for every protocol.
- `Http3ClientStream#writeHead`: remove a `transfer-encoding` header before writing the request head, mirroring `DefaultHttp2ClientStream`, so a manually set header is sanitized as well.

## Tests

- The shared `HttpClientFileUploadTest` helper now asserts per protocol: HTTP/1.1 uploads carry `transfer-encoding: chunked`, HTTP/2 and HTTP/3 uploads carry no `transfer-encoding` header. Without the change, the 8 chunked upload cases of `Http3ClientFileUploadTest` fail with `expected null, but was:<chunked>`; HTTP/1.1, HTTP/2, HTTP/2 multiplex and h2c upgrade variants are unaffected.
- `Http3ClientTest#testChunkedTransferEncodingHeaderIsSanitized`: a request with a manually set `transfer-encoding: chunked` header must not have it delivered to the server.

`Http1xTest`, `Http2Test`, the `http3` and `fileupload` test packages pass locally.
