### PR TITLE
Disable partially HTTP/3 test with io_uring

### DIFF
--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ClientTest.java
@@ -6,6 +6,8 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.http.HttpClientConfig;
+import io.vertx.core.impl.transports.IoUringTransport;
+import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.test.core.VertxTestBase;
@@ -13,6 +15,7 @@ import io.vertx.test.tls.Cert;
 import io.vertx.test.tls.Trust;
 import io.vertx.test.core.TestUtils;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
@@ -36,6 +39,7 @@ public class Http3ClientTest extends VertxTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
+    Assume.assumeFalse(((VertxInternal)vertx).transport() instanceof IoUringTransport);
     serverOptions = new HttpServerConfig();
     serverOptions.setVersions(HttpVersion.HTTP_3);
     serverSslOptions = new ServerSSLOptions().setKeyCertOptions(Cert.SERVER_JKS.get());
@@ -50,8 +54,12 @@ public class Http3ClientTest extends VertxTestBase {
 
   @Override
   protected void tearDown() throws Exception {
-    server.close().await();
-    client.close().await();
+    if (server != null) {
+      server.close().await();
+    }
+    if (client != null) {
+      client.close().await();
+    }
     super.tearDown();
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ServerTest.java
@@ -19,6 +19,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
+import io.vertx.core.impl.transports.IoUringTransport;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.SocketAddress;
@@ -71,14 +72,19 @@ public class Http3ServerTest extends VertxTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
+    Assume.assumeFalse(((VertxInternal)vertx).transport() instanceof IoUringTransport);
     client = Http3TestClient.client(vertx);
     server = vertx.createHttpServer(serverConfig(), sslOptions());
   }
 
   @Override
   protected void tearDown() throws Exception {
-    server.close().await();
-    client.close();
+    if (server != null) {
+      server.close().await();
+    }
+    if (client != null) {
+      client.close();
+    }
     super.tearDown();
   }
 


### PR DESCRIPTION
Motivation:

Some HTTP/3 with io_uring tests are freezing, until this is investigated and fixed, we should disable those tests to improve the CI feedback.

Changes:

Disable Http3ServerTest/Http3ClientTest for io_uring, keep Http3Test that does not seem to exhibit issues.

See:

https://github.com/eclipse-vertx/vert.x/issues/6342