### PR TITLE
fix: handle null address in NioTransport.convert to avoid NPE

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/transports/NioTransport.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/transports/NioTransport.java
@@ -48,6 +48,9 @@ public class NioTransport implements Transport {
 
   @Override
   public io.vertx.core.net.SocketAddress convert(SocketAddress address) {
+    if (address == null) {
+      return null;
+    }
     if (unixDomainSocketNioTransport != null && unixDomainSocketNioTransport.isUnixDomainSocketAddress(address)) {
       return unixDomainSocketNioTransport.convert(address);
     }


### PR DESCRIPTION
Fixes #6333

`DatagramChannel.localAddress()` returns null when the channel is not bound, and passing null to `NioTransport.convert(SocketAddress)` causes a NullPointerException in `isUnixDomainSocketAddress` (which calls `address.getClass()`).

Epoll/KQueue transports already handle this safely via `instanceof` checks (returning null for non-InetSocketAddress). This aligns NioTransport by returning null for null input.