### PR TITLE
Add a new ClientResolverConfig that configures the HTTP client resolver and implement max keep alive.

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/ClientResolverConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/ClientResolverConfig.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http;
+
+import java.time.Duration;
+
+/**
+ * Configuration of a client resolver, the resolver translates a logical address into a socket address and a port.
+ */
+public class ClientResolverConfig {
+
+  /**
+   * The default keep alive timeout : {@code 1} minute
+   */
+  public static final Duration DEFAULT_KEEP_ALIVE_TIMEOUT = Duration.ofMinutes(1);
+
+  /**
+   * The default max keep alive : {@code 5} minute
+   */
+  public static final Duration DEFAULT_MAX_KEEP_ALIVE = Duration.ofMinutes(5);
+
+  private Duration keepAliveTimeout;
+  private Duration maxKeepAlive;
+
+  public ClientResolverConfig() {
+    keepAliveTimeout = DEFAULT_KEEP_ALIVE_TIMEOUT;
+    maxKeepAlive = DEFAULT_MAX_KEEP_ALIVE;
+  }
+
+  public ClientResolverConfig(ClientResolverConfig other) {
+    keepAliveTimeout = other.keepAliveTimeout;
+    maxKeepAlive = other.maxKeepAlive;
+  }
+
+  /**
+   *
+   * @return the amoutn of time after which an unused entry is evicted
+   */
+  public Duration getKeepAliveTimeout() {
+    return keepAliveTimeout;
+  }
+
+  /**
+   * Set the {@code amount} of time after which an unused entry is evicted.
+   * @param amount the amount of time
+   * @return a reference to this, so the API can be used fluently
+   */
+  public ClientResolverConfig setKeepAliveTimeout(Duration amount) {
+    if (amount.isNegative() || amount.isZero()) {
+      throw new IllegalArgumentException("Invalid resolver idle timeout");
+    }
+    this.keepAliveTimeout = amount;
+    return this;
+  }
+
+  /**
+   * @return the maximum amount of time after which an entry is evicted
+   */
+  public Duration getMaxKeepAlive() {
+    return maxKeepAlive;
+  }
+
+  /**
+   * Set the maximum {@code amount} of time after which an entry is evicted.
+   *
+   * @param amount the amount of time
+   * @return a reference to this, so the API can be used fluently
+   */
+  public ClientResolverConfig setMaxKeepAlive(Duration amount) {
+    if (amount.isNegative() || amount.isZero()) {
+      throw new IllegalArgumentException("Invalid resolver max ttl");
+    }
+    this.maxKeepAlive = amount;
+    return this;
+  }
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/HttpClientConfig.java
@@ -80,6 +80,7 @@ public class HttpClientConfig {
   private String defaultHost;
   private int defaultPort;
   private ClientRedirectConfig redirectConfig;
+  private ClientResolverConfig resolverConfig;
   private ObservabilityConfig observabilityConfig;
   private boolean shared;
   private String name;
@@ -98,6 +99,7 @@ public class HttpClientConfig {
     this.defaultHost = HttpClientOptions.DEFAULT_DEFAULT_HOST;
     this.defaultPort = HttpClientOptions.DEFAULT_DEFAULT_PORT;
     this.redirectConfig = null;
+    this.resolverConfig = null;
     this.observabilityConfig = null;
     this.shared = HttpClientOptions.DEFAULT_SHARED;
     this.name = HttpClientOptions.DEFAULT_NAME;
@@ -117,6 +119,7 @@ public class HttpClientConfig {
     this.defaultHost = other.defaultHost;
     this.defaultPort = other.defaultPort;
     this.redirectConfig = other.redirectConfig != null ? new ClientRedirectConfig(other.redirectConfig) : null;
+    this.resolverConfig = other.resolverConfig != null ? new ClientResolverConfig(other.resolverConfig) : null;
     this.observabilityConfig = other.observabilityConfig != null ? new ObservabilityConfig(other.observabilityConfig) : null;
     this.shared = other.shared;
     this.name = other.name;
@@ -484,7 +487,7 @@ public class HttpClientConfig {
   }
 
   /**
-   * @return the client redirect config, it can be {@code null} in which case the default settings are used.
+   * @return the client redirect config, it can be {@code null} in which case the default config is used.
    */
   public ClientRedirectConfig getRedirectConfig() {
     return redirectConfig;
@@ -498,6 +501,24 @@ public class HttpClientConfig {
    */
   public HttpClientConfig setRedirectConfig(ClientRedirectConfig redirectConfig) {
     this.redirectConfig = redirectConfig;
+    return this;
+  }
+
+  /**
+   * @return the client resolver config, it can be {@code null} in which case the default config is used.
+   */
+  public ClientResolverConfig getResolverConfig() {
+    return resolverConfig;
+  }
+
+  /**
+   * Set the client resolver config, set to {code null} to use the default config.
+   *
+   * @param resolverConfig the resolver config
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientConfig setResolverConfig(ClientResolverConfig resolverConfig) {
+    this.resolverConfig = resolverConfig;
     return this;
   }
 

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientBuilderInternal.java
@@ -48,11 +48,9 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
   private Function<HttpClientResponse, Future<RequestOptions>> redirectHandler;
   private AddressResolver<?> addressResolver;
   private LoadBalancer loadBalancer;
-  private Duration resolverIdleTimeout;
 
   public HttpClientBuilderInternal(VertxInternal vertx) {
     this.vertx = vertx;
-    this.resolverIdleTimeout = Duration.ofSeconds(10);
   }
 
   public HttpClientBuilderInternal with(HttpClientConfig config) {
@@ -121,32 +119,26 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
     return this;
   }
 
-  public HttpClientBuilderInternal resolverIdleTimeout(Duration timeout) {
-    if (timeout.isNegative() || timeout.isZero()) {
-      throw new IllegalArgumentException("Invalid resolver idle timeout");
-    }
-    this.resolverIdleTimeout = timeout;
-    return this;
-  }
-
   private CloseFuture resolveCloseFuture() {
     ContextInternal context = vertx.getContext();
     return context != null ? context.closeFuture() : vertx.closeFuture();
   }
 
-  private EndpointResolver endpointResolver(HttpClientConfig co) {
+  private EndpointResolver endpointResolver(ClientResolverConfig config) {
     LoadBalancer _loadBalancer = loadBalancer;
     AddressResolver<?> _addressResolver = addressResolver;
     if (_addressResolver != null) {
       if (_loadBalancer == null) {
         _loadBalancer = LoadBalancer.ROUND_ROBIN;
       }
-      return new EndpointResolverImpl<>(vertx, _addressResolver.endpointResolver(vertx), _loadBalancer, resolverIdleTimeout.toMillis());
+      return new EndpointResolverImpl<>(vertx, _addressResolver.endpointResolver(vertx), _loadBalancer,
+        config.getKeepAliveTimeout(), config.getMaxKeepAlive());
     }
     return null;
   }
 
   private HttpClientImpl createHttpClientImpl(HttpClientConfig config,
+                                              ClientResolverConfig resolverConfig,
                                               ClientSSLOptions sslOptions,
                                               HttpClientMetrics<?, ?> httpMetrics,
                                               EndpointResolver resolver,
@@ -190,7 +182,8 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       nonProxyHosts,
       loadBalancer,
       followAlternativeServices,
-      resolverIdleTimeout,
+      resolverConfig.getKeepAliveTimeout(),
+      resolverConfig.getMaxKeepAlive(),
       config.isVerifyHost(),
       config.isSsl(),
       config.getDefaultHost(),
@@ -217,7 +210,8 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       List<String> nonProxyHosts,
       LoadBalancer loadBalancer,
       boolean followAlternativeServices,
-      Duration resolverIdeTimeout,
+      Duration resolverKeepAlive,
+      Duration resolverMaxTtl,
       boolean verifyHost,
       boolean defaultSsl,
       String defaultHost,
@@ -230,7 +224,9 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       HttpClientTransport quicTransport,
       HttpClientConfig config,
       HttpClientOptions options) {
-      super(vertx, resolver, redirectHandler, httpMetrics, poolOptions, defaultProxyOptions, nonProxyHosts, loadBalancer, followAlternativeServices, resolverIdeTimeout, verifyHost, defaultSsl, defaultHost, defaultPort, maxRedirects, versions, sslOptions, connectHandler, tcpTransport, quicTransport);
+      super(vertx, resolver, redirectHandler, httpMetrics, poolOptions, defaultProxyOptions, nonProxyHosts, loadBalancer,
+        followAlternativeServices, resolverKeepAlive, resolverMaxTtl, verifyHost, defaultSsl, defaultHost, defaultPort,
+        maxRedirects, versions, sslOptions, connectHandler, tcpTransport, quicTransport);
       this.config = config;
       this.options = options;
     }
@@ -312,12 +308,19 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       quicTransport = null;
     }
 
+    ClientResolverConfig resolverConfig;
+    if (co.getResolverConfig() == null) {
+      resolverConfig = new ClientResolverConfig();
+    } else {
+      resolverConfig = co.getResolverConfig();
+    }
+
     HttpClientTransport transport;
     String shared;
     EndpointResolver resolver;
     List<HttpVersion> supportedVersions = co.getVersions();
     if (supportedVersions.contains(HttpVersion.HTTP_1_0) || supportedVersions.contains(HttpVersion.HTTP_1_1) || supportedVersions.contains(HttpVersion.HTTP_2)) {
-      resolver = endpointResolver(co);
+      resolver = endpointResolver(resolverConfig);
       shared = co.isShared() ? co.getName() : null;
       TcpClientConfig clientConfig = netClientConfig(co)
         .setProxyOptions(null);
@@ -355,9 +358,9 @@ public final class HttpClientBuilderInternal implements HttpClientBuilder {
       resource = vertx.createSharedResource(
         "__vertx.shared.httpClients",
         co.getName(),
-        () -> createHttpClientImpl(co2, ssl, httpMetrics, resolver, redirectHandler, transport, quicTransport));
+        () -> createHttpClientImpl(co2, resolverConfig, ssl, httpMetrics, resolver, redirectHandler, transport, quicTransport));
     } else {
-      resource = createHttpClientImpl(co2, ssl, httpMetrics, resolver, redirectHandler, transport, quicTransport);
+      resource = createHttpClientImpl(co2, resolverConfig, ssl, httpMetrics, resolver, redirectHandler, transport, quicTransport);
     }
     ClientCloseableResource ccr = new ClientCloseableResource(cf, resource);
     cf.add(ccr);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -83,7 +83,8 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
                  List<String> nonProxyHosts,
                  LoadBalancer loadBalancer,
                  boolean followAlternativeServices,
-                 Duration resolverIdeTimeout,
+                 Duration resolverKeepAliveTimeout,
+                 Duration resolverMaxKeepAlive,
                  boolean verifyHost,
                  boolean defaultSsl,
                  String defaultHost,
@@ -106,7 +107,7 @@ public class HttpClientImpl extends HttpClientBase implements HttpClientInternal
     this.quicTransport = quicTransport;
     this.originEndpoints = new OriginResolver<>(vertx, resolveAll, this);
     this.resolver = (EndpointResolverInternal) resolver;
-    this.originResolver = new EndpointResolverImpl<>(vertx, originEndpoints, resolveAll ? loadBalancer : LoadBalancer.FIRST, resolverIdeTimeout.toMillis());
+    this.originResolver = new EndpointResolverImpl<>(vertx, originEndpoints, resolveAll ? loadBalancer : LoadBalancer.FIRST, resolverKeepAliveTimeout, resolverMaxKeepAlive);
     this.poolOptions = poolOptions;
     this.resourceManager = new ResourceManager<>();
     this.maxLifetime = MILLISECONDS.convert(poolOptions.getMaxLifetime(), poolOptions.getMaxLifetimeUnit());

--- a/vertx-core/src/main/java/io/vertx/core/internal/net/endpoint/EndpointResolverInternal.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/net/endpoint/EndpointResolverInternal.java
@@ -18,13 +18,16 @@ import io.vertx.core.net.endpoint.EndpointResolver;
 import io.vertx.core.net.endpoint.LoadBalancer;
 import io.vertx.core.net.endpoint.impl.EndpointResolverImpl;
 
+import java.time.Duration;
+
 public interface EndpointResolverInternal extends EndpointResolver {
 
   static EndpointResolverInternal create(VertxInternal vertx,
                                          io.vertx.core.spi.endpoint.EndpointResolver<?, ?, ?, ?> endpointResolver,
                                          LoadBalancer loadBalancer,
-                                         long expirationMillis) {
-    return new EndpointResolverImpl<>(vertx, endpointResolver, loadBalancer, expirationMillis);
+                                         Duration keepAlive,
+                                         Duration maxTtl) {
+    return new EndpointResolverImpl<>(vertx, endpointResolver, loadBalancer, keepAlive, maxTtl);
   }
 
   boolean resolves(Address address);

--- a/vertx-core/src/main/java/io/vertx/core/net/endpoint/impl/EndpointResolverImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/net/endpoint/impl/EndpointResolverImpl.java
@@ -22,6 +22,7 @@ import io.vertx.core.internal.resource.ResourceManager;
 import io.vertx.core.spi.endpoint.EndpointResolver;
 import io.vertx.core.spi.endpoint.EndpointBuilder;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -41,9 +42,11 @@ public class EndpointResolverImpl<S, A extends Address, N> implements EndpointRe
   private final LoadBalancer loadBalancer;
   private final EndpointResolver<A, N, S, ListOfServers> endpointResolver;
   private final ResourceManager<A, ManagedEndpoint> endpointManager;
-  private final long keepAliveMillis;
+  private final Duration keepAliveTimeout;
+  private final Duration maxKeepAlive;
 
-  public EndpointResolverImpl(VertxInternal vertx, EndpointResolver<A, N, S, ?> endpointResolver, LoadBalancer loadBalancer, long keepAliveMillis) {
+  public EndpointResolverImpl(VertxInternal vertx, EndpointResolver<A, N, S, ?> endpointResolver, LoadBalancer loadBalancer,
+                              Duration keepAliveTimeout, Duration maxKeepAlive) {
 
     if (loadBalancer == null) {
       loadBalancer = LoadBalancer.ROUND_ROBIN;
@@ -53,7 +56,8 @@ public class EndpointResolverImpl<S, A extends Address, N> implements EndpointRe
     this.loadBalancer = loadBalancer;
     this.endpointResolver = (EndpointResolver<A, N, S, ListOfServers>) endpointResolver;
     this.endpointManager = new ResourceManager<>();
-    this.keepAliveMillis = keepAliveMillis;
+    this.keepAliveTimeout = keepAliveTimeout;
+    this.maxKeepAlive = maxKeepAlive;
   }
 
   @Override
@@ -90,6 +94,7 @@ public class EndpointResolverImpl<S, A extends Address, N> implements EndpointRe
 
   private class EndpointImpl implements io.vertx.core.net.endpoint.Endpoint {
 
+    private final long creationTimestamp;
     private final AtomicLong lastAccessed;
     private final A address;
     private final S state;
@@ -98,6 +103,7 @@ public class EndpointResolverImpl<S, A extends Address, N> implements EndpointRe
       this.state = state;
       this.address = address;
       this.lastAccessed = lastAccessed;
+      this.creationTimestamp = lastAccessed.get();
     }
 
     @Override
@@ -140,7 +146,10 @@ public class EndpointResolverImpl<S, A extends Address, N> implements EndpointRe
 
     @Override
     protected void checkExpired() {
-      if (endpoint.succeeded() && keepAliveMillis > 0 && System.currentTimeMillis() - endpoint.result().lastAccessed.get() >= keepAliveMillis) {
+      long now = System.currentTimeMillis();
+      if (endpoint.succeeded()
+      && (((now - endpoint.result().creationTimestamp) >= maxKeepAlive.toMillis()) ||
+        (now - endpoint.result().lastAccessed.get() >= keepAliveTimeout.toMillis()))) {
         if (disposed.compareAndSet(false, true)) {
           decRefCount();
         }

--- a/vertx-core/src/test/java/io/vertx/test/fakedns/DnsServer.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakedns/DnsServer.java
@@ -2,6 +2,8 @@ package io.vertx.test.fakedns;
 
 import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.util.internal.PlatformDependent;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.dns.AddressResolverOptions;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -30,6 +32,12 @@ public class DnsServer implements TestRule {
 
   public boolean isStarted() {
     return STARTED.get() == Boolean.TRUE;
+  }
+
+  public VertxOptions vertxOptions() {
+    return new VertxOptions()
+      .setAddressResolverOptions(new AddressResolverOptions()
+        .addServer("127.0.0.1:" + port()));
   }
 
   @Override
@@ -86,5 +94,4 @@ public class DnsServer implements TestRule {
       }
     }
   }
-
 }

--- a/vertx-core/src/test/java/io/vertx/test/fakeresolver/FakeAddressResolver.java
+++ b/vertx-core/src/test/java/io/vertx/test/fakeresolver/FakeAddressResolver.java
@@ -65,6 +65,19 @@ public class FakeAddressResolver<B> implements AddressResolver<FakeAddress>, End
   }
 
   @Override
+  public Future<FakeState<B>> refresh(FakeAddress address, FakeState<B> state) {
+    FakeRegistration registration = map.get(state.name);
+    if (registration == null) {
+      return null;
+    } else {
+      FakeState<B> refreshedState = new FakeState<>(state.name, registration, state.builder);
+      registration.state = state;
+      refreshedState.refresh();
+      return Future.succeededFuture(refreshedState);
+    }
+  }
+
+  @Override
   public SocketAddress addressOf(FakeServerEndpoint server) {
     return server.socketAddress;
   }

--- a/vertx-core/src/test/java/io/vertx/test/http/AbstractHttpTest2.java
+++ b/vertx-core/src/test/java/io/vertx/test/http/AbstractHttpTest2.java
@@ -12,7 +12,6 @@
 package io.vertx.test.http;
 
 import io.vertx.core.*;
-import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.http.*;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.transport.Transport;
@@ -184,11 +183,11 @@ public abstract class AbstractHttpTest2 {
   public class VertxProviderWithResolver implements VertxProvider {
     @Override
     public Vertx call() {
-      VertxOptions options = new VertxOptions();
+      VertxOptions options;
       if (dnsServer.isStarted()) {
-        options
-          .setAddressResolverOptions(new AddressResolverOptions()
-            .addServer("127.0.0.1:" + dnsServer.port()));
+        options = dnsServer.vertxOptions();
+      } else {
+        options = new VertxOptions();
       }
       Transport transport = TRANSPORT;
       VertxBuilder builder = Vertx.builder();

--- a/vertx-core/src/test/java/io/vertx/tests/addressresolver/ResolvingHttpClientTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/addressresolver/ResolvingHttpClientTest.java
@@ -4,7 +4,6 @@ import io.vertx.core.Future;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
-import io.vertx.core.http.impl.HttpClientBuilderInternal;
 import io.vertx.core.http.impl.HttpClientImpl;
 import io.vertx.core.internal.http.HttpClientInternal;
 import io.vertx.core.net.endpoint.LoadBalancer;
@@ -541,7 +540,7 @@ public class ResolvingHttpClientTest extends VertxTestBase {
     )).toString();
     assertEquals("1", res);
     assertNotNull(registration2.state());
-    assertNotSame(registration1.state(), registration2.state());
+    assertSame(registration1.state(), registration2.state());
   }
 
   @Test
@@ -585,9 +584,9 @@ public class ResolvingHttpClientTest extends VertxTestBase {
     FakeAddressResolver resolver = new FakeAddressResolver();
     SocketAddress addr1 = SocketAddress.inetSocketAddress(HttpTestBase.DEFAULT_HTTP_PORT, "localhost");
     FakeRegistration registration = resolver.registerAddress("example.com", Arrays.asList(addr1));
-    HttpClientInternal client = ((HttpClientBuilderInternal) vertx.httpClientBuilder())
+    HttpClient client = vertx.httpClientBuilder()
+    .with(new HttpClientConfig().setResolverConfig(new ClientResolverConfig().setKeepAliveTimeout(Duration.ofSeconds(1))))
       .withAddressResolver(resolver)
-      .resolverIdleTimeout(Duration.ofSeconds(1))
       .build();
     String res = awaitFuture(client.request(new RequestOptions().setServer(new FakeAddress("example.com"))).compose(req -> req
       .send()

--- a/vertx-core/src/test/java/io/vertx/tests/endpoint/EndpointResolverTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/endpoint/EndpointResolverTest.java
@@ -20,6 +20,7 @@ import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakeresolver.*;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -41,7 +42,8 @@ public class EndpointResolverTest extends VertxTestBase {
   @Test
   public void testFiltering() {
     fakeResolver.registerAddress("example.com", List.of(addr1, addr2, addr3, addr4));
-    EndpointResolverImpl<FakeState, FakeAddress, FakeServerEndpoint> resolver = new EndpointResolverImpl<>((VertxInternal) vertx, fakeResolver, LoadBalancer.ROUND_ROBIN, 5000);
+    EndpointResolverImpl<FakeState, FakeAddress, FakeServerEndpoint> resolver = new EndpointResolverImpl<>((VertxInternal)
+      vertx, fakeResolver, LoadBalancer.ROUND_ROBIN, Duration.ofSeconds(5), Duration.ofMillis(10));
     Endpoint endpoint = resolver.resolveEndpoint(new FakeAddress("example.com")).await();
     Predicate<ServerEndpoint> even = s -> s.address().port() % 2 == 0;
     Predicate<ServerEndpoint> odd = s -> s.address().port() % 2 == 1;
@@ -59,7 +61,8 @@ public class EndpointResolverTest extends VertxTestBase {
   public void testFilterEmpty() {
     SocketAddress addr1 = SocketAddress.inetSocketAddress(8080, "localhost");
     fakeResolver.registerAddress("example.com", List.of(addr1, addr2, addr3, addr4));
-    EndpointResolverImpl<FakeState, FakeAddress, FakeServerEndpoint> resolver = new EndpointResolverImpl<>((VertxInternal) vertx, fakeResolver, LoadBalancer.ROUND_ROBIN, 5000);
+    EndpointResolverImpl<FakeState, FakeAddress, FakeServerEndpoint> resolver = new EndpointResolverImpl<>((VertxInternal) vertx,
+      fakeResolver, LoadBalancer.ROUND_ROBIN, Duration.ofSeconds(5), Duration.ofMillis(10));
     Endpoint endpoint = resolver.resolveEndpoint(new FakeAddress("example.com")).await();
     Predicate<ServerEndpoint> none = s -> false;
     assertEquals(null, endpoint.selectServer(none));
@@ -68,7 +71,8 @@ public class EndpointResolverTest extends VertxTestBase {
   @Test
   public void testRebuild() {
     FakeRegistration registration = fakeResolver.registerAddress("example.com", List.of(addr1));
-    EndpointResolverImpl<FakeState, FakeAddress, FakeServerEndpoint> resolver = new EndpointResolverImpl<>((VertxInternal) vertx, fakeResolver, LoadBalancer.ROUND_ROBIN, 5000);
+    EndpointResolverImpl<FakeState, FakeAddress, FakeServerEndpoint> resolver = new EndpointResolverImpl<>((VertxInternal) vertx,
+      fakeResolver, LoadBalancer.ROUND_ROBIN, Duration.ofSeconds(5), Duration.ofMillis(10));
     Endpoint endpoint = resolver.resolveEndpoint(new FakeAddress("example.com")).await();
     Predicate<ServerEndpoint> even = s -> s.address().port() % 2 == 0;
     Predicate<ServerEndpoint> odd = s -> s.address().port() % 2 == 1;
@@ -84,5 +88,16 @@ public class EndpointResolverTest extends VertxTestBase {
     assertEquals(addr4, endpoint.selectServer(odd).address());
     assertEquals(addr2, endpoint.selectServer(odd).address());
     assertEquals(addr4, endpoint.selectServer(odd).address());
+  }
+
+  @Test
+  public void testRefresh() {
+    FakeRegistration registration = fakeResolver.registerAddress("example.com", List.of(addr1));
+    EndpointResolverImpl<FakeState, FakeAddress, FakeServerEndpoint> resolver = new EndpointResolverImpl<>((VertxInternal) vertx,
+      fakeResolver, LoadBalancer.ROUND_ROBIN, Duration.ofSeconds(5), Duration.ofMillis(10));
+    Endpoint endpoint = resolver.resolveEndpoint(new FakeAddress("example.com")).await();
+    registration = fakeResolver.registerAddress("example.com", List.of(addr1, addr2));
+    endpoint = resolver.resolveEndpoint(new FakeAddress("example.com")).await();
+    assertEquals(2, endpoint.servers().size());
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/endpoint/MappingResolverTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/endpoint/MappingResolverTest.java
@@ -22,6 +22,7 @@ import io.vertx.test.core.VertxTestBase;
 import io.vertx.test.fakeresolver.FakeAddress;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -39,7 +40,7 @@ public class MappingResolverTest extends VertxTestBase {
       return m != null ? m.apply(addr) : null;
     });
     endpointResolver = EndpointResolverInternal.create(
-      (VertxInternal) vertx, ar.endpointResolver(vertx), LoadBalancer.ROUND_ROBIN, 5000);
+      (VertxInternal) vertx, ar.endpointResolver(vertx), LoadBalancer.ROUND_ROBIN, Duration.ofSeconds(5), Duration.ofMillis(10));
   }
 
   @Test

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpClientResolverTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpClientResolverTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.http;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.dns.AddressResolverOptions;
+import io.vertx.core.http.*;
+import io.vertx.core.internal.http.HttpClientInternal;
+import io.vertx.core.internal.net.endpoint.EndpointResolverInternal;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.test.core.VertxRunner;
+import io.vertx.test.fakedns.DnsRecord;
+import io.vertx.test.fakedns.DnsServer;
+import io.vertx.test.fakedns.MockDnsServer;
+import io.vertx.test.fakedns.WithDnsServer;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.ConnectException;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static io.vertx.core.http.HttpMethod.GET;
+import static io.vertx.test.core.TestUtils.assertWaitUntil;
+import static io.vertx.test.http.AbstractHttpTest.DEFAULT_HTTP_HOST;
+import static io.vertx.test.http.AbstractHttpTest.DEFAULT_HTTP_PORT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(VertxRunner.class)
+public class HttpClientResolverTest {
+
+  @Rule
+  public DnsServer dnsServer = new DnsServer();
+
+  public HttpClientResolverTest() {
+  }
+
+  @WithDnsServer(records = {@DnsRecord(name = "vertx.io", address = "127.0.0.1"), @DnsRecord(name = "vertx.io", address = "127.0.0.2")})
+  @Test
+  public void testDnsClientSideLoadBalancingDisabled() throws Exception {
+    Vertx vertx = Vertx.vertx(dnsServer.vertxOptions());
+    try {
+      testDnsClientSideLoadBalancing(vertx, false);
+    } finally {
+      vertx.close().await();
+    }
+  }
+
+  @WithDnsServer(records = {@DnsRecord(name = "vertx.io", address = "127.0.0.1"), @DnsRecord(name = "vertx.io", address = "127.0.0.2")})
+  @Test
+  public void testDnsClientSideLoadBalancingEnabled() throws Exception {
+    Vertx vertx = Vertx.vertx(dnsServer.vertxOptions());
+    try {
+      testDnsClientSideLoadBalancing(vertx, true);
+    } finally {
+      vertx.close().await();
+    }
+  }
+
+  private void testDnsClientSideLoadBalancing(Vertx vertx, boolean enabled) {
+    List<String> hosts = List.of("127.0.0.1", "127.0.0.2");
+    List<String> actualHosts = new ArrayList<>();
+    for (String host : hosts) {
+      try {
+        HttpServer server = vertx
+          .createHttpServer()
+          .requestHandler(request -> request.response().end())
+          .listen(DEFAULT_HTTP_PORT, host)
+          .await();
+        actualHosts.add(host);
+      } catch (Exception e) {
+        // Could be a bind error on MacOS or Windows
+        // on MacOS : 'sudo ifconfig lo0 alias 127.0.0.2 up'
+      }
+    }
+    AtomicReference<Set<String>> balancedHosts = new AtomicReference<>();
+    AtomicInteger idx = new AtomicInteger();
+    HttpClient client = vertx
+      .httpClientBuilder()
+      .with(new HttpClientConfig().setConnectTimeout(Duration.ofMillis(500)))
+      .withLoadBalancer(enabled ? endpoints -> () -> {
+        balancedHosts.set(endpoints
+          .stream()
+          .map(se -> se.address().hostAddress())
+          .collect(Collectors.toSet()));
+        return idx.getAndIncrement() % endpoints.size();
+      } : null)
+      .build();
+    Set<String> ipAdresses = new HashSet<>();
+    for (int i = 0;i < hosts.size();i++) {
+      SocketAddress addr = client
+        .request(GET, DEFAULT_HTTP_PORT, "vertx.io", "/")
+        .compose(r -> {
+          return r.send().compose(resp -> resp.end().map(r.connection().remoteAddress()));
+        })
+        .await();
+      ipAdresses.add(addr.hostAddress());
+    }
+    if (enabled) {
+      Assertions.assertThat(ipAdresses).containsAll(actualHosts);
+      Assertions.assertThat(balancedHosts.get()).containsAll(hosts);
+    } else {
+      assertEquals(Set.of("127.0.0.1"), ipAdresses);
+    }
+  }
+
+  @Test
+  public void testKeepAliveTimeout(Vertx vertx) {
+
+    HttpServer server = vertx
+      .createHttpServer()
+      .requestHandler(request -> {
+        request.response().end();
+      });
+    server
+      .listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST)
+      .await();
+
+    HttpClientConfig clientConfig = new HttpClientConfig().setResolverConfig(new ClientResolverConfig().setKeepAliveTimeout(Duration.ofMillis(50)));
+    HttpClient client = vertx.createHttpClient(clientConfig, new PoolOptions().setCleanerPeriod(50));
+
+    // Create a connection to the server first (warm-up) before
+    // we test the origin resolver
+    client.request(GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/")
+      .compose(request -> request
+        .send()
+        .expecting(HttpResponseExpectation.SC_OK)
+        .compose(HttpClientResponse::end))
+      .await();
+
+    long now1 = System.currentTimeMillis();
+    vertx.setPeriodic(1, id -> {
+      if (System.currentTimeMillis() - now1 > 500) {
+        vertx.cancelTimer(id);
+      }
+      client.request(GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/")
+        .compose(request -> request
+          .send()
+          .expecting(HttpResponseExpectation.SC_OK)
+          .compose(HttpClientResponse::end));
+    });
+    EndpointResolverInternal originResolver = ((HttpClientInternal) client).originResolver();
+    assertWaitUntil(() -> originResolver.size() == 1);
+    long now2 = System.currentTimeMillis();
+    assertWaitUntil(() -> originResolver.size() == 0);
+    long delta = System.currentTimeMillis() - now2;
+    assertTrue(delta >= 500);
+    assertTrue(delta <= 1000);
+  }
+
+  @Test
+  public void testMaxKeepAlive() throws Exception {
+
+    AtomicReference<String> ip = new AtomicReference<>("127.0.0.1");
+    MockDnsServer dnsServer = new MockDnsServer();
+    dnsServer.store(question -> {
+      List<io.netty.handler.codec.dns.DnsRecord> responses = new ArrayList<>();
+      responses.add(MockDnsServer.a("vertx.io", 0, ip.get()));
+      return responses;
+    });
+    dnsServer.start();
+
+    Vertx vertx = Vertx.vertx(new VertxOptions()
+      .setAddressResolverOptions(new AddressResolverOptions()
+        .setServers(List.of("127.0.0.1:" + MockDnsServer.PORT))));
+
+    try {
+      HttpServer server = vertx
+        .createHttpServer()
+        .requestHandler(request -> request.response().end())
+        .listen(DEFAULT_HTTP_PORT, "127.0.0.1")
+        .await();
+
+      HttpClientConfig clientConfig = new HttpClientConfig().setResolverConfig(new ClientResolverConfig().setMaxKeepAlive(Duration.ofMillis(500)));
+      HttpClient client = vertx.createHttpClient(clientConfig, new PoolOptions().setCleanerPeriod(10));
+      long now = System.currentTimeMillis();
+      while (true) {
+        assertTrue((System.currentTimeMillis() - now) < 20_000);
+        try {
+          client
+            .request(GET, DEFAULT_HTTP_PORT, "vertx.io", "/")
+            .compose(r -> {
+              return r.send().compose(HttpClientResponse::end);
+            })
+            .await();
+        } catch (Exception e) {
+          assertTrue(e instanceof ConnectException);
+          assertTrue((System.currentTimeMillis() - now) >= 500);
+          assertTrue((System.currentTimeMillis() - now) < 1000);
+          break;
+        }
+        ip.set("127.0.0.2");
+      }
+    } finally {
+      vertx.close().await();
+      dnsServer.stop();
+    }
+  }
+}

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpTest.java
@@ -30,8 +30,6 @@ import io.vertx.core.http.impl.*;
 import io.vertx.core.http.impl.headers.Http1xHeaders;
 import io.vertx.core.http.impl.tcp.TcpHttpServer;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.http.HttpClientInternal;
-import io.vertx.core.internal.net.endpoint.EndpointResolverInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
 import io.vertx.core.streams.ReadStream;
@@ -45,7 +43,6 @@ import io.vertx.test.http.SimpleHttpTest2;
 import io.vertx.test.tls.Cert;
 import io.vertx.tests.http.http3.Http3Test;
 import org.assertj.core.api.AbstractThrowableAssert;
-import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -65,7 +62,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.*;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static io.vertx.core.http.HttpMethod.*;
@@ -6172,68 +6168,6 @@ public abstract class HttpTest extends SimpleHttpTest2 {
     }
   }
 
-  @WithDnsServer(records = {@DnsRecord(name = "vertx.io", address = "127.0.0.1"), @DnsRecord(name = "vertx.io", address = "127.0.0.2")})
-  @Test
-  public void testDnsClientSideLoadBalancingDisabled() throws Exception {
-    testDnsClientSideLoadBalancing(false);
-  }
-
-  @WithDnsServer(records = {@DnsRecord(name = "vertx.io", address = "127.0.0.1"), @DnsRecord(name = "vertx.io", address = "127.0.0.2")})
-  @Test
-  public void testDnsClientSideLoadBalancingEnabled() throws Exception {
-    testDnsClientSideLoadBalancing(true);
-  }
-
-  private void testDnsClientSideLoadBalancing(boolean enabled) {
-    List<String> hosts = List.of("127.0.0.1", "127.0.0.2");
-    List<String> actualHosts = new ArrayList<>();
-    for (String host : hosts) {
-      try {
-        HttpServer server = config
-          .forServer()
-          .create(vertx)
-          .requestHandler(request -> request.response().end())
-          .listen(DEFAULT_HTTP_PORT, host)
-          .await();
-        actualHosts.add(host);
-      } catch (Exception e) {
-        // Could be a bind error on MacOS or Windows
-        // on MacOS : 'sudo ifconfig lo0 alias 127.0.0.2 up'
-      }
-    }
-    AtomicReference<Set<String>> balancedHosts = new AtomicReference<>();
-    AtomicInteger idx = new AtomicInteger();
-    HttpClient client = config
-      .forClient()
-      .setVerifyHost(false)
-      .setConnectTimeout(Duration.ofMillis(500))
-      .builder(vertx)
-      .withLoadBalancer(enabled ? endpoints -> () -> {
-        balancedHosts.set(endpoints
-          .stream()
-          .map(se -> se.address().hostAddress())
-          .collect(Collectors.toSet()));
-        return idx.getAndIncrement() % endpoints.size();
-      } : null)
-      .build();
-    Set<String> ipAdresses = new HashSet<>();
-    for (int i = 0;i < hosts.size();i++) {
-      SocketAddress addr = client
-        .request(GET, DEFAULT_HTTP_PORT, "vertx.io", "/")
-        .compose(r -> {
-          return r.send().compose(resp -> resp.end().map(r.connection().remoteAddress()));
-        })
-        .await();
-      ipAdresses.add(addr.hostAddress());
-    }
-    if (enabled) {
-      Assertions.assertThat(ipAdresses).containsAll(actualHosts);
-      Assertions.assertThat(balancedHosts.get()).containsAll(hosts);
-    } else {
-      assertEquals(Set.of("127.0.0.1"), ipAdresses);
-    }
-  }
-
   @Test
   public void testConcurrentWrites1() throws Exception {
     testConcurrentWrites(req -> req
@@ -6385,45 +6319,6 @@ public abstract class HttpTest extends SimpleHttpTest2 {
         .expecting(HttpResponseExpectation.SC_OK)
         .compose(HttpClientResponse::end))
       .await();
-  }
-
-  @Test
-  public void testResolverKeepAlive() throws Exception {
-    client = ((HttpClientBuilderInternal)httpClientBuilder()
-      .with(new PoolOptions().setCleanerPeriod(50)))
-      .resolverIdleTimeout(Duration.ofMillis(50))
-      .build();
-    server.requestHandler(request -> {
-      request.response().end();
-    });
-    startServer(testAddress);
-    // Create a connection to the server first (warm-up) before
-    // we test the origin resolver
-    client.request(requestOptions)
-      .compose(request -> request
-        .send()
-        .expecting(HttpResponseExpectation.SC_OK)
-        .compose(HttpClientResponse::end))
-      .await();
-    long now = System.currentTimeMillis();
-    vertx.setPeriodic(1, id -> {
-      if (System.currentTimeMillis() - now > 500) {
-        vertx.cancelTimer(id);
-      }
-      client.request(requestOptions)
-        .compose(request -> request
-          .send()
-          .expecting(HttpResponseExpectation.SC_OK)
-          .compose(HttpClientResponse::end));
-    });
-    EndpointResolverInternal originResolver = ((HttpClientInternal) client).originResolver();
-    assertWaitUntil(() -> originResolver.size() == 1);
-    long abc = System.currentTimeMillis();
-    assertWaitUntil(() -> originResolver.size() == 0);
-    long delta = System.currentTimeMillis() - abc;
-    System.out.println(delta);
-    assertTrue(delta >= 500);
-    assertTrue(delta <= 1000);
   }
 
   @Test


### PR DESCRIPTION
Motivation:

The HTTP client resolver has an internal keep alive setting for its entries.

This should be configurable.

In addition an absoluate keep alive duration should be configurable as well.

Changes:

Introduce ClientResolverConfig for HTTP client exposing the keep alive setting.

Add a max keep alive setting to ensure that constantly resolved entries are eventually evicted.
