### PR TITLE
HTTP/2 and HTTP/3 server response should not send an empty trailers frame

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -374,10 +374,12 @@ public class HttpServerResponseImpl implements HttpServerResponse {
   }
 
   private Future<Void> write(Buffer chunk, boolean end) {
-    Future<Void> future = write_(chunk, end && trailedMap == null);
+    // Trailers accessed but left empty are not sent, the last data frame ends the stream instead
+    MultiMap trailers = trailedMap != null && !trailedMap.isEmpty() ? trailedMap : null;
+    Future<Void> future = write_(chunk, end && trailers == null);
     if (end) {
-      if (trailedMap != null) {
-        future = stream.writeHeaders(trailedMap, true);
+      if (trailers != null) {
+        future = stream.writeHeaders(trailers, true);
       }
       Handler<Void> bodyEndHandler = this.bodyEndHandler;
       Handler<Void> endHandler = this.endHandler;

--- a/vertx-core/src/test/java/io/vertx/tests/http/Http2ServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/Http2ServerTest.java
@@ -884,6 +884,47 @@ public class Http2ServerTest extends Http2TestBase {
   }
 
   @Test
+  public void testEmptyTrailers() throws Exception {
+    // Accessing the trailers without adding any must not send an empty trailers frame,
+    // the end of stream is signaled by the last data frame instead
+    server.requestHandler(req -> {
+      HttpServerResponse resp = req.response();
+      resp.setChunked(true);
+      resp.trailers();
+      resp.end("some-content");
+    });
+    startServer();
+    TestClient client = new TestClient();
+    client.connect(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, request -> {
+      request.decoder.frameListener(new Http2EventAdapter() {
+        int headersCount;
+        @Override
+        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) throws Http2Exception {
+          int count = headersCount++;
+          vertx.runOnContext(v -> {
+            Assert.assertEquals("Unexpected trailers frame", 0, count);
+            Assert.assertFalse(endStream);
+          });
+        }
+        @Override
+        public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding, boolean endOfStream) throws Http2Exception {
+          String content = data.toString(StandardCharsets.UTF_8);
+          vertx.runOnContext(v -> {
+            Assert.assertEquals("some-content", content);
+            Assert.assertTrue("Expected the last data frame to end the stream", endOfStream);
+            testComplete();
+          });
+          return super.onDataRead(ctx, streamId, data, padding, endOfStream);
+        }
+      });
+      int id = request.nextStreamId();
+      request.encoder.writeHeaders(request.context, id, GET("/"), 0, true, request.context.newPromise());
+      request.context.flush();
+    });
+    await();
+  }
+
+  @Test
   public void testTrailers() throws Exception {
     server.requestHandler(req -> {
       HttpServerResponse resp = req.response();


### PR DESCRIPTION
## Motivation

`HttpServerResponse#trailers()` lazily creates the trailers map, and `HttpServerResponseImpl` only checks whether the map exists when the response ends:

```java
Future<Void> future = write_(chunk, end && trailedMap == null);
if (end && trailedMap != null) {
  future = stream.writeHeaders(trailedMap, true);
}
```

A handler that accesses `trailers()` without adding anything therefore sends the last DATA frame without `END_STREAM`, followed by an empty HEADERS frame carrying it. An empty trailers frame is valid HTTP/2, but it is an extra frame that serves no purpose, and as reported in #3985 some clients do not handle it well.

Fixes #3985 (the code discussed there has since been replaced by `HttpServerResponseImpl`, shared by HTTP/2 and HTTP/3; the behaviour is the same).

## Changes

- `HttpServerResponseImpl#write`: an empty trailers map is treated like no trailers, so `END_STREAM` rides on the last DATA frame. Non-empty trailers are sent as before.
- `Http2ServerTest#testEmptyTrailers`: with the raw test client, asserts that exactly one HEADERS frame is received and that the last DATA frame ends the stream when the trailers are accessed but left empty. Without the change it fails with `Unexpected trailers frame expected:<0> but was:<1>` / `Expected the last data frame to end the stream`.

HTTP/1.1 is unaffected: `Http1ServerResponse` has its own path where an empty trailer map already produces the same bytes as no trailers.

`Http2ServerTest`, `Http2Test`, `Http2MultiplexTest`, `Http3Test`, `Http3ServerTest` and the existing `testResponseTrailers*` / `testResponseNoTrailers` tests on HTTP/1.1, HTTP/2 and HTTP/3 pass locally.

Independent from #6278 (request trailers), which does not touch the response path.
