### PR TITLE
Keep the NetClient referenced in tests that rely on the connection staying open

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2Test.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2Test.java
@@ -19,6 +19,7 @@ import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.net.JdkSSLEngineOptions;
+import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.OpenSSLEngineOptions;
 import io.vertx.core.net.SSLEngineOptions;
@@ -52,6 +53,8 @@ import static org.junit.Assert.*;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class Http2Test extends HttpTest {
+
+  private NetClient netClient;
 
   public Http2Test() {
     this(false);
@@ -735,7 +738,10 @@ public class Http2Test extends HttpTest {
         }
       });
     startServer();
-    NetSocket so = vertx.createNetClient().connect(config.port(), config.host()).await();
+    // Keep a reference to the client: an unreferenced client is closed when it is garbage collected, which
+    // would close the connection before the handshake timeout happens
+    netClient = vertx.createNetClient();
+    netClient.connect(config.port(), config.host()).await();
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpConnectionEarlyResetTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpConnectionEarlyResetTest.java
@@ -14,6 +14,7 @@ package io.vertx.tests.http;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.http.HttpTestBase;
@@ -34,6 +35,7 @@ import org.assertj.core.api.Assertions;
 public class HttpConnectionEarlyResetTest extends VertxTestBase {
 
   private HttpServer httpServer;
+  private NetClient client;
   private AtomicReference<Throwable> caught = new AtomicReference<>();
   private CountDownLatch resetLatch = new CountDownLatch(1);
 
@@ -57,7 +59,10 @@ public class HttpConnectionEarlyResetTest extends VertxTestBase {
 
   @Test
   public void testExceptionCaught() throws Exception {
-    vertx.createNetClient(new NetClientOptions().setSoLinger(0)).connect(HttpTestBase.DEFAULT_HTTP_PORT, "localhost").onComplete(onSuccess(socket -> {
+    // Keep a reference to the client: an unreferenced client is closed when it is garbage collected, which
+    // would close the connection gracefully before the reset
+    client = vertx.createNetClient(new NetClientOptions().setSoLinger(0));
+    client.connect(HttpTestBase.DEFAULT_HTTP_PORT, "localhost").onComplete(onSuccess(socket -> {
       vertx.setTimer(2000, id -> {
         socket.close();
       });


### PR DESCRIPTION
## Motivation

`Http2Test#testSslHandshakeTimeout` is listed in #6218 as failing in 4 out of 60 CI runs with `Timeout Unsatisfied checkpoint`.

The test opens a connection with `vertx.createNetClient().connect(...).await()`, keeps neither the client nor the socket referenced and returns, then the checkpoint waits for the server to report `handshake timed out after 1234ms`. Since a client that is no longer referenced is closed when it is garbage collected, under memory pressure the connection is closed *before* the handshake timeout happens: the server sees a plain close, never reports the `SSLHandshakeException`, and the checkpoint is never satisfied. Adding a `System.gc()` loop after the connect reproduces the CI failure deterministically:

```
java.util.concurrent.TimeoutException: Unsatisfied checkpoint
```

`HttpConnectionEarlyResetTest#testExceptionCaught` has the same pattern: it expects a connection reset (`SO_LINGER=0`) two seconds after connecting, but a client closed by the garbage collector closes the connection gracefully instead and the latch never counts down.

## Changes

Keep the `NetClient` in a field in both tests so it stays referenced for the duration of the test (test-only change). `Http2Test#testSslHandshakeTimeout` passes with the forced garbage collection in place once the client is referenced.

Related to #6218.
