### PR TITLE
Deprecate HttpServerRequest.peerCertificateChain() and add peerCertificates() (4.x)

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -28,6 +28,7 @@ import io.vertx.core.streams.ReadStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
+import java.security.cert.Certificate;
 import javax.security.cert.X509Certificate;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -293,9 +294,23 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
    * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
    * @see #sslSession()
+   * @deprecated instead use {@link #peerCertificates()} or {@link #sslSession()}
    */
+  @Deprecated
   @GenIgnore
   X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
+
+  /**
+   * @return an ordered list of the peer certificates. Returns null if connection is
+   *         not SSL.
+   * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
+   * @see javax.net.ssl.SSLSession#getPeerCertificates()
+   * @see #sslSession()
+   */
+  @GenIgnore
+  default List<Certificate> peerCertificates() throws SSLPeerUnverifiedException {
+    return connection().peerCertificates();
+  }
 
   /**
    * @return the absolute URI corresponding to the HTTP request

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestWrapper.java
@@ -30,7 +30,9 @@ import io.vertx.core.streams.WriteStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
+import java.security.cert.Certificate;
 import javax.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -172,6 +174,11 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   @GenIgnore
   public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
     return delegate.peerCertificateChain();
+  }
+
+  @Override
+  public List<Certificate> peerCertificates() throws SSLPeerUnverifiedException {
+    return delegate.peerCertificates();
   }
 
   @Override

--- a/src/test/java/io/vertx/core/http/HttpTLSTest.java
+++ b/src/test/java/io/vertx/core/http/HttpTLSTest.java
@@ -248,7 +248,12 @@ public abstract class HttpTLSTest extends HttpTestBase {
   @Test
   // Client specifies cert and it is required
   public void testTLSClientCertRequired() throws Exception {
-    testTLS(Cert.CLIENT_JKS, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.CLIENT_JKS).requiresClientAuth().pass();
+    TLSTest test = testTLS(Cert.CLIENT_JKS, Trust.SERVER_JKS, Cert.SERVER_JKS, Trust.CLIENT_JKS).requiresClientAuth().pass();
+    // The client certificate chain is exposed by the server request
+    List<Certificate> certs = test.serverPeerCerts();
+    assertNotNull(certs);
+    assertFalse(certs.isEmpty());
+    assertTrue(certs.get(0) instanceof X509Certificate);
   }
 
   @Test
@@ -1053,6 +1058,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
         .setURI(DEFAULT_TEST_URI));
     };
     Certificate clientPeerCert;
+    List<Certificate> serverPeerCerts;
     String indicatedServerName;
 
     public TLSTest(Cert<?> clientCert, Trust<?> clientTrust, Cert<?> serverCert, Trust<?> serverTrust) {
@@ -1202,6 +1208,10 @@ public abstract class HttpTLSTest extends HttpTestBase {
       return clientPeerCert;
     }
 
+    public List<Certificate> serverPeerCerts() {
+      return serverPeerCerts;
+    }
+
     TLSTest pass() {
       return run(true);
     }
@@ -1303,6 +1313,12 @@ public abstract class HttpTLSTest extends HttpTestBase {
         indicatedServerName = req.connection().indicatedServerName();
         assertEquals(version, req.version());
         assertEquals(serverSSL, req.isSSL());
+        if (req.isSSL()) {
+          try {
+            serverPeerCerts = req.peerCertificates();
+          } catch (SSLPeerUnverifiedException ignore) {
+          }
+        }
         if (req.method() == HttpMethod.GET || req.method() == HttpMethod.HEAD) {
           req.response().end();
         } else {


### PR DESCRIPTION
Related to #5389

### Motivation

On 5.x this is already solved (7a75c821f removed every `javax.security.cert` usage), but on 4.x `HttpServerRequest.peerCertificateChain()` still returns `javax.security.cert.X509Certificate[]`, a JDK API deprecated for removal, and — unlike `HttpConnection`, `NetSocket` and `WebSocketBase`, which were deprecated and given a `peerCertificates()` replacement in 4.x — the request has no `java.security.cert` counterpart. Users get the "deprecated and marked for removal" warning with no way around it short of `req.connection().peerCertificates()`.

### Changes

- `HttpServerRequest.peerCertificateChain()` is `@Deprecated`, pointing to `peerCertificates()` / `sslSession()`.
- New `default List<Certificate> peerCertificates()` delegating to `connection().peerCertificates()` — a default method like the existing `isSSL()` / `sslSession()`, so it is source and binary compatible with external implementations of the interface.
- `HttpServerRequestWrapper` delegates explicitly.
- Test: `HttpTLSTest` captures `req.peerCertificates()` on the server side and `testTLSClientCertRequired` asserts the client chain is exposed (HTTP/1.x and HTTP/2).

Since master is already clean, #5389 itself could probably be closed once this lands (or independently).
