### PR TITLE
PQC improvements

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextManager.java
@@ -19,6 +19,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.impl.utils.LruCache;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.*;
 import io.vertx.core.spi.tls.SslContextFactory;
 
@@ -41,6 +43,7 @@ public abstract class SslContextManager<P extends SslContextProvider> {
     return CLIENT_AUTH_MAPPING.get(auth);
   }
 
+  private static final Logger log = LoggerFactory.getLogger(SslContextManager.class);
   public static final int DEFAULT_SSL_CONTEXT_PROVIDER_CACHE_SIZE = 64;
   private static final Config NULL_CONFIG = new Config(null, null, null, null, null);
   private static final EnumMap<ClientAuth, io.netty.handler.ssl.ClientAuth> CLIENT_AUTH_MAPPING = new EnumMap<>(ClientAuth.class);
@@ -86,6 +89,7 @@ public abstract class SslContextManager<P extends SslContextProvider> {
     }
     if (pqcPolicy == PqcEnforcementPolicy.STRICT || pqcPolicy == PqcEnforcementPolicy.CLIENT_NEGOTIATED) {
       if (engineOptions != null) {
+        // we check that the user provided a PQ compliant SSL Engine
         boolean pqcSupported;
         if (engineOptions instanceof JdkSSLEngineOptions) {
           pqcSupported = JdkSSLEngineOptions.isPqcAvailable();
@@ -93,15 +97,18 @@ public abstract class SslContextManager<P extends SslContextProvider> {
           pqcSupported = OpenSSLEngineOptions.isPqcAvailable();
         }
         if (!pqcSupported) {
-          throw new VertxException("PQC enforcement policy " + pqcPolicy + " requires X25519MLKEM768 but the configured SSL engine does not support it");
+          throw new VertxException("PQC enforcement policy " + pqcPolicy + " requires PQ compliant named groups but the configured SSL engine does not support it");
         }
       } else {
+        // the user didn't specify any SSL engine, we pick one for them
         if (JdkSSLEngineOptions.isPqcAvailable()) {
+          log.warn("JdkSslEngine supports PQ compliant groups, it will be used for the application");
           engineOptions = new JdkSSLEngineOptions();
         } else if (OpenSSLEngineOptions.isPqcAvailable()) {
+          log.warn("OpenSslEngine supports PQ compliant groups, it will be used for the application");
           engineOptions = new OpenSSLEngineOptions();
         } else {
-          throw new VertxException("PQC enforcement policy " + pqcPolicy + " requires X25519MLKEM768 but neither JDK nor OpenSSL support it");
+          throw new VertxException("PQC enforcement policy " + pqcPolicy + " requires PQ compliant named groups but neither JDK nor OpenSSL support it");
         }
       }
     }

--- a/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextManager.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/tls/SslContextManager.java
@@ -102,10 +102,10 @@ public abstract class SslContextManager<P extends SslContextProvider> {
       } else {
         // the user didn't specify any SSL engine, we pick one for them
         if (JdkSSLEngineOptions.isPqcAvailable()) {
-          log.warn("JdkSslEngine supports PQ compliant groups, it will be used for the application");
+          log.debug("JdkSslEngine supports PQ compliant groups, it will be used for the application");
           engineOptions = new JdkSSLEngineOptions();
         } else if (OpenSSLEngineOptions.isPqcAvailable()) {
-          log.warn("OpenSslEngine supports PQ compliant groups, it will be used for the application");
+          log.debug("OpenSslEngine supports PQ compliant groups, it will be used for the application");
           engineOptions = new OpenSSLEngineOptions();
         } else {
           throw new VertxException("PQC enforcement policy " + pqcPolicy + " requires PQ compliant named groups but neither JDK nor OpenSSL support it");

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
@@ -20,6 +20,8 @@ import io.vertx.core.net.PqcEnforcementPolicy;
 import javax.net.ssl.SSLEngine;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Pre Java 21 implementation: named groups not supported.
@@ -29,8 +31,11 @@ public class SslEngineUtils {
   private static final Logger log = LoggerFactory.getLogger(SslEngineUtils.class);
 
   private static final List<String> PQ_COMPLIANT_GROUPS = List.of("X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024");
-  private static final List<String> DEFAULT_KEY_EXCHANGE_GROUPS = List.of("X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024", "X25519", "secp256r1", "x448",
+  private static final List<String> DEFAULT_KEY_EXCHANGE_GROUPS = List.of("X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024", "X25519", "SecP256r1", "x448",
     "secp384r1", "secp521r1");
+  private static final Set<String> PQ_COMPLIANT_GROUPS_UPPER = PQ_COMPLIANT_GROUPS.stream()
+    .map(String::toUpperCase)
+    .collect(Collectors.toUnmodifiableSet());
 
   /**
    * Resolve the effective key exchange groups based on the PQC enforcement policy.
@@ -42,19 +47,28 @@ public class SslEngineUtils {
     }
     switch (pqcPolicy) {
       case STRICT:
-        if (groups != null && !groups.isEmpty()) {
-          if (!(PQ_COMPLIANT_GROUPS.containsAll(groups))) {
-            log.debug("PQC enforcement policy is STRICT: overriding key exchange groups " + groups + " with " + PQ_COMPLIANT_GROUPS);
-          }
-        }
-        return PQ_COMPLIANT_GROUPS;
-      case CLIENT_NEGOTIATED:
+        // we check if the user provided a set of named groups
         if (groups == null || groups.isEmpty()) {
-          log.debug("No key exchange groups list was specified, a default list containing X25519MLKEM768 is selected");
+          log.warn("No key exchange groups list was specified, the default list "+PQ_COMPLIANT_GROUPS+" is used");
+          // if they didn't we return the default set of named groups
+          return PQ_COMPLIANT_GROUPS;
+        }
+        // if they did, we check that the set they provided contains only PQ compliant groups
+        if (!groups.stream().allMatch(g -> PQ_COMPLIANT_GROUPS_UPPER.contains(g.toUpperCase()))) {
+          log.warn("PQC enforcement policy is STRICT: overriding key exchange groups " + groups + " with " + PQ_COMPLIANT_GROUPS);
+          return PQ_COMPLIANT_GROUPS;
+        }
+        // the user specified a set of PQ compliant groups, we can use it
+        return groups;
+      case CLIENT_NEGOTIATED:
+        // we check if the user provided a set of named groups
+        if (groups == null || groups.isEmpty()) {
+          log.warn("No key exchange groups list was specified, the default list "+DEFAULT_KEY_EXCHANGE_GROUPS+" is used");
           return DEFAULT_KEY_EXCHANGE_GROUPS;
         }
-        if (groups.stream().noneMatch(PQ_COMPLIANT_GROUPS::contains)) {
-          log.debug("PQC enforcement policy is CLIENT_NEGOTIATED: prepending " + PQ_COMPLIANT_GROUPS + " to key exchange groups " + groups);
+        // if they did, we check that the set they provided contains at least one PQ compliant group
+        if (groups.stream().noneMatch(g -> PQ_COMPLIANT_GROUPS_UPPER.contains(g.toUpperCase()))) {
+          log.warn("PQC enforcement policy is CLIENT_NEGOTIATED: prepending " + PQ_COMPLIANT_GROUPS + " to key exchange groups " + groups);
           List<String> result = new ArrayList<>(groups.size() + 1);
           result.addAll(PQ_COMPLIANT_GROUPS);
           result.addAll(groups);

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
@@ -49,7 +49,7 @@ public class SslEngineUtils {
       case STRICT:
         // we check if the user provided a set of named groups
         if (groups == null || groups.isEmpty()) {
-          log.warn("No key exchange groups list was specified, the default list "+PQ_COMPLIANT_GROUPS+" is used");
+          log.debug("No key exchange groups list was specified, the default list "+PQ_COMPLIANT_GROUPS+" is used");
           // if they didn't we return the default set of named groups
           return PQ_COMPLIANT_GROUPS;
         }
@@ -63,12 +63,12 @@ public class SslEngineUtils {
       case CLIENT_NEGOTIATED:
         // we check if the user provided a set of named groups
         if (groups == null || groups.isEmpty()) {
-          log.warn("No key exchange groups list was specified, the default list "+DEFAULT_KEY_EXCHANGE_GROUPS+" is used");
+          log.debug("No key exchange groups list was specified, the default list "+DEFAULT_KEY_EXCHANGE_GROUPS+" is used");
           return DEFAULT_KEY_EXCHANGE_GROUPS;
         }
         // if they did, we check that the set they provided contains at least one PQ compliant group
         if (groups.stream().noneMatch(g -> PQ_COMPLIANT_GROUPS_UPPER.contains(g.toUpperCase()))) {
-          log.warn("PQC enforcement policy is CLIENT_NEGOTIATED: prepending " + PQ_COMPLIANT_GROUPS + " to key exchange groups " + groups);
+          log.debug("PQC enforcement policy is CLIENT_NEGOTIATED: prepending " + PQ_COMPLIANT_GROUPS + " to key exchange groups " + groups);
           List<String> result = new ArrayList<>(groups.size() + 1);
           result.addAll(PQ_COMPLIANT_GROUPS);
           result.addAll(groups);

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/SslEngineUtils.java
@@ -55,7 +55,7 @@ public class SslEngineUtils {
         }
         // if they did, we check that the set they provided contains only PQ compliant groups
         if (!groups.stream().allMatch(g -> PQ_COMPLIANT_GROUPS_UPPER.contains(g.toUpperCase()))) {
-          log.warn("PQC enforcement policy is STRICT: overriding key exchange groups " + groups + " with " + PQ_COMPLIANT_GROUPS);
+          log.debug("PQC enforcement policy is STRICT: overriding key exchange groups " + groups + " with " + PQ_COMPLIANT_GROUPS);
           return PQ_COMPLIANT_GROUPS;
         }
         // the user specified a set of PQ compliant groups, we can use it

--- a/vertx-core/src/main/java21/io/vertx/core/impl/JdkDependent.java
+++ b/vertx-core/src/main/java21/io/vertx/core/impl/JdkDependent.java
@@ -10,10 +10,14 @@
  */
 package io.vertx.core.impl;
 
+import java.util.Arrays;
+import java.util.Set;
 import java.util.concurrent.ThreadFactory;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Utils dependent on the JDK implementation.
@@ -39,6 +43,21 @@ public class JdkDependent {
     return thread.isVirtual();
   }
 
+  private static final Set<String> PQ_COMPLIANT_GROUPS = Set.of("X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024");
+  private static final Set<String> PQ_COMPLIANT_GROUPS_UPPER = PQ_COMPLIANT_GROUPS.stream()
+    .map(String::toUpperCase)
+    .collect(Collectors.toUnmodifiableSet());
+
+  public static boolean isPqcAvailable() {
+    try {
+      SSLContext ctx = SSLContext.getDefault();
+      SSLParameters params = ctx.getDefaultSSLParameters();
+      String[] groups = params.getNamedGroups();
+      return groups != null && Arrays.stream(groups).anyMatch(g -> PQ_COMPLIANT_GROUPS_UPPER.contains(g.toUpperCase()));
+    } catch (Exception e) {
+      return false;
+    }
+  }
   public static void applyNamedGroups(SSLEngine engine, List<String> groups) {
     SSLParameters params = engine.getSSLParameters();
     params.setNamedGroups(groups.toArray(new String[0]));

--- a/vertx-core/src/test/java/io/vertx/it/HybridKeyExchangeTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/HybridKeyExchangeTest.java
@@ -327,7 +327,6 @@ public class HybridKeyExchangeTest extends HttpTestBase {
       server.listen().await();
       fail("Server should have failed to start");
     } catch (VertxException e) {
-      assertTrue(e.getMessage().contains("X25519MLKEM768"));
       assertTrue(e.getMessage().contains("does not support it"));
     }
   }
@@ -349,7 +348,6 @@ public class HybridKeyExchangeTest extends HttpTestBase {
         .build();
       fail("Client should have failed to build");
     } catch (VertxException e) {
-      assertTrue(e.getMessage().contains("X25519MLKEM768"));
       assertTrue(e.getMessage().contains("does not support it"));
     }
   }

--- a/vertx-core/src/test/java/io/vertx/it/HybridKeyExchangeTest.java
+++ b/vertx-core/src/test/java/io/vertx/it/HybridKeyExchangeTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class HybridKeyExchangeTest extends HttpTestBase {
 
+
   private static void assumeMlKemAvailable() {
     boolean available = OpenSsl.isAvailable();
     if (!available) {
@@ -595,6 +596,86 @@ public class HybridKeyExchangeTest extends HttpTestBase {
     }
   }
 
+
+  private static void assumeJdkPqcAvailable() {
+    Assume.assumeTrue("JDK PQC is not available", JdkSSLEngineOptions.isPqcAvailable());
+  }
+
+  @Test
+  public void testStrictPolicyHandshakeJdk() throws Exception {
+    assumeJdkPqcAvailable();
+    ServerSSLOptions serverSslOptions = new ServerSSLOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setKeyCertOptions(Cert.SERVER_PEM.get());
+
+    server = vertx.httpServerBuilder()
+      .with(new HttpServerConfig(new HttpServerOptions()
+        .setPort(DEFAULT_HTTPS_PORT)
+        .setHost(DEFAULT_HTTPS_HOST)))
+      .with(new JdkSSLEngineOptions())
+      .with(serverSslOptions)
+      .build();
+    server.requestHandler(req -> req.response().end("jdk-strict-ok"));
+    startServer(server);
+
+    ClientSSLOptions pqcClientSsl = new ClientSSLOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setTrustAll(true);
+    client = vertx.httpClientBuilder()
+      .with(new HttpClientOptions().setSsl(true))
+      .with(new JdkSSLEngineOptions())
+      .with(pqcClientSsl)
+      .build();
+
+    var bodyBuffer = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .expecting(req -> req.connection().sslSession().getProtocol().equals("TLSv1.3"))
+      .compose(HttpClientRequest::send)
+      .expecting(HttpResponseExpectation.SC_OK)
+      .compose(HttpClientResponse::body)
+      .await();
+    assertEquals("jdk-strict-ok", bodyBuffer.toString());
+  }
+
+  @Test
+  public void testStrictPolicyMTLSJdk() throws Exception {
+    assumeJdkPqcAvailable();
+    ServerSSLOptions serverSslOptions = new ServerSSLOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setClientAuth(io.vertx.core.http.ClientAuth.REQUIRED)
+      .setKeyCertOptions(Cert.SERVER_PEM_ROOT_CA.get())
+      .setTrustOptions(Trust.SERVER_PEM_ROOT_CA.get());
+
+    server = vertx.httpServerBuilder()
+      .with(new HttpServerConfig(new HttpServerOptions()
+        .setPort(DEFAULT_HTTPS_PORT)
+        .setHost(DEFAULT_HTTPS_HOST)))
+      .with(new JdkSSLEngineOptions())
+      .with(serverSslOptions)
+      .build();
+    server.requestHandler(req -> {
+      assertTrue(req.isSSL());
+      req.response().end("jdk-mtls-strict-ok");
+    });
+    startServer(server);
+
+    ClientSSLOptions pqcClientSsl = new ClientSSLOptions()
+      .setPqcEnforcementPolicy(PqcEnforcementPolicy.STRICT)
+      .setKeyCertOptions(Cert.CLIENT_PEM_ROOT_CA.get())
+      .setTrustAll(true);
+    client = vertx.httpClientBuilder()
+      .with(new HttpClientOptions().setSsl(true))
+      .with(new JdkSSLEngineOptions())
+      .with(pqcClientSsl)
+      .build();
+
+    var buffer = client.request(HttpMethod.GET, DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/")
+      .expecting(req -> req.connection().sslSession().getProtocol().equals("TLSv1.3"))
+      .compose(HttpClientRequest::send)
+      .expecting(HttpResponseExpectation.SC_OK)
+      .compose(HttpClientResponse::body)
+      .await();
+    assertEquals("jdk-mtls-strict-ok", buffer.toString());
+  }
 
   static class ServerHelloGroupExtractor extends ChannelInboundHandlerAdapter {
 

--- a/vertx-core/src/test/java/io/vertx/tests/net/SslEngineUtilsTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/net/SslEngineUtilsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.net;
+
+import io.vertx.core.net.PqcEnforcementPolicy;
+import io.vertx.core.net.impl.SslEngineUtils;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SslEngineUtilsTest {
+
+  // The canonical PQ compliant groups defined in SslEngineUtils
+  private static final List<String> PQ_COMPLIANT = List.of("X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024");
+
+  // --- STRICT policy ---
+
+  @Test
+  public void testStrictPolicyAcceptsAllLowercasePqGroups() {
+    List<String> groups = List.of("x25519mlkem768", "secp256r1mlkem768", "secp384r1mlkem1024");
+    assertEquals(groups, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.STRICT));
+  }
+
+  @Test
+  public void testStrictPolicyAcceptsAllUppercasePqGroups() {
+    List<String> groups = List.of("X25519MLKEM768", "SECP256R1MLKEM768", "SECP384R1MLKEM1024");
+    assertEquals(groups, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.STRICT));
+  }
+
+  @Test
+  public void testStrictPolicyAcceptsMixedCasePqGroups() {
+    List<String> groups = List.of("X25519Mlkem768", "secP256r1MLKEM768", "SecP384R1mlkem1024");
+    assertEquals(groups, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.STRICT));
+  }
+
+  @Test
+  public void testStrictPolicyOverridesGroupsContainingNonPqEntry() {
+    // Mixed: one PQ (wrong case) + one non-PQ — the non-PQ entry triggers override
+    List<String> groups = List.of("x25519mlkem768", "X25519");
+    List<String> result = SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.STRICT);
+    assertEquals(PQ_COMPLIANT, result);
+  }
+
+  @Test
+  public void testStrictPolicyOverridesNonPqGroups() {
+    List<String> groups = List.of("X25519", "secp256r1");
+    List<String> result = SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.STRICT);
+    assertEquals(PQ_COMPLIANT, result);
+  }
+
+  // --- CLIENT_NEGOTIATED policy ---
+
+  @Test
+  public void testClientNegotiatedDoesNotPrependWhenLowercasePqGroupPresent() {
+    List<String> groups = List.of("x25519mlkem768", "X25519");
+    assertEquals(groups, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.CLIENT_NEGOTIATED));
+  }
+
+  @Test
+  public void testClientNegotiatedDoesNotPrependWhenUppercasePqGroupPresent() {
+    List<String> groups = List.of("X25519MLKEM768", "secp256r1");
+    assertEquals(groups, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.CLIENT_NEGOTIATED));
+  }
+
+  @Test
+  public void testClientNegotiatedDoesNotPrependWhenMixedCasePqGroupPresent() {
+    List<String> groups = List.of("secP384r1MLKEM1024", "X25519");
+    assertEquals(groups, SslEngineUtils.resolveKeyExchangeGroups(groups, PqcEnforcementPolicy.CLIENT_NEGOTIATED));
+  }
+
+  @Test
+  public void testClientNegotiatedPrependsWhenNoPqGroupPresent() {
+    List<String> nonPq = List.of("X25519", "secp256r1");
+    List<String> result = SslEngineUtils.resolveKeyExchangeGroups(nonPq, PqcEnforcementPolicy.CLIENT_NEGOTIATED);
+    // PQ groups prepended, original groups preserved at the end
+    assertTrue(result.size() == nonPq.size() + PQ_COMPLIANT.size());
+    assertEquals(PQ_COMPLIANT, result.subList(0, PQ_COMPLIANT.size()));
+    assertEquals(nonPq, result.subList(PQ_COMPLIANT.size(), result.size()));
+  }
+}


### PR DESCRIPTION
- `STRICT PQC` policy now doesn't override user provided named groups if they're all PQ compliant
- groups comparisons, detection was case sensitive in SslEngineUtils and 21/.../JdkDependent, it is no longer
- logs describing the choices made by Vert.x regarding Ssl Engine and named groups selection are now 'warn' instead of 'debug': they will thus appear in Quarkus

added unit tests for SslEngineUtils checking the insensitiveness of the comparisons and the behaviour