### PR TITLE
Document that clients must be kept referenced to avoid being shut down when garbage collected

### DIFF
--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -922,6 +922,12 @@ You create an {@link io.vertx.core.http.HttpClient} instance with the default co
 
 By default, the client supports HTTP/1, HTTP/2 in plain text.
 
+IMPORTANT: Keep a reference to the client for as long as you use it. A client that is no longer referenced is
+shut down when it is garbage collected, as if {@link io.vertx.core.http.HttpClient#shutdown()} had been called: new
+requests are refused and connections are closed, which can surface as unexpected `Connection was closed` or
+`Client is closed` failures. Typically you store the client in a field of the verticle or of the component that uses it,
+instead of creating it inline in the code that performs a request.
+
 === Configuring an HTTP client
 
 If you want to configure the client, you create it as follows:
@@ -2310,23 +2316,27 @@ The {@link io.vertx.core.http.ServerWebSocket} instance enables you to retrieve 
 
 ==== WebSockets on the client
 
-e Vert.x {@link io.vertx.core.http.WebSocketClient} supports WebSockets.
+The Vert.x {@link io.vertx.core.http.WebSocketClient} supports WebSockets.
 
- You can connect a WebSocket to a server using one of the {@link io.vertx.core.http.WebSocketClient#connect} operations.
+You can connect a WebSocket to a server using one of the {@link io.vertx.core.http.WebSocketClient#connect} operations.
 
- The returned future will be completed with an instance of {@link io.vertx.core.http.WebSocket} when the connection has been made:
+The returned future will be completed with an instance of {@link io.vertx.core.http.WebSocket} when the connection has been made:
 [source,$lang]
 ----
 {@link examples.HttpExamples#clientWebSocketConnect}
 ----
 
-en connecting from a non Vert.x thread, you can create a {@link io.vertx.core.http.ClientWebSocket}, configure its handlers and
+IMPORTANT: Like the HTTP client, the WebSocket client is shut down when it is no longer referenced and garbage collected,
+which closes its WebSockets, including those with a handshake in progress. Keep a reference to the client for as long as
+its WebSockets are in use.
+
+When connecting from a non Vert.x thread, you can create a {@link io.vertx.core.http.ClientWebSocket}, configure its handlers and
 then connect to the server:
 
- [source,$lang]
- ----
- {@link examples.HttpExamples#clientWebSocketConfigurationAndConnect}
- ----
+[source,$lang]
+----
+{@link examples.HttpExamples#clientWebSocketConfigurationAndConnect}
+----
 
 By default, the client sets the `origin` header to the server host, e.g http://www.example.com. Some servers will refuse
 such request, you can configure the client to not set this header.

--- a/vertx-core/src/main/asciidoc/tcp.adoc
+++ b/vertx-core/src/main/asciidoc/tcp.adoc
@@ -253,6 +253,11 @@ The simplest way to create a TCP client, using all default options is as follows
 {@link examples.TcpExamples#defaultTcpClient}
 ----
 
+IMPORTANT: Keep a reference to the client for as long as you use it. A client that is no longer referenced is
+shut down when it is garbage collected, as if {@link io.vertx.core.net.NetClient#shutdown()} had been called (see
+<<_tcp_graceful_shut_down>>): sockets without a shutdown handler are closed immediately. Typically you store the client
+in a field of the verticle or of the component that uses it, instead of creating it inline in the code that connects.
+
 === Configuring a TCP client
 
 If you don't want the default, a client can be configured by passing in a {@link io.vertx.core.net.TcpClientConfig}


### PR DESCRIPTION
## Motivation

`HttpClient`, `NetClient` and `WebSocketClient` are lightweight proxies (`CleanableHttpClient`, `CleanableNetClient`, `CleanableWebSocketClient`) that are shut down when they are garbage collected. This is intentional, but it is not mentioned anywhere in the documentation, and users who create a client inline without keeping a reference to it regularly observe connections closed unexpectedly, requests refused with `Client is closed`, or WebSocket handshakes aborted, and report it as a bug: #5839 (WebSocket handshake), #5916 and #5987 (TCP / unpooled HTTP connections), #5577 (`Pool closed`). Even the test suite has been bitten (#5853, #6317).

## Changes

Docs only.

- `http.adoc`, "Creating an HTTP client": `IMPORTANT` admonition explaining that a client must stay referenced for as long as it is used, that an unreferenced client is shut down when garbage collected as if `HttpClient#shutdown()` had been called (new requests refused, connections closed), the failures this surfaces as, and where to keep the reference.
- `http.adoc`, "WebSockets on the client": the same note, mentioning that WebSockets with a handshake in progress are closed as well.
- `tcp.adoc`, "Creating a TCP client": the same note pointing at `NetClient#shutdown()` and the existing "TCP graceful shut down" section (sockets without a shutdown handler are closed immediately).

While there, in the WebSocket client section:
- fixed two truncated sentences (`e Vert.x ...` → `The Vert.x ...`, `en connecting ...` → `When connecting ...`) and stray leading spaces;
- the `clientWebSocketConfigurationAndConnect` example block was indented by one space, so it was rendered as a literal paragraph rather than a source block; it now renders as `[source,java]`.

Verified with `mvn compile` (docgen): the generated `http.adoc` / `tcp.adoc` contain the admonitions with resolved API links and the fixed source block.
