### PR TITLE
Report AsyncFile handler failures to the context

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -391,7 +391,7 @@ public class AsyncFileImpl implements AsyncFile {
     }
     if (handler != null) {
       checkContext();
-      handler.handle(buff);
+      context.dispatch(buff, handler);
     }
   }
 
@@ -403,7 +403,7 @@ public class AsyncFileImpl implements AsyncFile {
     }
     if (endHandler != null) {
       checkContext();
-      endHandler.handle(null);
+      context.dispatch(endHandler);
     }
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/file/FileSystemTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/file/FileSystemTest.java
@@ -38,6 +38,8 @@ import java.io.IOException;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.*;
 import java.nio.file.attribute.*;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -1364,6 +1366,52 @@ public class FileSystemTest extends VertxTestBase {
       });
     }));
     await();
+  }
+
+  @Test
+  public void testReadStreamHandlerExceptionReportedToContext() throws Exception {
+    testReadStreamHandlerExceptionReportedToContext(false);
+  }
+
+  @Test
+  public void testReadStreamEndHandlerExceptionReportedToContext() throws Exception {
+    testReadStreamHandlerExceptionReportedToContext(true);
+  }
+
+  private void testReadStreamHandlerExceptionReportedToContext(boolean fromEndHandler) throws Exception {
+    String fileName = "some-file.dat";
+    createFile(fileName, TestUtils.randomByteArray(1000));
+    RuntimeException failure = new RuntimeException("boom");
+    List<Throwable> reported = Collections.synchronizedList(new ArrayList<>());
+    AtomicBoolean ended = new AtomicBoolean();
+    AtomicBoolean streamExceptionHandlerCalled = new AtomicBoolean();
+    vertx.fileSystem().open(testDir + pathSep + fileName, new OpenOptions()).onComplete(TestUtils.onSuccess(rs -> {
+      // The file is bound to the current context: a failure of a handler must be reported there
+      Vertx.currentContext().exceptionHandler(err -> {
+        reported.add(err);
+        if (fromEndHandler) {
+          testComplete();
+        }
+      });
+      rs.exceptionHandler(t -> streamExceptionHandlerCalled.set(true));
+      rs.handler(chunk -> {
+        if (!fromEndHandler) {
+          throw failure;
+        }
+      });
+      rs.endHandler(v -> {
+        ended.set(true);
+        if (fromEndHandler) {
+          throw failure;
+        }
+        testComplete();
+      });
+    }));
+    await();
+    // The failure is reported to the context, not to the stream exception handler, and does not prevent the stream from ending
+    Assert.assertEquals(Collections.singletonList(failure), reported);
+    Assert.assertTrue(ended.get());
+    Assert.assertFalse(streamExceptionHandlerCalled.get());
   }
 
   @Test


### PR DESCRIPTION
Fixes #5343

### Motivation

When the data handler or the end handler of an `AsyncFile` read stream throws, nothing happens: the `InboundBuffer` catches the throwable in `handleEvent` and, since `AsyncFileImpl` never registers an exception handler on its queue, the failure is silently dropped. Neither the stream `exceptionHandler` nor the context ever sees it (the issue's reproducer prints nothing).

As discussed on the issue, the correct behaviour is to report such failures to the context, like event-bus consumers do.

### Changes

- `AsyncFileImpl.handleBuffer` / `handleEnd` now dispatch the handler through the context (`ContextInternal.dispatch`), so an exception thrown by the handler is reported via `Context.reportException` (context exception handler → `Vertx.exceptionHandler` → "Unhandled exception" log). The stream `exceptionHandler` keeps its I/O failure semantic and is not invoked for a handler failure; reading is not interrupted and the end handler is still called.
- Tests: `FileSystemTest.testReadStreamHandlerExceptionReportedToContext` / `testReadStreamEndHandlerExceptionReportedToContext` (fail without the change).

Note: `NettyFileUpload` (multipart uploads) has the same silent-swallow pattern with its `InboundBuffer`; left out of this PR since the issue is about `AsyncFile`, happy to address it here or separately if wanted.
