### PR TITLE
Disable HTTP/3 test with io_uring

### DIFF
--- a/vertx-core/pom.xml
+++ b/vertx-core/pom.xml
@@ -908,6 +908,10 @@
                 <io.netty.iouring.ringSize>512</io.netty.iouring.ringSize>
                 <io.netty.iouring.cqSize>1024</io.netty.iouring.cqSize>
               </systemPropertyVariables>
+              <excludes>
+                <exclude>io/vertx/it/**</exclude>
+                <exclude>io/vertx/tests/http/http3/**</exclude>
+              </excludes>
             </configuration>
           </plugin>
         </plugins>

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ClientTest.java
@@ -6,8 +6,6 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.http.HttpClientConfig;
-import io.vertx.core.impl.transports.IoUringTransport;
-import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.ClientSSLOptions;
 import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.test.core.VertxTestBase;
@@ -15,7 +13,6 @@ import io.vertx.test.tls.Cert;
 import io.vertx.test.tls.Trust;
 import io.vertx.test.core.TestUtils;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
@@ -39,7 +36,6 @@ public class Http3ClientTest extends VertxTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    Assume.assumeFalse(((VertxInternal)vertx).transport() instanceof IoUringTransport);
     serverOptions = new HttpServerConfig();
     serverOptions.setVersions(HttpVersion.HTTP_3);
     serverSslOptions = new ServerSSLOptions().setKeyCertOptions(Cert.SERVER_JKS.get());
@@ -54,12 +50,8 @@ public class Http3ClientTest extends VertxTestBase {
 
   @Override
   protected void tearDown() throws Exception {
-    if (server != null) {
-      server.close().await();
-    }
-    if (client != null) {
-      client.close().await();
-    }
+    server.close().await();
+    client.close().await();
     super.tearDown();
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ServerTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/http3/Http3ServerTest.java
@@ -19,7 +19,6 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
-import io.vertx.core.impl.transports.IoUringTransport;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.core.net.SocketAddress;
@@ -72,19 +71,14 @@ public class Http3ServerTest extends VertxTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    Assume.assumeFalse(((VertxInternal)vertx).transport() instanceof IoUringTransport);
     client = Http3TestClient.client(vertx);
     server = vertx.createHttpServer(serverConfig(), sslOptions());
   }
 
   @Override
   protected void tearDown() throws Exception {
-    if (server != null) {
-      server.close().await();
-    }
-    if (client != null) {
-      client.close();
-    }
+    server.close().await();
+    client.close();
     super.tearDown();
   }
 


### PR DESCRIPTION
Motivation:

Some HTTP/3 with io_uring tests are freezing, until this is investigated and fixed, we should disable those tests to improve the CI feedback.

Changes:

Disable HTTP/3 test for io_uring.
