### PR TITLE
Expose the underlying Netty allocator for a given HTTP stream.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.http.impl;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http.multipart.Attribute;
@@ -252,6 +253,11 @@ public class HttpServerRequestImpl extends HttpServerRequestBase {
   @Override
   public ContextInternal context() {
     return context;
+  }
+
+  @Override
+  public ByteBufAllocator allocator() {
+    return stream.allocator();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpStream.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.http.impl;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -40,6 +41,7 @@ public interface HttpStream {
 
   HttpConnection connection();
   ContextInternal context();
+  ByteBufAllocator allocator();
 
   Future<Void> writeChunk(Buffer buf, boolean end);
   Future<Void> writeFrame(int type, int flags, Buffer payload);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/StatisticsGatheringHttpClientStream.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.http.impl;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Future;
@@ -65,6 +66,11 @@ class StatisticsGatheringHttpClientStream implements HttpClientStream {
   @Override
   public ContextInternal context() {
     return delegate.context();
+  }
+
+  @Override
+  public ByteBufAllocator allocator() {
+    return delegate.allocator();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ClientConnection.java
@@ -12,6 +12,7 @@
 package io.vertx.core.http.impl.http1;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.*;
 import io.netty.handler.codec.DecoderResult;
@@ -654,6 +655,11 @@ public class Http1ClientConnection extends Http1Connection implements io.vertx.c
     @Override
     public ContextInternal context() {
       return context;
+    }
+
+    @Override
+    public ByteBufAllocator allocator() {
+      return conn.channel().alloc();
     }
 
     @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http1/Http1ServerRequest.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core.http.impl.http1;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.*;
@@ -188,6 +189,11 @@ public class Http1ServerRequest extends HttpServerRequestBase implements io.vert
   @Override
   public ContextInternal context() {
     return context;
+  }
+
+  @Override
+  public ByteBufAllocator allocator() {
+    return conn.channel().alloc();
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2Stream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2Stream.java
@@ -12,6 +12,7 @@
 package io.vertx.core.http.impl.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.EmptyHttp2Headers;
@@ -157,6 +158,10 @@ abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements Ht
 
   public final ContextInternal context() {
     return context;
+  }
+
+  public final ByteBufAllocator allocator() {
+    return connection.allocator();
   }
 
   public void priority(StreamPriority streamPriority) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2Connection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2Connection.java
@@ -11,6 +11,7 @@
 package io.vertx.core.http.impl.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.Headers;
 import io.netty.handler.stream.ChunkedInput;
 import io.vertx.core.Promise;
@@ -20,6 +21,8 @@ import io.vertx.core.internal.ContextInternal;
 public interface Http2Connection {
 
   ContextInternal context();
+
+  ByteBufAllocator allocator();
 
   boolean isSsl();
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
@@ -513,4 +513,9 @@ abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameL
   public void writeReset(int streamId, long code, Promise<Void> promise) {
     handler.writeReset(streamId, code, (FutureListener<Void>) promise);
   }
+
+  @Override
+  public ByteBufAllocator allocator() {
+    return channel.alloc();
+  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
@@ -11,6 +11,7 @@
 package io.vertx.core.http.impl.http2.multiplex;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
@@ -183,6 +184,10 @@ public abstract class Http2MultiplexConnection<S extends Http2Stream> extends Co
         channel.channelContext.channel().config().setAutoRead(true);
       }
     }
+  }
+
+  public ByteBufAllocator allocator() {
+    return channel.alloc();
   }
 
   public boolean supportsSendFile() {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Stream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http3/Http3Stream.java
@@ -11,6 +11,7 @@
 package io.vertx.core.http.impl.http3;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.http2.EmptyHttp2Headers;
 import io.netty.handler.codec.http3.*;
 import io.netty.util.ReferenceCountUtil;
@@ -361,5 +362,9 @@ public abstract class Http3Stream<S extends Http3Stream<S, C>, C extends Http3Co
 
   public final ContextInternal context() {
     return context;
+  }
+
+  public final ByteBufAllocator allocator() {
+    return stream.channelHandlerContext().alloc();
   }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/tcp/Http2UpgradeClientConnection.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.http.impl.tcp;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -157,6 +158,11 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
     @Override
     public ContextInternal context() {
       return delegate.context();
+    }
+
+    @Override
+    public ByteBufAllocator allocator() {
+      return delegate.allocator();
     }
 
     @Override
@@ -471,6 +477,11 @@ public class Http2UpgradeClientConnection implements io.vertx.core.http.impl.Htt
     @Override
     public ContextInternal context() {
       return upgradingStream.context();
+    }
+
+    @Override
+    public ByteBufAllocator allocator() {
+      return upgradingStream.allocator();
     }
 
     @Override

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestInternal.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.internal.http;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.spi.observability.HttpRequest;
@@ -25,6 +26,11 @@ public abstract class HttpServerRequestInternal implements HttpServerRequest {
    * @return the Vert.x context associated with this server request
    */
   public abstract ContextInternal context();
+
+  /**
+   * @return the stream allocator
+   */
+  public abstract ByteBufAllocator allocator();
 
   /**
    * @return the metric object returned by the {@link io.vertx.core.spi.metrics.HttpServerMetrics#requestBegin(io.vertx.core.net.SocketAddress, HttpRequest)} call

--- a/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/http/HttpServerRequestWrapper.java
@@ -1,5 +1,6 @@
 package io.vertx.core.internal.http;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.DecoderResult;
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.Fluent;
@@ -268,6 +269,11 @@ public class HttpServerRequestWrapper extends HttpServerRequestInternal {
   @Override
   public ContextInternal context() {
     return delegate.context();
+  }
+
+  @Override
+  public ByteBufAllocator allocator() {
+    return delegate.allocator();
   }
 
   @Override


### PR DESCRIPTION
Motivation:

The Netty allocator can be useful for HTTP server that fully control the response and wants to use pooled buffers, such as a gRPC client or server.

Changes:

Expose the underlying Netty allocator.
