### PR TITLE
Unregister the cleanable net client resource from the owner when the client closes

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -362,19 +362,20 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public NetClient createNetClient(TcpClientConfig config, ClientSSLOptions sslOptions) {
-    NetClientImpl netClient = new NetClientBuilder(this, new TcpClientConfig(config))
+    return cleanableClient(new NetClientBuilder(this, new TcpClientConfig(config))
       .sslOptions(sslOptions != null ? sslOptions.copy() : null)
-      .build();
-    CloseFuture fut = resolveCloseFuture();
-    fut.add(netClient);
-    return new CleanableNetClient(CleanerProvider.INSTANCE.get(), netClient);
+      .build());
   }
 
   public NetClient createNetClient(NetClientOptions options) {
-    NetClientImpl netClient = new NetClientBuilder(this, options).build();
+    return cleanableClient(new NetClientBuilder(this, options).build());
+  }
+
+  private NetClient cleanableClient(NetClientImpl netClient) {
     CloseFuture fut = resolveCloseFuture();
-    fut.add(netClient);
-    return new CleanableNetClient(CleanerProvider.INSTANCE.get(), netClient);
+    CleanableNetClient.ClientCloseableResource ccr = new CleanableNetClient.ClientCloseableResource(fut, netClient);
+    fut.add(ccr);
+    return new CleanableNetClient(CleanerProvider.INSTANCE.get(), ccr);
   }
 
   @Override

--- a/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetClient.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/impl/tcp/CleanableNetClient.java
@@ -10,10 +10,12 @@
  */
 package io.vertx.core.net.impl.tcp;
 
+import io.vertx.core.Closeable;
 import io.vertx.core.Completable;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.impl.CleanableObject;
+import io.vertx.core.internal.CloseFuture;
 import io.vertx.core.internal.CloseableResource;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.net.NetClientInternal;
@@ -21,6 +23,7 @@ import io.vertx.core.net.*;
 import io.vertx.core.spi.metrics.Metrics;
 
 import java.lang.ref.Cleaner;
+import java.time.Duration;
 
 /**
  * A lightweight proxy of Vert.x {@link NetClient} that can be collected by the garbage collector and release
@@ -88,4 +91,35 @@ public class CleanableNetClient extends CleanableObject<NetClientInternal> imple
     NetClientInternal delegate = get();
     return delegate == null ? null : delegate.getMetrics();
   }
+
+  public static class ClientCloseableResource implements CloseableResource<NetClientInternal>, Closeable {
+
+    private final CloseFuture owner;
+    private final CloseableResource<NetClientInternal> resource;
+
+    public ClientCloseableResource(CloseFuture owner, CloseableResource<NetClientInternal> resource) {
+      this.owner = owner;
+      this.resource = resource;
+    }
+
+    @Override
+    public void close(Completable<Void> completion) {
+      resource
+        .shutdown(Duration.ZERO)
+        .onComplete(completion);
+    }
+
+    @Override
+    public NetClientInternal get() {
+      return resource.get();
+    }
+
+    @Override
+    public Future<Void> shutdown(Duration duration) {
+      owner.remove(this);
+      return resource.shutdown(duration);
+    }
+  }
+
+
 }

--- a/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/vertx/VertxTest.java
@@ -254,11 +254,8 @@ public class VertxTest extends VertxTestBase {
   @Test
   public void testFinalizeHttpClientRegisteredWithCloseHook() {
     Vertx vertx = Vertx.vertx();
-
     try {
-
       AtomicReference<HttpClientInternal> ref = new AtomicReference<>();
-
       String id = vertx.deployVerticle(context -> {
         HttpClientInternal client = (HttpClientInternal) vertx.createHttpClient();
         ref.set(client);
@@ -282,7 +279,49 @@ public class VertxTest extends VertxTestBase {
   }
 
   @Test
-  public void testCascadeCloseHttpClient() throws Exception {
+  public void testFinalizeNetClientRegisteredWithCloseHook() {
+    Vertx vertx = Vertx.vertx();
+    try {
+      AtomicReference<NetClient> ref = new AtomicReference<>();
+      String id = vertx.deployVerticle(context -> {
+        ref.set(vertx.createNetClient());
+        return Future.succeededFuture();
+      }).await();
+      NetClient proxy = ref.getAndSet(null);
+      Assert.assertNotNull(proxy);
+      NetClientInternal real = ((CleanableNetClient) proxy).unwrap();
+      WeakReference<NetClientInternal> realWeakRef = new WeakReference<>(real);
+      real = null;
+      proxy.close().await();
+      runGC();
+      Assert.assertNull(realWeakRef.get());
+      vertx.undeploy(id).await();
+      runGC();
+      Assert.assertNull(realWeakRef.get());
+    } finally {
+      vertx.close().await();
+    }
+  }
+
+  @Test
+  public void testFinalizeNetClientRegisteredWithVertxCloseHook() {
+    Vertx vertx = Vertx.vertx();
+    try {
+      NetClient proxy = vertx.createNetClient();
+      NetClientInternal real = ((CleanableNetClient) proxy).unwrap();
+      WeakReference<NetClientInternal> realWeakRef = new WeakReference<>(real);
+      real = null;
+      proxy.close().await();
+      proxy = null;
+      runGC();
+      Assert.assertNull(realWeakRef.get());
+    } finally {
+      vertx.close().await();
+    }
+  }
+
+  @Test
+  public void testCascadeCloseHttpClient() {
     Vertx vertx1 = vertx();
     try {
       HttpServer server = vertx1.createHttpServer();


### PR DESCRIPTION
Motivation:

The net client does not unregister the client close hook from its owner context leading to a client leak when the client is closed either explicitly or via a cleaner collection.

Changes:

Ensure that when the client is shutdown, the close hook is removed.
