### PR TITLE
NPE thrown by isUnixDomainSocketAddress

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
@@ -328,7 +328,8 @@ public class DatagramSocketImpl implements DatagramSocket, MetricsProvider, Clos
 
   @Override
   public SocketAddress localAddress() {
-    return context.owner().transport().convert(channel.localAddress());
+    InetSocketAddress localAddress = channel.localAddress();
+    return localAddress != null ? context.owner().transport().convert(localAddress) : null;
   }
 
   @Override

--- a/vertx-core/src/test/java/io/vertx/tests/datagram/DatagramTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/datagram/DatagramTest.java
@@ -535,4 +535,14 @@ public class DatagramTest extends VertxTestBase {
       }));
     await();
   }
+
+  @Test
+  public void shouldNotThrowWhenReadingLocalAddressBeforeBind() {
+    peer1 = vertx.createDatagramSocket(new DatagramSocketOptions());
+    try {
+      peer1.localAddress();
+    } catch (Exception e) {
+      fail(e);
+    }
+  }
 }


### PR DESCRIPTION
See #6333

NPE thrown when the provided address is null (may happen if checking the local address of an unbounded server).

Other transports are protected from this because they use instanceof. This transport can't use it because it uses method lookups.