### PR TITLE
Implement JDK PQC availability detection (5.1 backport of #6244)

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/impl/JdkDependent.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/JdkDependent.java
@@ -43,6 +43,10 @@ public class JdkDependent {
     return false;
   }
 
+  public static boolean isPqcAvailable() {
+    return false;
+  }
+
   public static void applyNamedGroups(SSLEngine engine, List<String> groups) {
     if (log.isDebugEnabled()) {
       log.warn("Cannot apply key exchange groups " + groups + " on JDK SSL engine: requires JDK 20+");

--- a/vertx-core/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/JdkSSLEngineOptions.java
@@ -14,6 +14,7 @@ package io.vertx.core.net;
 import io.netty.handler.ssl.SslProvider;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
+import io.vertx.core.impl.JdkDependent;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tls.DefaultSslContextFactory;
 import io.vertx.core.spi.tls.SslContextFactory;
@@ -58,12 +59,11 @@ public class JdkSSLEngineOptions extends SSLEngineOptions {
   }
 
   /**
-   * @return if PQC key exchange (X25519MLKEM768) is available via the JDK SSL engine
-   * @implNote currently this returns {@code false} but implementation will change in the future when JDK support evolves
+   * @return if PQC key exchange is available via the JDK SSL engine, i.e. the JDK supports
+   * at least one of the PQ-compliant named groups (X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024)
    */
   public static synchronized boolean isPqcAvailable() {
-    // Todo: implement it when JDK add supports
-    return false;
+    return JdkDependent.isPqcAvailable();
   }
 
   public JdkSSLEngineOptions() {


### PR DESCRIPTION
Backport of #6244 to `5.1`.

`5.1` received the JDK 21 implementation of `JdkDependent.isPqcAvailable()` with #6337, but `JdkSSLEngineOptions.isPqcAvailable()` on that branch still returns `false` unconditionally (`// Todo: implement it when JDK add supports`), so `STRICT` and `CLIENT_NEGOTIATED` refuse to start on the JDK engine even when the JDK supports a PQ-compliant named group. `master` (#6244) and `4.x` (#6245) have the delegation; `5.1` does not.

This is the same two-file change as #6244: `JdkSSLEngineOptions.isPqcAvailable()` delegates to `JdkDependent.isPqcAvailable()`, and the base (pre-21) `JdkDependent` gets the `false` implementation. The JDK 21 detection and the `HybridKeyExchangeTest` changes are already on `5.1`.

Verified with a Quarkus application using the packaged `vertx-core` 5.1.8-SNAPSHOT from this branch, on a JDK 25.0.5 EA build where `X25519MLKEM768` is a default named group (`openssl s_client -tls1_3 -groups ...` as the client):

| Runtime | Policy | PQ client | Classical-only client |
|---|---|---|---|
| JDK 25.0.5 EA, JVM | `STRICT` | `Negotiated TLS1.3 group: X25519MLKEM768` | rejected (alert 10) |
| JDK 25.0.5 EA, JVM | `CLIENT_NEGOTIATED` | `X25519MLKEM768` | classical handshake |
| Mandrel 25.0.5 EA, native image | `STRICT` | `X25519MLKEM768` | rejected |
| JDK 21, JVM | `STRICT` | – | still fails to start with "neither JDK nor OpenSSL support it", as before |

`HybridKeyExchangeTest` passes on JDK 21 and on the 25.0.5 EA (in-tree it runs against `target/classes`, where the base `JdkDependent` applies, so its JDK cases are skipped there; the table above is what exercises the multi-release path).
