### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
       - name: Install JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ inputs.jdk }}
           distribution: temurin

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
       - name: Install JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: |
             21


### PR DESCRIPTION
###### Problem:

The active CI and deployment workflows use actions/setup-java v5.

###### Solution:

Upgrade both references to actions/setup-java v6.

###### Result:

The workflows use the current setup-java major release.