### PR TITLE
Investigate inbound HTTP message deframing 

### DIFF
--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpBodyDecoder.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpBodyDecoder.java
@@ -1,0 +1,13 @@
+package io.vertx.core.http.impl;
+
+import io.netty.buffer.ByteBuf;
+
+public interface HttpBodyDecoder {
+
+  int handle(ByteBuf content);
+
+  void next();
+
+  void end();
+
+}

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -46,5 +46,8 @@ public interface HttpClientStream extends HttpStream {
   HttpClientStream fetch(long amount);
 
   HttpClientStream updatePriority(StreamPriority streamPriority);
-
+  @Override
+  default HttpClientStream bodyDecoder(HttpBodyDecoder decoder) {
+    return (HttpClientStream)HttpStream.super.bodyDecoder(decoder);
+  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpServerStream.java
@@ -54,7 +54,9 @@ public interface HttpServerStream extends HttpStream {
 
   void sendFile(ChunkedInput<ByteBuf> file, Promise<Void> promise);
 
-
   HttpServerStream updatePriority(StreamPriority streamPriority);
-
+  @Override
+  default HttpServerStream bodyDecoder(HttpBodyDecoder decoder) {
+    return (HttpServerStream)HttpStream.super.bodyDecoder(decoder);
+  }
 }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/HttpStream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/HttpStream.java
@@ -15,10 +15,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpConnection;
-import io.vertx.core.http.HttpFrame;
-import io.vertx.core.http.HttpVersion;
-import io.vertx.core.http.StreamPriority;
+import io.vertx.core.http.*;
 import io.vertx.core.internal.ContextInternal;
 
 /**
@@ -48,6 +45,10 @@ public interface HttpStream {
   Future<Void> writeReset(long code);
 
   Future<Boolean> cancel();
+
+  default HttpStream bodyDecoder(HttpBodyDecoder decoder) {
+    throw new UnsupportedOperationException();
+  }
 
   HttpStream resetHandler(Handler<Long> handler);
   HttpStream exceptionHandler(Handler<Throwable> handler);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2Stream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2Stream.java
@@ -40,10 +40,10 @@ import io.vertx.core.net.impl.MessageWrite;
  */
 abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements HttpStream, Http2Stream {
 
-  private static final HttpHeaders EMPTY = new HttpHeaders(EmptyHttp2Headers.INSTANCE);
+  private static final Buffer EMPTY = BufferInternal.buffer(Unpooled.EMPTY_BUFFER);
 
   private final OutboundMessageQueue<MessageWrite> outboundQueue;
-  private final InboundMessageQueue<Object> inboundQueue;
+  private final InboundMessageQueue<Buffer> inboundQueue;
   private final Http2Connection connection;
   protected final VertxInternal vertx;
   protected final ContextInternal context;
@@ -55,6 +55,9 @@ abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements Ht
   private boolean headersSent;
   private boolean trailersSent;
   private boolean writable;
+
+  // Written by event-loop - read by context with happens-before relationship
+  private MultiMap trailers;
 
   // Client context
   private StreamPriority priority;
@@ -85,14 +88,13 @@ abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements Ht
     this.id = id_;
     this.inboundQueue = new InboundMessageQueue<>(connection.context().eventLoop(), context.executor()) {
       @Override
-      protected void handleMessage(Object item) {
-        if (item instanceof MultiMap) {
-          handleTrailers((MultiMap) item);
+      protected void handleMessage(Buffer item) {
+        if (item == EMPTY) {
+          handleTrailers(trailers);
         } else {
-          Buffer data = (Buffer) item;
-          int len = data.length();
+          int len = item.length();
           connection.context().execute(len, v -> connection.consumeCredits(DefaultHttp2Stream.this.id, v));
-          handleData(data);
+          handleData(item);
         }
       }
     };
@@ -241,20 +243,21 @@ abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements Ht
   }
 
   public final void onTrailers() {
-    onTrailers(EMPTY);
+    onTrailers(null);
   }
 
-  public final void onTrailers(HttpHeaders trailers) {
+  public final void onTrailers(HttpHeaders t) {
     if (trailersReceived) {
       throw new IllegalStateException();
     }
     trailersReceived = true;
+    trailers = t;
     StreamObserver observer = observer();
     if (observer != null) {
       observer.observeInboundTrailers(bytesRead);
     }
     connection.flushBytesRead();
-    inboundQueue.write(trailers);
+    inboundQueue.write(EMPTY);
   }
 
   public final long id() {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2Stream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/DefaultHttp2Stream.java
@@ -15,7 +15,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.EventLoop;
-import io.netty.handler.codec.http2.EmptyHttp2Headers;
 import io.netty.handler.stream.ChunkedInput;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -28,22 +27,24 @@ import io.vertx.core.http.impl.HttpStream;
 import io.vertx.core.http.impl.HttpUtils;
 import io.vertx.core.http.impl.headers.HttpHeaders;
 import io.vertx.core.http.impl.observability.StreamObserver;
+import io.vertx.core.http.impl.HttpBodyDecoder;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.buffer.BufferInternal;
 import io.vertx.core.internal.concurrent.InboundMessageQueue;
 import io.vertx.core.internal.concurrent.OutboundMessageQueue;
 import io.vertx.core.net.impl.MessageWrite;
+import io.vertx.core.net.impl.VertxHandler;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements HttpStream, Http2Stream {
 
-  private static final Buffer EMPTY = BufferInternal.buffer(Unpooled.EMPTY_BUFFER);
+  private static final ByteBuf EMPTY = Unpooled.wrappedBuffer(new byte[1]);
 
   private final OutboundMessageQueue<MessageWrite> outboundQueue;
-  private final InboundMessageQueue<Buffer> inboundQueue;
+  private final InboundMessageQueue<ByteBuf> inboundQueue;
   private final Http2Connection connection;
   protected final VertxInternal vertx;
   protected final ContextInternal context;
@@ -77,6 +78,9 @@ abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements Ht
   private Handler<StreamPriority> priorityChangeHandler;
   private Handler<Void> drainHandler;
 
+  //
+  private HttpBodyDecoder decoder;
+
   DefaultHttp2Stream(Http2Connection connection, ContextInternal context) {
     this(-1, connection, context, true);
   }
@@ -88,13 +92,23 @@ abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements Ht
     this.id = id_;
     this.inboundQueue = new InboundMessageQueue<>(connection.context().eventLoop(), context.executor()) {
       @Override
-      protected void handleMessage(Buffer item) {
-        if (item == EMPTY) {
+      protected long evalMessage(ByteBuf data) {
+        if (data == EMPTY) {
+          return 1;
+        } else {
+          int len = data.readableBytes();
+          connection.context().execute(len, v -> connection.consumeCredits(DefaultHttp2Stream.this.id, v));
+          return decoder.handle(data);
+        }
+      }
+      @Override
+      protected void handleMessage(ByteBuf data, long amount) {
+        if (data == EMPTY) {
           handleTrailers(trailers);
         } else {
-          int len = item.length();
-          connection.context().execute(len, v -> connection.consumeCredits(DefaultHttp2Stream.this.id, v));
-          handleData(item);
+          for (int i = 0;i < amount;i++) {
+            decoder.next();
+          }
         }
       }
     };
@@ -134,6 +148,26 @@ abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements Ht
         this.trailersReceived = true;
       }
     }
+    this.decoder = new HttpBodyDecoder() {
+      private Buffer buffer;
+      @Override
+      public int handle(ByteBuf content) {
+        buffer = BufferInternal.buffer(VertxHandler.safeBuffer(content));
+        return 1;
+      }
+      @Override
+      public void next() {
+        Buffer item = buffer;
+        buffer = null;
+        Handler<Buffer> handler = dataHandler;
+        if (handler != null) {
+          context.dispatch(item, handler);
+        }
+      }
+      @Override
+      public void end() {
+      }
+    };
   }
 
   public final HttpVersion version() {
@@ -230,8 +264,12 @@ abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements Ht
     context.execute(new HttpFrameImpl(type, flags, payload), this::handleCustomFrame);
   }
 
-  public void onData(Buffer data) {
-    bytesRead += data.length();
+  public void onData(ByteBuf data) {
+    // Warning : we retain the buffer and we don't release it on close
+    // when close happens we should flush the queue and cumulate the result
+    // for later delivery
+    data.retain();
+    bytesRead += data.readableBytes();
     inboundQueue.write(data);
   }
 
@@ -427,6 +465,12 @@ abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements Ht
   }
 
   @Override
+  public S bodyDecoder(HttpBodyDecoder decoder) {
+    this.decoder = decoder;
+    return (S)this;
+  }
+
+  @Override
   public Future<Boolean> cancel() {
     return writeReset(0x08L).map(true);
   }
@@ -481,13 +525,6 @@ abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements Ht
     return (S)this;
   }
 
-  private void handleData(Buffer buf) {
-    Handler<Buffer> handler = dataHandler;
-    if (handler != null) {
-      context.dispatch(buf, handler);
-    }
-  }
-
   public S customFrameHandler(Handler<HttpFrame> handler) {
     customFrameHandler = handler;
     return (S)this;
@@ -510,6 +547,7 @@ abstract class DefaultHttp2Stream<S extends DefaultHttp2Stream<S>> implements Ht
     if (handler != null) {
       context.dispatch(trailers, handler);
     }
+    decoder.end();
   }
 
   public S resetHandler(Handler<Long> handler) {

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2Stream.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/Http2Stream.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.core.http.impl.http2;
 
+import io.netty.buffer.ByteBuf;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.GoAway;
 import io.vertx.core.http.StreamPriority;
@@ -36,7 +37,7 @@ public interface Http2Stream {
 
   void onPriorityChange(StreamPriority streamPriority);
   void onHeaders(HttpHeaders headers);
-  void onData(Buffer buffer);
+  void onData(ByteBuf buffer);
   void onCustomFrame(int type, int flags, Buffer payload);
   void onTrailers();
   void onTrailers(HttpHeaders trailers);

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/codec/Http2ConnectionImpl.java
@@ -53,7 +53,7 @@ abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameL
 
   private static final Logger log = LoggerFactory.getLogger(Http2ConnectionImpl.class);
 
-  private static ByteBuf safeBuffer(ByteBuf buf) {
+  public static ByteBuf safeBuffer(ByteBuf buf) {
     ByteBuf buffer = VertxByteBufAllocator.DEFAULT.heapBuffer(buf.readableBytes());
     buffer.writeBytes(buf);
     return buffer;
@@ -300,9 +300,7 @@ abstract class Http2ConnectionImpl extends ConnectionBase implements Http2FrameL
   public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding, boolean endOfStream) {
     Http2Stream stream = stream(streamId);
     if (stream != null) {
-      data = safeBuffer(data);
-      Buffer buff = BufferInternal.buffer(data);
-      stream.onData(buff);
+      stream.onData(data);
       if (endOfStream) {
         stream.onTrailers();
       }

--- a/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
+++ b/vertx-core/src/main/java/io/vertx/core/http/impl/http2/multiplex/Http2MultiplexConnection.java
@@ -106,15 +106,12 @@ public abstract class Http2MultiplexConnection<S extends Http2Stream> extends Co
 
   void receiveData(ChannelHandlerContext chctx, int streamId, ByteBuf content, boolean ended, int initialWindowSize) {
     StreamChannel channel = channels.get(streamId);
-    ByteBuf buffer = VertxByteBufAllocator.DEFAULT.heapBuffer(content.readableBytes());
-    buffer.writeBytes(content, content.readerIndex(), content.readableBytes());
-    Buffer buff = BufferInternal.buffer(buffer);
-    channel.bytesConsumed += buff.length();
+    channel.bytesConsumed += content.readableBytes();
     if (channel.bytesConsumed > initialWindowSize) {
       chctx.channel().config().setAutoRead(false);
     }
     S stream = channel.stream;
-    stream.onData(buff);
+    stream.onData(content);
     if (ended) {
       stream.onTrailers();
     }

--- a/vertx-core/src/main/java/io/vertx/core/internal/concurrent/InboundMessageQueue.java
+++ b/vertx-core/src/main/java/io/vertx/core/internal/concurrent/InboundMessageQueue.java
@@ -35,6 +35,7 @@ public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
   // Accessed by consumer thread
   private boolean draining;
   private boolean needsDrain;
+  private long value;
   private boolean consumerClosed;
 
   // Any thread
@@ -75,16 +76,30 @@ public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
     if (consumerClosed) {
       return false;
     } else {
+      long v = value;
       while (true) {
         long d = DEMAND_UPDATER.get(this);
         if (d == 0L) {
           return false;
-        } else if (d == Long.MAX_VALUE || DEMAND_UPDATER.compareAndSet(this, d, d - 1)) {
-          break;
+        } else {
+          if (v == 0) {
+            v = evalMessage(msg);
+          }
+          if (d == Long.MAX_VALUE) {
+            handleMessage(msg, v);
+            value = 0;
+            return true;
+          } else {
+            long m = Math.min(v, d);
+            if (DEMAND_UPDATER.compareAndSet(this, d, d - m)) {
+              long r = v - m;
+              handleMessage(msg, m);
+              value = r;
+              return r == 0;
+            }
+          }
         }
       }
-      handleMessage(msg);
-      return true;
     }
   }
 
@@ -255,6 +270,10 @@ public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
     }
   }
 
+  public long demand() {
+    return DEMAND_UPDATER.get(this);
+  }
+
   private void releaseMessages() {
     List<M> messages = mqp.clear();
     for (M elt : messages) {
@@ -275,10 +294,33 @@ public class InboundMessageQueue<M> implements Predicate<M>, Runnable {
   }
 
   /**
+   * Handle the message and return an evaluation of its cost, the return cost
+   * will be substracted to the queue demand.
+   *
+   * The returned value cab be any value greater or equals to zero, it is fine to be zero
+   * in case the message is not sufficient to be processed and a follow up message is necessary.
+   *
+   * @param msg the message
+   * @return the cost
+   * @implNote the default implementation returns {@code 1}
+   */
+  protected long evalMessage(M msg) {
+    return 1;
+  }
+
+  /**
+   *
+   */
+  protected void handleMessage(M msg, long amount) {
+    handleMessage(msg);
+  }
+
+  /**
    * Handle a message, executed on a consumer thread.
    *
    * @param msg the message
    */
+  @Deprecated
   protected void handleMessage(M msg) {
   }
 

--- a/vertx-core/src/test/java/io/vertx/tests/concurrent/InboundMessageQueueTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/concurrent/InboundMessageQueueTest.java
@@ -13,16 +13,15 @@ package io.vertx.tests.concurrent;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.internal.concurrent.InboundMessageQueue;
+import io.vertx.test.core.TestUtils;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntConsumer;
 
@@ -530,5 +529,144 @@ public abstract class InboundMessageQueueTest extends VertxTestBase {
       });
     });
     await();
+  }
+
+  class TestChannel2 extends InboundMessageQueue<Integer> {
+    public TestChannel2() {
+      super(((ContextInternal) context).eventLoop(), ((ContextInternal) context).executor());
+    }
+    List<Integer> cumulation = new ArrayList<>();
+    @Override
+    protected long evalMessage(Integer msg) {
+      return msg;
+    }
+    @Override
+    protected void handleMessage(Integer msg) {
+      cumulation.add(msg);
+    }
+  }
+
+  @Test
+  public void testPartialEval() {
+    TestChannel2 queue = new TestChannel2();
+    producerTask(() -> {
+      queue.pause();
+      queue.write(5);
+      consumerTask(() -> {
+        assertEquals(0, queue.cumulation.size());
+        queue.fetch(3);
+        consumerTask(() -> {
+          assertEquals(List.of(5), queue.cumulation);
+          queue.fetch(3);
+          consumerTask(() -> {
+            assertEquals(List.of(5), queue.cumulation);
+            assertEquals(1, queue.demand());
+            testComplete();
+          });
+        });
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testZeroEvalIsNotGreedy() {
+    TestChannel2 queue = new TestChannel2();
+    producerTask(() -> {
+      queue.pause();
+      queue.write(0);
+      consumerTask(() -> {
+        assertEquals(0, queue.cumulation.size());
+        queue.fetch(1);
+        consumerTask(() -> {
+          assertEquals(1, queue.cumulation.size());
+          assertEquals(1, queue.demand());
+          testComplete();
+        });
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void deframingTest() {
+    for (int i = 0;i <= 8;i++) {
+      deframingTest(1 + i);
+    }
+  }
+
+  // Check we can implement a deframer
+  public void deframingTest(int times) {
+    List<Buffer> collected = Collections.synchronizedList(new ArrayList<>());
+    InboundMessageQueue<Buffer> queue = new InboundMessageQueue<>(((ContextInternal) context).eventLoop(), ((ContextInternal) context).executor()) {
+      final ArrayDeque<Buffer> pending = new ArrayDeque<>();
+      Buffer cumlation = Buffer.buffer();
+      @Override
+      protected long evalMessage(Buffer msg) {
+        cumlation.appendBuffer(msg);
+        int prev = 0;
+        int next;
+        while (prev + 4 < cumlation.length() && (next = prev + 4 + cumlation.getInt(prev)) <= cumlation.length()) {
+          Buffer buffer = cumlation.getBuffer(prev + 4, next);
+          pending.add(buffer);
+          prev = next;
+        }
+        if (prev > 0) {
+          cumlation = cumlation.getBuffer(prev, cumlation.length());
+        }
+        return pending.size();
+      }
+      @Override
+      protected void handleMessage(Buffer msg, long amount) {
+        while (amount-- > 0) {
+          collected.add(pending.poll());
+        }
+      }
+    };
+    Buffer[] buffers = {
+      Buffer.buffer(TestUtils.randomAlphaString(1024)),
+      Buffer.buffer(TestUtils.randomAlphaString(256)),
+      Buffer.buffer(TestUtils.randomAlphaString(512)),
+      Buffer.buffer(TestUtils.randomAlphaString(128))
+    };
+    Buffer payload = Buffer.buffer();
+    for (Buffer buffer : buffers) {
+      payload.appendInt(buffer.length());
+      payload.appendBuffer(buffer);
+    }
+    // Split payload for testing
+    int delta = payload.length() / times;
+    List<Buffer> parts = new ArrayList<>();
+    int idx = 0;
+    for (int i = 0;i < times - 1;i++) {
+      parts.add(payload.getBuffer(idx, idx + delta));
+      idx += delta;
+    }
+    parts.add(payload.getBuffer(idx, payload.length()));
+    io.vertx.core.Promise<Void> latch = io.vertx.core.Promise.promise();
+    producerTask(() -> {
+      queue.pause();
+      for (Buffer part : parts) {
+        queue.write(part);
+      }
+      consumerTask(() -> {
+        queue.fetch(2);
+        consumerTask(() -> {
+          assertEquals(2, collected.size());
+          queue.fetch(1);
+          consumerTask(() -> {
+            assertEquals(3, collected.size());
+            queue.fetch(1);
+            consumerTask(() -> {
+              assertEquals(4, collected.size());
+              latch.succeed();
+            });
+          });
+        });
+      });
+    });
+    latch
+      .future()
+      .await();
   }
 }

--- a/vertx-core/src/test/java/io/vertx/tests/http/HttpBodyCodecTest.java
+++ b/vertx-core/src/test/java/io/vertx/tests/http/HttpBodyCodecTest.java
@@ -1,0 +1,55 @@
+package io.vertx.tests.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
+import io.vertx.core.http.impl.HttpResponseHead;
+import io.vertx.core.http.impl.HttpServerConnection;
+import io.vertx.core.http.impl.headers.HttpResponseHeaders;
+import io.vertx.core.http.impl.HttpBodyDecoder;
+import io.vertx.test.core.TestUtils;
+import io.vertx.test.http.HttpConfigurator;
+import io.vertx.test.http.SimpleHttpTest2;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class HttpBodyCodecTest extends SimpleHttpTest2 {
+
+  public HttpBodyCodecTest() {
+    super(HttpConfigurator.H2.MULTIPLEX);
+  }
+
+  @Test
+  public void testBodyDecoder() throws Exception {
+    Buffer body = Buffer.buffer(TestUtils.randomAlphaString(1024));
+    server.connectionHandler(connection -> {
+      HttpServerConnection serverConnection = (HttpServerConnection) connection;
+      serverConnection.streamHandler(stream -> {
+        stream.bodyDecoder(new HttpBodyDecoder() {
+          @Override
+          public int handle(ByteBuf content) {
+            ReferenceCountUtil.release(content);
+            return 10;
+          }
+          @Override
+          public void next() {
+          }
+          @Override
+          public void end() {
+            stream.writeHead(new HttpResponseHead(200, null, new HttpResponseHeaders(serverConnection.newHeaders())), null, true);
+          }
+        });
+      });
+    });
+    server.requestHandler(request -> {
+      fail();
+    });
+    startServer(testAddress);
+    client.request(new RequestOptions(requestOptions).setMethod(HttpMethod.POST))
+      .compose(request -> {
+        return request.send(body).compose(HttpClientResponse::end);
+      }).await();
+  }
+}


### PR DESCRIPTION
Motivation:

Let HTTP streams provide a pluggable message deframer of pooled buffers instead of implementing it on top of the HTTP API.

The following can be retrofit:

- Vert.x Buffer dispatch
- Form and file upload processing

Server side HTTP/1.x has no implementation and relies on a custom implementation of `HttpServerRequest` instead of providing an `HttpServerStream` implementation, thus it would need to be rewritten or written.

Status:

Investigation, for further use, targetting 5.3

