### PR TITLE
Document that accessing HttpServerResponse trailers commits the response to sending a trailers frame

### DIFF
--- a/vertx-core/src/main/asciidoc/http.adoc
+++ b/vertx-core/src/main/asciidoc/http.adoc
@@ -677,6 +677,10 @@ Or use {@link io.vertx.core.http.HttpServerResponse#putTrailer}.
 {@link examples.HttpExamples#serverResponsePutTrailer}
 ----
 
+NOTE: accessing {@link io.vertx.core.http.HttpServerResponse#trailers} commits the response to sending trailers when it
+ends: an HTTP/2 or HTTP/3 stream is then ended by a trailers frame instead of the last data frame, even when no trailer
+was added. Only call it when you actually write trailers.
+
 ==== Serving files directly from disk or the classpath
 
 If you were writing a web server, one way to serve a file from disk would be to open it as an {@link io.vertx.core.file.AsyncFile}

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -155,13 +155,21 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   HttpServerResponse putHeader(CharSequence name, Iterable<CharSequence> values);
 
   /**
+   * Returns the HTTP trailers of this response, the map is created on the first call.
+   *
+   * <p> Calling this method commits the response to sending trailers when it ends: for HTTP/2 and HTTP/3 the
+   * stream is ended by a trailers frame instead of the last data frame, even when no trailer has been added.
+   * Do not call this method unless trailers are actually written.
+   *
    * @return The HTTP trailers
    */
   @CacheReturn
   MultiMap trailers();
 
   /**
-   * Put an HTTP trailer
+   * Put an HTTP trailer.
+   *
+   * <p> Like {@link #trailers()}, this commits the response to sending trailers when it ends.
    *
    * @param name  the trailer name
    * @param value  the trailer value


### PR DESCRIPTION
Follow-up to #6319, as suggested there.

`HttpServerResponse#trailers()` creates the trailers map lazily, and once it exists the response ends with a trailers frame on HTTP/2 and HTTP/3, even when no trailer has been added. Ending a stream with an empty headers frame is valid and the behaviour is kept, but the side effect of merely accessing the trailers was undocumented and caused the confusion in #3985.

Docs only:

- javadoc on `HttpServerResponse#trailers()` (map created on first call, calling it commits the response to sending trailers when it ends, do not call it unless trailers are written) and a cross-reference on `putTrailer(String, String)`;
- a `NOTE` in the "Chunked HTTP responses and trailers" section of the HTTP documentation.

The wording is scoped to HTTP/2 and HTTP/3: on HTTP/1.1 an empty trailer map produces the same bytes as no trailers.
