### PR TITLE
Fix HTTP/1 active-request metric lifecycle when connection closes before request body completes

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerConnection.java
@@ -513,6 +513,10 @@ public class Http1ServerConnection extends Http1Connection implements HttpServer
     if (responseInProgress != null) {
       responseInProgress.handleException(HttpUtils.CONNECTION_CLOSED_EXCEPTION);
     }
+    Http1ServerRequest requestInProgress = this.requestInProgress;
+    if (requestInProgress != null && requestInProgress != responseInProgress && requestInProgress.response() != null) {
+      requestInProgress.handleException(HttpUtils.CONNECTION_CLOSED_EXCEPTION);
+    }
     super.handleClosed();
   }
 
@@ -521,7 +525,7 @@ public class Http1ServerConnection extends Http1Connection implements HttpServer
     boolean ret = super.handleException(t);
     Http1ServerRequest responseInProgress = this.responseInProgress;
     Http1ServerRequest requestInProgress = this.requestInProgress;
-    if (requestInProgress != null) {
+    if (requestInProgress != null && requestInProgress.response() != null) {
       requestInProgress.reportMetricsFailed = true;
       requestInProgress.handleException(t);
     }

--- a/vertx-core/src/test/java/io/vertx/tests/metrics/Http1xMetricsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/metrics/Http1xMetricsTest.java
@@ -13,12 +13,17 @@ package io.vertx.tests.metrics;
 import io.vertx.core.ThreadingModel;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.net.NetClient;
+import io.vertx.test.fakemetrics.FakeHttpServerMetrics;
+import io.vertx.test.fakemetrics.FakeMetricsBase;
+import io.vertx.test.fakemetrics.HttpServerMetric;
 import io.vertx.test.http.HttpConfigurator;
 import io.vertx.test.core.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class Http1xMetricsTest extends HttpMetricsTestBase {
 
@@ -45,5 +50,72 @@ public class Http1xMetricsTest extends HttpMetricsTestBase {
       req.connection().close();
     }));
     TestUtils.awaitLatch(latch);
+  }
+
+  @Test
+  public void testActiveRequestMetricCleanedUpAfterEarlyResponseAndConnectionClose() throws Exception {
+    AtomicReference<HttpServerMetric> metricRef = new AtomicReference<>();
+    server.requestHandler(req -> {
+      FakeHttpServerMetrics metrics = FakeMetricsBase.httpMetricsOf(server);
+      metricRef.set(metrics.getRequestMetric(req));
+      req.response().setStatusCode(401).end();
+    });
+    startServer(testAddress);
+
+    CountDownLatch latch = new CountDownLatch(1);
+    NetClient netClient = vertx.createNetClient();
+    try {
+      netClient.connect(testAddress.port(), "127.0.0.1").onSuccess(socket -> {
+        StringBuilder received = new StringBuilder();
+        socket.handler(buf -> {
+          received.append(buf.toString());
+          if (received.toString().contains("\r\n\r\n")) {
+            socket.handler(null);
+            socket.close().onComplete(v -> latch.countDown());
+          }
+        });
+        socket.write(
+          "GET / HTTP/1.1\r\n" +
+          "Host: 127.0.0.1\r\n" +
+          "Content-Length: 1\r\n" +
+          "Connection: keep-alive\r\n" +
+          "\r\n"
+        );
+      });
+      latch.await();
+      // responseEnd is the correct terminal call: the 401 response completed normally
+      assertWaitUntil(() -> metricRef.get() != null && metricRef.get().responseEnded.get());
+      Assert.assertFalse(metricRef.get().failed.get());
+    } finally {
+      netClient.close();
+    }
+  }
+
+  @Test
+  public void testActiveRequestMetricCleanedUpAfterConnectionCloseBeforeBodyComplete() throws Exception {
+    AtomicReference<HttpServerMetric> metricRef = new AtomicReference<>();
+    server.requestHandler(req -> {
+      FakeHttpServerMetrics metrics = FakeMetricsBase.httpMetricsOf(server);
+      metricRef.set(metrics.getRequestMetric(req));
+      // Do not respond — body will never arrive
+    });
+    startServer(testAddress);
+
+    NetClient netClient = vertx.createNetClient();
+    try {
+      netClient.connect(testAddress.port(), "127.0.0.1").onSuccess(socket ->
+        socket.write(
+          "POST / HTTP/1.1\r\n" +
+          "Host: 127.0.0.1\r\n" +
+          "Content-Length: 10\r\n" +
+          "\r\n"
+        ).onComplete(v -> socket.close())
+      );
+      // requestReset is the correct terminal call: connection closed before any response was sent
+      assertWaitUntil(() -> metricRef.get() != null && metricRef.get().failed.get());
+      Assert.assertFalse(metricRef.get().responseEnded.get());
+    } finally {
+      netClient.close();
+    }
   }
 }


### PR DESCRIPTION
When the server sends an early response before the request body is fully received and the client then closes the connection, responseEnd() is already called by reportResponseComplete() at response-write time. The additional requestReset() call in handleClosed() violates the SPI contract of exactly one terminal call per request.

Fix handleClosed() by delegating to requestInProgress.handleException() behind a requestInProgress.response != null guard, which skips pipelined requests where handleBegin() was never called (avoiding a null metric NPE) and relies on the existing !response.ended() check to prevent a double terminal call.

Apply the same response != null guard to handleException() to prevent the equivalent NPE under IO errors.

Add two regression tests using Vert.x NetClient: one verifying that responseEnd is the terminal call when an early 401 is sent and the client closes before delivering the body; one verifying that requestReset is the terminal call when the client closes before the body with no response sent.

Assisted-by: Anthropic Claude (claude-sonnet-4-6)