### PR TITLE
Interruping a suspended virtual thread should leave its task queue in a consistent state.

### DIFF
--- a/vertx-core-java21-tests/src/test/java/io/vertx/tests/virtualthread/ContextTest.java
+++ b/vertx-core-java21-tests/src/test/java/io/vertx/tests/virtualthread/ContextTest.java
@@ -459,21 +459,23 @@ public class ContextTest extends VertxTestBase {
         Promise<String> promise = Promise.promise();
         new Thread(() -> {
           while (current.getState() != Thread.State.WAITING) {
-            try {
-              Thread.sleep(10);
-            } catch (InterruptedException e) {
-              throw new RuntimeException(e);
-            }
+            Thread.yield();
           }
           current.interrupt();
+          while (current.getState() != Thread.State.TERMINATED) {
+            Thread.yield();
+          }
+          promise.succeed();
+          context.runOnContext(v -> {
+            testComplete();
+          });
         }).start();
         try {
-          Future.await(promise.future());
+          promise.future().await();
           fail();
         } catch (Exception expected) {
           assertFalse(current.isInterrupted());
           assertEquals(expected.getClass(), InterruptedException.class);
-          testComplete();
         }
       }
     }, new DeploymentOptions().setThreadingModel(ThreadingModel.VIRTUAL_THREAD));

--- a/vertx-core/src/main/java/io/vertx/core/impl/TaskQueue.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/TaskQueue.java
@@ -18,6 +18,7 @@ import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A task queue that always run all tasks in order. The executor to run the tasks is passed
@@ -241,7 +242,7 @@ public class TaskQueue {
 
   private class ContinuationTask extends CountDownLatch implements Task, WorkerExecutor.Execution {
 
-    private static final int ST_CREATED = 0, ST_SUSPENDED = 1, ST_RESUMED = 2;
+    private static final int ST_CREATED = 0, ST_SUSPENDED = 1, ST_DONE = 2;
 
     private final ExecuteTask task;
     private final Thread thread;
@@ -258,27 +259,30 @@ public class TaskQueue {
     }
 
     @Override
-    public void resume() {
-      resume(() -> {});
+    public boolean resume() {
+      return resume(() -> {});
     }
 
     @Override
-    public void resume(Runnable callback) {
+    public boolean resume(Runnable callback) {
       synchronized (tasks) {
         if (closed) {
-          return;
+          return false;
         }
         switch (status) {
           case ST_SUSPENDED:
             boolean removed = continuations.remove(this);
             assert removed;
             latch = () -> {
-              callback.run();
-              countDown();
+              try {
+                callback.run();
+              } finally {
+                countDown();
+              }
             };
             if (currentExecutor != null) {
               tasks.addFirst(this);
-              return;
+              return true;
             }
             currentExecutor = executor;
             currentThread = thread;
@@ -291,12 +295,44 @@ public class TaskQueue {
             assert currentTask == task;
             latch = callback;
             break;
+          case ST_DONE:
+            return false;
           default:
             throw new IllegalStateException();
         }
-        status = ST_RESUMED;
+        status = ST_DONE;
       }
       latch.run();
+      return true;
+    }
+
+    @Override
+    public void await() throws InterruptedException {
+      try {
+        super.await();
+      } catch (InterruptedException e) {
+        interrupted();
+        throw e;
+      }
+    }
+
+    @Override
+    public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+      try {
+        return super.await(timeout, unit);
+      } catch (InterruptedException e) {
+        interrupted();
+        throw e;
+      }
+    }
+
+    private void interrupted() {
+      synchronized (tasks) {
+        if (status == ST_SUSPENDED) {
+          continuations.remove(this);
+          status = ST_DONE;
+        }
+      }
     }
 
     @Override
@@ -320,7 +356,7 @@ public class TaskQueue {
           throw new IllegalStateException();
         }
         switch (status) {
-          case ST_RESUMED:
+          case ST_DONE:
             countDown();
             return false;
           case ST_SUSPENDED:

--- a/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
+++ b/vertx-core/src/main/java/io/vertx/core/impl/WorkerExecutor.java
@@ -105,15 +105,16 @@ public class WorkerExecutor implements EventExecutor {
     /**
      * Like {@link #resume(Runnable)}.
      */
-    void resume();
+    boolean resume();
 
     /**
      * Resume the task, the {@code callback} will be executed when the task is resumed, before the task thread
      * is un-parked.
      *
      * @param callback called after the task is resumed
+     * @return whether the continuation was actually resumed
      */
-    void resume(Runnable callback);
+    boolean resume(Runnable callback);
 
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/context/TaskQueueTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/context/TaskQueueTest.java
@@ -152,6 +152,32 @@ public class TaskQueueTest extends AsyncTestBase {
     await();
   }
 
+  @Test
+  public void testInterruptSuspended() {
+    disableThreadChecks();
+    taskQueue.execute(() -> {
+      WorkerExecutor.Execution execution = taskQueue.current();
+      CountDownLatch latch = execution.trySuspend();
+      Thread current = Thread.currentThread();
+      new Thread(() -> {
+        while (current.getState() != Thread.State.WAITING) {
+          Thread.yield();
+        }
+        current.interrupt();
+        while (current.getState() != Thread.State.TERMINATED) {
+          Thread.yield();
+        }
+        assertFalse(execution.resume());
+        taskQueue.execute(this::testComplete, executor);
+      }).start();
+      try {
+        latch.await();
+      } catch (InterruptedException expected) {
+      }
+    }, executor);
+    await();
+  }
+
   // Need to do unschedule when nested test!
 
   @Test


### PR DESCRIPTION
Motivation:

When a virtual thread is suspended on a vertx context, interrupting this virtual maintains in an inconsistent state: the continuation is still listed in the continuation map and the continuation task remains in suspended state.

Instead the continuation map entry should be removed and the task should move to the final state.

Changes:

Override CountDownLatch await to handle interrupted exception, when the virtual thread is interrupted, the continuation task is removed from the map and the tasks move to the final state.

Rename the state ST_RESUMED to ST_DONE which is the final state of the continuation.
